### PR TITLE
Issue 40221: Update verbiage in standard database authentication audit log entry

### DIFF
--- a/src/org/labkey/test/tests/AuditLogTest.java
+++ b/src/org/labkey/test/tests/AuditLogTest.java
@@ -279,7 +279,7 @@ public class AuditLogTest extends BaseWebDriverTest
         expectedLogValues.add(getCurrentUser() + " stopped impersonating group: " + adminGroup);
         expectedLogValues.add(getCurrentUser() + " logged out.");
         expectedLogValues.add(AUDIT_TEST_USER + " failed to login: incorrect password");
-        expectedLogValues.add(getCurrentUser() + " logged in successfully via Database authentication.");
+        expectedLogValues.add(getCurrentUser() + " logged in successfully via the \"Standard database authentication\" configuration.");
         expectedLogValues.add(AUDIT_TEST_USER + "fail failed to login: user does not exist");
         expectedLogValues.add(AUDIT_TEST_USER + " was deleted from the system");
 


### PR DESCRIPTION
#### Rationale
Need to update this test to reflect the new "logged in successfully" message that the product sends to the audit log.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1082