### PR TITLE
Item 7350: GpatAssayTest fix for updating assay results domain properties via domain designer UI

### DIFF
--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -841,11 +841,6 @@ public abstract class Locator extends By
         return tagWithAttribute("input", "type", "checkbox").withPredicate(xpath("../../following-sibling::td/span").containing(label));
     }
 
-    public static XPathLocator gwtNextButtonOnImportGridByColLabel(String label)
-    {
-        return tagWithClass("div", "x-tbar-page-next").withPredicate(xpath("../preceding-sibling::td/span").containing(label));
-    }
-
     public static Locator permissionRendered()
     {
         return Locators.pageSignal("policyRendered");

--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -831,11 +831,6 @@ public abstract class Locator extends By
         return tagWithClass("select", "gwt-ListBox").withPredicate(xpath("../preceding-sibling::label").withText(label));
     }
 
-    public static XPathLocator gwtListBoxByName(String name)
-    {
-        return tagWithClass("select", "gwt-ListBox").withAttribute("name", name);
-    }
-
     public static XPathLocator gwtCheckBoxOnImportGridByColLabel(String label)
     {
         return tagWithAttribute("input", "type", "checkbox").withPredicate(xpath("../../following-sibling::td/span").containing(label));

--- a/src/org/labkey/test/tests/GpatAssayTest.java
+++ b/src/org/labkey/test/tests/GpatAssayTest.java
@@ -335,16 +335,4 @@ public class GpatAssayTest extends BaseWebDriverTest
         log("Clicking +  to add new file");
         click(Locator.xpath("//a[contains(@class, 'labkey-file-add-icon-enabled')]"));
     }
-
-
-    private void waitForGwtDialog(String caption)
-    {
-        waitForElement(Locator.xpath("//div[contains(@class, 'gwt-DialogBox')]//div[contains(@class, 'Caption') and text()='" + caption + "']"), WAIT_FOR_JAVASCRIPT);
-    }
-
-    private void clickGwtTab(String tabName)
-    {
-        WebElement element = Locator.tagWithClass("div", "gwt-TabBarItem").withChild(Locator.xpath("//div[contains(@class, 'gwt-Label') and text()='" + tabName + "']")).findElement(getDriver());
-        element.click();
-    }
 }

--- a/src/org/labkey/test/tests/GpatAssayTest.java
+++ b/src/org/labkey/test/tests/GpatAssayTest.java
@@ -108,21 +108,11 @@ public class GpatAssayTest extends BaseWebDriverTest
         setFormElement(Locator.name("AssayDesignerName"), ASSAY_NAME_XLS);
         fireEvent(Locator.xpath("//input[@id='AssayDesignerName']"), SeleniumEvent.blur);
         uncheckCheckbox(Locator.gwtCheckBoxOnImportGridByColLabel("Role"));
-        click(Locator.gwtNextButtonOnImportGridByColLabel("Score"));
-        waitForGwtDialog("Score Column Properties");
-        clickGwtTab("Validators");
-        checkCheckbox(Locator.checkboxByName("required"));
-        clickButton("OK", 0);
-        click(Locator.gwtNextButtonOnImportGridByColLabel("Primary"));
-        waitForGwtDialog("Primary Column Properties");
-        clickGwtTab("Advanced");
-        checkCheckbox(Locator.checkboxByName("mvEnabled"));
-        clickButton("OK", 0);
         assertEquals("SpecimenID", getFormElement(Locator.name("SpecimenID")));
         assertEquals("ptid", getFormElement(Locator.name("ParticipantID")));
         assertEquals("VisitID", getFormElement(Locator.name("VisitID")));
         assertEquals("DrawDt", getFormElement(Locator.name("Date")));
-        clickButton("Begin import");
+        setAssayResultsProperties();
         clickButton("Next", defaultWaitForPage);
         clickButton("Save and Finish", defaultWaitForPage);
         waitAndClick(Locator.linkWithText(GPAT_ASSAY_XLS));
@@ -155,21 +145,11 @@ public class GpatAssayTest extends BaseWebDriverTest
         setFormElement(Locator.name("AssayDesignerName"), ASSAY_NAME_XLSX);
         fireEvent(Locator.xpath("//input[@id='AssayDesignerName']"), SeleniumEvent.blur);
         uncheckCheckbox(Locator.gwtCheckBoxOnImportGridByColLabel("Role"));
-        click(Locator.gwtNextButtonOnImportGridByColLabel("Score"));
-        waitForGwtDialog("Score Column Properties");
-        clickGwtTab("Validators");
-        checkCheckbox(Locator.checkboxByName("required"));
-        clickButton("OK", 0);
-        click(Locator.gwtNextButtonOnImportGridByColLabel("Primary"));
-        waitForGwtDialog("Primary Column Properties");
-        clickGwtTab("Advanced");
-        checkCheckbox(Locator.checkboxByName("mvEnabled"));
-        clickButton("OK", 0);
         assertEquals("SpecimenID", getFormElement(Locator.name("SpecimenID")));
         assertEquals("ptid", getFormElement(Locator.name("ParticipantID")));
         assertEquals("VisitID", getFormElement(Locator.name("VisitID")));
         assertEquals("DrawDt", getFormElement(Locator.name("Date")));
-        clickButton("Begin import");
+        setAssayResultsProperties();
         clickButton("Next", defaultWaitForPage);
         clickButton("Save and Finish", defaultWaitForPage);
         waitAndClick(Locator.linkWithText(GPAT_ASSAY_XLSX));
@@ -183,30 +163,22 @@ public class GpatAssayTest extends BaseWebDriverTest
         setFormElement(Locator.name("AssayDesignerName"), ASSAY_NAME_TSV);
         fireEvent(Locator.xpath("//input[@id='AssayDesignerName']"), SeleniumEvent.blur);
         uncheckCheckbox(Locator.gwtCheckBoxOnImportGridByColLabel("Role"));
-        click(Locator.gwtNextButtonOnImportGridByColLabel("Score"));
-        waitForGwtDialog("Score Column Properties");
-        clickGwtTab("Validators");
-        checkCheckbox(Locator.checkboxByName("required"));
-        clickButton("OK", 0);
-        click(Locator.gwtNextButtonOnImportGridByColLabel("Primary"));
-        waitForGwtDialog("Primary Column Properties");
-        clickGwtTab("Advanced");
-        checkCheckbox(Locator.checkboxByName("mvEnabled"));
-        clickButton("OK", 0);
         assertEquals("SpecimenID", getFormElement(Locator.name("SpecimenID")));
         assertEquals("ptid", getFormElement(Locator.name("ParticipantID")));
         assertEquals("VisitID", getFormElement(Locator.name("VisitID")));
         assertEquals("DrawDt", getFormElement(Locator.name("Date")));
 
-        clickButton("Show Assay Designer");     // todo: map this page
+        clickButton("Show Assay Designer");
         ReactAssayDesignerPage assayDesignerPage = new ReactAssayDesignerPage(getDriver());
         DomainFormPanel results = assayDesignerPage.expandFieldsPanel("Results");
-        results.getField(4)
-                .setLabel("Blank");
-        results.getField(7)
+        results.getField(4) // field name = Primary
+                .setLabel("Blank")
+                .setMissingValuesEnabled(true);
+        results.getField(7) // field name = Score
                 .setName("Result")
                 .setLabel("Result")
-                .setImportAliases("Score");
+                .setImportAliases("Score")
+                .setRequiredField(true);
         assayDesignerPage.clickFinish();
 
         clickButton("Next", defaultWaitForPage);
@@ -256,6 +228,16 @@ public class GpatAssayTest extends BaseWebDriverTest
         assertTextPresent(
                 "Header", "HCJDRSZ07IVO6P", "HCJDRSZ07IL1GX", "HCJDRSZ07H5SPZ",
                 "CACCAGACAGGTGTTATGGTGTGTGCCTGTAATCCCAGCTACTTGGGAGGGAGCTCAGGT");
+    }
+
+    private void setAssayResultsProperties()
+    {
+        clickButton("Show Assay Designer");
+        ReactAssayDesignerPage assayDesignerPage = new ReactAssayDesignerPage(getDriver());
+        DomainFormPanel results = assayDesignerPage.expandFieldsPanel("Results");
+        results.getField("Score").setRequiredField(true);
+        results.getField("Primary").setMissingValuesEnabled(true);
+        assayDesignerPage.clickFinish();
     }
 
     private void importFastaGpatAssay(String fileName, String assayName)


### PR DESCRIPTION
#### Rationale
With the refactor of the "Create New General Assay Design" from file scenario so that it no longer uses the GWT PropertiesEditor (see related PR), the GpatAssayTest needs an update so that it goes through the assay designer for the results property updates that it was previously making on the TsvImportAction page.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1204
* https://github.com/LabKey/provenance/pull/23

#### Changes
* GpatAssayTest fix for updating assay results domain properties via domain designer UI
