### PR TITLE
Prevent some timeouts from executeScriptAsync

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -442,7 +442,10 @@ public abstract class WebDriverWrapper implements WrapsDriver
      */
     public Object executeAsyncScript(String script, Object... arguments)
     {
-        script = "var callback = arguments[arguments.length - 1];\n" + script; // See WebDriver documentation
+        script = "var callback = arguments[arguments.length - 1];\n" +
+                "try {" +
+                script + // See WebDriver documentation
+                "} catch (error) { callback(error); }"; // ensure that the callback is invoked when an exception would otherwise prevent it
         return ((JavascriptExecutor) getDriver()).executeAsyncScript(script, arguments);
     }
 

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -442,9 +442,9 @@ public abstract class WebDriverWrapper implements WrapsDriver
      */
     public Object executeAsyncScript(String script, Object... arguments)
     {
-        script = "var callback = arguments[arguments.length - 1];\n" +
+        script = "var callback = arguments[arguments.length - 1];\n" + // See WebDriver documentation for details on injected callback
                 "try {" +
-                script + // See WebDriver documentation
+                script +
                 "} catch (error) { callback(error); }"; // ensure that the callback is invoked when an exception would otherwise prevent it
         return ((JavascriptExecutor) getDriver()).executeAsyncScript(script, arguments);
     }


### PR DESCRIPTION
ensure that the callback is invoked when an exception would prevent it

Looks good on TeamCity:
https://teamcity.labkey.org/project/LabkeyTrunk?branch=executeAsyncCallback