### PR TITLE
Automated test fixes to match the shared component bug fixes in 20.7

### DIFF
--- a/src/org/labkey/test/components/glassLibrary/grids/GridBar.java
+++ b/src/org/labkey/test/components/glassLibrary/grids/GridBar.java
@@ -308,12 +308,12 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
             return Locator.tagWithClass("div", "query-grid-bar");
         }
 
-        static final Locator pgRightButton = Locator.tagWithClassContaining("div", "paging")
+        static final Locator pgRightButton = Locator.tagWithClassContaining("span", "paging")
                 .descendant(Locator.tag("button").withChild(Locator.tagWithClass("i", "fa fa-chevron-right")));
-        static final Locator pgLeftButton =Locator.tagWithClassContaining("div", "paging")
+        static final Locator pgLeftButton =Locator.tagWithClassContaining("span", "paging")
                 .descendant(Locator.tag("button").withChild(Locator.tagWithClass("i", "fa fa-chevron-left")));
 
-        static final Locator pagingCountsSpan = Locator.xpath("//div[contains(@class, 'paging')]/span[@data-min]");
+        static final Locator pagingCountsSpan = Locator.xpath("//span[contains(@class, 'paging')]/span[@data-min]");
         static final Locator.XPathLocator viewSelectorButtonGroup = Locator.tagWithClass("div", "dropdown")
                 .withChild(Locator.button("Grid Views"));
         static final Locator.XPathLocator viewSelectorToggleButton = Locator.button("Grid Views");

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -295,7 +295,7 @@ public class FieldDefinition extends PropertyDescriptor
         DateAndTime("Date Time", "date"),
         Boolean("Boolean", "boolean"),
         Double("Number (Double)", "float"),
-        Decimal("Decimal", "float"),
+        Decimal("Decimal (floating point)", "float"),
         File("File", "fileLink"),
         AutoInteger("Auto-Increment Integer", "int"),
         Flag("Flag", "string", "http://www.labkey.org/exp/xml#flag", null),


### PR DESCRIPTION
#### Rationale
As part of issue [39934](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39934), the domain designer fields type selection options for "Decimal" has been changed to clarify the DB type of the field (i.e. new display label is "Decimal (floating point)". This PR matches that change on the automated test side.

As part of issue [39468](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39468), the QueryGridPanel button bar was changed to fix layout issues in narrow windows. This PR matches that change on the automated test side.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/271
* https://github.com/LabKey/platform/pull/1293
* https://github.com/LabKey/sampleManagement/pull/292
* https://github.com/LabKey/biologics/pull/607

#### Changes
* Domain field type text changed in dropdown from "Decimal" to "Decimal (floating point)"
* QueryGridPanel button bar fix locator for paging DOM change from div to span