### PR TITLE
Skip short URLs during post-test crawling

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -487,7 +487,7 @@ public class Crawler
                     urlText.startsWith("javascript:") ||
                     urlText.startsWith("ftp://"))
             {
-                if (!urlText.contains(WebTestHelper.getBaseURL()) || urlText.equals(WebTestHelper.getBaseURL()))
+                if (!urlText.contains(WebTestHelper.getBaseURL()) || urlText.equals(WebTestHelper.getBaseURL()) || isLabKeyShortUrl(urlText))
                 {
                     _relativeURL = null;
                     _actionId = null;
@@ -524,6 +524,11 @@ public class Crawler
             if (null != getActionId() && StringUtils.isBlank(StringUtils.strip(getActionId().getFolder(),"/")))
                 p += (_prioritizeAdminPages ? -1 : 1);
             priority = p + random.nextFloat();
+        }
+
+        private boolean isLabKeyShortUrl(String urlText)
+        {
+            return urlText.startsWith(WebTestHelper.getBaseURL()) && urlText.endsWith(".url");
         }
 
         public boolean isFromForm()


### PR DESCRIPTION
Vagisha hit this problem on TeamCity with a new test that happens to visit pages that contain a short URL

https://teamcity.labkey.org/viewLog.html?buildId=823537&tab=buildResultsDiv&buildTypeId=LabkeyTrunk_ModuleSuites_TargettedMSPostgres

https://www.labkey.org/Documentation/wiki-page.view?name=shortURL

She proposed this patch that seems reasonable to me.

