### PR TITLE
Migrate exemption for pepSearch action to its new home in "ms2" controller

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -193,7 +193,7 @@ public class Crawler
             new ControllerActionId("login", "verifyToken"), // returns XML, which WDW.waitForPageToLoad can't handle
             new ControllerActionId("luminex", "exportDefaultValues"), // download action
             new ControllerActionId("microarray", "designer"), // assay designer prompts to save design when navigating away
-            new ControllerActionId("ms1", "pepSearch"), // TODO: 36995: Check for SQL injection in StatementWrapper is not precise enough
+            new ControllerActionId("ms2", "pepSearch"), // TODO: 36995: Check for SQL injection in StatementWrapper is not precise enough
             new ControllerActionId("ms2", "showParamsFile"),
             // Tested directly in XTandemTest
             new ControllerActionId("ms2", "showPeptide"),


### PR DESCRIPTION
Avoids false-positive in SQL injection check. Same server-side code, just in a new home