### PR TITLE
Admin console defaults to "Settings"

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -986,9 +986,13 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         goToProjectSettings();
     }
 
+    /**
+     * @deprecated Use {@link org.labkey.test.LabKeySiteWrapper#goToAdminConsole}
+     */
+    @Deprecated
     public void goToAdmin()
     {
-        beginAt("/admin/showAdmin.view");
+        goToAdminConsole();
     }
 
     public UserDetailsPage goToMyAccount()

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -989,7 +989,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
     /**
      * @deprecated Use {@link org.labkey.test.LabKeySiteWrapper#goToAdminConsole}
      */
-    @Deprecated
+    @Deprecated (forRemoval = true)
     public void goToAdmin()
     {
         goToAdminConsole();

--- a/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
+++ b/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
@@ -70,6 +70,12 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
         return getTexts(elementCache().findActiveUsers());
     }
 
+    public String getServerGUID()
+    {
+        goToServerInformationSection();
+        return elementCache().findServerGUID().getText();
+    }
+
     public void clickAnalyticsSettings()
     {
         goToSettingsSection();
@@ -219,6 +225,11 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
         protected List<WebElement> findActiveUsers()
         {
             return Locator.tagWithName("table", "activeUsers").append(Locator.tag("td").position(1)).findElements(this);
+        }
+
+        protected WebElement findServerGUID()
+        {
+            return Locator.tagWithText("td", "Server GUID").followingSibling("td").findElement(this);
         }
     }
 }


### PR DESCRIPTION
#### Rationale
Switching the admin console to default to the "Settings" page caused a failure in the `MothershipReportTest` due to it expecting to land on the "Server Information" tab of the admin console. 

This PR updates the `ShowAdminPage` component to support retrieving the server GUID from the admin console UI which is now utilized by `MothershipHelper` (see https://github.com/LabKey/platform/pull/1160/commits/2f3d98136e99a08b6cd4523bd957a7df254626d3).

Additionally, I've deprecated usage of `LabKeySiteWrapper.goToAdmin()` in favor of using `LabKeySiteWrapper.goToAdminConsole()`. I would actually prefer to remove `goToAdmin()` all together (this was the last usage I could find locally) but a chose the more defensive strategy instead.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1160

#### Changes
* Switch `goToAdmin()` to use `goToAdminConsole()` and deprecate `goToAdmin()`.
* Retrieve the server GUID from a `ShowAdminPage` instance via `getServerGUID()`.
