### PR TITLE
Issue 38911: exec task doesn't include same replacements as script task

### DIFF
--- a/modules/pipelinetest/resources/pipeline/pipelines/timeout-exec-test.js
+++ b/modules/pipelinetest/resources/pipeline/pipelines/timeout-exec-test.js
@@ -4,5 +4,14 @@
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
 print('hello Nashorn timeout world!');
-java.lang.Thread.sleep(10*1000);
+print("arguments.length: " + arguments.length);
+var timeout = 10;
+for (var i = 0; i < arguments.length; i++) {
+    print("  arg[" + i  + "]=" + arguments[i]);
+    if (arguments[i] === '-t') {
+        timeout = parseInt(arguments[i+1]);
+    }
+}
+print('sleeping for ' + timeout + ' seconds');
+java.lang.Thread.sleep(1000 * timeout);
 print('goodbye Nashorn timeout world!');

--- a/modules/pipelinetest/resources/pipeline/pipelines/timeout-exec-test.pipeline.xml
+++ b/modules/pipelinetest/resources/pipeline/pipelines/timeout-exec-test.pipeline.xml
@@ -12,7 +12,8 @@
             </outputs>
             <!-- jjs is the command-line frontend to Nashorn included in the JDK -->
             <exec installPath="${JAVA_HOME}/bin" timeout="3">
-                jjs pipeline/pipelines/timeout-exec-test.js
+                jjs pipeline/pipelines/timeout-exec-test.js -- -t 8
+                    ${pipeline, protocol name} "${httpSessionId}"
             </exec>
         </task>
     </tasks>

--- a/src/org/labkey/test/tests/FileBasedPipelineTest.java
+++ b/src/org/labkey/test/tests/FileBasedPipelineTest.java
@@ -316,6 +316,11 @@ public class FileBasedPipelineTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText("ERROR"));
         assertTextPresent(
                 "INFO : hello Nashorn timeout world!",
+                // ${pipeline, protocol name} token replacement
+                "arg[3]=" + protocolName,
+                // ${httpSessionId} token replacement. Expect apikey prefix
+                "arg[4]=apikey|",
+                "sleeping for 8 seconds",
                 "Process killed after exceeding timeout of 3 seconds");
         assertTextNotPresent("goodbye Nashorn timeout world!");
     }

--- a/src/org/labkey/test/tests/FileBasedPipelineTest.java
+++ b/src/org/labkey/test/tests/FileBasedPipelineTest.java
@@ -317,9 +317,9 @@ public class FileBasedPipelineTest extends BaseWebDriverTest
         assertTextPresent(
                 "INFO : hello Nashorn timeout world!",
                 // ${pipeline, protocol name} token replacement
-                "arg[3]=" + protocolName,
+                "arg[2]=" + protocolName,
                 // ${httpSessionId} token replacement. Expect apikey prefix
-                "arg[4]=apikey|",
+                "arg[3]=apikey|",
                 "sleeping for 8 seconds",
                 "Process killed after exceeding timeout of 3 seconds");
         assertTextNotPresent("goodbye Nashorn timeout world!");


### PR DESCRIPTION
- tokenize command line, preserve space within quotes and curly ${tokens}
- include additional replacements in CommandTaskImpl generated command line