### PR TITLE
Don't test for a specific version of Rlabkey

### DIFF
--- a/data/api/rlabkey-api.xml
+++ b/data/api/rlabkey-api.xml
@@ -3,14 +3,12 @@
         <url>
             <![CDATA[
                 library(Rlabkey)
-                print("Latest Rlabkey version: 2.3.2")
-                print(paste("Found Rlabkey version:", installed.packages()["Rlabkey","Version"]))
+                cat("Found Rlabkey\nVersion:", installed.packages()["Rlabkey","Version"])
             ]]>
         </url>
         <response>
             <![CDATA[
-                [1] "Latest Rlabkey version: 2.3.2"
-                [1] "Found Rlabkey version: 2.3.2"
+                Found Rlabkey
             ]]>
         </response>
     </test>

--- a/data/api/rlabkey-api.xml
+++ b/data/api/rlabkey-api.xml
@@ -1,9 +1,9 @@
 <ApiTests xmlns="http://labkey.org/query/xml">
-    <test name="Rlabkey version check" type="post">
+    <test name="Rlabkey version check" type="debug">
         <url>
             <![CDATA[
                 library(Rlabkey)
-                cat("Found Rlabkey\nVersion:", installed.packages()["Rlabkey","Version"])
+                cat("Found Rlabkey\nVersion:", installed.packages()["Rlabkey","Version"], '\n')
             ]]>
         </url>
         <response>

--- a/src/org/labkey/test/tests/RlabkeyTest.java
+++ b/src/org/labkey/test/tests/RlabkeyTest.java
@@ -270,6 +270,11 @@ public class RlabkeyTest extends BaseWebDriverTest
                     TestLogger.error("Script for failed test case: " + test.getName() + ":\n" + sb.toString());
                     errors.add(test.getName());
                 }
+                else if ("DEBUG".equalsIgnoreCase(test.getType()))
+                {
+                    String reportText = _rReportHelper.getReportText();
+                    TestLogger.log("Report Output:\n" + reportText);
+                }
                 TestLogger.decreaseIndent();
             }
             _rReportHelper.clickSourceTab();

--- a/src/org/labkey/test/util/RReportHelper.java
+++ b/src/org/labkey/test/util/RReportHelper.java
@@ -16,6 +16,7 @@
 package org.labkey.test.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
@@ -116,11 +117,17 @@ public class RReportHelper
         _test._ext4Helper.clickTabContainingText("Report");
         _test._ext4Helper.waitForMaskToDisappear(BaseWebDriverTest.WAIT_FOR_JAVASCRIPT * 5);
 
-        Locator l = Locator.xpath("//div[@class='reportView']//pre");
-        _test.waitForElement(l);
-        String html = _test.getText(l).replaceAll(" +", " ");
+        String html = getReportText();
 
         return checkScriptOutput(html, expectedLines, failOnError);
+    }
+
+    @NotNull
+    public String getReportText()
+    {
+        Locator l = Locator.xpath("//div[@class='reportView']//pre");
+        _test.waitForElement(l);
+        return _test.getText(l).replaceAll(" +", " ");
     }
 
     public boolean executeScriptDirectly(String script, String expectedLines) throws IOException


### PR DESCRIPTION
This check has only ever made updating Rlabkey more difficult. I hasn't, nor is it likely to, catch any regressions.
I've updated the helpers to print the Rlabkey version for possible debugging purposes.