### PR TITLE
Fb dataset from file test migration

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -578,8 +578,6 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         signIn();
         setServerDebugLogging();
         setExperimentalFlags();
-        ExperimentalFeaturesHelper.enableExperimentalFeature(createDefaultConnection(true),
-                "experimental-reactdesigner");
 
         // Start logging JS errors.
         resumeJsErrorChecker();

--- a/src/org/labkey/test/pages/DatasetPropertiesPage.java
+++ b/src/org/labkey/test/pages/DatasetPropertiesPage.java
@@ -48,8 +48,6 @@ public class DatasetPropertiesPage extends LabKeyPage<DatasetPropertiesPage.Elem
 
     public DatasetDesignerPage clickEditDefinition()
     {
-        ExperimentalFeaturesHelper.enableExperimentalFeature(
-                createDefaultConnection(true),"experimental-reactdesigner");
         doAndWaitForPageToLoad(() -> shortWait().until(LabKeyExpectedConditions.clickUntilStale(elementCache().editDefinitionButton)));
         return new DatasetDesignerPage(getDriver());
     }

--- a/src/org/labkey/test/pages/ManageDatasetsPage.java
+++ b/src/org/labkey/test/pages/ManageDatasetsPage.java
@@ -51,8 +51,6 @@ public class ManageDatasetsPage extends LabKeyPage<ManageDatasetsPage.ElementCac
 
     public DatasetDesignerPage clickCreateNewDataset()
     {
-        ExperimentalFeaturesHelper.enableExperimentalFeature(
-                createDefaultConnection(true),"experimental-reactdesigner");
         clickAndWait(elementCache().createNewDatasetLink);
         return new DatasetDesignerPage(getDriver());
     }

--- a/src/org/labkey/test/pages/study/DatasetDesignerPage.java
+++ b/src/org/labkey/test/pages/study/DatasetDesignerPage.java
@@ -9,6 +9,7 @@ import org.labkey.test.components.glassLibrary.components.ReactSelect;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.html.RadioButton;
+import org.labkey.test.components.html.ToggleButton;
 import org.labkey.test.components.study.AdvancedDatasetSettingsDialog;
 import org.labkey.test.pages.DatasetPropertiesPage;
 import org.openqa.selenium.WebDriver;
@@ -168,8 +169,6 @@ public class DatasetDesignerPage extends DomainDesigner<DatasetDesignerPage.Elem
         return  elementCache().keyFieldSelect.isEnabled();
     }
 
-    // get/select additional key field
-    // get/set 'let server manage fields to make entries unique' checkbox
 
     public DatasetDesignerPage setShowInOverview(boolean checked)
     {
@@ -229,6 +228,32 @@ public class DatasetDesignerPage extends DomainDesigner<DatasetDesignerPage.Elem
         }
     }
 
+    // note: auto-import slider is only shown when you've inferred fields from file
+    public DatasetDesignerPage setAutoImport(boolean autoImport)
+    {
+        elementCache().autoImportSlider().set(autoImport);
+        return this;
+    }
+
+    public boolean getAutoImport()
+    {
+        return elementCache().autoImportSlider().get();
+    }
+
+    public DatasetDesignerPage setPreviewMappedColumn(String columnLabel, String value)
+    {
+        elementCache().columnMapSelect(columnLabel).filterSelect(value);
+        return this;
+    }
+
+    public String getPreviewMappedColumnValue(String columnLabel)
+    {
+        return elementCache().columnMapSelect(columnLabel).getValue();
+    }
+    // find ptid column select
+    // find visit column select
+
+
     @Override
     protected ElementCache newElementCache()
     {
@@ -272,5 +297,19 @@ public class DatasetDesignerPage extends DomainDesigner<DatasetDesignerPage.Elem
 
         protected final Checkbox keyPropertyManagedBox = new Checkbox(Locator.inputById("keyPropertyManaged")
                 .findWhenNeeded(propertiesPanel));
+
+        // this is only shown when inferring fields from a file
+        protected ToggleButton autoImportSlider()
+        {
+            return new ToggleButton.ToggleButtonFinder(getDriver()).withState("Import Data").waitFor(fieldsPanel);
+        }
+
+        protected FilteringReactSelect columnMapSelect(String labelText)
+        {   // find the row with the specified label span, then get the select in it
+            WebElement container = Locator.tag("div").withChild(Locator.tag("div")
+                    .withChild(Locator.tagWithClass("span", "domain-no-wrap").withText(labelText)))
+                    .waitForElement(fieldsPanel, 2000);
+            return FilteringReactSelect.finder(getDriver()).find(container);
+        }
     }
 }

--- a/src/org/labkey/test/pages/study/DatasetDesignerPage.java
+++ b/src/org/labkey/test/pages/study/DatasetDesignerPage.java
@@ -117,7 +117,10 @@ public class DatasetDesignerPage extends DomainDesigner<DatasetDesignerPage.Elem
     public DatasetDesignerPage setIsDemographicData(boolean checked)
     {
         expandPropertiesPanel();
-        setDataRowUniquenessType(DataRowUniquenessType.PTID_ONLY);
+        if (checked)
+            setDataRowUniquenessType(DataRowUniquenessType.PTID_ONLY);
+        else
+            setDataRowUniquenessType(DataRowUniquenessType.PTID_TIMEPOINT);
         return this;
     }
 

--- a/src/org/labkey/test/pages/study/DatasetDesignerPage.java
+++ b/src/org/labkey/test/pages/study/DatasetDesignerPage.java
@@ -234,13 +234,13 @@ public class DatasetDesignerPage extends DomainDesigner<DatasetDesignerPage.Elem
     // note: auto-import slider is only shown when you've inferred fields from file
     public DatasetDesignerPage setAutoImport(boolean autoImport)
     {
-        elementCache().autoImportSlider().set(autoImport);
+        elementCache().autoImportToggle().set(autoImport);
         return this;
     }
 
     public boolean getAutoImport()
     {
-        return elementCache().autoImportSlider().get();
+        return elementCache().autoImportToggle().get();
     }
 
     public DatasetDesignerPage setPreviewMappedColumn(String columnLabel, String value)
@@ -302,7 +302,7 @@ public class DatasetDesignerPage extends DomainDesigner<DatasetDesignerPage.Elem
                 .findWhenNeeded(propertiesPanel));
 
         // this is only shown when inferring fields from a file
-        protected ToggleButton autoImportSlider()
+        protected ToggleButton autoImportToggle()
         {
             return new ToggleButton.ToggleButtonFinder(getDriver()).withState("Import Data").waitFor(fieldsPanel);
         }

--- a/src/org/labkey/test/tests/DataViewsTest.java
+++ b/src/org/labkey/test/tests/DataViewsTest.java
@@ -27,6 +27,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.categories.DailyC;
 import org.labkey.test.components.BodyWebPart;
 import org.labkey.test.components.html.BootstrapMenu;
+import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
@@ -640,12 +641,14 @@ public class DataViewsTest extends ParticipantListTest
     private void createDataset(@LoggedParam String name)
     {
         waitAndClickAndWait(Locator.linkWithText("Create New Dataset"));
-        setFormElement(Locator.xpath("//input[@name='typeName']"), name);
-        clickButton("Next");
-        waitForElement(Locator.xpath("//input[@id='name0-input']"));
-        setFormElement(Locator.xpath("//input[@id='name0-input']"), "XTest");
-        clickButton("Save");
-        clickButton("Manage Datasets");
+        DatasetDesignerPage datasetDesignerPage = new DatasetDesignerPage(getDriver())
+                .setName(name);
+        datasetDesignerPage
+                .getFieldsPanel()
+                .manuallyDefineFields("XTest");
+        datasetDesignerPage.clickSave()
+            .clickManageDatasets();
+
         assertElementPresent(Locator.linkWithText(name));
     }
 }

--- a/src/org/labkey/test/tests/visualization/ColumnChartTest.java
+++ b/src/org/labkey/test/tests/visualization/ColumnChartTest.java
@@ -83,12 +83,8 @@ public class ColumnChartTest extends BaseWebDriverTest
         selectQuery("study", DATA_SOURCE_1);
         click(Locator.linkWithText("edit definition"));
 
-        waitForText("Edit Dataset Definition");
-
         log("Set the '" + PREGNANCY_COLUMN_NAME + "', '" + LANGUAGE_COLUMN_NAME + "', and '" + SIGNATURE_COLUMN_NAME + "' fields to be dimensions but not measures.");
-
         DatasetDesignerPage datasetDesignerPage = new DatasetDesignerPage(getDriver());
-
         DomainFormPanel domainFormPanel = datasetDesignerPage.getFieldsPanel();
         domainFormPanel.getField(PREGNANCY_COLUMN_NAME)
                 .setDimension(true)

--- a/src/org/labkey/test/tests/visualization/ColumnChartTest.java
+++ b/src/org/labkey/test/tests/visualization/ColumnChartTest.java
@@ -81,7 +81,7 @@ public class ColumnChartTest extends BaseWebDriverTest
         log("Go to the schema browser and modify some of the fields.");
         goToSchemaBrowser();
         selectQuery("study", DATA_SOURCE_1);
-        click(Locator.linkWithText("edit definition"));
+        clickAndWait(Locator.linkWithText("Edit Definition"));
 
         log("Set the '" + PREGNANCY_COLUMN_NAME + "', '" + LANGUAGE_COLUMN_NAME + "', and '" + SIGNATURE_COLUMN_NAME + "' fields to be dimensions but not measures.");
         DatasetDesignerPage datasetDesignerPage = new DatasetDesignerPage(getDriver());

--- a/src/org/labkey/test/util/ListHelper.java
+++ b/src/org/labkey/test/util/ListHelper.java
@@ -28,14 +28,11 @@ import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.html.OptionSelect;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.params.FieldDefinition;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WrapsDriver;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
@@ -77,11 +74,6 @@ public class ListHelper extends LabKeySiteWrapper
         setFormElement(Locator.id("tsv3"), listData);
         _extHelper.selectComboBoxItem("Format:", "Comma-separated text (csv)");
         submitImportTsv_success();
-    }
-
-    public PropertiesEditor getListFieldEditor()
-    {
-        return PropertiesEditor.PropertiesEditor(getDriver()).withTitle("List Fields").find();
     }
 
     public void uploadData(String listData)
@@ -278,11 +270,6 @@ public class ListHelper extends LabKeySiteWrapper
             fieldsPanel.addField(col);
         }
         listDefinitionPage.clickSave();
-    }
-
-    public void addField(ListColumn col)
-    {
-        getListFieldEditor().addField(col);
     }
 
     private void beginCreateListFromTab(String tabName, String listName)


### PR DESCRIPTION
#### Rationale
updates tests that upload file information into dataset at create-time.  Also addresses product issues found while converting these tests.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/1185

#### Changes
pull out GWT dataset designer code, navigate via new UI by default
pull out calls to activate the exp switch to cause callers to go via new UI
