### PR TITLE
Issue 38403: Support DB report name as URL parameter in addition to RowId

### DIFF
--- a/src/org/labkey/test/tests/visualization/BarPlotTest.java
+++ b/src/org/labkey/test/tests/visualization/BarPlotTest.java
@@ -33,6 +33,8 @@ import org.labkey.test.util.LabKeyExpectedConditions;
 import org.labkey.test.util.LogMethod;
 
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
 
 @Category({DailyC.class, Reports.class, Charting.class, Hosting.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 8)
@@ -210,6 +212,10 @@ public class BarPlotTest extends GenericChartsTest
 
         log("Save the plot.");
         savePlot(BAR_PLOT_SAVE_NAME_3, "This is a bar plot from the grouped bar plot test.");
+
+        log("Verify it can be resolved by report name as well as ID");
+        beginAt(getCurrentRelativeURL().replaceAll("reportId=.*", "reportId=" + URLEncoder.encode("db:" + BAR_PLOT_SAVE_NAME_3, Charset.defaultCharset())));
+        waitForText("APX-1: Abbreviated Physical Exam");
     }
 
     @LogMethod


### PR DESCRIPTION
See corresponding PR in platform branch. This verifies that both the default RowId-based and name-based URL parameters are both working