### PR TITLE
Try to make sure IntelliJ can build tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,12 +32,17 @@ project.dependencies {
     else
     {
         // Use local version outside of TeamCity so as to not confuse IntelliJ
-        implementation(project(BuildUtils.getApiProjectPath(project.gradle))) { transitive = false }
+        BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getApiProjectPath(project.gradle), transitive: false)
     }
 
     // Issue 36184: Tests can't find selenium-ie-driver library when running on Windows on TeamCity
     // Workaround to ensure that the class-loader finds InternetExplorerDriver
     implementation "org.seleniumhq.selenium:selenium-ie-driver:${seleniumVersion}"
+}
+
+if (project.findProject(BuildUtils.getApiProjectPath(project.gradle)) != null)
+{
+    project.evaluationDependsOn(BuildUtils.getApiProjectPath(project.gradle))
 }
 
 BuildUtils.addLabKeyDependency(

--- a/build.gradle
+++ b/build.gradle
@@ -40,11 +40,6 @@ project.dependencies {
     implementation "org.seleniumhq.selenium:selenium-ie-driver:${seleniumVersion}"
 }
 
-if (project.findProject(BuildUtils.getApiProjectPath(project.gradle)) != null)
-{
-    project.evaluationDependsOn(BuildUtils.getApiProjectPath(project.gradle))
-}
-
 BuildUtils.addLabKeyDependency(
         project: project,
         config: 'uiTestImplementation',


### PR DESCRIPTION
@labkey-chrisj was getting compilation errors (unable to locate the schema classes from the api module) when attempting to run tests in IntelliJ. These are two of the the fixes I attempted.
I first added the `evaluationDependsOn` line but that didn't work.
It started working after switching the dependency to use `BuildUtils.addLabKeyDependency` and configuring Gradle in IntelliJ to "[Build and Run using: Gradle](https://www.jetbrains.com/help/idea/gradle-settings.html#)". We were unable to repro the failure after reverting everything.
@labkey-susanh Would you expect build problems without the changes here? I'm suspecting that it was the IntelliJ setting but wanted to be sure I didn't mess up these dependencies.