### PR TITLE
Use deprecated "default" configuration after switch to java-library for api module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,13 @@ project.dependencies {
     else
     {
         // Use local version outside of TeamCity so as to not confuse IntelliJ
-        BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getApiProjectPath(project.gradle), transitive: false)
+        BuildUtils.addLabKeyDependency(
+                project: project,
+                config: "implementation",
+                depProjectPath: BuildUtils.getApiProjectPath(project.gradle),
+                depProjectConfig: "default",  // TODO this is deprecated so need to figure out the proper way to declare this
+                transitive: false
+        )
     }
 
     // Issue 36184: Tests can't find selenium-ie-driver library when running on Windows on TeamCity


### PR DESCRIPTION
### Rationale
Converting the api module to use the java-library plugin brought with it the side effect that the jar file is no longer a default artifact when declaring dependencies.  Using the deprecated "default" configuration for this dependency declaration for now until I can figure out the right way to use Gradle variants here (and for the dependency on the remote api jar.

#### Changes
* Update dependency declaration for api jar to use the default configuration.