### PR TITLE
RlabkeyTest fixes related to labkey.domain.create changes with study datasets

### DIFF
--- a/data/api/rlabkey-api-study.xml
+++ b/data/api/rlabkey-api-study.xml
@@ -27,23 +27,7 @@
         </url>
         <response>
             <![CDATA[
-                HTTP request was unsuccessful. Status code = 500, Error message = Category ID and category name cannot both be specified
-            ]]>
-        </response>
-    </test>
-    <test name="create a dataset with a invalid category name" type="post">
-        <url>
-            <![CDATA[
-                library(Rlabkey)
-                df <- data.frame(customInt=c(1:3), customString=c("aaa", "bbb", "ccc"))
-                fields <- labkey.domain.inferFields(baseUrl="%baseUrl%", folderPath="%projectName%", df)
-                dd <- labkey.domain.createDesign(name="test dataset one", fields=fields)
-                labkey.domain.create(baseUrl="%baseUrl%", folderPath="%projectName%", domainKind="StudyDatasetVisit", domainDesign=dd, options=list(categoryName = "Invalid"))
-            ]]>
-        </url>
-        <response>
-            <![CDATA[
-                HTTP request was unsuccessful. Status code = 500, Error message = Unable to find a category named : Invalid in this folder.
+                HTTP request was unsuccessful. Status code = 500, Error message = Category ID and category name cannot both be specified.
             ]]>
         </response>
     </test>


### PR DESCRIPTION
#### Rationale
The RlabkeyTest has a few test cases that make use of the labkey.domain.create API helper from Rlabkey to test cases related to study dataset creation and issue list def creation. Recent server side API changes for both study dataset and issue list def look to have caused failures in this test. This PR fixes those issues (see changes mentioned below).

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1146

#### Changes
* RlabkeyTest.testRlabkeyStudyApi remove an invalid category test now that we do allow for new category creation during labkey.domain.create
