### PR TITLE
Add helper to create users without complaining if they already exist

### DIFF
--- a/src/org/labkey/test/pages/security/AddUsersPage.java
+++ b/src/org/labkey/test/pages/security/AddUsersPage.java
@@ -1,0 +1,77 @@
+package org.labkey.test.pages.security;
+
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.components.html.Checkbox;
+import org.labkey.test.components.html.Input;
+import org.labkey.test.pages.LabKeyPage;
+import org.labkey.test.pages.user.ShowUsersPage;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+public class AddUsersPage extends LabKeyPage<AddUsersPage.ElementCache>
+{
+    public AddUsersPage(WebDriver driver)
+    {
+        super(driver);
+    }
+
+    public static AddUsersPage beginAt(WebDriverWrapper webDriverWrapper)
+    {
+        webDriverWrapper.beginAt(WebTestHelper.buildURL("security", "addUsers"));
+        return new AddUsersPage(webDriverWrapper.getDriver());
+    }
+
+    public AddUsersPage setNewUsers(List<String> newUsers)
+    {
+        elementCache().newUsersInput.set(String.join("\n", newUsers));
+        return this;
+    }
+
+    public AddUsersPage setClonedUser(String clonedUser)
+    {
+        if (clonedUser != null)
+        {
+            elementCache().clonePermissionCheckbox.set(true);
+            elementCache().cloneUserInput.set(clonedUser);
+        }
+        return this;
+    }
+
+    public AddUsersPage setSendNotification(boolean sendNotification)
+    {
+        elementCache().sendNotificationCheckbox.set(sendNotification);
+        return this;
+    }
+
+    public AddUsersPage clickAddUsers()
+    {
+        clickAndWait(elementCache().addUsersButton);
+        return new AddUsersPage(getDriver());
+    }
+
+    public ShowUsersPage clickDone()
+    {
+        clickAndWait(elementCache().doneButton);
+        return new ShowUsersPage(getDriver());
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends LabKeyPage.ElementCache
+    {
+        final Input newUsersInput = Input.Input(Locator.id("newUsers"), getDriver()).findWhenNeeded(this);
+        final Checkbox clonePermissionCheckbox = Checkbox.Checkbox(Locator.id("cloneUserCheck")).findWhenNeeded(this);
+        final Input cloneUserInput = Input.Input(Locator.id("cloneUser"), getDriver()).findWhenNeeded(this);
+        final Checkbox sendNotificationCheckbox = Checkbox.Checkbox(Locator.id("sendMail")).findWhenNeeded(this);
+        final WebElement addUsersButton = Locator.lkButton("Add Users").findWhenNeeded(this);
+        final WebElement doneButton = Locator.lkButton("Done").findWhenNeeded(this);
+    }
+}

--- a/src/org/labkey/test/tests/FolderExportTest.java
+++ b/src/org/labkey/test/tests/FolderExportTest.java
@@ -335,10 +335,7 @@ public class FolderExportTest extends BaseWebDriverTest
     private void createUsers(String...users)
     {
         log("Creating " + users.length + " users");
-        for (String user : users)
-        {
-            _userHelper.createUser(user);
-        }
+        _userHelper.ensureUsersExist(Arrays.asList(users));
     }
 
     @LogMethod

--- a/src/org/labkey/test/util/APIUserHelper.java
+++ b/src/org/labkey/test/util/APIUserHelper.java
@@ -45,6 +45,19 @@ public class APIUserHelper extends AbstractUserHelper
     }
 
     @Override
+    public void ensureUsersExist(List<String> userEmails)
+    {
+        Map<String, Integer> existingUsers = getUserIds(userEmails, true);
+        for (String email : userEmails)
+        {
+            if (!existingUsers.containsKey(email))
+            {
+                createUser(email);
+            }
+        }
+    }
+
+    @Override
     public CreateUserResponse createUser(final String userName, final boolean sendEmail, final boolean verifySuccess)
     {
         CreateUserCommand command = new CreateUserCommand(userName)

--- a/src/org/labkey/test/util/AbstractUserHelper.java
+++ b/src/org/labkey/test/util/AbstractUserHelper.java
@@ -16,11 +16,11 @@
 package org.labkey.test.util;
 
 import org.labkey.remoteapi.security.CreateUserResponse;
-import org.labkey.test.LabKeySiteWrapper;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -30,6 +30,11 @@ public abstract class AbstractUserHelper
 {
     private WebDriverWrapper _driverWrapper;
     protected static final Map<String, String> usersAndDisplayNames = new HashMap<>();
+
+    protected AbstractUserHelper(WebDriverWrapper driverWrapper)
+    {
+        _driverWrapper = driverWrapper;
+    }
 
     public WebDriverWrapper getWrapper()
     {
@@ -71,9 +76,8 @@ public abstract class AbstractUserHelper
         if (!newDisplayName.equals(previousDisplayName))
         {
             usersAndDisplayNames.remove(email); // Forget cached display name in case something goes wrong
-            getWrapper().goToSiteUsers();
+            DataRegionTable users = getWrapper().goToSiteUsers().getUsersTable();
 
-            DataRegionTable users = new DataRegionTable("Users", getWrapper().getDriver());
             users.setFilter("Email", "Equals", email);
             int userRow = users.getRowIndex("Email", email);
             assertFalse("No such user: " + email, userRow == -1);
@@ -86,11 +90,6 @@ public abstract class AbstractUserHelper
             getWrapper().clickButton("Submit");
             usersAndDisplayNames.put(email, newDisplayName);
         }
-    }
-
-    public AbstractUserHelper(WebDriverWrapper driverWrapper)
-    {
-        _driverWrapper = driverWrapper;
     }
 
     public CreateUserResponse createUser(String userName)
@@ -130,6 +129,7 @@ public abstract class AbstractUserHelper
         _deleteUsers(failIfNotFound, userEmails);
     }
 
+    public abstract void ensureUsersExist(List<String> userEmails);
     public abstract CreateUserResponse createUser(String userName, boolean sendEmail, boolean verifySuccess);
     protected abstract void _deleteUser(String userEmail);
     protected abstract void _deleteUsers(boolean failIfNotFound, String... userEmails);


### PR DESCRIPTION
The primary change her is to add `AbstractUserHelper.ensureUsersExist`. The rest is just implementation and some refactors to share code with existing helper methods.