### PR TITLE
Don't ignore unexpected alerts when impersonating

### DIFF
--- a/src/org/labkey/test/components/internal/ImpersonateWindow.java
+++ b/src/org/labkey/test/components/internal/ImpersonateWindow.java
@@ -19,6 +19,7 @@ import org.labkey.test.components.ext4.Window;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.Alert;
+import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.firefox.FirefoxDriver;
@@ -45,6 +46,10 @@ public abstract class ImpersonateWindow extends Window<ImpersonateWindow.Element
                     {
                         TestLogger.log("Ignoring alert on impersonation: " + alertText);
                         alert.accept();
+                    }
+                    else
+                    {
+                        throw new UnhandledAlertException("Unexpected alert when attempting to impersonate", alertText);
                     }
                 }
             }


### PR DESCRIPTION
Related to the intermittent error in [RespectPhiColumnUiTest.verifyShowPhiColumn](https://teamcity.labkey.org/viewLog.html?buildId=783699&buildTypeId=LabkeyTrunk_GitSqlserver2014#testNameId7059327643234359949)
```
	at org.labkey.test.components.html.SiteNavBar$UserMenu.impersonate(SiteNavBar.java:288)
	at org.labkey.test.LabKeySiteWrapper.impersonate(LabKeySiteWrapper.java:1242)
	at org.labkey.test.tests.compliance.BasePhiColumnTest.validateDatasetAndListUIColumns(BasePhiColumnTest.java:489)
	at org.labkey.test.tests.compliance.RespectPhiColumnUiTest.verifyShowPhiColumn(RespectPhiColumnUiTest.java:105)
```
Probably won't fix the problem but might get us some more informative error messages.