### PR TITLE
Use DeferredErrorCollector to take screenshots of all search failures

### DIFF
--- a/src/org/labkey/test/pages/search/SearchResultsPage.java
+++ b/src/org/labkey/test/pages/search/SearchResultsPage.java
@@ -15,12 +15,9 @@
  */
 package org.labkey.test.pages.search;
 
-import org.labkey.test.LabKeySiteWrapper;
 import org.labkey.test.Locator;
-import org.labkey.test.components.ComponentElements;
 import org.labkey.test.components.search.SearchForm;
 import org.labkey.test.pages.LabKeyPage;
-import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -30,7 +27,7 @@ import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertTrue;
 
-public class SearchResultsPage extends LabKeyPage
+public class SearchResultsPage extends LabKeyPage<SearchResultsPage.Elements>
 {
     public SearchResultsPage(WebDriver test)
     {
@@ -44,7 +41,7 @@ public class SearchResultsPage extends LabKeyPage
 
     public Integer getResultCount()
     {
-        String countStr = elements().resultsCount().getText();
+        String countStr = elementCache().resultsCount().getText();
         Pattern pattern = Pattern.compile("Found (\\d+) results?");
         Matcher matcher = pattern.matcher(countStr);
 
@@ -52,23 +49,37 @@ public class SearchResultsPage extends LabKeyPage
         return Integer.parseInt(matcher.group(1));
     }
 
+    public WebElement getResultsPanel()
+    {
+        return elementCache().searchResultsPanel;
+    }
+
+    public WebElement getFolderResultsPanel()
+    {
+        return elementCache().folderSearchResultsPanel;
+    }
+
     public List<WebElement> getResults()
     {
-        return elements().searchResultCards();
+        return elementCache().searchResultCards();
     }
 
     public void openAdvancedOptions()
     {
         if (!isAdvancedOptionsOpen())
-            elements().advancedOptionsToggle.click();
-            waitFor(()-> isAdvancedOptionsOpen(), WAIT_FOR_JAVASCRIPT);
+        {
+            elementCache().advancedOptionsToggle.click();
+            waitFor(this::isAdvancedOptionsOpen, "Advanced options panel did not expand", WAIT_FOR_JAVASCRIPT);
+        }
     }
 
     public void closeAdvancedOptions()
     {
         if (isAdvancedOptionsOpen())
-            elements().advancedOptionsToggle.click();
-        waitFor(()-> !isAdvancedOptionsOpen(), WAIT_FOR_JAVASCRIPT);
+        {
+            elementCache().advancedOptionsToggle.click();
+            waitFor(()-> !isAdvancedOptionsOpen(), "Advanced options panel did not collapse", WAIT_FOR_JAVASCRIPT);
+        }
     }
 
     public boolean isAdvancedOptionsOpen()
@@ -93,19 +104,14 @@ public class SearchResultsPage extends LabKeyPage
         return this;
     }
 
-    Elements elements()
+    @Override
+    protected Elements newElementCache()
     {
         return new Elements();
     }
 
-    private class Elements extends ComponentElements
+    protected class Elements extends LabKeyPage.ElementCache
     {
-        @Override
-        protected SearchContext getContext()
-        {
-            return getDriver();
-        }
-
         public WebElement advancedOptionsToggle = Locator.tagWithClass("a", "search-advanced-toggle").waitForElement(this, WAIT_FOR_JAVASCRIPT);
 
         WebElement resultsCount()
@@ -122,5 +128,8 @@ public class SearchResultsPage extends LabKeyPage
         {
             return Locator.tagWithClass("div", "labkey-search-result").findElements(this);
         }
+
+        private WebElement searchResultsPanel = Locator.byClass("labkey-search-results").findWhenNeeded(this);
+        private WebElement folderSearchResultsPanel = Locator.byClass("labkey-folders-search-results").findWhenNeeded(this);
     }
 }

--- a/src/org/labkey/test/pages/search/SearchResultsPage.java
+++ b/src/org/labkey/test/pages/search/SearchResultsPage.java
@@ -22,6 +22,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -49,14 +50,14 @@ public class SearchResultsPage extends LabKeyPage<SearchResultsPage.Elements>
         return Integer.parseInt(matcher.group(1));
     }
 
-    public WebElement getResultsPanel()
+    public Optional<WebElement> getResultsPanel()
     {
-        return elementCache().searchResultsPanel;
+        return elementCache().getSearchResultsPanel();
     }
 
-    public WebElement getFolderResultsPanel()
+    public Optional<WebElement> getFolderResultsPanel()
     {
-        return elementCache().folderSearchResultsPanel;
+        return elementCache().getFolderSearchResultsPanel();
     }
 
     public List<WebElement> getResults()
@@ -130,6 +131,15 @@ public class SearchResultsPage extends LabKeyPage<SearchResultsPage.Elements>
         }
 
         private WebElement searchResultsPanel = Locator.byClass("labkey-search-results").findWhenNeeded(this);
-        private WebElement folderSearchResultsPanel = Locator.byClass("labkey-folders-search-results").findWhenNeeded(this);
+
+        public Optional<WebElement> getSearchResultsPanel()
+        {
+            return Locator.byClass("labkey-search-results").findOptionalElement(this);
+        }
+
+        public Optional<WebElement> getFolderSearchResultsPanel()
+        {
+            return Locator.byClass("labkey-folders-search-results").findOptionalElement(this);
+        }
     }
 }

--- a/src/org/labkey/test/tests/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/FileContentUploadTest.java
@@ -169,7 +169,7 @@ public class FileContentUploadTest extends BaseWebDriverTest
         _searchHelper.enqueueSearchItem(FILE_DESCRIPTION, true, Locator.linkContainingText(newFileName));
         _searchHelper.enqueueSearchItem(CUSTOM_PROPERTY_VALUE, true, Locator.linkContainingText(newFileName));
 
-        _searchHelper.verifySearchResults("/" + getProjectName() + "/@files/" + folderName);
+        _searchHelper.verifySearchResults("/" + getProjectName() + "/@files/" + folderName, "searchAfterRename");
 
         // Delete file.
         clickProject(getProjectName());
@@ -179,7 +179,7 @@ public class FileContentUploadTest extends BaseWebDriverTest
         _searchHelper.enqueueSearchItem(FILE_DESCRIPTION);
         _searchHelper.enqueueSearchItem(CUSTOM_PROPERTY_VALUE);
 
-        _searchHelper.verifySearchResults("/" + getProjectName() + "/@files/" + folderName);
+        _searchHelper.verifySearchResults("/" + getProjectName() + "/@files/" + folderName, "searchAfterDelete");
 
         clickProject(getProjectName());
         _fileBrowserHelper.clickFileBrowserButton(BrowserAction.AUDIT_HISTORY);

--- a/src/org/labkey/test/tests/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/FileContentUploadTest.java
@@ -164,20 +164,22 @@ public class FileContentUploadTest extends BaseWebDriverTest
         final String newFileName = "changedFilename.html";
         _fileBrowserHelper.renameFile(folderName + "/" + filename, newFileName);
 
+        _searchHelper.enqueueSearchItem(filename); // No results for old file name
         _searchHelper.enqueueSearchItem(newFileName, true, Locator.linkContainingText(newFileName));
         _searchHelper.enqueueSearchItem(FILE_DESCRIPTION, true, Locator.linkContainingText(newFileName));
         _searchHelper.enqueueSearchItem(CUSTOM_PROPERTY_VALUE, true, Locator.linkContainingText(newFileName));
 
-        _searchHelper.verifySearchResults("/" + getProjectName() + "/@files/" + folderName, false);
-        _searchHelper.assertNoSearchResult(filename);
+        _searchHelper.verifySearchResults("/" + getProjectName() + "/@files/" + folderName);
 
         // Delete file.
         clickProject(getProjectName());
         _fileBrowserHelper.deleteFile(folderName + "/" + newFileName);
         waitForElementToDisappear(Locator.css(".labkey-filecontent-grid div.x4-grid-cell-inner").withText(newFileName));
-        _searchHelper.assertNoSearchResult(newFileName);
-        _searchHelper.assertNoSearchResult(FILE_DESCRIPTION);
-        _searchHelper.assertNoSearchResult(CUSTOM_PROPERTY_VALUE);
+        _searchHelper.enqueueSearchItem(newFileName);
+        _searchHelper.enqueueSearchItem(FILE_DESCRIPTION);
+        _searchHelper.enqueueSearchItem(CUSTOM_PROPERTY_VALUE);
+
+        _searchHelper.verifySearchResults("/" + getProjectName() + "/@files/" + folderName);
 
         clickProject(getProjectName());
         _fileBrowserHelper.clickFileBrowserButton(BrowserAction.AUDIT_HISTORY);

--- a/src/org/labkey/test/util/SearchHelper.java
+++ b/src/org/labkey/test/util/SearchHelper.java
@@ -173,7 +173,7 @@ public class SearchHelper
                 throw new IllegalArgumentException("Search result crawling not yet implemented");
         }
 
-        errorCollector.recordResults();
+        errorCollector.recordResults(); // Should no-op unless failOnError == true
 
         if (notFound.isEmpty())
             _test.log("All items were found");

--- a/src/org/labkey/test/util/SearchHelper.java
+++ b/src/org/labkey/test/util/SearchHelper.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
@@ -193,7 +194,8 @@ public class SearchHelper
             {
                 if (failOnError)
                 {
-                    errorCollector.error("Incorrect search results for [\"" + searchTerm + "\"]. Missing results: " + missingResults.toString());
+                    errorCollector.error("Incorrect search results for [\"" + searchTerm + "\"]. Missing results: \n" +
+                            missingResults.stream().map(Locator::toString).collect(Collectors.joining("\n")));
                 }
                 else
                 {

--- a/src/org/labkey/test/util/SearchHelper.java
+++ b/src/org/labkey/test/util/SearchHelper.java
@@ -34,7 +34,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 
@@ -258,11 +257,11 @@ public class SearchHelper
 
         _test.log("Searching for: '" + searchTerm + "'.");
 
-        Optional<WebElement> bodyInput = Locators.bodyPanel().append(Locator.input("q")).findOptionalElement(_test.getDriver());
-        if (bodyInput.isPresent()) // Search results page or search webpart
+        WebElement searchInput = Locator.input("q").findElementOrNull(Locators.bodyPanel().findElement(_test.getDriver()));
+        if (searchInput != null) // Search results page or search webpart
         {
-            _test.setFormElement(bodyInput.get(), searchTerm);
-            _test.doAndWaitForPageToLoad(() -> bodyInput.get().sendKeys(Keys.ENTER));
+            _test.setFormElement(searchInput, searchTerm);
+            _test.doAndWaitForPageToLoad(() -> searchInput.sendKeys(Keys.ENTER));
             return new SearchResultsPage(_test.getDriver());
         }
         else // Use header search

--- a/src/org/labkey/test/util/SearchHelper.java
+++ b/src/org/labkey/test/util/SearchHelper.java
@@ -52,7 +52,7 @@ public class SearchHelper
 
     public SearchHelper(BaseWebDriverTest test)
     {
-        this(test, 6);
+        this(test, 4);
     }
     private static final Locator noResultsLocator = Locator.byClass("labkey-search-results-counts").withText("Found 0 results");
     private static final String unsearchableValue = "UNSEARCHABLE";
@@ -126,7 +126,7 @@ public class SearchHelper
     {
         _test.log("Verifying " + items.size() + " items");
         List<String> notFound = new ArrayList<>();
-        DeferredErrorCollector errorCollector = _test.checker().withScreenshot(description);
+        DeferredErrorCollector errorCollector = new DeferredErrorCollector(_test).withScreenshot(description);
         for (String searchTerm : items.keySet())
         {
             SearchItem item = items.get(searchTerm);
@@ -192,6 +192,8 @@ public class SearchHelper
             _test.log("All items were found");
         else
             _test.log(notFound.size() + " items were not found.");
+
+        errorCollector.recordResults();
 
         return notFound;
     }

--- a/src/org/labkey/test/util/SearchHelper.java
+++ b/src/org/labkey/test/util/SearchHelper.java
@@ -53,7 +53,7 @@ public class SearchHelper
 
     public SearchHelper(BaseWebDriverTest test)
     {
-        this(test, 1);
+        this(test, 6);
     }
     private static final Locator noResultsLocator = Locator.byClass("labkey-search-results-counts").withText("Found 0 results");
     private static final String unsearchableValue = "UNSEARCHABLE";
@@ -163,8 +163,9 @@ public class SearchHelper
 
             for (Locator loc : expectedResults)
             {
-                if ((resultsPage.getResultsPanel().isEmpty() || !loc.existsIn(resultsPage.getResultsPanel().get()))
-                        && (resultsPage.getFolderResultsPanel().isEmpty() || !loc.existsIn(resultsPage.getFolderResultsPanel().get())))
+                boolean inResultsPanel = resultsPage.getResultsPanel().map(loc::existsIn).orElse(false);
+                boolean inFolderResultsPanel = resultsPage.getFolderResultsPanel().map(loc::existsIn).orElse(false);
+                if (!inResultsPanel && !inFolderResultsPanel)
                 {
                     missingResults.add(loc);
                     if (!failOnError)


### PR DESCRIPTION
Previously, it would just perform a search on one of the failed search terms. This is problematic for two reasons: 
1 The screenshot might not actually match the fail state.
2 You only get a screenshot for one failed search even when there were several.

This change also makes the search helper explicitly verify that expected search results appear in the search results panel.

Depends on product changes in https://github.com/LabKey/platform/pull/644