### PR TITLE
Create package derived module suite subsets

### DIFF
--- a/src/org/labkey/junit/runner/WebTestProperties.java
+++ b/src/org/labkey/junit/runner/WebTestProperties.java
@@ -34,7 +34,7 @@ public abstract class WebTestProperties
     private static ModuleMap associatedModules = new ModuleMap();
     private static final List<String> installedModules = getInstalledModules();
 
-    private static void loadTestProperties(Class testClass)
+    private static void loadTestProperties(Class<?> testClass)
     {
         if (!WebTest.class.isAssignableFrom(testClass))
             return;
@@ -42,7 +42,7 @@ public abstract class WebTestProperties
         try
         {
             WebTest test;
-            Constructor<WebTest> c = testClass.getConstructor();
+            Constructor<WebTest> c = (Constructor<WebTest>) testClass.getConstructor();
             test = c.newInstance();
 
             List<String> modules = test.getAssociatedModules();
@@ -64,7 +64,7 @@ public abstract class WebTestProperties
         }
     }
 
-    public static Collection<String> getAssociatedModules(Class test)
+    public static Collection<String> getAssociatedModules(Class<?> test)
     {
         if (!associatedModules.containsKey(test))
         {
@@ -76,17 +76,17 @@ public abstract class WebTestProperties
     /**
      * This assumes that info for all relevant tests has already been stashed
      */
-    public static Collection<Class> getAssociatedTests(String module)
+    public static Collection<Class<?>> getAssociatedTests(String module)
     {
         return associatedTests.getOrDefault(module, Collections.emptySet());
     }
 
     // A simple MultiMap
-    public static class TestMap extends CaseInsensitiveHashMap<Collection<Class>>
+    public static class TestMap extends CaseInsensitiveHashMap<Collection<Class<?>>>
     {
-        public Collection<Class> put(String key, Class clazz)
+        public Collection<Class<?>> put(String key, Class<?> clazz)
         {
-            Collection<Class> collection = get(key);
+            Collection<Class<?>> collection = get(key);
 
             if (null == collection)
             {
@@ -100,9 +100,9 @@ public abstract class WebTestProperties
     }
 
     // A simple MultiMap
-    public static class ModuleMap extends HashMap<Class, Collection<String>>
+    public static class ModuleMap extends HashMap<Class<?>, Collection<String>>
     {
-        public Collection<String> put(Class key, String module)
+        public Collection<String> put(Class<?> key, String module)
         {
             Collection<String> collection = get(key);
 
@@ -126,6 +126,6 @@ public abstract class WebTestProperties
 
         String[] moduleNames = modulesDir.list((dir, name) -> (new File(dir, name)).isDirectory());
 
-        return Arrays.asList(moduleNames);
+        return moduleNames != null ? Arrays.asList(moduleNames) : Collections.emptyList();
     }
 }

--- a/src/org/labkey/test/TestSet.java
+++ b/src/org/labkey/test/TestSet.java
@@ -28,15 +28,15 @@ import java.util.Set;
 public class TestSet
 {
     private String _suite;
-    private List<Class> _tests;
+    private List<Class<?>> _tests;
 
-    TestSet(@NotNull Set<Class> tests, @NotNull String suite)
+    TestSet(@NotNull Set<Class<?>> tests, @NotNull String suite)
     {
         _tests = new ArrayList<>(tests);
         _suite = suite;
     }
 
-    public TestSet(Set<Class> tests)
+    public TestSet(Set<Class<?>> tests)
     {
         this(tests, "Custom");
     }
@@ -46,7 +46,7 @@ public class TestSet
         this(new HashSet<>());
     }
 
-    void setTests(List<Class> tests)
+    void setTests(List<Class<?>> tests)
     {
         _tests = tests;
     }
@@ -56,9 +56,9 @@ public class TestSet
         addTests(tests.getTestList());
     }
 
-    void addTests(Collection<Class> tests)
+    void addTests(Collection<Class<?>> tests)
     {
-        for (Class test : tests)
+        for (Class<?> test : tests)
         {
             if (!_tests.contains(test))
                 _tests.add(test);
@@ -70,7 +70,7 @@ public class TestSet
         removeTests(tests.getTestList());
     }
 
-    void removeTests(Collection<Class> tests)
+    void removeTests(Collection<Class<?>> tests)
     {
         _tests.removeAll(tests);
     }
@@ -85,7 +85,7 @@ public class TestSet
         return _suite;
     }
 
-    public List<Class> getTestList()
+    public List<Class<?>> getTestList()
     {
         return _tests;
     }
@@ -93,13 +93,13 @@ public class TestSet
     public List<String> getTestNames()
     {
         List<String> testNames = new ArrayList<>();
-        for (Class test : _tests)
+        for (Class<?> test : _tests)
             testNames.add(test.getSimpleName());
         return testNames;
     }
 
     // Move the named test to the Nth position in the list, maintaining the order of all other tests.
-    public boolean prioritizeTest(Class priorityTest, int N)
+    public boolean prioritizeTest(Class<?> priorityTest, int N)
     {
         if (_tests.contains(priorityTest))
         {


### PR DESCRIPTION
Use test packages to define more targeted suites:
Consider the test `org.labkey.test.tests.moduleName.featureArea.subArea.TestClass
Currently, such a test would be added to the following suites:
 - moduleName
 - featureArea
 - subArea
This change would, additionally, create the following suites:
 - moduleName.featureArea
 - moduleName.featureArea.subArea

#### Rationale
We want to trigger subsets of module-specific tests without hard-coding test lists on TeamCity. Sample Manager tests already have a package structure that indicates what product sub-area they cover. This will leverage that pattern to define new suites made up of particular sub-areas.

_Note: this also cleans up numerous IntelliJ warnings._