### PR TITLE
Standardize duration strings logged by tests

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -734,7 +734,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                 Long elapsed = System.currentTimeMillis() - testStartTimeStamp;
 
                 TestLogger.resetLogger();
-                TestLogger.log("\\\\ Test Case Complete - " + description.getMethodName() + " [" + getElapsedString(elapsed) + "] //");
+                TestLogger.log("\\\\ Test Case Complete - " + description.getMethodName() + TestLogger.formatElapsedTime(elapsed) + " //");
             }
 
             @Override
@@ -743,7 +743,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                 Long elapsed = System.currentTimeMillis() - testStartTimeStamp;
 
                 TestLogger.resetLogger();
-                TestLogger.log("\\\\ Failed Test Case - " + description.getMethodName() + " [" + getElapsedString(elapsed) + "] //");
+                TestLogger.log("\\\\ Failed Test Case - " + description.getMethodName() + TestLogger.formatElapsedTime(elapsed) + " //");
             }
 
             @Override
@@ -756,15 +756,6 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                     TestLogger.increaseIndent();
                 }
 
-            }
-
-            private String getElapsedString(long elapsed)
-            {
-                return String.format("%dm %d.%ds",
-                        TimeUnit.MILLISECONDS.toMinutes(elapsed),
-                        TimeUnit.MILLISECONDS.toSeconds(elapsed) -
-                                TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(elapsed)),
-                        elapsed - TimeUnit.SECONDS.toMillis(TimeUnit.MILLISECONDS.toSeconds(elapsed)));
             }
         };
 

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1028,7 +1028,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
             final String fullURL = WebTestHelper.getBaseURL() + relativeURL;
 
             long elapsedTime = doAndWaitForPageToLoad(() -> getDriver().navigate().to(fullURL), millis);
-            logMessage += " [" + elapsedTime + " ms]";
+            logMessage += TestLogger.formatElapsedTime(elapsedTime);
 
 
             return elapsedTime;
@@ -1046,7 +1046,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
         {
 
             long elapsedTime = doAndWaitForPageToLoad(() -> getDriver().navigate().to(url), milliseconds);
-            logMessage += " [" + elapsedTime + " ms]";
+            logMessage += TestLogger.formatElapsedTime(elapsedTime);
 
             return elapsedTime;
         }
@@ -2020,7 +2020,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
     {
         if (!waitFor(checker, wait))
         {
-            throw new TimeoutException(failMessage + " [" + wait + "ms]");
+            throw new TimeoutException(failMessage + TestLogger.formatElapsedTime(wait));
         }
     }
 
@@ -2283,7 +2283,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
     public void waitForTextToDisappear(final String text, int wait)
     {
-        String failMessage = "Text: " + text + " was still present after [" + wait + "ms]";
+        String failMessage = "Text: " + text + " was still present after [" + wait + " ms]";
         waitFor(() -> !isTextPresent(text), failMessage, wait);
     }
 

--- a/src/org/labkey/test/aspects/ImpersonationLoggingAspect.java
+++ b/src/org/labkey/test/aspects/ImpersonationLoggingAspect.java
@@ -21,8 +21,6 @@ import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.annotation.Pointcut;
 import org.labkey.test.util.TestLogger;
 
-import java.util.concurrent.TimeUnit;
-
 @Aspect
 public class ImpersonationLoggingAspect
 {
@@ -48,7 +46,7 @@ public class ImpersonationLoggingAspect
         else
         {
             TestLogger.decreaseIndent();
-            TestLogger.log("><Switch Impersonation : " + _impersonating + " [" + getElapsedString(_startTime) + "] -> " + impersonating);
+            TestLogger.log("><Switch Impersonation : " + _impersonating + TestLogger.formatElapsedTime(System.currentTimeMillis() - _startTime) + " -> " + impersonating);
             TestLogger.increaseIndent();
 
             _impersonating = impersonating;
@@ -61,21 +59,12 @@ public class ImpersonationLoggingAspect
     {
         String impersonating = _impersonating;
 
-        String elapsedStr = getElapsedString(_startTime);
+        String elapsedStr = TestLogger.formatElapsedTime(System.currentTimeMillis() - _startTime);
 
         TestLogger.decreaseIndent();
-        TestLogger.log("<<Stop Impersonating - " + impersonating + " [" + elapsedStr + "]");
+        TestLogger.log("<<Stop Impersonating - " + impersonating + elapsedStr);
 
         _impersonating = null;
     }
 
-    private String getElapsedString(Long startTime)
-    {
-        Long elapsed = System.currentTimeMillis() - startTime;
-        return String.format("%dm %d.%ds",
-                TimeUnit.MILLISECONDS.toMinutes(elapsed),
-                TimeUnit.MILLISECONDS.toSeconds(elapsed) -
-                        TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(elapsed)),
-                elapsed - TimeUnit.SECONDS.toMillis(TimeUnit.MILLISECONDS.toSeconds(elapsed)));
-    }
 }

--- a/src/org/labkey/test/aspects/MethodLoggingAspect.java
+++ b/src/org/labkey/test/aspects/MethodLoggingAspect.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Stack;
-import java.util.concurrent.TimeUnit;
 
 @Aspect
 public class MethodLoggingAspect
@@ -119,25 +118,9 @@ public class MethodLoggingAspect
 
         if (!method.equals(caller)) // Don't double-log overloaded methods
         {
-            long minutesPart = TimeUnit.MILLISECONDS.toMinutes(elapsed);
-            long secondsPart = TimeUnit.MILLISECONDS.toSeconds(elapsed) -
-                    TimeUnit.MINUTES.toSeconds(minutesPart);
-            long millisecondsPart = elapsed - TimeUnit.SECONDS.toMillis(TimeUnit.MILLISECONDS.toSeconds(elapsed));
-            StringBuilder elapsedStr = new StringBuilder();
-            if (minutesPart > 0)
-            {
-                elapsedStr.append(minutesPart).append("m ");
-            }
-            elapsedStr.append(secondsPart);
-            if (minutesPart == 0)
-            {
-                String millisecondsStr = String.valueOf(millisecondsPart);
-                String padding = StringUtils.repeat("0", 3 - millisecondsStr.length());
-                elapsedStr.append(".").append(padding).append(millisecondsPart);
-            }
-            elapsedStr.append("s");
+            String elapsedStr = TestLogger.formatElapsedTime(elapsed);
             TestLogger.decreaseIndent();
-            TestLogger.log(logPrefix + method + argString + " <" + elapsedStr + ">"); // Only log on successful return
+            TestLogger.log(logPrefix + method + argString + " " + elapsedStr); // Only log on successful return
         }
     }
 

--- a/src/org/labkey/test/tests/JUnitTest.java
+++ b/src/org/labkey/test/tests/JUnitTest.java
@@ -44,6 +44,7 @@ import org.labkey.test.categories.UnitTests;
 import org.labkey.test.util.JUnitFooter;
 import org.labkey.test.util.JUnitHeader;
 import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.TestLogger;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -372,7 +373,7 @@ public class JUnitTest extends TestSuite
 
         private String getLogTestString(String message, long startTime)
         {
-            return "remote junit " + message + ": " + _remoteClass + " [" + commaf0.format(System.currentTimeMillis() - startTime) + " ms]";
+            return "remote junit " + message + ": " + _remoteClass + TestLogger.formatElapsedTime(System.currentTimeMillis() - startTime);
         }
 
         static String dump(String response, boolean dumpFailures)

--- a/src/org/labkey/test/util/TestLogger.java
+++ b/src/org/labkey/test/util/TestLogger.java
@@ -16,11 +16,13 @@
 package org.labkey.test.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.test.TestProperties;
 
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 public class TestLogger
 {
@@ -102,5 +104,49 @@ public class TestLogger
     {
         String d = new SimpleDateFormat("HH:mm:ss,SSS").format(new Date()); // Include time with log entry.  Use format that matches labkey log.
         out.println(d + " " + getIndentString() + str);
+    }
+
+    /**
+     * Format an elapsed time to be suitable for log messages.
+     * Over one minute:
+     *  " &lt;1m 25s&gt;"
+     * Over one minute:
+     *  " &lt;8.059s&gt;"
+     * Less than on second:
+     *  " &lt;125ms&gt;"
+     * @param milliseconds Elapsed time in milliseconds
+     * @return Formatted time
+     */
+    @NotNull
+    public static String formatElapsedTime(long milliseconds)
+    {
+        long minutesPart = TimeUnit.MILLISECONDS.toMinutes(milliseconds);
+        long secondsPart = TimeUnit.MILLISECONDS.toSeconds(milliseconds) -
+                TimeUnit.MINUTES.toSeconds(minutesPart);
+        long millisecondsPart = milliseconds - TimeUnit.SECONDS.toMillis(TimeUnit.MILLISECONDS.toSeconds(milliseconds));
+
+        StringBuilder elapsedStr = new StringBuilder(" <");
+        if (minutesPart == 0 && secondsPart == 0) // milliseconds only
+        {
+            elapsedStr.append(millisecondsPart);
+            elapsedStr.append("ms");
+        }
+        else
+        {
+            if (minutesPart > 0)
+            {
+                elapsedStr.append(minutesPart).append("m ");
+            }
+            elapsedStr.append(secondsPart);
+            if (minutesPart == 0)
+            {
+                String millisecondsStr = String.valueOf(millisecondsPart);
+                String padding = StringUtils.repeat("0", 3 - millisecondsStr.length());
+                elapsedStr.append(".").append(padding).append(millisecondsPart);
+            }
+            elapsedStr.append("s");
+        }
+        elapsedStr.append(">");
+        return elapsedStr.toString();
     }
 }


### PR DESCRIPTION
Avoid messages that appear to be ANSI format sequences ("[5m")

This will fix cases where TeamCity trims out the time from timeout messages:
e.g.: `org.openqa.selenium.TimeoutException: Test did not finish!s]`
That "`s]`" should be something like "`[10000ms]`"