### PR TITLE
Issue 37776: updateUrl in custom assay does not get used in Biologics UI

### DIFF
--- a/data/api/http-api.xml
+++ b/data/api/http-api.xml
@@ -725,4 +725,41 @@
 }]]></response>
     </test>
 
+    <test name="apiVersion=17.1, includeMetadata=false, columns=*, includeUpdateColumn=true" type="post">
+        <url>
+            <![CDATA[query/HTTPApiVerifyProject/selectRows.api]]></url>
+        <formData>{
+            "schemaName": "lists",
+            "queryName": "Test List",
+            "query.Good~eq": 2,
+            "apiVersion": 17.1,
+            "query.columns": "Month,Good",
+            "includeMetadata": false,
+            "includeUpdateColumn": true,
+            }
+        </formData>
+        <response><![CDATA[{
+  "schemaName" : [ "lists" ],
+  "queryName" : "Test List",
+  "rows" : [ {
+    "data" : {
+      "Month" : {
+        "formattedValue" : "4",
+        "value" : "2000-04-01 00:00:00.000"
+      },
+      "Good" : {
+        "value" : 2
+      }
+    },
+    "links" : {
+      "edit" : {
+        "href" : "/labkey/HTTPApiVerifyProject/query-updateQueryRow.view?schemaName=lists&query.queryName=Test%20List&Color=Gray",
+        "title" : "edit"
+      }
+    }
+  } ],
+  "rowCount" : 1
+}]]></response>
+    </test>
+
 </ApiTests>


### PR DESCRIPTION
include edit link when column list is provided and includeUpdateColumn=true