### PR TITLE
Dumbster code cleanup

### DIFF
--- a/modules/dumbster/src/org/labkey/dumbster/DumbsterController.java
+++ b/modules/dumbster/src/org/labkey/dumbster/DumbsterController.java
@@ -33,6 +33,7 @@ import org.labkey.api.util.MailHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.NavTree;
+import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.template.PageConfig;
 import org.labkey.dumbster.model.DumbsterManager;
@@ -163,7 +164,10 @@ public class DumbsterController extends SpringActionController
             if (!getUser().hasRootAdminPermission())
                 throw new UnauthorizedException();
 
-            SmtpMessage message = DumbsterManager.get().getMessages()[form.getMessage()];
+            SmtpMessage[] messages = DumbsterManager.get().getMessages();
+            if (form.getMessage() >= messages.length)
+                throw new NotFoundException();
+            SmtpMessage message = messages[form.getMessage()];
             Map<String, String> map = MailHelper.getBodyParts(DumbsterManager.convertToMimeMessage(message));
 
             String output;

--- a/modules/dumbster/src/org/labkey/dumbster/view/mailWebPart.jsp
+++ b/modules/dumbster/src/org/labkey/dumbster/view/mailWebPart.jsp
@@ -31,6 +31,8 @@
 <%@ page import="org.labkey.dumbster.view.MailPage" %>
 <%@ page import="java.util.Iterator" %>
 <%@ page import="java.util.Set" %>
+<%@ page import="static org.labkey.api.util.DOM.Attribute.*" %>
+<%@ page import="static org.labkey.api.util.DOM.*" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -195,17 +197,17 @@ function toggleRecorder(checkbox)
             <td><a onclick="toggleBody('email_headers_<%=rowIndex%>'); return false;">View headers</a>
                 <div id="email_headers_<%=rowIndex%>" style="display: none;"><br><%=unsafe(headers.toString())%></div></td>
             <td>
-                <%=text(contentTypes.contains("text/html") ? "<a href=\"" + h(DumbsterController.getViewMessageURL(c, rowIndex - 1, "html")) + "\" target=\"_messageHtml\">HTML</a>" : "&nbsp;")%>
+                <%=contentTypes.contains("text/html") ? createHtml(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "html")).at(target, "_messageHtml"), "HTML")) : unsafe("&nbsp;")%>
             </td>
             <td>
-                <%=text(contentTypes.contains("text/plain") ? "<a href=\"" + h(DumbsterController.getViewMessageURL(c, rowIndex - 1, "text")) + "\" target=\"_messageText\">Text</a>" : "&nbsp;")%>
+                <%=contentTypes.contains("text/plain") ? createHtml(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "text")).at(target, "_messageText"), "Text")) : unsafe("&nbsp;")%>
             </td>
         </tr>
 <%
         }
     }
 %>
-    <tr id=<%=q(renderId)%> style="display: <%=text(messages.length > 0 ? "none" : "")%>;"><td colspan="6">No email recorded.</td></tr>
+    <tr id=<%=q(renderId)%> style="display: <%=unsafe(messages.length > 0 ? "none" : "")%>;"><td colspan="6">No email recorded.</td></tr>
 </table>
 <%
     if (getUser().hasRootAdminPermission())


### PR DESCRIPTION
Found these changes to stop using deprecated jsp methods in dumbster: https://github.com/LabKey/testAutomation/commit/284ba48d94ace5d077f2e602796ac8f604fa5791
I refined it a bit further to use the new `DOM` builder classes and fixed an `NPE` that I came across.