### PR TITLE
UserIdRenderer does not render link if user does not have SeeUserDeta…

### DIFF
--- a/src/org/labkey/test/tests/UserDetailsPermissionTest.java
+++ b/src/org/labkey/test/tests/UserDetailsPermissionTest.java
@@ -146,7 +146,9 @@ public class UserDetailsPermissionTest extends BaseWebDriverTest
         log("Verify that emails cannot be seen in list via lookup");
         clickAndWait(Locator.linkWithText(EMAIL_TEST_LIST));
         DataRegionTable.findDataRegion(this).goToView(HIDDEN_COL_VIEW);
-        assertElementPresent(Locator.linkWithText(_userHelper.getDisplayNameForEmail(CHECKED_USER)));
+        assertTextPresent(_userHelper.getDisplayNameForEmail(CHECKED_USER));
+        // This user does not have permission to see user details, so no link
+        assertElementNotPresent(Locator.linkWithText(_userHelper.getDisplayNameForEmail(CHECKED_USER)));
         assertTextNotPresent(CHECKED_USER, ADMIN_USER, HIDDEN_STRING);
 
         stopImpersonating();


### PR DESCRIPTION
#### Rationale
Server correctly uses UserIdRenderer now for a test column.  Need to update test to match.