### PR TITLE
Issue 39354: ReturnURLString.getActionURL regression

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -1276,7 +1276,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
      * Stop impersonating user
      * @param goHome go to Server Home or return to page where impersonation started
      */
-    public void stopImpersonating(Boolean goHome)
+    public void stopImpersonating(boolean goHome)
     {
         navBar().stopImpersonating();
         if (goHome)

--- a/src/org/labkey/test/components/html/SiteNavBar.java
+++ b/src/org/labkey/test/components/html/SiteNavBar.java
@@ -268,11 +268,13 @@ public class SiteNavBar extends WebDriverComponent<SiteNavBar.Elements>
         public void impersonate(String fakeUser)
         {
             ImpersonateUserWindow window;
-            try {
+            try
+            {
                 clickSubMenu(false, "Impersonate", "User");
                 window = new ImpersonateUserWindow(getDriver());
                 window.getComponentElement().isDisplayed(); // force it to resolve
-            }catch (NoSuchElementException notfound)
+            }
+            catch (NoSuchElementException notfound)
             {
                 clickSubMenu(false, "Impersonate", "User");
                 window = new ImpersonateUserWindow(getDriver());
@@ -291,11 +293,13 @@ public class SiteNavBar extends WebDriverComponent<SiteNavBar.Elements>
         public void impersonateRoles(String oneRole, String... roles)
         {
             ImpersonateRoleWindow window;
-            try {
+            try
+            {
                 clickSubMenu(false, "Impersonate", "Roles");
                 window = new ImpersonateRoleWindow(getDriver());
                 window.getComponentElement().isDisplayed(); // force it to find/resolve
-            } catch (NoSuchElementException notFound)
+            }
+            catch (NoSuchElementException notFound)
             {
                 clickSubMenu(false, "Impersonate", "Roles");
                 window = new ImpersonateRoleWindow(getDriver());
@@ -310,11 +314,13 @@ public class SiteNavBar extends WebDriverComponent<SiteNavBar.Elements>
         {
             ImpersonateGroupWindow window;
 
-            try{
+            try
+            {
                 clickSubMenu(false, "Impersonate", "Group");
                 window = new ImpersonateGroupWindow(getDriver());
                 window.getComponentElement().isDisplayed(); // force it to resolve
-            }catch (NoSuchElementException retry)
+            }
+            catch (NoSuchElementException retry)
             {
                 clickSubMenu(false, "Impersonate", "Group");
                 window = new ImpersonateGroupWindow(getDriver());

--- a/src/org/labkey/test/util/URLBuilder.java
+++ b/src/org/labkey/test/util/URLBuilder.java
@@ -107,6 +107,7 @@ public class URLBuilder
             if (!_containerPath.startsWith("/"))
                 url.append("/");
             url.append(URIUtil.encodePath(_containerPath)
+                    .replace("+", "%2B")
                     .replace("[", "%5B")
                     .replace("]", "%5D"));
         }


### PR DESCRIPTION
#815 broke ReturnURLString.getActionURL for URLs containing a '+' in the path part.  Originally, the raw returnUrl string was used to create the ActionURL, but my change to use the parsed URLHelper to construct the ActionURL revealed that URLHelper and ActionURL were inconsistent in how the URL string was decoded.

Fixes LabModulesTest