### PR TITLE
Item 7102: Add RlabkeyTest cases for some of the changes in Rlabkey v2.4.0

### DIFF
--- a/data/api/rlabkey-api-list.xml
+++ b/data/api/rlabkey-api-list.xml
@@ -5,7 +5,9 @@
                 library(Rlabkey)
                 df <- data.frame(intKey=c(1:3), customInt=c(1:3), customString=c("aaa", "bbb", "ccc"))
                 fields <- labkey.domain.inferFields(baseUrl="%baseUrl%", folderPath="%projectName%", df)
-                dd <- labkey.domain.createDesign(name="test list", fields=fields)
+                indices = labkey.domain.createIndices(list("intKey", "customInt"), TRUE)
+                indices = labkey.domain.createIndices(list("customInt"), FALSE, indices)
+                dd <- labkey.domain.createDesign(name="test list", fields=fields, indices=indices)
                 labkey.domain.create(baseUrl="%baseUrl%", folderPath="%projectName%", domainKind="IntList", domainDesign=dd, options=list(keyName = "intKey"))
             ]]>
         </url>

--- a/data/api/rlabkey-api-security.xml
+++ b/data/api/rlabkey-api-security.xml
@@ -1,0 +1,65 @@
+<ApiTests xmlns="http://labkey.org/query/xml">
+    <test name="create containers" type="post">
+        <url>
+            <![CDATA[
+                library(Rlabkey)
+                labkey.security.createContainer(baseUrl="%baseUrl%", parentPath="%projectName%", name = "FromAPI1", title = "From API 1", folderType = "Collaboration")
+                labkey.security.createContainer(baseUrl="%baseUrl%", parentPath="%projectName%", name = "FromAPI2", title = "From API 2", folderType = "Collaboration")
+                labkey.security.createContainer(baseUrl="%baseUrl%", parentPath="%projectName%", name = "FromAPI3", title = "From API 3", folderType = "Collaboration")
+            ]]>
+        </url>
+        <response>
+            <![CDATA[
+                name
+                [1] "FromAPI1"
+                $path
+                [1] "/RlabkeyTest Project/FromAPI1"
+                $title
+                [1] "From API 1"
+                name
+                [1] "FromAPI2"
+                $path
+                [1] "/RlabkeyTest Project/FromAPI2"
+                $title
+                [1] "From API 2"
+                name
+                [1] "FromAPI3"
+                $path
+                [1] "/RlabkeyTest Project/FromAPI3"
+                $title
+                [1] "From API 3"
+                $folderType
+                [1] "Collaboration"
+             ]]>
+        </response>
+    </test>
+    <test name="move container" type="post">
+        <url>
+            <![CDATA[
+                library(Rlabkey)
+                labkey.security.moveContainer(baseUrl="%baseUrl%", folderPath = paste("%projectName%", "FromAPI2", sep="/"), destinationParent = paste("%projectName%", "FromAPI1", sep="/"))
+            ]]>
+        </url>
+        <response>
+            <![CDATA[
+                $newPath
+                [1] "/RlabkeyTest Project/FromAPI1/FromAPI2"
+                $success
+                [1] TRUE
+             ]]>
+        </response>
+    </test>
+    <test name="delete container" type="post">
+        <url>
+            <![CDATA[
+                library(Rlabkey)
+                labkey.security.deleteContainer(baseUrl="%baseUrl%", folderPath = paste("%projectName%", "FromAPI3", sep="/"))
+            ]]>
+        </url>
+        <response>
+            <![CDATA[
+                named list()
+             ]]>
+        </response>
+    </test>
+</ApiTests>

--- a/src/org/labkey/test/tests/RlabkeyTest.java
+++ b/src/org/labkey/test/tests/RlabkeyTest.java
@@ -28,6 +28,7 @@ import org.labkey.test.categories.DailyB;
 import org.labkey.test.pages.issues.AdminPage;
 import org.labkey.test.pages.issues.ListPage;
 import org.labkey.test.pages.study.CreateStudyPage;
+import org.labkey.test.util.APIContainerHelper;
 import org.labkey.test.util.APITestHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.IssuesHelper;
@@ -71,6 +72,7 @@ public class RlabkeyTest extends BaseWebDriverTest
     private static final File RLABKEY_API_QUERY = TestFileUtils.getSampleData("api/rlabkey-api-query.xml");
     private static final File RLABKEY_API_STUDY = TestFileUtils.getSampleData("api/rlabkey-api-study.xml");
     private static final File RLABKEY_API_WEBDAV = TestFileUtils.getSampleData("api/rlabkey-api-webdav.xml");
+    private static final File RLABKEY_API_SECURITY = TestFileUtils.getSampleData("api/rlabkey-api-security.xml");
 
     @BeforeClass
     public static void setupProject()
@@ -185,6 +187,19 @@ public class RlabkeyTest extends BaseWebDriverTest
         createCategoriesViaApi();
 
         doRLabkeyTest(RLABKEY_API_STUDY);
+    }
+
+    @Test
+    public void testRlabkeySecurityApi() throws Exception
+    {
+        doRLabkeyTest(RLABKEY_API_SECURITY);
+
+        // verify the folder creation, move, and deletion from the test
+        APIContainerHelper helper = (APIContainerHelper) _containerHelper;
+        assertTrue("Expected container to exist", helper.doesContainerExist(getProjectName() + "/FromAPI1"));
+        assertTrue("Expected container to exist", helper.doesContainerExist(getProjectName() + "/FromAPI2")); // exists because of alias to old location before move
+        assertTrue("Expected container to exist", helper.doesContainerExist(getProjectName() + "/FromAPI1/FromAPI2")); // exists because of alias to old location before move
+        assertTrue("Expected container not to exist", !helper.doesContainerExist(getProjectName() + "/FromAPI3")); // folder was deleted
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
See related PR, changes were made to the Rlabkey package to support indices during list domain creation and support container create, delete, and move. This PR adds some test coverage for those changes (not exhaustive as it doesn't check various error states for the API calls).

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-r/pull/47

#### Changes
* add indices to a list domain creation, it isn't checked after the fact but verify that it doesn't error out the API call
* add container create, move, delete test case with verification of container path existence after test completion