### PR TITLE
Re-add `module.properties` to miniassay test module

### DIFF
--- a/modules/miniassay/module.properties
+++ b/modules/miniassay/module.properties
@@ -1,0 +1,1 @@
+ModuleClass: org.labkey.api.module.SimpleModule


### PR DESCRIPTION
Gradle requires `module.properties` for all modules