### PR TITLE
enables regression coverage for issue 38341

### DIFF
--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -587,7 +587,6 @@ public class DomainDesignerTest extends BaseWebDriverTest
      * @throws Exception
      */
     @Test
-    @Ignore("ignore this test until issue 38341 is resolved")
     public void showHideFieldOnDefaultGridView() throws Exception
     {
         String sampleSet = "showFieldOnDefaultGridViewSampleSet";


### PR DESCRIPTION
Found the issue when writing automation; the test method for regressing it has been marked @Ignore since it was checked in
This just removes the @Ignore annotation

(side note: this fix is also in 20.3)