### PR TITLE
refactor tests to use the template list selector

### DIFF
--- a/src/org/labkey/test/pages/assay/plate/PlateDesignerPage.java
+++ b/src/org/labkey/test/pages/assay/plate/PlateDesignerPage.java
@@ -149,7 +149,7 @@ public class PlateDesignerPage extends LabKeyPage<PlateDesignerPage.ElementCache
             return params;
         }
 
-        public Locator templateListLocator()
+        public String templateListOption()
         {
             StringBuilder sb = new StringBuilder();
             sb.append("new ")
@@ -165,8 +165,7 @@ public class PlateDesignerPage extends LabKeyPage<PlateDesignerPage.ElementCache
                 sb.append(" ").append(templateType);
             }
             sb.append(" template");
-
-            return Locator.linkWithText(sb.toString());
+            return sb.toString();
         }
 
         public static PlateDesignerParams _96well()

--- a/src/org/labkey/test/pages/assay/plate/PlateTemplateListPage.java
+++ b/src/org/labkey/test/pages/assay/plate/PlateTemplateListPage.java
@@ -30,7 +30,8 @@ public class PlateTemplateListPage extends LabKeyPage<PlateTemplateListPage.Elem
 
     public PlateDesignerPage clickNewPlate(PlateDesignerPage.PlateDesignerParams params)
     {
-        clickAndWait(params.templateListLocator());
+        selectOptionByText(elementCache().templateList, params.templateListOption());
+        clickAndWait(Locator.lkButton("create"));
 
         return new PlateDesignerPage(getDriver());
     }
@@ -44,5 +45,6 @@ public class PlateTemplateListPage extends LabKeyPage<PlateTemplateListPage.Elem
     protected class ElementCache extends LabKeyPage.ElementCache
     {
         WebElement templateTable = Locator.tagWithClass("table", "labkey-data-region-legacy").findWhenNeeded(this);
+        WebElement templateList = Locator.tagWithId("select", "plate_template").findWhenNeeded(this);
     }
 }

--- a/src/org/labkey/test/tests/DrugSensitivityAssayTest.java
+++ b/src/org/labkey/test/tests/DrugSensitivityAssayTest.java
@@ -22,6 +22,8 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.DailyB;
 import org.labkey.test.pages.ReactAssayDesignerPage;
+import org.labkey.test.pages.assay.plate.PlateDesignerPage;
+import org.labkey.test.pages.assay.plate.PlateTemplateListPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.QCAssayScriptHelper;
@@ -183,9 +185,11 @@ public class DrugSensitivityAssayTest extends AbstractAssayTest
 
     protected void createTemplate()
     {
-        clickButton("Manage Assays");
-        clickButton("Configure Plate Templates");
-        clickAndWait(Locator.linkWithText("new 96 well (8x12) Drug Sensitivity default template"));
+        PlateTemplateListPage templateListPage = PlateTemplateListPage.beginAt(this);
+        templateListPage.clickNewPlate((PlateDesignerPage.PlateDesignerParams
+                ._96well()
+                .setAssayType("Drug Sensitivity")
+                .setTemplateType("default")));
         final WebElement nameField = waitForElement(Locator.id("templateName"), WAIT_FOR_JAVASCRIPT);
         setFormElement(nameField, PLATE_TEMPLATE_NAME);
         fireEvent(nameField, SeleniumEvent.change);

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -33,6 +33,8 @@ import org.labkey.test.components.labkey.LabKeyAlert;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.admin.PermissionsPage;
 import org.labkey.test.pages.assay.RunQCPage;
+import org.labkey.test.pages.assay.plate.PlateDesignerPage;
+import org.labkey.test.pages.assay.plate.PlateTemplateListPage;
 import org.labkey.test.tests.AbstractAssayTest;
 import org.labkey.test.util.AssayImportOptions;
 import org.labkey.test.util.AssayImporter;
@@ -192,13 +194,11 @@ public class NabAssayTest extends AbstractAssayTest
             .setPlateTemplate("NAb: 5 specimens in duplicate")
             .clickFinish();
 
-        // go back into assay design to configure templates
-        clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));
-        ReactAssayDesignerPage assayDesignerPage = _assayHelper.clickEditAssayDesign();
-        assayDesignerPage.goToConfigureTemplates();
-
-        // todo: implement in/refactor to use template page
-        clickAndWait(Locator.linkWithText("new 96 well (8x12) NAb single-plate template"));
+        PlateTemplateListPage templateListPage = PlateTemplateListPage.beginAt(this);
+        templateListPage.clickNewPlate((PlateDesignerPage.PlateDesignerParams
+                ._96well()
+                .setAssayType("NAb")
+                .setTemplateType("single-plate")));
 
         setFormElement(Locator.inputById("templateName"), PLATE_TEMPLATE_NAME);
 

--- a/src/org/labkey/test/tests/nab/NabHighThroughputAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabHighThroughputAssayTest.java
@@ -26,6 +26,8 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.DailyA;
 import org.labkey.test.pages.ReactAssayDesignerPage;
+import org.labkey.test.pages.assay.plate.PlateDesignerPage;
+import org.labkey.test.pages.assay.plate.PlateTemplateListPage;
 import org.labkey.test.util.AssayImportOptions;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.DilutionAssayHelper;
@@ -79,11 +81,11 @@ public class NabHighThroughputAssayTest extends BaseWebDriverTest
         portalHelper.addWebPart("Assay List");
         clickProject(getProjectName());
 
-        //create a new nab assay
-        clickButton("Manage Assays");
-
-        clickButton("Configure Plate Templates");
-        clickAndWait(Locator.linkWithText("new 384 well (16x24) NAb high-throughput (single plate dilution) template"));
+        PlateTemplateListPage templateListPage = PlateTemplateListPage.beginAt(this);
+        templateListPage.clickNewPlate((PlateDesignerPage.PlateDesignerParams
+                ._384well()
+                .setAssayType("NAb")
+                .setTemplateType("high-throughput (single plate dilution)")));
 
         Locator.IdLocator nameField = Locator.id("templateName");
         waitForElement(nameField, WAIT_FOR_JAVASCRIPT);
@@ -94,7 +96,11 @@ public class NabHighThroughputAssayTest extends BaseWebDriverTest
         assertTextPresent(PLATE_TEMPLATE_NAME);
 
         // create the cross plate dilution template
-        clickAndWait(Locator.linkWithText("new 384 well (16x24) NAb high-throughput (cross plate dilution) template"));
+        templateListPage = PlateTemplateListPage.beginAt(this);
+        templateListPage.clickNewPlate((PlateDesignerPage.PlateDesignerParams
+                ._384well()
+                .setAssayType("NAb")
+                .setTemplateType("high-throughput (cross plate dilution)")));
 
         waitForElement(nameField, WAIT_FOR_JAVASCRIPT);
         setFormElement(nameField, CPD_PLATE_TEMPLATE_NAME);

--- a/src/org/labkey/test/tests/nab/NabMultiVirusPlateTest.java
+++ b/src/org/labkey/test/tests/nab/NabMultiVirusPlateTest.java
@@ -28,6 +28,8 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.DailyA;
 import org.labkey.test.pages.ReactAssayDesignerPage;
+import org.labkey.test.pages.assay.plate.PlateDesignerPage;
+import org.labkey.test.pages.assay.plate.PlateTemplateListPage;
 import org.labkey.test.util.AssayImportOptions;
 import org.labkey.test.util.AssayImporter;
 import org.labkey.test.util.DataRegionTable;
@@ -103,10 +105,11 @@ public class NabMultiVirusPlateTest extends BaseWebDriverTest
         PortalHelper portalHelper = new PortalHelper(this);
         portalHelper.addWebPart("Assay List");
 
-        clickButton("Manage Assays");
-
-        clickButton("Configure Plate Templates");
-        clickAndWait(Locator.linkWithText("new 384 well (16x24) NAb multi-virus plate template"));
+        PlateTemplateListPage templateListPage = PlateTemplateListPage.beginAt(this);
+        templateListPage.clickNewPlate((PlateDesignerPage.PlateDesignerParams
+                ._384well()
+                .setAssayType("NAb")
+                .setTemplateType("multi-virus plate")));
 
         waitForElement(Locator.xpath("//input[@id='templateName']"), WAIT_FOR_JAVASCRIPT);
         setFormElement(Locator.xpath("//input[@id='templateName']"), PLATE_TEMPLATE_NAME);


### PR DESCRIPTION
#### Rationale
A UI improvement was made recently in the manage plate templates page. Now instead of listing all of the templates in a table, we populate a dropdown.  There are several tests that are expecting the old UI and this PR will refactor them to use the new UI.         

#### Related Pull Requests
- [33862: Plate Template pages needs to be more user friendly](https://github.com/LabKey/platform/pull/1220)

#### Changes
* Refactor existing tests to use the PlateTemplateListPage