### PR TITLE
7066: Invalid Dataset API call update

### DIFF
--- a/src/org/labkey/test/tests/ClientAPITest.java
+++ b/src/org/labkey/test/tests/ClientAPITest.java
@@ -473,7 +473,7 @@ public class ClientAPITest extends BaseWebDriverTest
                 "   options : {\n" +
                 "       keyPropertyName : 'intFieldOne',\n" +
                 "       useTimeKeyField : false,\n" +
-                "       demographics : true\n" +
+                "       demographics : false\n" +
                 "   },\n" +
                 "   success: callback," +
                 "   failure: callback"+


### PR DESCRIPTION
#### Rationale
Creating a dataset that is demographics data and also has a third key column is not valid.

#### Changes
Toggle 'demographics' to false. Since the test isn't testing any demographics or third key behavior, this change shouldn't effect test coverage.
