### PR TITLE
Issue 30769: Migrate wiki edit page to use standard JS file chooser

### DIFF
--- a/src/org/labkey/test/tests/WikiLongTest.java
+++ b/src/org/labkey/test/tests/WikiLongTest.java
@@ -237,7 +237,7 @@ public class WikiLongTest extends BaseWebDriverTest
         click(Locator.linkWithText("Attach a file"));
 
         File file = _wikiHelper.getSampleFile();
-        setFormElement(Locator.name("formFiles[0]"), file);
+        setFormElement(Locator.name("formFiles[00]"), file);
         _wikiHelper.saveWikiPage();
         waitForElement(Locator.linkContainingText(file.getName()));
         assertTextPresent(WIKI_PAGE3_WEBPART_TEST,

--- a/src/org/labkey/test/tests/WikiTest.java
+++ b/src/org/labkey/test/tests/WikiTest.java
@@ -99,7 +99,7 @@ public class WikiTest extends BaseWebDriverTest
         log("test attachments in wiki");
         click(Locator.linkWithText("Attach a file"));
         File file = wikiHelper.getSampleFile();
-        setFormElement(Locator.name("formFiles[0]"), file);
+        setFormElement(Locator.name("formFiles[00]"), file);
         wikiHelper.saveWikiPage();
 
         DataRegionTable.DataRegion(getDriver()).withName(WIKI_PAGE_WEBPART_ID).waitFor();


### PR DESCRIPTION
File attachments now use conventional file picker rather than unstandardized code unique to wiki edit page.