### PR TITLE
Add GitHub workflow for automated release branching

### DIFF
--- a/.github/workflows/branch_release.yml
+++ b/.github/workflows/branch_release.yml
@@ -19,6 +19,6 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Create branches and PRs
-      uses: labkey-tchad/gitHubActions/branch-release@master
+      uses: LabKey/gitHubActions/branch-release@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/branch_release.yml
+++ b/.github/workflows/branch_release.yml
@@ -1,0 +1,24 @@
+# Workflow to automate creation and updating of release branches
+name: Release Branching
+
+# Trigger on tags created by TeamCity
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  branch_release:
+    if: github.event.created && github.event.sender.login == 'labkey-teamcity'
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Create branches and PRs
+      uses: labkey-tchad/gitHubActions/branch-release@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge_release.yml
+++ b/.github/workflows/merge_release.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Merge PR
-      uses: labkey-tchad/gitHubActions/merge-release@master
+      uses: LabKey/gitHubActions/merge-release@master
       with:
         target_branch: ${{ github.event.pull_request.base.ref }}
         merge_branch: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/merge_release.yml
+++ b/.github/workflows/merge_release.yml
@@ -1,0 +1,27 @@
+# Workflow to automate merging release branches
+name: Release Merging
+
+# Trigger on PR approval
+on:
+  pull_request_review:
+    types:
+      - submitted
+
+jobs:
+  merge_release:
+    if: github.event.review.state == 'approved' && github.event.pull_request.user.login == 'github-actions[bot]'
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Merge PR
+      uses: labkey-tchad/gitHubActions/merge-release@master
+      with:
+        target_branch: ${{ github.event.pull_request.base.ref }}
+        merge_branch: ${{ github.event.pull_request.head.ref }}
+        pr_number: ${{ github.event.pull_request.number }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Rationale
Creating release branches currently requires a lot of manual work and a full enlistment of all LabKey modules. These workflows will allow us to perform most branching and merging tasks from GitHub and TeamCity.

Action definitions
* https://github.com/labkey/gitHubActions

Remaining work:
Configure TeamCity 20.3 project to tag selected SNAPSHOT installers which will trigger the branching workflow.