### PR TITLE
Remove FireFox preference that is causing many tests to fail

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -321,7 +321,8 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
                     profile.setPreference("browser.ssl_override_behavior", 0);
 
-                    profile.setPreference("dom.disable_beforeunload", false);
+                    // TODO: Issue 38785: dom.disable_beforeunload FireFox preference is causing numerous test failures
+                    // profile.setPreference("dom.disable_beforeunload", false);
 
                     profile.setAcceptUntrustedCertificates(true);
                     profile.setAssumeUntrustedCertificateIssuer(false);

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -992,12 +992,8 @@ public class DomainDesignerTest extends BaseWebDriverTest
         assertEquals("expect default value to be green", "green", updatedColor.getAllProperties().get("defaultValue"));
     }
 
-    /**
-     * verifies that a sampleset field with data (and blank values) will warn the user if they attempt to mark that field
-     * 'required'
-     * @throws Exception
-     */
     @Test
+    @Ignore("Issue 38785: dom.disable_beforeunload FireFox preference is causing numerous test failures")
     public void verifyExpectedWarningOnNavigateWithUncomittedChanges() throws Exception
     {
         goToProjectHome();


### PR DESCRIPTION
Temprarily(?) backing out part of the domain designer test coverage while we figure out a solution to all these test timeouts.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=38785