### PR TITLE
Update references to sample study

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -121,10 +121,10 @@ import static org.labkey.test.WebTestHelper.GC_ATTEMPT_LIMIT;
 import static org.labkey.test.WebTestHelper.MAX_LEAK_LIMIT;
 import static org.labkey.test.WebTestHelper.buildURL;
 import static org.labkey.test.WebTestHelper.logToServer;
-import static org.labkey.test.params.FieldDefinition.PhiSelectType;
-import static org.labkey.test.params.FieldDefinition.PhiSelectType.NotPHI;
 import static org.labkey.test.components.ext4.Window.Window;
 import static org.labkey.test.components.html.RadioButton.RadioButton;
+import static org.labkey.test.params.FieldDefinition.PhiSelectType;
+import static org.labkey.test.params.FieldDefinition.PhiSelectType.NotPHI;
 
 /**
  * This class should be used as the base for all functional test classes
@@ -810,7 +810,6 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             {
                 if (isTestRunningOnTeamCity())
                 {
-                    getArtifactCollector().addArtifactLocation(new File(TestFileUtils.getLabKeyRoot(), "sampledata"));
                     getArtifactCollector().addArtifactLocation(new File(TestFileUtils.getLabKeyRoot(), "build/deploy/files"));
                     getArtifactCollector().dumpPipelineFiles();
                 }

--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -206,10 +206,6 @@ public abstract class TestFileUtils
             sampledataDirs.add(new File(getTestRoot(), "data"));
         }
 
-        //TODO: temp remove root/sampledata folder during move
-        sampledataDirs.remove(new File(getLabKeyRoot(), "sampledata"));
-
-
         File foundFile = null;
         for (File sampledataDir : sampledataDirs)
         {

--- a/src/org/labkey/test/tests/filecontent/FilesWebpartFileRootTest.java
+++ b/src/org/labkey/test/tests/filecontent/FilesWebpartFileRootTest.java
@@ -91,7 +91,7 @@ public class FilesWebpartFileRootTest extends BaseWebDriverTest
         Assert.assertTrue("Import Data button should be present when file root is @files and no pipeline override exists", isElementPresent(importDataBtn));
 
         log("Override pipeline root for project");
-        setPipelineRoot(TestFileUtils.getLabKeyRoot() + "/sampledata/");
+        setPipelineRoot(TestFileUtils.getSampleData("fileTypes").getAbsolutePath());
         goToProjectHome();
         Assert.assertTrue("Import Data button should not be present when file root is @files and pipeline override exists", !isElementPresent(importDataBtn));
 

--- a/src/org/labkey/test/tests/filecontent/FilesWebpartFileRootTest.java
+++ b/src/org/labkey/test/tests/filecontent/FilesWebpartFileRootTest.java
@@ -91,7 +91,7 @@ public class FilesWebpartFileRootTest extends BaseWebDriverTest
         Assert.assertTrue("Import Data button should be present when file root is @files and no pipeline override exists", isElementPresent(importDataBtn));
 
         log("Override pipeline root for project");
-        setPipelineRoot(TestFileUtils.getSampleData("fileTypes").getAbsolutePath());
+        setPipelineRoot(TestFileUtils.getSampleData("AssayAPI").getParentFile().getAbsolutePath());
         goToProjectHome();
         Assert.assertTrue("Import Data button should not be present when file root is @files and pipeline override exists", !isElementPresent(importDataBtn));
 

--- a/src/org/labkey/test/util/StudyHelper.java
+++ b/src/org/labkey/test/util/StudyHelper.java
@@ -30,6 +30,7 @@ import org.labkey.test.pages.study.CreateStudyPage;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.pages.study.ManageVisitPage;
 import org.labkey.test.pages.study.StudySecurityPage;
+import org.labkey.test.util.core.webdav.WebDavUploadHelper;
 import org.openqa.selenium.interactions.Actions;
 
 import java.io.File;
@@ -467,12 +468,22 @@ public class StudyHelper
 
     public static String getPipelinePath()
     {
-        return getStudySampleData("study.xml").getParentFile().getAbsolutePath();
+        return getSampleStudy().getAbsolutePath();
+    }
+
+    public static File getSampleStudy()
+    {
+        return TestFileUtils.getSampleData("study/study.xml").getParentFile();
     }
 
     public static File getStudySampleData(String relativePath)
     {
         return TestFileUtils.getSampleData("study/" + relativePath);
+    }
+
+    public static void uploadSampleStudy(String containerPath)
+    {
+        new WebDavUploadHelper(containerPath).uploadDirectory(getSampleStudy());
     }
 
     public enum TimepointType

--- a/src/org/labkey/test/util/StudyHelper.java
+++ b/src/org/labkey/test/util/StudyHelper.java
@@ -30,7 +30,6 @@ import org.labkey.test.pages.study.CreateStudyPage;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.pages.study.ManageVisitPage;
 import org.labkey.test.pages.study.StudySecurityPage;
-import org.labkey.test.util.core.webdav.WebDavUploadHelper;
 import org.openqa.selenium.interactions.Actions;
 
 import java.io.File;
@@ -468,22 +467,12 @@ public class StudyHelper
 
     public static String getPipelinePath()
     {
-        return getSampleStudy().getAbsolutePath();
-    }
-
-    public static File getSampleStudy()
-    {
-        return TestFileUtils.getSampleData("study/study.xml").getParentFile();
+        return TestFileUtils.getSampleData("study/study.xml").getParentFile().getAbsolutePath();
     }
 
     public static File getStudySampleData(String relativePath)
     {
         return TestFileUtils.getSampleData("study/" + relativePath);
-    }
-
-    public static void uploadSampleStudy(String containerPath)
-    {
-        new WebDavUploadHelper(containerPath).uploadDirectory(getSampleStudy());
     }
 
     public enum TimepointType


### PR DESCRIPTION
#### Rationale
There was a study in the root `sampledata/study` used by numerous tests. Many had the study's location hard-coded instead of using `TestFileUtils.getSampleData`

#### Changes
* Remove hard-coded references to deleted root `sampledata` directory
* Update `StudyHelper` with the sample study's new location (`testAutomation/data/study`)
