### PR TITLE
fix AliquotTest and SampleSetTest

### DIFF
--- a/src/org/labkey/test/tests/AliquotTest.java
+++ b/src/org/labkey/test/tests/AliquotTest.java
@@ -312,6 +312,11 @@ public class AliquotTest extends SpecimenBaseTest
         setExpectSpecimenImportError(true);
         waitForSpecimenImport();
 
+        // Check there was an error in the specimen merge.
+        clickAndWait(Locator.linkWithText("ERROR"));
+        assertTextPresent("With an editable specimen repository, importing may not reference any existing specimen. " +
+                "8 imported specimen events refer to existing specimens.");
+
         // Make sure the expected errors have been logged and will not hang up the test later on.
         checkExpectedErrors(1);
     }

--- a/src/org/labkey/test/tests/SampleSetTest.java
+++ b/src/org/labkey/test/tests/SampleSetTest.java
@@ -1532,7 +1532,7 @@ public class SampleSetTest extends BaseWebDriverTest
         goToModule("Query");
         viewQueryData("auditLog", "SampleSetAuditEvent");
         assertTextPresent(
-                "Samples inserted or updated in: " + sampleSetName);
+                "Samples inserted in: " + sampleSetName);
 
     }
 


### PR DESCRIPTION
fix AliquotTest
- use raw string in labkey:radio currentValue so Objects.equals in RadioTag.isChecked will return true
- add expected error message to test

fix SampleSetTest
- expected audit log message has changed