### PR TITLE
Prevent NPE after using `DataRegionFinder.locatedBy(..)`

### DIFF
--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -210,7 +210,9 @@ public class DataRegionTable extends DataRegion
         @Override
         protected DataRegionTable construct(WebElement el, WebDriver driver)
         {
-            DataRegionTable constructed = new DataRegionTable(new RefindingWebElement(el, buildLocator(), getContext()).withTimeout(getTimeout()), driver);
+            if (buildLocator() != null && getContext() != null) // Prevent NPE after using `DataRegionFinder.locatedBy(..)`
+                el = new RefindingWebElement(el, buildLocator(), getContext()).withTimeout(getTimeout());
+            DataRegionTable constructed = new DataRegionTable(el, driver);
             constructed.setUpdateTimeout(getTimeout());
             if (!_lazy)
                 constructed.elementCache();


### PR DESCRIPTION
Preemptive fix for a corner-case I ran across locally.

Looks good on TeamCity:
https://teamcity.labkey.org/project/LabkeyTrunk?branch=dataregion_npe