### PR TITLE
Item 7002: Automated test fixes related to shared component domain designer refactors for shared code

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -337,15 +337,13 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         elementCache().setCharCountRadio.set(true);
         getWrapper().waitFor(() -> !isCharCountDisabled(),
                 "character count input did not become enabled in time", 1000);
-        getWrapper().setFormElementJS(elementCache().charScaleInput, strCharCount);
-        elementCache().charScaleInput.sendKeys(Keys.TAB);
-        WebDriverWrapper.sleep(1000); // ugh;
+        elementCache().charScaleInput.setValue(strCharCount);
         return this;
     }
 
     public boolean isCharCountDisabled()
     {
-        return elementCache().charScaleInput.getAttribute("disabled") != null;
+        return elementCache().charScaleInput.getComponentElement().getAttribute("disabled") != null;
     }
 
     public boolean isCustomCharSelected()
@@ -357,7 +355,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
     public Integer getCustomCharCount()
     {
         expand();
-        return Integer.parseInt(getWrapper().getFormElement(elementCache().charScaleInput));
+        return Integer.parseInt(elementCache().charScaleInput.getValue());
     }
 
     public boolean isMaxTextLengthPresent(int rowIndex)
@@ -745,8 +743,8 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
                 .refindWhenNeeded(this));
         public RadioButton setCharCountRadio = new RadioButton(Locator.tagWithAttributeContaining("input", "id", "domainpropertiesrow-customLength-")
                 .refindWhenNeeded(this));
-        public WebElement charScaleInput = Locator.tagWithAttributeContaining("input", "id", "domainpropertiesrow-scale")
-                .refindWhenNeeded(this);
+        public Input charScaleInput = new Input(Locator.tagWithAttributeContaining("input", "id", "domainpropertiesrow-scale")
+                .refindWhenNeeded(this), getDriver());
 
         public Locator.XPathLocator getCharScaleInputLocForRow(int rowIndex)
         {

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -249,7 +249,7 @@ public class DomainFormPanel extends WebDriverComponent<DomainFormPanel.ElementC
     public WebElement getPanelAlertWebElement()
     {
         getWrapper().waitFor(()-> BootstrapLocators.infoBanner.existsIn(getDriver()),
-                "the error alert did not appear as expected", 1000);
+                "the info alert did not appear as expected", 1000);
 
         // It would be better to not return a raw WebElement but who knows what the future holds, different alerts
         // may show different controls.

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -215,6 +215,21 @@ public class DomainFormPanel extends WebDriverComponent<DomainFormPanel.ElementC
         return hasPanelTitle() ? elementCache().panelTitle.getText() : null;
     }
 
+    public String getPanelErrorText()
+    {
+        return getPanelErrorWebElement().getText();
+    }
+
+    public WebElement getPanelErrorWebElement()
+    {
+        getWrapper().waitFor(()-> BootstrapLocators.errorBanner.existsIn(getDriver()),
+                "the error alert did not appear as expected", 1000);
+
+        // It would be better to not return a raw WebElement but who knows what the future holds, different alerts
+        // may show different controls.
+        return BootstrapLocators.errorBanner.existsIn(getDriver()) ? BootstrapLocators.errorBanner.findElement(getDriver()) : null;
+    }
+
     /**
      * Get the alert message that is shown only in the alert panel. An example of this is the Results Field in
      * Sample Manager requires a field that is a sample look-up, if it missing an alert is shown.
@@ -233,12 +248,12 @@ public class DomainFormPanel extends WebDriverComponent<DomainFormPanel.ElementC
      */
     public WebElement getPanelAlertWebElement()
     {
-        getWrapper().waitFor(()-> BootstrapLocators.errorBanner.existsIn(getDriver()),
+        getWrapper().waitFor(()-> BootstrapLocators.infoBanner.existsIn(getDriver()),
                 "the error alert did not appear as expected", 1000);
 
         // It would be better to not return a raw WebElement but who knows what the future holds, different alerts
         // may show different controls.
-        return BootstrapLocators.errorBanner.existsIn(getDriver()) ? BootstrapLocators.errorBanner.findElement(getDriver()) : null;
+        return BootstrapLocators.infoBanner.existsIn(getDriver()) ? BootstrapLocators.infoBanner.findElement(getDriver()) : null;
     }
 
     @Override

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -1,6 +1,7 @@
 package org.labkey.test.components.domain;
 
 import org.apache.commons.lang3.StringUtils;
+import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.WebDriverComponent;
@@ -69,10 +70,7 @@ public class DomainFormPanel extends WebDriverComponent<DomainFormPanel.ElementC
         if (fieldDefinition.getFormat() != null)
             fieldRow.setNumberFormat(fieldDefinition.getFormat());
         if (fieldDefinition.getScale() != null)
-            if (fieldDefinition.getScale() <= 4000)
-                fieldRow.setCharCount(fieldDefinition.getScale());
-            else
-                fieldRow.allowMaxChar();
+            fieldRow.setCharCount(fieldDefinition.getScale());
         if (fieldDefinition.getURL() != null)
             fieldRow.setUrl(fieldDefinition.getURL());
         if (fieldDefinition.getMvEnabled())
@@ -225,10 +223,7 @@ public class DomainFormPanel extends WebDriverComponent<DomainFormPanel.ElementC
      */
     public String getPanelAlertText()
     {
-        if(elementCache().panelAlertText.isDisplayed())
-            return elementCache().panelAlertText.getText();
-        else
-            return "";
+        return getPanelAlertWebElement().getText();
     }
 
     /**
@@ -238,12 +233,12 @@ public class DomainFormPanel extends WebDriverComponent<DomainFormPanel.ElementC
      */
     public WebElement getPanelAlertWebElement()
     {
+        getWrapper().waitFor(()-> BootstrapLocators.errorBanner.existsIn(getDriver()),
+                "the error alert did not appear as expected", 1000);
+
         // It would be better to not return a raw WebElement but who knows what the future holds, different alerts
         // may show different controls.
-        if(elementCache().panelAlertText.isDisplayed())
-            return elementCache().panelAlert;
-        else
-            return null;
+        return BootstrapLocators.errorBanner.existsIn(getDriver()) ? BootstrapLocators.errorBanner.findElement(getDriver()) : null;
     }
 
     @Override
@@ -326,8 +321,6 @@ public class DomainFormPanel extends WebDriverComponent<DomainFormPanel.ElementC
         WebElement expandToggle = Locator.tagWithClass("svg", "domain-form-expand-btn").findWhenNeeded(DomainFormPanel.this);
         Locator.XPathLocator panelTitleLoc = Locator.tagWithClass("span", "domain-panel-title");
         WebElement panelTitle = panelTitleLoc.findWhenNeeded(DomainFormPanel.this);
-        WebElement panelAlert = Locator.css("div.alert-info").findWhenNeeded(DomainFormPanel.this);
-        WebElement panelAlertText = Locator.css("div.alert-info > div > div").findWhenNeeded(DomainFormPanel.this);
         WebElement panelBody = Locator.byClass("panel-body").findWhenNeeded(this);
     }
 

--- a/src/org/labkey/test/components/labkey/ui/samples/SampleTypeDesigner.java
+++ b/src/org/labkey/test/components/labkey/ui/samples/SampleTypeDesigner.java
@@ -27,11 +27,18 @@ public class SampleTypeDesigner extends WebDriverComponent<SampleTypeDesigner.El
 
     private final WebElement _el;
     private final WebDriver _driver;
+    private boolean _useFinishButton;
 
     public SampleTypeDesigner(WebDriver driver)
     {
         _driver = driver;
         _el = Locator.id("app").findElement(_driver); // Full page component
+    }
+
+    public SampleTypeDesigner(WebDriver driver, boolean useFinishButton)
+    {
+        this(driver);
+        _useFinishButton = useFinishButton;
     }
 
     @Override
@@ -85,17 +92,17 @@ public class SampleTypeDesigner extends WebDriverComponent<SampleTypeDesigner.El
 
     public boolean isSaveButtonEnabled()
     {
-        return elementCache().saveButton.isEnabled();
+        return elementCache().getSaveButton().isEnabled();
     }
 
     public void clickSave()
     {
-        elementCache().saveButton.click();
+        elementCache().getSaveButton().click();
     }
 
     public List<WebElement> clickSaveExpectingError()
     {
-        elementCache().saveButton.click();
+        elementCache().getSaveButton().click();
         return BootstrapLocators.errorBanner.waitForElements(getWrapper().shortWait());
     }
 
@@ -207,6 +214,14 @@ public class SampleTypeDesigner extends WebDriverComponent<SampleTypeDesigner.El
 
         protected final WebElement cancelButton = Locator.button("Cancel").findWhenNeeded(this);
         protected final WebElement saveButton = Locator.button("Save").findWhenNeeded(this);
+
+        // the SM app uses alternate text for the sample type designer save buttons
+        protected final WebElement finishButton = Locator.buttonContainingText("Finish").findWhenNeeded(this);
+
+        protected WebElement getSaveButton()
+        {
+            return _useFinishButton ? finishButton : saveButton;
+        }
 
         protected List<Input> parentAliases()
         {

--- a/src/org/labkey/test/components/labkey/ui/samples/SampleTypeDesigner.java
+++ b/src/org/labkey/test/components/labkey/ui/samples/SampleTypeDesigner.java
@@ -196,12 +196,18 @@ public class SampleTypeDesigner extends WebDriverComponent<SampleTypeDesigner.El
         return elementCache().parentAliasSelect(index).getSelections().get(0);
     }
 
+    public void expandPropertiesPanel()
+    {
+        elementCache().propertiesPanelHeader.click();
+    }
+
     protected class ElementCache extends Component<?>.ElementCache
     {
         protected final Input nameInput = Input.Input(Locator.id("entity-name"), getDriver()).findWhenNeeded(this);
         protected final Input nameExpressionInput = Input.Input(Locator.id("entity-nameExpression"), getDriver()).waitFor(this);
         protected final Input descriptionInput = Input.Input(Locator.id("entity-description"), getDriver()).findWhenNeeded(this);
         protected final WebElement addAliasButton = Locator.tagWithClass("i","container--addition-icon").findWhenNeeded(this);
+        protected final WebElement propertiesPanelHeader = Locator.id("sample-type-properties-hdr").findWhenNeeded(this);
 
         protected final DomainFormPanel _fieldEditorPanel = new DomainFormPanel.DomainFormPanelFinder(getDriver()).index(1).timeout(1000).findWhenNeeded(this);
 

--- a/src/org/labkey/test/components/labkey/ui/samples/SampleTypeDesigner.java
+++ b/src/org/labkey/test/components/labkey/ui/samples/SampleTypeDesigner.java
@@ -9,6 +9,7 @@ import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.glassLibrary.components.ReactSelect;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.params.FieldDefinition;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -27,18 +28,11 @@ public class SampleTypeDesigner extends WebDriverComponent<SampleTypeDesigner.El
 
     private final WebElement _el;
     private final WebDriver _driver;
-    private boolean _useFinishButton;
 
     public SampleTypeDesigner(WebDriver driver)
     {
         _driver = driver;
         _el = Locator.id("app").findElement(_driver); // Full page component
-    }
-
-    public SampleTypeDesigner(WebDriver driver, boolean useFinishButton)
-    {
-        this(driver);
-        _useFinishButton = useFinishButton;
     }
 
     @Override
@@ -220,7 +214,17 @@ public class SampleTypeDesigner extends WebDriverComponent<SampleTypeDesigner.El
 
         protected WebElement getSaveButton()
         {
-            return _useFinishButton ? finishButton : saveButton;
+            try
+            {
+                if (finishButton.isDisplayed())
+                    return finishButton;
+            }
+            catch (NoSuchElementException nse)
+            {
+                // noop, just use the save button element
+            }
+
+            return saveButton;
         }
 
         protected List<Input> parentAliases()

--- a/src/org/labkey/test/components/labkey/ui/samples/SampleTypeDesigner.java
+++ b/src/org/labkey/test/components/labkey/ui/samples/SampleTypeDesigner.java
@@ -9,7 +9,6 @@ import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.glassLibrary.components.ReactSelect;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.params.FieldDefinition;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -86,17 +85,17 @@ public class SampleTypeDesigner extends WebDriverComponent<SampleTypeDesigner.El
 
     public boolean isSaveButtonEnabled()
     {
-        return elementCache().getSaveButton().isEnabled();
+        return elementCache().saveButton.isEnabled();
     }
 
     public void clickSave()
     {
-        elementCache().getSaveButton().click();
+        elementCache().saveButton.click();
     }
 
     public List<WebElement> clickSaveExpectingError()
     {
-        elementCache().getSaveButton().click();
+        elementCache().saveButton.click();
         return BootstrapLocators.errorBanner.waitForElements(getWrapper().shortWait());
     }
 
@@ -207,25 +206,9 @@ public class SampleTypeDesigner extends WebDriverComponent<SampleTypeDesigner.El
         protected final DomainFormPanel _fieldEditorPanel = new DomainFormPanel.DomainFormPanelFinder(getDriver()).index(1).timeout(1000).findWhenNeeded(this);
 
         protected final WebElement cancelButton = Locator.button("Cancel").findWhenNeeded(this);
-        protected final WebElement saveButton = Locator.button("Save").findWhenNeeded(this);
 
         // the SM app uses alternate text for the sample type designer save buttons
-        protected final WebElement finishButton = Locator.buttonContainingText("Finish").findWhenNeeded(this);
-
-        protected WebElement getSaveButton()
-        {
-            try
-            {
-                if (finishButton.isDisplayed())
-                    return finishButton;
-            }
-            catch (NoSuchElementException nse)
-            {
-                // noop, just use the save button element
-            }
-
-            return saveButton;
-        }
+        protected final WebElement saveButton = Locator.XPathLocator.union(Locator.button("Save"), Locator.buttonContainingText("Finish")).findWhenNeeded(this);
 
         protected List<Input> parentAliases()
         {

--- a/src/org/labkey/test/pages/experiment/CreateSampleSetPage.java
+++ b/src/org/labkey/test/pages/experiment/CreateSampleSetPage.java
@@ -117,6 +117,12 @@ public class CreateSampleSetPage extends LabKeyPage<CreateSampleSetPage.ElementC
         return elementCache()._designer.getDomainEditor();
     }
 
+    public CreateSampleSetPage expandPropertiesPanel()
+    {
+        elementCache()._designer.expandPropertiesPanel();
+        return this;
+    }
+
     public void clickSave()
     {
         doAndWaitForPageToLoad(() -> elementCache()._designer.clickSave());

--- a/src/org/labkey/test/tests/SampleSetTest.java
+++ b/src/org/labkey/test/tests/SampleSetTest.java
@@ -41,8 +41,10 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.DailyC;
 import org.labkey.test.components.CustomizeView;
+import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.pages.ReactAssayDesignerPage;
+import org.labkey.test.pages.experiment.CreateSampleSetPage;
 import org.labkey.test.pages.experiment.UpdateSampleSetPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
@@ -1996,6 +1998,46 @@ public class SampleSetTest extends BaseWebDriverTest
         clickProject(PROJECT_NAME);
         assertElementPresent(Locator.linkWithText(CASE_INSENSITIVE_SAMPLE_SET));
         assertElementNotPresent(Locator.linkWithText(LOWER_CASE_SAMPLE_SET));
+    }
+
+    @Test
+    public void testReservedFieldNames()
+    {
+        SampleSetHelper sampleHelper = new SampleSetHelper(this);
+
+        clickProject(PROJECT_NAME);
+        CreateSampleSetPage creaetePage = sampleHelper
+            .goToCreateNewSampleSet()
+            .setName("ReservedFieldNameValidation");
+
+        DomainFormPanel domainFormPanel = creaetePage.getDomainEditor();
+
+        log("Verify error message for reserved field names");
+        domainFormPanel.addField("created");
+        assertEquals("Sample Type reserved field name error", Arrays.asList(
+                "Property name 'created' is a reserved name."),
+                getTexts(creaetePage.clickSaveExpectingError()));
+        domainFormPanel.removeAllFields(false);
+        domainFormPanel.addField("rowid");
+        assertEquals("Sample Type reserved field name error", Arrays.asList(
+                "Property name 'rowid' is a reserved name."),
+                getTexts(creaetePage.clickSaveExpectingError()));
+        domainFormPanel.removeAllFields(false);
+
+        log("Verify error message for a few other special field names");
+        domainFormPanel.addField("name");
+        assertEquals("Sample Type 'name' field name error", Arrays.asList(
+                "The field name 'Name' is already taken. Please provide a unique name for each field.",
+                "Please correct errors in Fields before saving."),
+                getTexts(creaetePage.clickSaveExpectingError()));
+        domainFormPanel.removeAllFields(false);
+
+        log("Verify error message for a few other special field names");
+        domainFormPanel.addField("sampleid");
+        assertEquals("Sample Type SampleId field name error", Arrays.asList(
+                "The SampleId field name is reserved for imported or generated sample ids."),
+                getTexts(creaetePage.clickSaveExpectingError()));
+        domainFormPanel.removeAllFields(false);
     }
 
     @Test

--- a/src/org/labkey/test/tests/list/ColumnResizeTest.java
+++ b/src/org/labkey/test/tests/list/ColumnResizeTest.java
@@ -123,7 +123,6 @@ public class ColumnResizeTest extends BaseWebDriverTest
      * Uses: Lists and the List Designer
      */
     @Test
-    @Ignore // remove when resolved: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39938
     public void testColumnResizing()
     {
         setUpList(LIST_NAME);
@@ -133,7 +132,7 @@ public class ColumnResizeTest extends BaseWebDriverTest
 
         log("Validate Scale: Existing fields");
         // Issue 39877: max text length options should not be visible for text key field of list
-        //assertWidgetNotVisible(fieldsPanel, KEY_ROW);    //Check scale widget is not available for key
+        assertMaxTextLengthNotVisible(fieldsPanel, KEY_ROW);    //Check scale widget is not available for key
 
         //Check unhidden
         assertMaxChecked(fieldsPanel, MAX_ROW);  //Check max checked for field set to max
@@ -143,7 +142,7 @@ public class ColumnResizeTest extends BaseWebDriverTest
         assertMaxNotChecked(fieldsPanel, MULTI_ROW);
 
         //Check hiding
-        assertWidgetNotVisible(fieldsPanel, NUMBER_ROW); //Check widget is not available for number
+        assertMaxTextLengthNotVisible(fieldsPanel, NUMBER_ROW); //Check widget is not available for number
 
         //Check value is as expected for field
         assertScaleEquals(fieldsPanel, LT_ROW, LT_SCALE);    //Check arbitrary scale can be set
@@ -180,7 +179,6 @@ public class ColumnResizeTest extends BaseWebDriverTest
      * Uses: Lists and the List Designer
      */
     @Test
-    @Ignore // remove when resolved: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39938
     public void testResizeColumnWithData()
     {
         //Create List
@@ -242,7 +240,7 @@ public class ColumnResizeTest extends BaseWebDriverTest
         assertEquals(String.format("Scale for row [%d] is actually [%d] vs expected [%d]", rowIndex, scale, expected), expected, scale);
     }
 
-    private void assertWidgetNotVisible(DomainFormPanel fieldsPanel, int rowIndex)
+    private void assertMaxTextLengthNotVisible(DomainFormPanel fieldsPanel, int rowIndex)
     {
         DomainFieldRow fieldRow = fieldsPanel.getField(rowIndex).expand();
         assertFalse("Max text length options should not be visible for field " + rowIndex, fieldRow.isMaxTextLengthPresent(rowIndex));

--- a/src/org/labkey/test/tests/list/ColumnResizeTest.java
+++ b/src/org/labkey/test/tests/list/ColumnResizeTest.java
@@ -204,7 +204,7 @@ public class ColumnResizeTest extends BaseWebDriverTest
         changeScale(fieldsPanel, MAX_ROW, LT_SCALE, false);
         listDefinitionPage.clickSaveExpectingError();
         String expectedErrorTxt ="The property \"" + MAX_COLUMN_NAME + "\" cannot be scaled down. It contains existing values exceeding [" + LT_SCALE + "] characters.";
-        assertEquals(expectedErrorTxt, fieldsPanel.getPanelAlertText());
+        assertEquals(expectedErrorTxt, fieldsPanel.getPanelErrorText());
         checkExpectedErrors(0);  // Shouldn't log any SQLExceptions - product should detect inability to scale and not issue an alter query
 
         //Cancel changes


### PR DESCRIPTION
#### Rationale
Changes were made in the shared components package to consolidate shared pieces of the various domain designer components. Those changes were pulled into platform and SM with the related PRs and these test fixes were needed as a result.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/195
* https://github.com/LabKey/platform/pull/997
* https://github.com/LabKey/sampleManagement/pull/218

#### Changes
* Issue 39938: Fix for domain designer text option handling of the "max text length" input and radio options
* Re-enable the test cases in ColumnResizeTest (related to fix for 38838)
* Add SampleSetTest test case for verifying error messages for reserved field check on create sample set
* Update SampleSetParentColumnTest test case for parent alias validation against domain fields to check on both create and update of sample set