### PR TITLE
Issue 38592: Rename webapps/Experiment directory to have same casing as resources directory

### DIFF
--- a/src/org/labkey/test/tests/LookupToSampleIDTest.java
+++ b/src/org/labkey/test/tests/LookupToSampleIDTest.java
@@ -212,7 +212,7 @@ public class LookupToSampleIDTest extends BaseWebDriverTest
     {
         clickAndWait(Locator.linkContainingText(assayName));
         clickAndWait(new DataRegionTable("Batches", this).link(0, "Name"));
-        clickAndWait(Locator.tag("img").withAttribute("src", "/labkey/Experiment/images/graphIcon.gif"));
+        clickAndWait(Locator.tag("img").withAttribute("src", "/labkey/experiment/images/graphIcon.gif"));
         clickAndWait(Locator.linkWithText("Text View"));
         clickAndWait(Locator.linkContainingText("123456"));
     }


### PR DESCRIPTION
#### Rationale
Though the renaming of these paths is not strictly necessary it will avoid confusion and make searching easier for references to the things in the webapps/experiment directory easier.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1140
* https://github.com/LabKey/commonAssays/pull/165

#### Changes
* Rename paths that reference resources from experiment, just to avoid confusion