### PR TITLE
40217: Reconcile client-side and server-side timeouts

### DIFF
--- a/src/org/labkey/test/tests/JUnitTest.java
+++ b/src/org/labkey/test/tests/JUnitTest.java
@@ -338,7 +338,7 @@ public class JUnitTest extends TestSuite
                 Map<String, Object> params = new HashMap<>();
                 params.put("testCase", _remoteClass);
                 command.setParameters(params);
-                command.setTimeout(_timeout * 1000 * 2);
+                command.setTimeout(_timeout * 1000);
 
                 CommandResponse response = command.execute(connection, "/");
                 Map<String, Object> resultJson = response.getParsedData();


### PR DESCRIPTION
#### Rationale
Test harness was increasing client-side timeout for running tests under the false assumption that the server was enforcing the defined test timeout and would send an appropriate failure for tests that run for too long.

#### Related Issue
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40217

#### Changes
* Use test timeout defined in `@TestTimeout` annotation
