### PR TITLE
Allow tests to download certificates

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -248,6 +248,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
                     prefs.put("pdfjs.disabled", true); // Download PDFs
                     prefs.put("credentials_enable_service", false);
                     prefs.put("profile.password_manager_enabled", false);
+                    prefs.put("safebrowsing.enabled", false); // Disable "This type of file can harm your computer."
                     options.setExperimentalOption("prefs", prefs);
                     options.setExperimentalOption("detach", true); // Leaves browser window open after stopping the driver service
                     options.addArguments("test-type"); // Suppress '--ignore-certificate-errors' warning

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -305,6 +305,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
                                     "application/octet-stream," +
                                     "application/pdf," +
                                     "application/zip," +
+                                    "application/x-x509-ca-cert," + // .crt, .cer
                                     "application/x-gzip," +
                                     "application/x-zip-compressed," +
                                     "application/xml," +


### PR DESCRIPTION
#### Rationale
Some new tests need to download certificate files.

#### Related Pull Requests
* https://github.com/LabKey/connectors/pull/34

#### Changes
* Add certificate mime type to list of files that will download without prompting
