### PR TITLE
Another test looking for an old audit message.

### DIFF
--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -941,7 +941,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
         assertElementPresent(Locator.tagWithClass("div", "lk-body-title")
                 .child(Locator.tagWithText("*", "Details")));
         table = new DataRegionTable("query", this);
-        assertEquals("Row was updated.", table.getDataAsText(0, "Comment"));
+        assertEquals("A row was updated.", table.getDataAsText(0, "Comment"));
         assertEquals("A row was inserted.", table.getDataAsText(1, "Comment"));
 
         // click the details link


### PR DESCRIPTION
#### Rationale
Test is failing

#### Changes
* update expected text from audit log to match actual text. (Just like a previous update, but this one was hidden behind that one.)