### PR TITLE
Allow 'suite' parameter to specify a subset of an existing suite

### DIFF
--- a/src/org/labkey/test/Runner.java
+++ b/src/org/labkey/test/Runner.java
@@ -782,11 +782,8 @@ public class Runner extends TestSuite
 
     private static TestSet getSuite(String suiteName)
     {
-        try
-        {
-            return _suites.getTestSet(suiteName);
-        }
-        catch (Exception e)
+        TestSet testSet = _suites.getTestSet(suiteName);
+        if (testSet == null)
         {
             List<String> sortedSuites = new ArrayList<>(_suites.getSuites());
             Collections.sort(sortedSuites);
@@ -796,6 +793,7 @@ public class Runner extends TestSuite
                 System.err.println("   " + suite);
             throw new IllegalArgumentException("Couldn't find suite '" + suiteName + "'. Check log for details.");
         }
+        return testSet;
     }
 
     protected static List<String> getSpecifiedSuites()


### PR DESCRIPTION
Got inspired to try this out last Friday. We might account for expected test execution time (based on timeout annotation) but that could be a future refinement.

With this change we could get rid of the DailyA/B/C suites and use `Daily[1/3]`, `Daily[2/3]`, `Daily[3/3]` or split up any suite to run segments in parallel.