### PR TITLE
Remove path assumption from WebDavPage

### DIFF
--- a/src/org/labkey/test/pages/files/WebDavPage.java
+++ b/src/org/labkey/test/pages/files/WebDavPage.java
@@ -32,14 +32,9 @@ public class WebDavPage extends LabKeyPage<WebDavPage.ElementCache>
         _fileBrowserHelper = new FileBrowserHelper(driver);
     }
 
-    public static WebDavPage beginAt(WebDriverWrapper driver)
+    public static WebDavPage beginAt(WebDriverWrapper driver, String path)
     {
-        return beginAt(driver, driver.getCurrentContainerPath());
-    }
-
-    public static WebDavPage beginAt(WebDriverWrapper driver, String containerPath)
-    {
-        driver.beginAt(WebTestHelper.getBaseURL() + "/_webdav/" + containerPath + "/@files/");
+        driver.beginAt(WebTestHelper.getBaseURL() + "/_webdav/" + path);
         return new WebDavPage(driver.getDriver());
     }
 


### PR DESCRIPTION
#### Rationale
A [recent platform change](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=40122) made the file root of the root project (`_webdav/@files`) unreachable by WebDav. This broke `WebDavTest.testWebfilesCaching` when it tried to navigate there to verify something unrelated. There's no particular reason for `WebDavPage.beginAt` to force `@files` onto the URL so I removed it. The validation in `WebDavTest` now goes to `_webdav` which still provides the information required by that test.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/1047