### PR TITLE
Don't clobber unexpected alerts when navigating.

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1747,7 +1747,6 @@ public abstract class WebDriverWrapper implements WrapsDriver
     {
         _testTimeout = true;
         new WebDriverWait(getDriver(), millis / 1000)
-                .ignoring(WebDriverException.class)
                 .withMessage("waiting for browser to navigate")
                 .until(ExpectedConditions.stalenessOf(toBeStale));
         waitForOnReady("jQuery");


### PR DESCRIPTION
This has been causing some unexpected alerts to look like a navigation timeout.
For example, this failure from `StudyDatasetsTest`:
```
org.openqa.selenium.TimeoutException: Expected condition failed: waiting for browser to navigate (tried for 60 second(s) with 500 milliseconds interval)
	[..]
	at org.labkey.test.WebDriverWrapper.waitForPageToLoad(WebDriverWrapper.java:1752)
	at org.labkey.test.WebDriverWrapper.doAndWaitForPageToLoad(WebDriverWrapper.java:1816)
	at org.labkey.test.WebDriverWrapper.clickAndWait(WebDriverWrapper.java:2590)
	at org.labkey.test.WebDriverWrapper.clickAndWait(WebDriverWrapper.java:2585)
	at org.labkey.test.pages.EditDatasetDefinitionPage.save(EditDatasetDefinitionPage.java:48)
	at org.labkey.test.tests.study.StudyDatasetsTest.renameDataset(StudyDatasetsTest.java:202)
	at org.labkey.test.tests.study.StudyDatasetsTest.verifyReportAndViewDatasetReferences(StudyDatasetsTest.java:407)
	at org.labkey.test.tests.study.StudyDatasetsTest.testDatasets(StudyDatasetsTest.java:146)
```
should actually be failing like this:
```
org.openqa.selenium.UnhandledAlertException: Dismissed user prompt dialog: The server encountered an error: 500  There was an error processing the request.
ExecutingSelector; uncategorized SQLException for SQL []; SQL state [null]; error code [0]; This connection has already been closed, and may have been left in a bad state. See nested exception for potentially suspect code.; nested exception is java.sql.SQLException: This connection has already been closed, and may have been left in a bad state. See nested exception for potentially suspect code.
(Error type: org.springframework.jdbc.UncategorizedSQLException): 
	[..]
	at org.labkey.test.WebDriverWrapper.waitForPageToLoad(WebDriverWrapper.java:1751)
	at org.labkey.test.WebDriverWrapper.doAndWaitForPageToLoad(WebDriverWrapper.java:1815)
	at org.labkey.test.WebDriverWrapper.clickAndWait(WebDriverWrapper.java:2589)
	at org.labkey.test.WebDriverWrapper.clickAndWait(WebDriverWrapper.java:2584)
	at org.labkey.test.pages.EditDatasetDefinitionPage.save(EditDatasetDefinitionPage.java:48)
	at org.labkey.test.tests.study.StudyDatasetsTest.renameDataset(StudyDatasetsTest.java:202)
	at org.labkey.test.tests.study.StudyDatasetsTest.verifyReportAndViewDatasetReferences(StudyDatasetsTest.java:407)
	at org.labkey.test.tests.study.StudyDatasetsTest.testDatasets(StudyDatasetsTest.java:146)
```