### PR TITLE
Make addConditionalFormat work for multiple rows

### DIFF
--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -1092,7 +1092,7 @@ public abstract class Locator extends By
         {
             return new XPathCSSLocator(
                     _xLoc.last(),
-                    _cssLoc.lastChild());
+                    _cssLoc.lastOfType());
         }
 
         @Override
@@ -1647,6 +1647,11 @@ public abstract class Locator extends By
         public CssLocator lastChild()
         {
             return append(":last-child");
+        }
+
+        public CssLocator lastOfType()
+        {
+            return append(":last-of-type");
         }
 
         @Override

--- a/src/org/labkey/test/components/PropertiesEditor.java
+++ b/src/org/labkey/test/components/PropertiesEditor.java
@@ -607,20 +607,25 @@ public class PropertiesEditor extends WebPartPanel<PropertiesEditor.ElementCache
                 getWrapper().shortWait().until(ExpectedConditions.stalenessOf(filterDialog));
                 if (format.isBold())
                 {
-                    getWrapper().checkCheckbox(Locator.checkboxByName("Bold").last());
+                    getWrapper().checkCheckbox(findLastCheckbox("Bold"));
                 }
                 if (format.isItalics())
                 {
-                    getWrapper().checkCheckbox(Locator.checkboxByName("Italic").last());
-                }
-                if (format.isUnderline())
-                {
-                    getWrapper().checkCheckbox(Locator.checkboxByName("Underline").last());
+                    getWrapper().checkCheckbox(findLastCheckbox("Italic"));
                 }
                 if (format.isStrikethrough())
                 {
-                    getWrapper().checkCheckbox(Locator.checkboxByName("Strikethrough").last());
+                    getWrapper().checkCheckbox(findLastCheckbox("Strikethrough"));
                 }
+            }
+
+            private WebElement findLastCheckbox(String name)
+            {
+                List<WebElement> elements = Locator.checkboxByName(name).findElements(this);
+                if (elements.isEmpty())
+                    Locator.checkboxByName(name).findElement(this); // Should throw NoSuchElementException
+
+                return elements.get(elements.size() - 1);
             }
         }
 

--- a/src/org/labkey/test/params/Format.java
+++ b/src/org/labkey/test/params/Format.java
@@ -3,32 +3,24 @@ package org.labkey.test.params;
 public class Format
 {
     public static final Format BOLD = new Builder().setBold(true).build();
-    public static final Format UNDERLINE = new Builder().setUnderline(true).build();
     public static final Format ITALIC = new Builder().setItalics(true).build();
     public static final Format STRIKETHROUGH = new Builder().setStrikethrough(true).build();
     public static final Format NONE = new Builder().build();
 
     private final boolean _bold;
-    private final boolean _underline;
     private final boolean _italics;
     private final boolean _strikethrough;
 
     private Format(Builder builder)
     {
         _bold = builder._bold;
-        _underline = builder._underline;
-        _italics = builder._underline;
+        _italics = builder._italics;
         _strikethrough = builder._strikethrough;
     }
 
     public boolean isBold()
     {
         return _bold;
-    }
-
-    public boolean isUnderline()
-    {
-        return _underline;
     }
 
     public boolean isItalics()
@@ -44,7 +36,6 @@ public class Format
     public static class Builder
     {
         private boolean _bold;
-        private boolean _underline;
         private boolean _italics;
         private boolean _strikethrough;
 
@@ -55,12 +46,6 @@ public class Format
         public Builder setBold(boolean bold)
         {
             _bold = bold;
-            return this;
-        }
-
-        public Builder setUnderline(boolean underline)
-        {
-            _underline = underline;
             return this;
         }
 


### PR DESCRIPTION
Make XPathLocator.last() work consistently
Remove reference to non-existent 'underline' conditional format

Fixes ListTest failure