### PR TITLE
Added various getters to return content from a domain designer page.

### DIFF
--- a/src/org/labkey/test/components/DomainDesignerPage.java
+++ b/src/org/labkey/test/components/DomainDesignerPage.java
@@ -82,11 +82,19 @@ public class DomainDesignerPage extends LabKeyPage<DomainDesignerPage.ElementCac
         return elementCache().domainFormPanel(title);
     }
 
+    /**
+     * Get a list of the Domain Panels on this page.
+     * @return List of DomainFormElement
+     */
     public List<DomainFormPanel> getPanels()
     {
         return new DomainFormPanel.DomainFormPanelFinder(getDriver()).findAll();
     }
 
+    /**
+     * Get the titles of the panels on this page.
+     * @return List of strings with the panel titles.
+     */
     public List<String> getPanelTitles()
     {
         List<String> titles = new ArrayList<>();

--- a/src/org/labkey/test/components/DomainDesignerPage.java
+++ b/src/org/labkey/test/components/DomainDesignerPage.java
@@ -103,6 +103,7 @@ public class DomainDesignerPage extends LabKeyPage<DomainDesignerPage.ElementCac
                 "the error alert did not appear as expected", 1000);
         return  errorAlert().getText();
     }
+
     public WebElement errorAlert()
     {
         return BootstrapLocators.dangerAlert.existsIn(getDriver()) ? BootstrapLocators.dangerAlert.findElement(getDriver()) : null;
@@ -114,6 +115,7 @@ public class DomainDesignerPage extends LabKeyPage<DomainDesignerPage.ElementCac
                 "the warning alert did not appear as expected", 1000);
         return  warningAlert().getText();
     }
+
     public WebElement warningAlert()
     {
         return BootstrapLocators.warningAlert.existsIn(getDriver()) ? BootstrapLocators.warningAlert.findElement(getDriver()) : null;
@@ -125,6 +127,7 @@ public class DomainDesignerPage extends LabKeyPage<DomainDesignerPage.ElementCac
                 "the info alert did not appear as expected", 1000);
         return  infoAlert().getText();
     }
+
     public WebElement infoAlert()
     {
         return BootstrapLocators.infoAlert.existsIn(getDriver()) ? BootstrapLocators.infoAlert.findElement(getDriver()) : null;
@@ -136,6 +139,7 @@ public class DomainDesignerPage extends LabKeyPage<DomainDesignerPage.ElementCac
                 BootstrapLocators.dangerAlert, BootstrapLocators.infoAlert, BootstrapLocators.warningAlert, BootstrapLocators.successAlert);
         return alert.getText();
     }
+
     public String anyAlert()
     {
         WebElement alert = Locator.findAnyElementOrNull(getDriver(),

--- a/src/org/labkey/test/components/DomainDesignerPage.java
+++ b/src/org/labkey/test/components/DomainDesignerPage.java
@@ -13,6 +13,9 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class DomainDesignerPage extends LabKeyPage<DomainDesignerPage.ElementCache>
 {
     public DomainDesignerPage(WebDriver driver)
@@ -77,6 +80,21 @@ public class DomainDesignerPage extends LabKeyPage<DomainDesignerPage.ElementCac
     public DomainFormPanel fieldsPanel(String title)
     {
         return elementCache().domainFormPanel(title);
+    }
+
+    public List<DomainFormPanel> getPanels()
+    {
+        return new DomainFormPanel.DomainFormPanelFinder(getDriver()).findAll();
+    }
+
+    public List<String> getPanelTitles()
+    {
+        List<String> titles = new ArrayList<>();
+        for(DomainFormPanel formPanel : getPanels())
+        {
+            titles.add(formPanel.getPanelTitle());
+        }
+        return titles;
     }
 
     public String waitForError()

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -87,8 +87,20 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
     public FieldDefinition.ColumnType getType()
     {
-        String typeString = getWrapper().getFormElement(elementCache().fieldTypeSelectInput);
-        return Enum.valueOf(FieldDefinition.ColumnType.class, typeString);
+        // The previous code doesn't work:
+        //  String typeString = getWrapper().getFormElement(elementCache().fieldTypeSelectInput);
+        //  return Enum.valueOf(FieldDefinition.ColumnType.class, typeString);
+        // getFormElement get's the value attribute which is not the same as the text shown and not the
+        // same as the Enum.valueOf. To get a match get the text shown in the control and compare it
+        // to the enum's label attribute.
+
+        String typeString = getWrapper().getSelectedOptionText(elementCache().fieldTypeSelectInput);
+        for(FieldDefinition.ColumnType ct : FieldDefinition.ColumnType.values())
+        {
+            if(ct.getLabel().equalsIgnoreCase(typeString))
+                return ct;
+        }
+        return null;
     }
 
     private DomainFieldRow setType(String columnType)

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -188,6 +188,35 @@ public class DomainFormPanel extends WebDriverComponent<DomainFormPanel.ElementC
         return elementCache().panelTitle.getText();
     }
 
+    /**
+     * Get the alert message that is shown only in the alert panel. An example of this is the Results Field in
+     * Sample Manager requires a field that is a sample look-up, if it missing an alert is shown.
+     * This alert can only be dismissed by adding the field.
+     * @return String of the alert message, empty if not present.
+     */
+    public String getPanelAlertText()
+    {
+        if(elementCache().panelAlertText.isDisplayed())
+            return elementCache().panelAlertText.getText();
+        else
+            return "";
+    }
+
+    /**
+     * There may be an element in the alert that a test will need to interact with so return the alert element and let
+     * the test find the control it needs.
+     * @return The div wrapping the alert in the panel, null otherwise.
+     */
+    public WebElement getPanelAlertWebElement()
+    {
+        // It would be better to not return a raw WebElement but who knows what the future holds, different alerts
+        // may show different controls.
+        if(elementCache().panelAlertText.isDisplayed())
+            return elementCache().panelAlert;
+        else
+            return null;
+    }
+
     @Override
     protected ElementCache newElementCache()
     {
@@ -272,6 +301,8 @@ public class DomainFormPanel extends WebDriverComponent<DomainFormPanel.ElementC
         Locator.XPathLocator collapseIconLoc = Locator.tagWithClass("svg", "domain-form-collapse-btn");
         WebElement collapseIcon = collapseIconLoc.refindWhenNeeded(DomainFormPanel.this);
         WebElement panelTitle = Locator.xpath("//div//span[not(@class)]").findWhenNeeded(DomainFormPanel.this);
+        WebElement panelAlert = Locator.css("div.alert-info").findWhenNeeded(DomainFormPanel.this);
+        WebElement panelAlertText = Locator.css("div.alert-info > div > div").findWhenNeeded(DomainFormPanel.this);
     }
 
     public static class DomainFormPanelFinder extends WebDriverComponentFinder<DomainFormPanel, DomainFormPanelFinder>

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -183,6 +183,11 @@ public class DomainFormPanel extends WebDriverComponent<DomainFormPanel.ElementC
         return elementCache().expandIconLoc.existsIn(this);
     }
 
+    public String getPanelTitle()
+    {
+        return elementCache().panelTitle.getText();
+    }
+
     @Override
     protected ElementCache newElementCache()
     {
@@ -266,6 +271,7 @@ public class DomainFormPanel extends WebDriverComponent<DomainFormPanel.ElementC
         WebElement expandIcon = expandIconLoc.refindWhenNeeded(DomainFormPanel.this);
         Locator.XPathLocator collapseIconLoc = Locator.tagWithClass("svg", "domain-form-collapse-btn");
         WebElement collapseIcon = collapseIconLoc.refindWhenNeeded(DomainFormPanel.this);
+        WebElement panelTitle = Locator.xpath("//div//span[not(@class)]").findWhenNeeded(DomainFormPanel.this);
     }
 
     public static class DomainFormPanelFinder extends WebDriverComponentFinder<DomainFormPanel, DomainFormPanelFinder>

--- a/src/org/labkey/test/components/glassLibrary/components/MultiMenu.java
+++ b/src/org/labkey/test/components/glassLibrary/components/MultiMenu.java
@@ -6,6 +6,7 @@ package org.labkey.test.components.glassLibrary.components;
 
 import org.junit.Assert;
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
@@ -67,10 +68,13 @@ public class MultiMenu extends BootstrapMenu
         List<String> menuText = new ArrayList<>();
 
         boolean stale;
+        boolean loading;
+        int tries = 1;
 
         do {
 
             stale = false;
+            loading = false;
 
             try
             {
@@ -79,7 +83,15 @@ public class MultiMenu extends BootstrapMenu
                 menuText = new ArrayList<>();
 
                 for (WebElement menuItem : topMenuList) {
+
+                    String menuItemText = menuItem.getText();
+
+                    // Check to see if we are still loading data.
+                    if(menuItemText.toLowerCase().contains("loading"))
+                        loading = true;
+
                     menuText.add(menuItem.getText());
+
                 }
 
             }
@@ -88,11 +100,16 @@ public class MultiMenu extends BootstrapMenu
                 stale = true;
             }
 
+            if(stale || loading )
+                WebDriverWrapper.sleep(500);
+
+            tries++;
+
             // Keep trying until we get valid menu text.
-            // TODO I'm not sure about the "loading" text. The test failed for me once with this message but I
-            //  didn't get a chance to capture the actual text. I will leave as is, and if it fails in TC because
-            //  of  a loading text value this can be updated.
-        } while(stale || menuText.contains("Loading assays...") || menuText.contains("Loading sample sets..."));
+        } while((stale || loading) && (tries <= 10));
+
+        if(tries > 10)
+            throw new RuntimeException("Menu text never returned.");
 
         return menuText;
     }

--- a/src/org/labkey/test/components/glassLibrary/components/MultiMenu.java
+++ b/src/org/labkey/test/components/glassLibrary/components/MultiMenu.java
@@ -99,6 +99,7 @@ public class MultiMenu extends BootstrapMenu
             {
                 // This happens in the time between the change of the menu content from containing "loading"
                 // to having data (like "sample sets").
+                getComponentElement().isDisplayed(); // will throw an uncaught 'StaleReferenceException' if the entire menu went stale
                 stale = true;
             }
 
@@ -111,8 +112,14 @@ public class MultiMenu extends BootstrapMenu
             // Keep trying until we get valid menu text.
         } while((stale || loading) && (tries <= 10));
 
-        if(tries > 10)
-            throw new RuntimeException("Menu text never returned.");
+        if (stale)
+        {
+            throw new RuntimeException("Menu items kept going stale");
+        }
+        if (loading)
+        {
+            throw new RuntimeException("Menu items still loading. " + menuText.toString());
+        }
 
         return menuText;
     }

--- a/src/org/labkey/test/components/glassLibrary/components/MultiMenu.java
+++ b/src/org/labkey/test/components/glassLibrary/components/MultiMenu.java
@@ -92,7 +92,7 @@ public class MultiMenu extends BootstrapMenu
             // TODO I'm not sure about the "loading" text. The test failed for me once with this message but I
             //  didn't get a chance to capture the actual text. I will leave as is, and if it fails in TC because
             //  of  a loading text value this can be updated.
-        } while(stale || menuText.contains("Loading..."));
+        } while(stale || menuText.contains("Loading assays...") || menuText.contains("Loading sample sets..."));
 
         return menuText;
     }

--- a/src/org/labkey/test/components/glassLibrary/components/MultiMenu.java
+++ b/src/org/labkey/test/components/glassLibrary/components/MultiMenu.java
@@ -97,9 +97,12 @@ public class MultiMenu extends BootstrapMenu
             }
             catch(StaleElementReferenceException staleExc)
             {
+                // This happens in the time between the change of the menu content from containing "loading"
+                // to having data (like "sample sets").
                 stale = true;
             }
 
+            // Just a small pause, no need to keep hitting the DOM if it looks like the server is doing something
             if(stale || loading )
                 WebDriverWrapper.sleep(500);
 

--- a/src/org/labkey/test/pages/ReactAssayDesignerPage.java
+++ b/src/org/labkey/test/pages/ReactAssayDesignerPage.java
@@ -58,6 +58,7 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
     }
 
     // I think the name field is the only field that can be enabled/disabled.
+    // For example once an assay is created you can't change it's name so the field will be disabled.
     public boolean isNameEnabled()
     {
         return null == elementCache().nameInput.getComponentElement().getAttribute( "disabled");

--- a/src/org/labkey/test/pages/ReactAssayDesignerPage.java
+++ b/src/org/labkey/test/pages/ReactAssayDesignerPage.java
@@ -23,7 +23,6 @@ import org.labkey.test.components.html.Input;
 import org.labkey.test.components.html.OptionSelect;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
 
 import java.io.File;
@@ -53,10 +52,26 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
         return this;
     }
 
+    public String getName()
+    {
+        return elementCache().nameInput.get();
+    }
+
+    // I think the name field is the only field that can be enabled/disabled.
+    public boolean isNameEnabled()
+    {
+        return null == elementCache().nameInput.getComponentElement().getAttribute( "disabled");
+    }
+
     public ReactAssayDesignerPage setDescription(String description)
     {
         elementCache().descriptionInput.set(description);
         return this;
+    }
+
+    public String getDescription()
+    {
+        return elementCache().descriptionInput.get();
     }
 
     public ReactAssayDesignerPage setAutoCopyTarget(String containerPath)
@@ -101,10 +116,20 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
         return this;
     }
 
+    public boolean getEditableRuns()
+    {
+        return elementCache().editableRunsCheckbox.get();
+    }
+
     public ReactAssayDesignerPage setEditableResults(boolean checked)
     {
         elementCache().editableResultCheckbox.set(checked);
         return this;
+    }
+
+    public boolean getEditableResults()
+    {
+        return elementCache().editableResultCheckbox.get();
     }
 
     public ReactAssayDesignerPage setBackgroundImport(boolean checked)

--- a/src/org/labkey/test/pages/ReactAssayDesignerPage.java
+++ b/src/org/labkey/test/pages/ReactAssayDesignerPage.java
@@ -61,7 +61,7 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
     // For example once an assay is created you can't change it's name so the field will be disabled.
     public boolean isNameEnabled()
     {
-        return null == elementCache().nameInput.getComponentElement().getAttribute( "disabled");
+        return elementCache().nameInput.getComponentElement().isEnabled();
     }
 
     public ReactAssayDesignerPage setDescription(String description)

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -314,7 +314,8 @@ public class FieldDefinition
         Flag("Flag", "Flag (String)", null),
         Attachment("Attachment", "Attachment", "attachment"),
         User("User", "User", "int"),
-        Lookup("Lookup", "Lookup", null);
+        Lookup("Lookup", "Lookup", null),
+        Sample("Sample", "Sample", null);
 
         private final String _label; // the display value in the UI for this kind of field
         private final String _description; // TODO remove this after GWT designer removed


### PR DESCRIPTION
Made some minor changes to the DomainDesigner pages to return list of the panes present (needed to validate behavior in SampleManager).
Fixed an issue in DomainFieldRow.getType.
Added getters for some of the fields in the ReactDesignerPage that are used in the SampleManager tests.
