### PR TITLE
Scroll to hidden fields checkbox

### DIFF
--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -534,7 +534,10 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
     //enable customize view grid to show hidden fields
     public void showHiddenItems()
     {
-        _driver.click(Locator.tagWithText("Label", "Show Hidden Fields"));
+        Checkbox hiddenFields = Ext4Checkbox().withLabel("Show Hidden Fields").find(this);
+        hiddenFields.check();
+        WebDriverWrapper.waitFor(hiddenFields::isChecked, "Hidden Fields not shown", 1000);
+
         BaseWebDriverTest.sleep(250); // wait for columns to display
     }
 

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -535,6 +535,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
     public void showHiddenItems()
     {
         Checkbox hiddenFields = Ext4Checkbox().withLabel("Show Hidden Fields").find(this);
+        getWrapper().scrollIntoView(hiddenFields.getComponentElement());
         hiddenFields.check();
         WebDriverWrapper.waitFor(hiddenFields::isChecked, "Hidden Fields not shown", 1000);
 


### PR DESCRIPTION
NLP tests have been failing because this checkbox for a particular data region ends up a pixel from the bottom of the window and clicks aren't getting through.