### PR TITLE
Move drop zone interaction into FileBrowserHelper

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3331,6 +3331,11 @@ public abstract class WebDriverWrapper implements WrapsDriver
         setInput(dropZone, files);
     }
 
+    /**
+     * @deprecated Use {@link org.labkey.test.util.FileBrowserHelper#dragAndDropFileInDropZone(File)} or
+     * {@link org.labkey.test.util.FileBrowserHelper#dragDropUpload(File)}
+     */
+    @Deprecated
     public void dragAndDropFileInDropZone(File fileName)
     {
         //Offsets for the drop zone
@@ -3350,6 +3355,8 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
         //setting the input
         input.sendKeys(fileName.getAbsolutePath());
+
+        executeScript("LABKEY.internal.FileDrop.hideDropzones()");
     }
 
     public void setFormElement(Locator loc, File file)

--- a/src/org/labkey/test/tests/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/FileContentUploadTest.java
@@ -279,11 +279,11 @@ public class FileContentUploadTest extends BaseWebDriverTest
         final File testFile = TestFileUtils.getSampleData("security/InlineFile_drop.html");
 
         log("Dropping the file object in drop zone");
-        dragAndDropFileInDropZone(testFile.getAbsoluteFile());
+        _fileBrowserHelper.dragDropUpload(testFile.getAbsoluteFile());
 
         log("Verifying file is uploaded");
-        waitForElement(Locator.tagWithText("span",testFile.getName()));
-        assertElementPresent(Locator.tagWithText("span",testFile.getName()));
+        waitForElement(Locator.tagWithText("span", testFile.getName()));
+        assertElementPresent(Locator.tagWithText("span", testFile.getName()));
     }
 
     @NotNull

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -512,6 +512,46 @@ public class FileBrowserHelper extends WebDriverWrapper
         assertEquals("Description didn't clear after upload", "", getFormElement(Locator.name("description")));
     }
 
+    /**
+     *
+     * @param file
+     */
+    @LogMethod
+    public void dragAndDropFileInDropZone(@LoggedParam File file)
+    {
+        waitForFileGridReady();
+
+        //Offsets for the drop zone
+        int offsetX = 0;
+        int offsetY = 0;
+
+        //Min version of the JS script - creates the dataTransfer object
+        String JS_DROP_FILES = "var c=arguments,b=c[0],k=c[1];c=c[2];for(var d=b.ownerDocument||document,l=0;;){var e=b.getBoundingClientRect(),g=e.left+(k||e.width/2),h=e.top+(c||e.height/2),f=d.elementFromPoint(g,h);if(f&&b.contains(f))break;if(1<++l)throw b=Error('Element not interactable'),b.code=15,b;}var a=d.createElement('INPUT');a.setAttribute('type','file');a.setAttribute('multiple','');a.setAttribute('style','position:fixed;z-index:2147483647;left:0;top:0;');a.onchange=function(b){a.parentElement.removeChild(a);b.stopPropagation();var c={constructor:DataTransfer,effectAllowed:'all',dropEffect:'none',types:['Files'],files:a.files,setData:function(){},getData:function(){},clearData:function(){},setDragImage:function(){}};window.DataTransferItemList&&(c.items=Object.setPrototypeOf(Array.prototype.map.call(a.files,function(a){return{constructor:DataTransferItem,kind:'file',type:a.type,getAsFile:function(){return a},getAsString:function(b){var c=new FileReader;c.onload=function(a){b(a.target.result)};c.readAsText(a)}}}),{constructor:DataTransferItemList,add:function(){},clear:function(){},remove:function(){}}));['dragenter','dragover','drop'].forEach(function(a){var b=d.createEvent('DragEvent');b.initMouseEvent(a,!0,!0,d.defaultView,0,0,0,g,h,!1,!1,!1,!1,0,null);Object.setPrototypeOf(b,null);b.dataTransfer=c;Object.setPrototypeOf(b,DragEvent.prototype);f.dispatchEvent(b)})};d.documentElement.appendChild(a);a.getBoundingClientRect();return a;";
+
+        //Execute the script to make the drop zone visible.
+        executeScript("LABKEY.internal.FileDrop.showDropzones()");
+
+        WebElement dropzone = Locator.tagWithClass("div", "dropzone").findElement(getDriver());
+        WebElement input = (WebElement) executeScript(JS_DROP_FILES, dropzone, offsetX, offsetY);
+
+        //setting the input
+        input.sendKeys(file.getAbsolutePath());
+    }
+
+    @LogMethod (quiet = true)
+    public void dragDropUpload(@LoggedParam File file)
+    {
+        dragDropUpload(file, file.getName());
+    }
+
+    @LogMethod (quiet = true)
+    public void dragDropUpload(@LoggedParam File file, @LoggedParam String expectedFileName)
+    {
+        doAndWaitForFileListRefresh(() -> dragAndDropFileInDropZone(file));
+        waitForElement(fileGridCell.withText(expectedFileName));
+        waitForGrid();
+    }
+
     public void importFile(String filePath, String importAction)
     {
         selectFileBrowserItem(filePath);


### PR DESCRIPTION
Add synchronization to avoid getting blocked by dropzone mask

This should fix the intermittent failure in `FileWatcherDatasetTest.testDatasetWithoutDomainUpdates` where it tries to drop two files in succession.