### PR TITLE
19.3 fb domain designer test fixes

### DIFF
--- a/src/org/labkey/test/components/DomainDesignerPage.java
+++ b/src/org/labkey/test/components/DomainDesignerPage.java
@@ -155,7 +155,7 @@ public class DomainDesignerPage extends LabKeyPage<DomainDesignerPage.ElementCac
         }
         WebElement finishButton()
         {
-            return Locator.button("Finish")
+            return Locator.button("Save")
                     .waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT);
         }
         WebElement cancelBtn()

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -663,9 +663,10 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
                 .findWhenNeeded(this);
 
 
-        public Locator expandToggleLoc = Locator.tagWithClass("div", "domain-field-icon")
-                .child(Locator.tagWithAttribute("svg", "data-icon", "plus-square"));
-        public Locator collapseToggleLoc = Locator.tagWithAttribute("svg", "data-icon", "minus-square");
+        public Locator expandToggleLoc = Locator.tagWithClass("div", "field-icon")
+                .child(Locator.tagWithClassContaining("svg", "fa-plus-square"));
+        public Locator collapseToggleLoc = Locator.tagWithClass("div", "field-icon")
+                .child(Locator.tagWithClassContaining("svg",  "minus-square"));
 
         public WebElement expandToggle = expandToggleLoc.findWhenNeeded(this);
 

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -11,7 +11,6 @@ import org.labkey.test.components.html.RadioButton;
 import org.labkey.test.components.html.SelectWrapper;
 import org.labkey.test.params.FieldDefinition;
 import org.openqa.selenium.SearchContext;
-import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -716,10 +715,6 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
             Locator selectLoc = Locator.name("domainpropertiesrow-lookupSchema")
                     .withoutPredicate(Locator.tagWithText("option", "Loading..."));
             Select select = SelectWrapper.Select(selectLoc).waitFor(this);
-            getWrapper().shortWait().ignoring(StaleElementReferenceException.class).withMessage("select did not have options in time")
-                    .until(driver -> {
-                        return select.getOptions().size() > 0 && !select.getOptions().get(0).getText().equals("Loading...");
-                    });
             return select;
         }
 
@@ -728,10 +723,6 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
             Locator selectLoc = Locator.name("domainpropertiesrow-lookupQueryValue")
                     .withoutPredicate(Locator.tagWithText("option", "Loading..."));
             Select select  = SelectWrapper.Select(selectLoc).waitFor(this);
-            getWrapper().shortWait().ignoring(StaleElementReferenceException.class).withMessage("select did not have options in time")
-                    .until(driver -> {
-                        return select.getOptions().size() > 0 && !select.getOptions().get(0).getText().equals("Loading...");
-                    });
             return select;
         }
 

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -11,6 +11,7 @@ import org.labkey.test.components.html.RadioButton;
 import org.labkey.test.components.html.SelectWrapper;
 import org.labkey.test.params.FieldDefinition;
 import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -711,17 +712,25 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
         public Select getFromSchemaInput()
         {
-            Select select = SelectWrapper.Select(Locator.name("domainpropertiesrow-lookupSchema")).find(this);
-            getWrapper().waitFor(()-> select.getOptions().size() > 0 && !select.getOptions().get(0).getText().equals("Loading..."),
-                    "select did not have options in the expected time", WAIT_FOR_JAVASCRIPT);
+            Locator selectLoc = Locator.name("domainpropertiesrow-lookupSchema")
+                    .withoutPredicate(Locator.tagWithText("option", "Loading..."));
+            Select select = SelectWrapper.Select(selectLoc).waitFor(this);
+            getWrapper().shortWait().ignoring(StaleElementReferenceException.class).withMessage("select did not have options in time")
+                    .until(driver -> {
+                        return select.getOptions().size() > 0 && !select.getOptions().get(0).getText().equals("Loading...");
+                    });
             return select;
         }
 
         public Select getFromTargetTableInput()
         {
-            Select select = SelectWrapper.Select(Locator.name("domainpropertiesrow-lookupQueryValue")).find(this);
-            getWrapper().waitFor(()-> select.getOptions().size() > 0 && !select.getOptions().get(0).getText().equals("Loading..."),
-                    "select did not have options in the expected time", WAIT_FOR_JAVASCRIPT);
+            Locator selectLoc = Locator.name("domainpropertiesrow-lookupQueryValue")
+                    .withoutPredicate(Locator.tagWithText("option", "Loading..."));
+            Select select  = SelectWrapper.Select(selectLoc).waitFor(this);
+            getWrapper().shortWait().ignoring(StaleElementReferenceException.class).withMessage("select did not have options in time")
+                    .until(driver -> {
+                        return select.getOptions().size() > 0 && !select.getOptions().get(0).getText().equals("Loading...");
+                    });
             return select;
         }
 

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -1490,25 +1490,21 @@ public class DomainDesignerTest extends BaseWebDriverTest
     public Map<String, Object> getPropertyValidator(PropertyDescriptor column, String name)
     {
         List<Map<String, Object>> validators = (ArrayList<Map<String, Object>>)column.getAllProperties().get("propertyValidators");
-        List<Map<String, Object>> filteredList = validators.stream()
+        Map<String, Object> validator = validators.stream()
                 .filter(a-> a.get("name").equals(name))
-                .collect(Collectors.toList());
-        if (filteredList.size() == 0)
-            return null;
-        else
-            return filteredList.get(0);
+                .findFirst().orElse(null);
+        assertNotNull("did not find expected validator on column", validator);
+        return validator;
     }
 
     public Map<String, Object> getConditionalFormats(PropertyDescriptor column, String filterExpression)
     {
         List<Map<String, Object>> validators = (ArrayList<Map<String, Object>>)column.getAllProperties().get("conditionalFormats");
-        List<Map<String, Object>> list = validators.stream()
+        Map<String, Object> conditionalFormat = validators.stream()
                 .filter(a-> a.get("filter").equals(filterExpression))
-                .collect(Collectors.toList());
-        if (list.size() == 0)
-            return null;
-        else
-            return list.get(0);
+                .findFirst().orElse(null);
+        assertNotNull("did not find expected conditionalFormat on column", conditionalFormat);
+        return conditionalFormat;
     }
 
     @Override

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -1327,6 +1327,8 @@ public class DomainDesignerTest extends BaseWebDriverTest
 
         valDialog.clickApply();
         domainDesignerPage.clickFinish();
+        waitAndClickAndWait(Locator.linkWithText(listName));
+        DataRegionTable.DataRegion(getDriver()).withName("query").waitFor();
 
         // now confirm 2 validators on the field
         DomainResponse newResponse = dgen.getDomain(createDefaultConnection(true));
@@ -1396,6 +1398,8 @@ public class DomainDesignerTest extends BaseWebDriverTest
                 .clickRemove();
         dlg.clickApply();
         domainDesignerPage.clickFinish();
+        waitAndClickAndWait(Locator.linkWithText(listName));
+        DataRegionTable.DataRegion(getDriver()).withName("query").waitFor();
 
         // now verify we have 2 formats on the size field
         DomainResponse updatedResponse = dgen.getDomain(createDefaultConnection(true));
@@ -1486,21 +1490,25 @@ public class DomainDesignerTest extends BaseWebDriverTest
     public Map<String, Object> getPropertyValidator(PropertyDescriptor column, String name)
     {
         List<Map<String, Object>> validators = (ArrayList<Map<String, Object>>)column.getAllProperties().get("propertyValidators");
-        Map<String, Object> validator = validators.stream()
+        List<Map<String, Object>> filteredList = validators.stream()
                 .filter(a-> a.get("name").equals(name))
-                .collect(Collectors.toList())
-                .get(0);
-        return validator;
+                .collect(Collectors.toList());
+        if (filteredList.size() == 0)
+            return null;
+        else
+            return filteredList.get(0);
     }
 
     public Map<String, Object> getConditionalFormats(PropertyDescriptor column, String filterExpression)
     {
         List<Map<String, Object>> validators = (ArrayList<Map<String, Object>>)column.getAllProperties().get("conditionalFormats");
-        Map<String, Object> validator = validators.stream()
+        List<Map<String, Object>> list = validators.stream()
                 .filter(a-> a.get("filter").equals(filterExpression))
-                .collect(Collectors.toList())
-                .get(0);
-        return validator;
+                .collect(Collectors.toList());
+        if (list.size() == 0)
+            return null;
+        else
+            return list.get(0);
     }
 
     @Override

--- a/src/org/labkey/test/tests/SampleSetParentColumnTest.java
+++ b/src/org/labkey/test/tests/SampleSetParentColumnTest.java
@@ -707,7 +707,7 @@ public class SampleSetParentColumnTest extends BaseWebDriverTest
         clickFolder(SUB_FOLDER_NAME);
         DomainDesignerPage domainDesignerPage = sampleHelper.goToEditSampleSetFields(SAMPLE_SET_NAME);
         domainDesignerPage.fieldsPanel().addField(GOOD_PARENT_NAME);
-        domainDesignerPage.clickFinish();
+        domainDesignerPage.clickFinishExpectingError();
 
         errorMsgLocator = Locator.tagWithClass("div", "alert-danger");
         waitForElement(errorMsgLocator);


### PR DESCRIPTION
- change schema/table lookup select getters to wait for options
- expect errors rather than navigation in specific tests
- update tests to wait for save before getting domain for verification