### PR TITLE
Fixing NPE in listHelper. ListHelper assumes a column will have a label.

### DIFF
--- a/src/org/labkey/test/util/ListHelper.java
+++ b/src/org/labkey/test/util/ListHelper.java
@@ -351,6 +351,7 @@ public class ListHelper extends LabKeySiteWrapper
             expectedTexts.add(col.getLabel());
         }
         expectedTexts.remove("");
+        expectedTexts.remove(null);
         assertTextPresent(new ArrayList<>(expectedTexts));
     }
 


### PR DESCRIPTION
If no column label is given col.getLabel returns null and puts null in the list which results in a NPE later down the line.