### PR TITLE
Use labkeyClientApiVersion for dependency declaration

### DIFF
--- a/data/qc/build.gradle
+++ b/data/qc/build.gradle
@@ -4,7 +4,7 @@ import org.labkey.gradle.util.BuildUtils;
 apply plugin: 'java'
 
 dependencies {
-  BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getRemoteApiProjectPath(gradle))
+  BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getRemoteApiProjectPath(gradle), depVersion: project.labkeyClientApiVersion)
 }
 
 sourceSets {


### PR DESCRIPTION
**Rationale**
Moving the Java remoteapi into its own repository and not requiring a build to always have an enlistment in this repository means we will always need to declare the proper version number for the api jar.