### PR TITLE
UserTest fixes for user profile changes

### DIFF
--- a/src/org/labkey/test/tests/UserTest.java
+++ b/src/org/labkey/test/tests/UserTest.java
@@ -141,18 +141,24 @@ public class UserTest extends BaseWebDriverTest
     public void testSiteUsersPermission()
     {
         goToSiteUsers();
-        assertTextPresent("Last Login", "Last Name", "Active");
+        assertTextPresent("Email", "Display Name", "First Name", "Last Login", "Has Password");
 
         goToMyAccount();
-        assertTextPresent("First Name", "Last Login");
+        for (String label : Arrays.asList("Email", "Display Name", "First Name", "Last Login", "Has Password", "Avatar"))
+            assertTrue(hasUserProfileFormLabel(label));
 
         impersonate(NORMAL_USER);
-
         goToMyAccount();
-        assertTextPresent("First Name");
-        assertTextNotPresent("Last Login");
-
+        for (String label : Arrays.asList("Display Name", "First Name", "Last Login", "Avatar"))
+            assertTrue(hasUserProfileFormLabel(label));
+        for (String label : Arrays.asList("Email", "Has Password"))
+            assertFalse(hasUserProfileFormLabel(label));
         stopImpersonating();
+    }
+
+    private boolean hasUserProfileFormLabel(String label)
+    {
+        return isElementPresent(Locator.tagWithClass("td", "lk-form-label").withText(label + ":"));
     }
 
     @Test


### PR DESCRIPTION
- bring back ShowUpdateAction bulk validation of columns to show all column errors at once on LKS user profile submit
- change testSiteUsersPermission check to expect the Last Login field to be present, even for a non-site admin