### PR TITLE
Use existing helpers to parse email body in email record table

### DIFF
--- a/modules/dumbster/src/org/labkey/dumbster/DumbsterController.java
+++ b/modules/dumbster/src/org/labkey/dumbster/DumbsterController.java
@@ -173,7 +173,11 @@ public class DumbsterController extends SpringActionController
             String output;
             String desiredContentType = "text/plain";
 
-            if ("html".equals(form.getType()))
+            if ("raw".equals(form.getType()))
+            {
+                output = message.toString();
+            }
+            else if ("html".equals(form.getType()))
             {
                 String html = map.get("text/html");
 

--- a/modules/dumbster/src/org/labkey/dumbster/view/mailWebPart.jsp
+++ b/modules/dumbster/src/org/labkey/dumbster/view/mailWebPart.jsp
@@ -135,7 +135,7 @@ function toggleRecorder(checkbox)
         <td class="labkey-column-header labkey-col-header-filter" align="left"><div>Date/Time</div></td>
         <td class="labkey-column-header labkey-col-header-filter" align="left"><div>Message</div></td>
         <td class="labkey-column-header labkey-col-header-filter" align="left"><div>Headers</div></td>
-        <td colspan="2" class="labkey-column-header labkey-col-header-filter" align="center"><div>View</div></td>
+        <td colspan="3" class="labkey-column-header labkey-col-header-filter" align="center"><div>View</div></td>
     </tr>
     <%
     if (messages.length > 0)
@@ -197,8 +197,8 @@ function toggleRecorder(checkbox)
                 <div id="email_body_<%=rowIndex%>" style="display: none;"><hr><%=body%></div></td>
             <td><a onclick="toggleBody('email_headers_<%=rowIndex%>'); return false;">View headers</a>
                 <div id="email_headers_<%=rowIndex%>" style="display: none;"><hr><%=unsafe(headers.toString())%></div></td>
-            <%=hasHtml ? createHtml(TD(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "html")).at(target, "_messageHtml"), "HTML"))) : unsafe("")%>
-            <%=hasText ? createHtml(TD(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "text")).at(target, "_messageText"), "Text"))) : unsafe("")%>
+            <%=hasHtml ? createHtml(TD(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "html")).at(target, "_messageHtml"), "HTML"))) : createHtml(TD())%>
+            <%=hasText ? createHtml(TD(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "text")).at(target, "_messageText"), "Text"))) : createHtml(TD())%>
             <%=createHtml(TD(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "raw")).at(target, "_messageText"), "Raw")))%>
         </tr>
 <%

--- a/modules/dumbster/src/org/labkey/dumbster/view/mailWebPart.jsp
+++ b/modules/dumbster/src/org/labkey/dumbster/view/mailWebPart.jsp
@@ -29,10 +29,12 @@
 <%@ page import="org.labkey.dumbster.DumbsterController" %>
 <%@ page import="org.labkey.dumbster.model.DumbsterManager" %>
 <%@ page import="org.labkey.dumbster.view.MailPage" %>
-<%@ page import="java.util.Iterator" %>
-<%@ page import="java.util.Set" %>
+<%@ page import="javax.mail.MessagingException" %>
+<%@ page import="javax.mail.internet.MimeMessage" %>
 <%@ page import="static org.labkey.api.util.DOM.Attribute.*" %>
 <%@ page import="static org.labkey.api.util.DOM.*" %>
+<%@ page import="java.util.Iterator" %>
+<%@ page import="java.util.Map" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -146,11 +148,6 @@ function toggleRecorder(checkbox)
             else
             {    %><tr class="labkey-row"><% }
 
-            String[] lines = m.getBody().split("\n");
-            StringBuilder body = new StringBuilder();
-            boolean sawHtml = false;
-            boolean inHtml = false;
-            boolean inMessageBody = false;
 
             StringBuilder headers = new StringBuilder();
             Iterator i = m.getHeaderNames();
@@ -162,46 +159,47 @@ function toggleRecorder(checkbox)
                 headers.append(": ");
                 headers.append(h(m.getHeaderValue(header)));
                 headers.append("<br/>\n");
-                if (header.equals("Content-Type") && m.getHeaderValue(header).indexOf("text/html") == 0)
-                    sawHtml = true;
             }
 
-            for (String line : lines)
+            boolean hasHtml = false;
+            boolean hasText = false;
+            HtmlString body;
+            try
             {
-                if (line.indexOf("Content-Type: text/html") == 0)
-                    sawHtml = true;
-                else if (sawHtml && "".equals(line))
-                    inHtml = true;    
-                else if (line.indexOf("------=") == 0)
-                    sawHtml = inHtml = false;
-                else if (inHtml && line.trim().equals("</td></tr>"))
-                    inMessageBody = false;
+                MimeMessage mimeMessage = DumbsterManager.convertToMimeMessage(m);
+                Map<String, String> map = MailHelper.getBodyParts(mimeMessage);
 
-                if (inHtml && !inMessageBody)
-                    body.append(line).append('\n');
+                hasHtml = map.get("text/html") != null;
+                hasText = map.get("text/plain") != null;
+
+                if (hasHtml)
+                {
+                    body = unsafe(map.get("text/html"));
+                }
+                else if (hasText)
+                {
+                    body = h(map.get("text/plain"));
+                }
                 else
-                    body.append(h(line)).append("<br>\n");
-
-                if (inHtml && line.indexOf("id=\"message-body\"") > 0)
-                    inMessageBody = true;
+                {
+                    body = createHtml(DIV(cl("labkey-error"), "No message body"));
+                }
             }
-
-            Set<String> contentTypes = MailHelper.getBodyPartContentTypes(DumbsterManager.convertToMimeMessage(m));
-
+            catch (MessagingException e)
+            {
+                body = createHtml(DIV(cl("labkey-error"), "Error parsing email: " + e.getMessage()));
+            }
 %>
             <td><%=h(m.getHeaderValue("To"))%></td>
             <td><%=h(m.getHeaderValue("From"))%></td>
             <td><%=formatDateTime(m.getCreatedTimestamp())%></td>
             <td><a onclick="toggleBody('email_body_<%=rowIndex%>'); return false;"><%=h(m.getHeaderValue("Subject"))%></a>
-                <div id="email_body_<%=rowIndex%>" style="display: none;"><br><%=HtmlString.unsafe(body.toString())%></div></td>
+                <div id="email_body_<%=rowIndex%>" style="display: none;"><hr><%=body%></div></td>
             <td><a onclick="toggleBody('email_headers_<%=rowIndex%>'); return false;">View headers</a>
-                <div id="email_headers_<%=rowIndex%>" style="display: none;"><br><%=unsafe(headers.toString())%></div></td>
-            <td>
-                <%=contentTypes.contains("text/html") ? createHtml(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "html")).at(target, "_messageHtml"), "HTML")) : unsafe("&nbsp;")%>
-            </td>
-            <td>
-                <%=contentTypes.contains("text/plain") ? createHtml(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "text")).at(target, "_messageText"), "Text")) : unsafe("&nbsp;")%>
-            </td>
+                <div id="email_headers_<%=rowIndex%>" style="display: none;"><hr><%=unsafe(headers.toString())%></div></td>
+            <%=hasHtml ? createHtml(TD(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "html")).at(target, "_messageHtml"), "HTML"))) : unsafe("")%>
+            <%=hasText ? createHtml(TD(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "text")).at(target, "_messageText"), "Text"))) : unsafe("")%>
+            <%=createHtml(TD(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "raw")).at(target, "_messageText"), "Raw")))%>
         </tr>
 <%
         }

--- a/src/org/labkey/test/components/dumbster/EmailRecordTable.java
+++ b/src/org/labkey/test/components/dumbster/EmailRecordTable.java
@@ -206,10 +206,10 @@ public class EmailRecordTable extends Table
         int colIndex = EmailColumn.View.getIndex();
         do
         {
-            view = StringUtils.trimToNull(getDataAsText(rowIndex, colIndex++));
-            if (view != null)
+            view = getDataAsText(rowIndex, colIndex++);
+            if (view != null && !view.isBlank())
             {
-                views.add(view);
+                views.add(view.trim());
             }
         } while (view != null);
         emailMessage.setViews(views);

--- a/src/org/labkey/test/components/dumbster/EmailRecordTable.java
+++ b/src/org/labkey/test/components/dumbster/EmailRecordTable.java
@@ -200,16 +200,18 @@ public class EmailRecordTable extends Table
 
     private void parseViewCell(EmailMessage emailMessage)
     {
-        String html = getDataAsText(emailMessage.getRowIndex(), EmailColumn.View_HTML.getIndex()).trim();
-        String text = getDataAsText(emailMessage.getRowIndex(), EmailColumn.View_Text.getIndex()).trim();
-        String raw = getDataAsText(emailMessage.getRowIndex(), EmailColumn.View_Raw.getIndex()).trim();
         List<String> views = new ArrayList<>();
-        if (!html.isEmpty())
-            views.add(html);
-        if (!text.isEmpty())
-            views.add(text);
-        if (!raw.isEmpty())
-            views.add(raw);
+        String view;
+        int rowIndex = emailMessage.getRowIndex();
+        int colIndex = EmailColumn.View.getIndex();
+        do
+        {
+            view = StringUtils.trimToNull(getDataAsText(rowIndex, colIndex++));
+            if (view != null)
+            {
+                views.add(view);
+            }
+        } while (view != null);
         emailMessage.setViews(views);
     }
 
@@ -302,9 +304,7 @@ public class EmailRecordTable extends Table
         DateTime(3),
         Message(4),
         Headers(5),
-        View_HTML(6),
-        View_Text(7),
-        View_Raw(8);
+        View(6);
 
         private final int index;
 

--- a/src/org/labkey/test/components/dumbster/EmailRecordTable.java
+++ b/src/org/labkey/test/components/dumbster/EmailRecordTable.java
@@ -202,11 +202,14 @@ public class EmailRecordTable extends Table
     {
         String html = getDataAsText(emailMessage.getRowIndex(), EmailColumn.View_HTML.getIndex()).trim();
         String text = getDataAsText(emailMessage.getRowIndex(), EmailColumn.View_Text.getIndex()).trim();
+        String raw = getDataAsText(emailMessage.getRowIndex(), EmailColumn.View_Raw.getIndex()).trim();
         List<String> views = new ArrayList<>();
         if (!html.isEmpty())
             views.add(html);
         if (!text.isEmpty())
             views.add(text);
+        if (!raw.isEmpty())
+            views.add(raw);
         emailMessage.setViews(views);
     }
 
@@ -300,7 +303,8 @@ public class EmailRecordTable extends Table
         Message(4),
         Headers(5),
         View_HTML(6),
-        View_Text(7);
+        View_Text(7),
+        View_Raw(8);
 
         private final int index;
 

--- a/src/org/labkey/test/tests/ClientAPITest.java
+++ b/src/org/labkey/test/tests/ClientAPITest.java
@@ -1096,11 +1096,11 @@ public class ClientAPITest extends BaseWebDriverTest
         assertTextNotPresent(EMAIL_SUBJECT_ERROR);
         EmailRecordTable.EmailMessage emailMessage;
         emailMessage = mailTable.getMessage(EMAIL_SUBJECT_ALL);
-        assertEquals("Wrong views available for: " + EMAIL_SUBJECT_ALL, Arrays.asList("HTML", "Text"), emailMessage.getViews());
+        assertEquals("Wrong views available for: " + EMAIL_SUBJECT_ALL, Arrays.asList("HTML", "Text", "Raw"), emailMessage.getViews());
         emailMessage = mailTable.getMessage(EMAIL_SUBJECT_PLAIN);
-        assertEquals("Wrong views available for: " + EMAIL_SUBJECT_PLAIN, Arrays.asList("Text"), emailMessage.getViews());
+        assertEquals("Wrong views available for: " + EMAIL_SUBJECT_PLAIN, Arrays.asList("Text", "Raw"), emailMessage.getViews());
         emailMessage = mailTable.getMessage(EMAIL_SUBJECT_HTML);
-        assertEquals("Wrong views available for: " + EMAIL_SUBJECT_HTML, Arrays.asList("HTML"), emailMessage.getViews());
+        assertEquals("Wrong views available for: " + EMAIL_SUBJECT_HTML, Arrays.asList("HTML", "Raw"), emailMessage.getViews());
         emailMessage = mailTable.getMessage("");
         assertEquals("Wrong recipients for email with blank subject", Arrays.asList(EMAIL_RECIPIENTS), Arrays.asList(emailMessage.getTo()));
         emailMessage = mailTable.getMessage(EMAIL_SUBJECT_NON_USER);


### PR DESCRIPTION
Don't include headers in "Message" cell
Provide raw view for ViewMessage action