### PR TITLE
6373: Script-based filewatcher automated tests

### DIFF
--- a/modules/pipelinetest/resources/pipeline/pipelines/filewatcher-test-invisible.pipeline.xml
+++ b/modules/pipelinetest/resources/pipeline/pipelines/filewatcher-test-invisible.pipeline.xml
@@ -1,0 +1,8 @@
+<pipeline xmlns="http://labkey.org/pipeline/xml"
+          name="filewatcher-test-invisible" version="0.1">
+    <description>Task that is not evokable by filewatcher</description>
+    <tasks>
+      <taskref ref="org.labkey.api.exp.pipeline.XarGeneratorId"/>
+    </tasks>
+    <triggerConfiguration allow="false"/>
+</pipeline>

--- a/modules/pipelinetest/resources/pipeline/pipelines/filewatcher-test.pipeline.xml
+++ b/modules/pipelinetest/resources/pipeline/pipelines/filewatcher-test.pipeline.xml
@@ -1,0 +1,8 @@
+<pipeline xmlns="http://labkey.org/pipeline/xml"
+          name="filewatcher-test" version="0.1">
+    <description> Pipeline task with help text</description>
+    <help>Hello! I am help text.</help>
+    <tasks>
+      <taskref ref="pipelinetest:task:r-copy-inline"/>
+    </tasks>
+</pipeline>

--- a/src/org/labkey/test/pages/admin/ImportFolderPage.java
+++ b/src/org/labkey/test/pages/admin/ImportFolderPage.java
@@ -70,6 +70,8 @@ public class ImportFolderPage extends LabKeyPage<ImportFolderPage.ElementCache> 
         clickButton("Import Folder");
     }
 
+    public void clickManageFileWatcherTriggers() { clickAndWait(elementCache().manageFileWatcherTriggersButton); }
+
     @NotNull
     @Override
     public WebDriver getWrappedDriver()
@@ -116,5 +118,6 @@ public class ImportFolderPage extends LabKeyPage<ImportFolderPage.ElementCache> 
 
         WebElement importFolderButton = Locator.lkButton("Import Folder").findWhenNeeded(this);
         WebElement usePipelineButton = Locator.lkButton("Use Pipeline").findWhenNeeded(this);
+        WebElement manageFileWatcherTriggersButton = Locator.lkButton("Manage File Watcher Triggers").findWhenNeeded(this);
     }
 }

--- a/src/org/labkey/test/tests/FileBasedPipelineTest.java
+++ b/src/org/labkey/test/tests/FileBasedPipelineTest.java
@@ -35,6 +35,7 @@ import org.labkey.test.util.PipelineAnalysisHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.RReportHelper;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
 
 import java.io.File;
 import java.util.Arrays;
@@ -85,16 +86,14 @@ public class FileBasedPipelineTest extends BaseWebDriverTest
         DataRegionTable pipelineTable = new DataRegionTable("query", getDriver());
         pipelineTable.clickInsertNewRow();
 
-        setFormElement(Locator.name("pipelineId"), pipelineTaskWithHelpText);
-        assertTextPresent(helpText);
+        selectOptionByText(Locator.id("pipelineTaskSelect"), pipelineTaskWithHelpText);
+        Locator.byClass("lk-trigger-help-text").containing(helpText);
 
-        assertTextNotPresent(pipelineTaskInvisible);
+        Locator.id("pipelineTaskSelect").notContaining(pipelineTaskInvisible);
 
-        setFormElement(Locator.name("pipelineId"), pipelineTaskNoHelpText);
-        // assert null is not on page within top bubble
+        selectOptionByText(Locator.id("pipelineTaskSelect"), pipelineTaskNoHelpText);
+        Locator.byClass("lk-trigger-help-text").notContaining("null");
     }
-
-
 
     @Test
     public void testRCopyPipeline()

--- a/src/org/labkey/test/tests/FileBasedPipelineTest.java
+++ b/src/org/labkey/test/tests/FileBasedPipelineTest.java
@@ -35,7 +35,6 @@ import org.labkey.test.util.PipelineAnalysisHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.RReportHelper;
 import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.WebElement;
 
 import java.io.File;
 import java.util.Arrays;
@@ -71,28 +70,6 @@ public class FileBasedPipelineTest extends BaseWebDriverTest
     public void startTest()
     {
         goToProjectHome();
-    }
-
-    @Test
-    public void testScriptBasedFilewatchers()
-    {
-        String pipelineTaskWithHelpText = "Pipeline task with help text";
-        String helpText = "Hello! I am help text.";
-        String pipelineTaskNoHelpText = "two-steps";
-        String pipelineTaskInvisible = "Task that is not evokable by filewatcher";
-
-        goToFolderManagement().goToImportTab();
-        clickAndWait(Locator.lkButton("Manage file watcher triggers"));
-        DataRegionTable pipelineTable = new DataRegionTable("query", getDriver());
-        pipelineTable.clickInsertNewRow();
-
-        selectOptionByText(Locator.id("pipelineTaskSelect"), pipelineTaskWithHelpText);
-        Locator.byClass("lk-trigger-help-text").containing(helpText);
-
-        Locator.id("pipelineTaskSelect").notContaining(pipelineTaskInvisible);
-
-        selectOptionByText(Locator.id("pipelineTaskSelect"), pipelineTaskNoHelpText);
-        Locator.byClass("lk-trigger-help-text").notContaining("null");
     }
 
     @Test

--- a/src/org/labkey/test/tests/FileBasedPipelineTest.java
+++ b/src/org/labkey/test/tests/FileBasedPipelineTest.java
@@ -73,6 +73,30 @@ public class FileBasedPipelineTest extends BaseWebDriverTest
     }
 
     @Test
+    public void testScriptBasedFilewatchers()
+    {
+        String pipelineTaskWithHelpText = "Pipeline task with help text";
+        String helpText = "Hello! I am help text.";
+        String pipelineTaskNoHelpText = "two-steps";
+        String pipelineTaskInvisible = "Task that is not evokable by filewatcher";
+
+        goToFolderManagement().goToImportTab();
+        clickAndWait(Locator.lkButton("Manage file watcher triggers"));
+        DataRegionTable pipelineTable = new DataRegionTable("query", getDriver());
+        pipelineTable.clickInsertNewRow();
+
+        setFormElement(Locator.name("pipelineId"), pipelineTaskWithHelpText);
+        assertTextPresent(helpText);
+
+        assertTextNotPresent(pipelineTaskInvisible);
+
+        setFormElement(Locator.name("pipelineId"), pipelineTaskNoHelpText);
+        // assert null is not on page within top bubble
+    }
+
+
+
+    @Test
     public void testRCopyPipeline()
     {
         final String folderName = "rCopy";


### PR DESCRIPTION
So I confirmed that these are the checks we want to do:

1. If a pipeline (defined in the xml) contains a 'help' element, we check that the help text is displayed in the upper blue html help text container on the "Create Pipeline Trigger" page.
2. To test for encoding issues, we check that "null" is not present in the help text container if no 'help' xml element is defined.
3. If a pipeline xml file is in the module, its description is shown as an option in the 'Pipeline Task' select options. (This is pre-existing functionality.)
4. If a pipeline specifies that element triggerConfiguration's allow="false", its description is not shown in the 'Pipeline Task' select options. (This is new functionality.)
5. We do _not_ have to check whether the triggers actually work, because that is outside the scope of the dev product changes, and that functionality is already covered by other tests.
