### PR TITLE
Make domain designer button panel Locator overridable

### DIFF
--- a/src/org/labkey/test/components/QueryMetadataEditorPage.java
+++ b/src/org/labkey/test/components/QueryMetadataEditorPage.java
@@ -57,18 +57,24 @@ public class QueryMetadataEditorPage extends DomainDesigner<QueryMetadataEditorP
     public class ElementCache extends DomainDesigner.ElementCache
     {
         private final WebElement resetButton = Locator.button("Reset To Default")
-                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+                .findWhenNeeded(buttonPanel).withTimeout(WAIT_FOR_JAVASCRIPT);
         private final WebElement aliasFieldButton = Locator.button("Alias Field")
-                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+                .findWhenNeeded(buttonPanel).withTimeout(WAIT_FOR_JAVASCRIPT);
         private final WebElement viewDataButton = Locator.button("View Data")
-                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+                .findWhenNeeded(buttonPanel).withTimeout(WAIT_FOR_JAVASCRIPT);
         private final WebElement editSourceButton = Locator.button("Edit Source")
-                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+                .findWhenNeeded(buttonPanel).withTimeout(WAIT_FOR_JAVASCRIPT);
 
         @Override
         protected int getFieldPanelIndex()
         {
             return 0;
+        }
+
+        @Override
+        protected Locator.XPathLocator buttonPanelLocator()
+        {
+            return Locator.byClass("query-metadata-editor-buttons");
         }
     }
 }

--- a/src/org/labkey/test/components/domain/BaseDomainDesigner.java
+++ b/src/org/labkey/test/components/domain/BaseDomainDesigner.java
@@ -82,7 +82,13 @@ public abstract class BaseDomainDesigner<EC extends BaseDomainDesigner.ElementCa
 
     public abstract class ElementCache extends Component<EC>.ElementCache
     {
-        public final WebElement cancelButton = Locator.button("Cancel").findWhenNeeded(this);
-        public final WebElement saveButton = Locator.css(".domain-designer-buttons > .pull-right").findWhenNeeded(this);
+        protected final WebElement buttonPanel = buttonPanelLocator().findWhenNeeded(this);
+        public final WebElement cancelButton = Locator.button("Cancel").findWhenNeeded(buttonPanel);
+        public final WebElement saveButton = Locator.byClass("pull-right").findWhenNeeded(buttonPanel);
+
+        protected Locator.XPathLocator buttonPanelLocator()
+        {
+            return Locator.byClass("domain-designer-buttons");
+        }
     }
 }


### PR DESCRIPTION
#### Rationale
The query metadata editor used a different class and styling for its domain designer button bar. This fixes `LinkedSchemaTest` and possibly others.

#### Related Pull Requests
* #311
