### PR TITLE
DataClassTest fix for domain designer required field properties error handling changes

### DIFF
--- a/src/org/labkey/test/tests/DataClassTest.java
+++ b/src/org/labkey/test/tests/DataClassTest.java
@@ -141,9 +141,12 @@ public class DataClassTest extends BaseWebDriverTest
         DomainFormPanel domainFormPanel = createPage.getDomainEditor();
         domainFormPanel.manuallyDefineFields(" ");
         assertEquals("Data class missing field name error", Arrays.asList(
-                "Please provide a name for each field.",
+                "Missing required field properties.",
                 "Please correct errors in Fields before saving."),
                 createPage.clickSaveExpectingErrors());
+        assertEquals("Data class missing field name detail error",
+                "New Field. Error: Please provide a name for each field.",
+                domainFormPanel.getField(0).detailsMessage());
         domainFormPanel.removeAllFields(false);
 
         log("Verify error message for unique field names");


### PR DESCRIPTION
#### Rationale
The related PRs addressed a few misc domain designer related issues, including updates to the field level error handling behavior. This PR is to fix a related automated test failure for those error handling changes.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1219
* https://github.com/LabKey/sampleManagement/pull/275
* https://github.com/LabKey/labkey-ui-components/pull/256

#### Changes
* DataClassTest fix for domain designer required field properties error handling changes
