### PR TITLE
Remove workaround for incorrect wiki regex

### DIFF
--- a/src/org/labkey/test/tests/MessagesLongTest.java
+++ b/src/org/labkey/test/tests/MessagesLongTest.java
@@ -28,7 +28,6 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.DailyA;
 import org.labkey.test.components.dumbster.EmailRecordTable;
-import org.labkey.test.components.ext4.Window;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.pages.admin.PermissionsPage;
 import org.labkey.test.pages.announcements.AdminPage;
@@ -219,9 +218,7 @@ public class MessagesLongTest extends BaseWebDriverTest
         assertElementPresent(Locator.tagWithText("li", "hair clogs"));
         assertElementPresent(Locator.tagWithText("li", "stinky feet"));
         assertElementPresent(Locator.tagWithText("li", "internet trolls"));
-        clickButton("Submit", 0);
-        Window confirmWindow = Window.Window(getDriver()).withTitle("Confirm message formatting").find();
-        confirmWindow.clickButton("Yes");
+        clickButton("Submit");
         assertElementPresent(Locator.tagWithText("h1", "Holy Header, Batman!"));
         assertElementPresent(Locator.tagWithText("strong", "bold as bold can possibly be"));
 


### PR DESCRIPTION
It looks like the test was expecting a bad confirmation that was fixed in:
https://github.com/LabKey/platform/commit/fec9210af95962e3754ab3158d5d2e0c7afc20ff