### PR TITLE
19.3 fb issue38940

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -12,6 +12,7 @@ import org.labkey.test.components.html.SelectWrapper;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.LabKeyExpectedConditions;
 import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -518,10 +519,26 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
     {
         return getComponentElement().getAttribute("class").contains("domain-row-border-error");
     }
+    public DomainFieldRow waitForError()
+    {
+        getWrapper().shortWait().ignoring(StaleElementReferenceException.class)
+                .until(driver -> {
+                   return this.hasFieldError();
+                });
+        return this;
+    }
 
     public boolean hasFieldWarning()
     {
         return getComponentElement().getAttribute("class").contains("domain-row-border-warning");
+    }
+    public DomainFieldRow waitForWarning()
+    {
+        getWrapper().shortWait().ignoring(StaleElementReferenceException.class)
+                .until(driver -> {
+                    return this.hasFieldWarning();
+                });
+        return this;
     }
 
     // conditional formatting and validation options

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -12,7 +12,6 @@ import org.labkey.test.components.html.SelectWrapper;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.LabKeyExpectedConditions;
 import org.openqa.selenium.SearchContext;
-import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -521,10 +520,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
     }
     public DomainFieldRow waitForError()
     {
-        getWrapper().shortWait().ignoring(StaleElementReferenceException.class)
-                .until(driver -> {
-                   return this.hasFieldError();
-                });
+        getWrapper().waitFor(()-> this.hasFieldError(), WAIT_FOR_JAVASCRIPT);
         return this;
     }
 
@@ -534,10 +530,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
     }
     public DomainFieldRow waitForWarning()
     {
-        getWrapper().shortWait().ignoring(StaleElementReferenceException.class)
-                .until(driver -> {
-                    return this.hasFieldWarning();
-                });
+        getWrapper().waitFor(()-> this.hasFieldWarning(), WAIT_FOR_JAVASCRIPT);
         return this;
     }
 

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -43,7 +43,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -305,13 +307,14 @@ public class DomainDesignerTest extends BaseWebDriverTest
         assertTrue("expect error to contain [Please provide a name for each field.] but was[" + hasNoNameError + "]",
                 hasNoNameError.contains("Please provide a name for each field."));
 
-        String warningfieldMessage = noNameRow.setName("&totally not a sketchy sql injection attack")
+        String warningFieldMessage = noNameRow.setName("&has weird characters that make scripts hard to write")
                 .waitForWarning()
                 .detailsMessage();
         String expectedWarning = "New field. Warning: SQL queries, R scripts, and other code are easiest to write when field names only contain combination of letters, numbers, and underscores, and start with a letter or underscore";
-        assertTrue("expect error to contain [" + expectedWarning + "] but was[" + warningfieldMessage + "]",
-                warningfieldMessage.contains(expectedWarning));
+        assertThat("expected error", warningFieldMessage, containsString(expectedWarning));
 
+        assertEquals("save button should be disabled with field errors present", "true",
+                domainDesignerPage.finishButton().getAttribute("disabled"));
         domainDesignerPage.clickCancelAndDiscardChanges();
     }
 
@@ -507,20 +510,18 @@ public class DomainDesignerTest extends BaseWebDriverTest
         String blarg2DetailsMsg = blarg2.waitForError().detailsMessage();
         String clientFieldWarningMsg = clientFieldWarning.waitForWarning().detailsMessage();
 
-        assertTrue("expect error message to contain [" + reservedErrMsg + "] but was [" + modRowDetailsMsg + "]",
-                modRowDetailsMsg.contains(reservedErrMsg));
-        assertTrue("expect error message to contain [" + blargErrMsg + "] but was [" + blarg1DetailsMsg + "]",
-                blarg1DetailsMsg.contains(blargErrMsg));
-        assertTrue("expect error message to contain [" + blargErrMsg + "] but was [" + blarg2DetailsMsg + "]",
-                blarg2DetailsMsg.contains(blargErrMsg));
-        assertTrue("expect warning message to contain [" + expectedWarnMsg + "] but was [" + clientFieldWarningMsg + "]",
-                clientFieldWarningMsg.contains(expectedWarnMsg));
+        assertThat("expected warning", clientFieldWarningMsg, containsString(expectedWarnMsg));
+        assertThat("expected error", blarg1DetailsMsg, containsString(blargErrMsg));
+        assertThat("expected error", blarg2DetailsMsg, containsString(blargErrMsg));
+        assertThat("expected error", modRowDetailsMsg, containsString(reservedErrMsg));
 
         assertTrue("expect field error when using reserved field names", modifiedRow.hasFieldError());
         assertTrue("expect error for duplicate field names", blarg1.hasFieldError());
         assertTrue("expect error for duplicate field names", blarg2.hasFieldError());
         assertTrue("expect warning for field name with spaces or special characters", clientFieldWarning.hasFieldWarning());
 
+        assertFalse("'save' button should not be enabled when field errors are present",
+                domainDesignerPage.finishButton().isEnabled());
         domainDesignerPage.clickCancelAndDiscardChanges();
     }
 

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -313,8 +313,6 @@ public class DomainDesignerTest extends BaseWebDriverTest
         String expectedWarning = "New field. Warning: SQL queries, R scripts, and other code are easiest to write when field names only contain combination of letters, numbers, and underscores, and start with a letter or underscore";
         assertThat("expected error", warningFieldMessage, containsString(expectedWarning));
 
-        assertEquals("save button should be disabled with field errors present", "true",
-                domainDesignerPage.finishButton().getAttribute("disabled"));
         domainDesignerPage.clickCancelAndDiscardChanges();
     }
 
@@ -520,8 +518,6 @@ public class DomainDesignerTest extends BaseWebDriverTest
         assertTrue("expect error for duplicate field names", blarg2.hasFieldError());
         assertTrue("expect warning for field name with spaces or special characters", clientFieldWarning.hasFieldWarning());
 
-        assertFalse("'save' button should not be enabled when field errors are present",
-                domainDesignerPage.finishButton().isEnabled());
         domainDesignerPage.clickCancelAndDiscardChanges();
     }
 

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -305,6 +305,13 @@ public class DomainDesignerTest extends BaseWebDriverTest
         assertTrue("expect error to contain [Please provide a name for each field.] but was[" + hasNoNameError + "]",
                 hasNoNameError.contains("Please provide a name for each field."));
 
+        String warningfieldMessage = noNameRow.setName("&totally not a sketchy sql injection attack")
+                .waitForWarning()
+                .detailsMessage();
+        String expectedWarning = "New field. Warning: SQL queries, R scripts, and other code are easiest to write when field names only contain combination of letters, numbers, and underscores, and start with a letter or underscore";
+        assertTrue("expect error to contain [" + expectedWarning + "] but was[" + warningfieldMessage + "]",
+                warningfieldMessage.contains(expectedWarning));
+
         domainDesignerPage.clickCancelAndDiscardChanges();
     }
 
@@ -491,15 +498,23 @@ public class DomainDesignerTest extends BaseWebDriverTest
         DomainFieldRow clientFieldWarning = domainFormPanel.addField("select * from table");
 
         domainDesignerPage.clickFinishExpectingError();
-        // TODO: Look for warning on row instead of banner.  We're not doing warning banners anymore
-//        String clientWarning = domainDesignerPage.waitForWarning();
-//        String multipleIssuesError = domainDesignerPage.waitForError();
-//        String expectedErrMsg = "Multiple fields contain issues that need to be fixed. Review the red highlighted fields below for more information.";
-//        String expectedWarningMsg = " SQL queries, R scripts, and other code are easiest to write when field names only contain combination of letters, numbers, and underscores, and start with a letter or underscore.";
-//        assertTrue("expect error message to contain [" + expectedErrMsg + "] but was [" + multipleIssuesError + "]",
-//                multipleIssuesError.contains(expectedErrMsg));
-//        assertTrue("expect warning message to contain [" + expectedWarningMsg + "] but was [" + clientWarning + "]",
-//                clientWarning.contains(expectedWarningMsg));
+        String expectedWarnMsg = "New field. Warning: SQL queries, R scripts, and other code are easiest to write when field names only contain combination of letters, numbers, and underscores, and start with a letter or underscore.";
+        String blargErrMsg = "New field. Error: The field name 'blarg' is already taken. Please provide a unique name for each field.";
+        String reservedErrMsg = "New field. Error: 'modified' is a reserved field name in 'fieldsWithReservedNamesSampleSet'.";
+        String modRowDetailsMsg = modifiedRow.waitForError()
+                .detailsMessage();
+        String blarg1DetailsMsg = blarg1.waitForError().detailsMessage();
+        String blarg2DetailsMsg = blarg2.waitForError().detailsMessage();
+        String clientFieldWarningMsg = clientFieldWarning.waitForWarning().detailsMessage();
+
+        assertTrue("expect error message to contain [" + reservedErrMsg + "] but was [" + modRowDetailsMsg + "]",
+                modRowDetailsMsg.contains(reservedErrMsg));
+        assertTrue("expect error message to contain [" + blargErrMsg + "] but was [" + blarg1DetailsMsg + "]",
+                blarg1DetailsMsg.contains(blargErrMsg));
+        assertTrue("expect error message to contain [" + blargErrMsg + "] but was [" + blarg2DetailsMsg + "]",
+                blarg2DetailsMsg.contains(blargErrMsg));
+        assertTrue("expect warning message to contain [" + expectedWarnMsg + "] but was [" + clientFieldWarningMsg + "]",
+                clientFieldWarningMsg.contains(expectedWarnMsg));
 
         assertTrue("expect field error when using reserved field names", modifiedRow.hasFieldError());
         assertTrue("expect error for duplicate field names", blarg1.hasFieldError());

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -480,7 +480,7 @@ public class DomainDesignerTest extends BaseWebDriverTest
     }
 
     @Test
-    public void testAddFieldsWithReservedNames() throws Exception
+    public void testFieldNameErrors() throws Exception
     {
         String sampleSet = "fieldsWithReservedNamesSampleSet";
 


### PR DESCRIPTION
restores field-level error and warning validation test coverage in Domain Designer.
adds synchronizing wait-for-error/warning methods to domainFieldRow