### PR TITLE
Rename SampleSet* tests to SampleType*

### DIFF
--- a/src/org/labkey/test/params/experiment/SampleTypeDefinition.java
+++ b/src/org/labkey/test/params/experiment/SampleTypeDefinition.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DOMAIN_KIND;
+import static org.labkey.test.util.exp.SampleTypeAPIHelper.SAMPLE_TYPE_DOMAIN_KIND;
 
 /**
  * Defines a Sample Type. Suitable for use with UI and API helpers.

--- a/src/org/labkey/test/params/experiment/SampleTypeDefinition.java
+++ b/src/org/labkey/test/params/experiment/SampleTypeDefinition.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.labkey.test.tests.SampleSetTest.SAMPLE_TYPE_DOMAIN_KIND;
+import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DOMAIN_KIND;
 
 /**
  * Defines a Sample Type. Suitable for use with UI and API helpers.

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DOMAIN_KIND;
+import static org.labkey.test.util.exp.SampleTypeAPIHelper.SAMPLE_TYPE_DOMAIN_KIND;
 
 @Category({BVT.class})
 public class DomainDesignerTest extends BaseWebDriverTest

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.labkey.test.tests.SampleSetTest.SAMPLE_TYPE_DOMAIN_KIND;
+import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DOMAIN_KIND;
 
 @Category({BVT.class})
 public class DomainDesignerTest extends BaseWebDriverTest

--- a/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
@@ -344,7 +344,7 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         log("Validate that the number of Sample Types in the imported folder is the expected value. If not fail test.");
         Assert.assertTrue("Does not look like the Sample Type has been imported.", isElementVisible(Locator.linkWithText(SAMPLE_TYPE_NAME)));
 
-        DataRegionTable sampleTypesDataRegion = new DataRegionTable("SampleType", getWrappedDriver());
+        DataRegionTable sampleTypesDataRegion = new DataRegionTable(SampleTypeTest.SAMPLE_TYPE_DATA_REGION_NAME, getWrappedDriver());
 
         Assert.assertEquals("Number of Sample Types not as expected.", 1, sampleTypesDataRegion.getDataRowCount());
 

--- a/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
@@ -36,6 +36,7 @@ import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
+import org.labkey.test.util.exp.SampleTypeAPIHelper;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
@@ -344,7 +345,7 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         log("Validate that the number of Sample Types in the imported folder is the expected value. If not fail test.");
         Assert.assertTrue("Does not look like the Sample Type has been imported.", isElementVisible(Locator.linkWithText(SAMPLE_TYPE_NAME)));
 
-        DataRegionTable sampleTypesDataRegion = new DataRegionTable(SampleTypeTest.SAMPLE_TYPE_DATA_REGION_NAME, getWrappedDriver());
+        DataRegionTable sampleTypesDataRegion = new DataRegionTable(SampleTypeAPIHelper.SAMPLE_TYPE_DATA_REGION_NAME, getWrappedDriver());
 
         Assert.assertEquals("Number of Sample Types not as expected.", 1, sampleTypesDataRegion.getDataRowCount());
 

--- a/src/org/labkey/test/tests/SampleTypeLimitsTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLimitsTest.java
@@ -28,8 +28,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DATA_REGION_NAME;
-import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DOMAIN_KIND;
+import static org.labkey.test.util.exp.SampleTypeAPIHelper.SAMPLE_TYPE_DATA_REGION_NAME;
+import static org.labkey.test.util.exp.SampleTypeAPIHelper.SAMPLE_TYPE_DOMAIN_KIND;
 
 /**
  * Test cases that use large amounts of data or in other ways stress the system. If they fail they can interfere with

--- a/src/org/labkey/test/tests/SampleTypeLimitsTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLimitsTest.java
@@ -28,8 +28,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.labkey.test.tests.SampleSetTest.SAMPLE_TYPE_DATA_REGION_NAME;
-import static org.labkey.test.tests.SampleSetTest.SAMPLE_TYPE_DOMAIN_KIND;
+import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DATA_REGION_NAME;
+import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DOMAIN_KIND;
 
 /**
  * Test cases that use large amounts of data or in other ways stress the system. If they fail they can interfere with

--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.labkey.test.tests.SampleSetTest.SAMPLE_TYPE_DOMAIN_KIND;
+import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DOMAIN_KIND;
 
 @Category({DailyC.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 10)
@@ -221,7 +221,7 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
                 new FieldDefinition("StringCol", FieldDefinition.ColumnType.String),
                 new FieldDefinition("DateCol", FieldDefinition.ColumnType.DateAndTime),
                 new FieldDefinition("BoolCol", FieldDefinition.ColumnType.Boolean));
-        File sampleTypeFile = TestFileUtils.getSampleData("sampleSet.xlsx");
+        File sampleTypeFile = TestFileUtils.getSampleData("sampleType.xlsx");
 
         clickProject(PROJECT_NAME);
         SampleTypeHelper sampleHelper = new SampleTypeHelper(this);

--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DOMAIN_KIND;
+import static org.labkey.test.util.exp.SampleTypeAPIHelper.SAMPLE_TYPE_DOMAIN_KIND;
 
 @Category({DailyC.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 10)

--- a/src/org/labkey/test/tests/SampleTypeParentColumnTest.java
+++ b/src/org/labkey/test/tests/SampleTypeParentColumnTest.java
@@ -29,8 +29,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_COLUMN_NAME;
-import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DOMAIN_KIND;
+import static org.labkey.test.util.exp.SampleTypeAPIHelper.SAMPLE_TYPE_COLUMN_NAME;
+import static org.labkey.test.util.exp.SampleTypeAPIHelper.SAMPLE_TYPE_DOMAIN_KIND;
 
 @Category({DailyC.class})
 public class SampleTypeParentColumnTest extends BaseWebDriverTest

--- a/src/org/labkey/test/tests/SampleTypeParentColumnTest.java
+++ b/src/org/labkey/test/tests/SampleTypeParentColumnTest.java
@@ -29,11 +29,11 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.labkey.test.tests.SampleSetTest.SAMPLE_TYPE_COLUMN_NAME;
-import static org.labkey.test.tests.SampleSetTest.SAMPLE_TYPE_DOMAIN_KIND;
+import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_COLUMN_NAME;
+import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DOMAIN_KIND;
 
 @Category({DailyC.class})
-public class SampleSetParentColumnTest extends BaseWebDriverTest
+public class SampleTypeParentColumnTest extends BaseWebDriverTest
 {
     private static final String PROJECT_NAME = "SampleTypeParentAliasProject";
     private static final String SUB_FOLDER_NAME = "ParentAliasSubFolder";
@@ -80,7 +80,7 @@ public class SampleSetParentColumnTest extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject()
     {
-        SampleSetParentColumnTest init = (SampleSetParentColumnTest) getCurrentTest();
+        SampleTypeParentColumnTest init = (SampleTypeParentColumnTest) getCurrentTest();
 
         // Comment out this line (after you run once) it will make iterating on  tests much easier.
         init.doSetup();
@@ -105,7 +105,6 @@ public class SampleSetParentColumnTest extends BaseWebDriverTest
 
         createAndPopulateSampleType(SIBLING_SAMPLE_TYPE_NAME, PROJECT_NAME + "/" + SUB_FOLDER_NAME, "SIB_", "Use me as a parent (sub folder). ");
         createAndPopulateDataClass(SIBLING_DATA_CLASS_NAME, PROJECT_NAME + "/" + SUB_FOLDER_NAME, "DCSIB_", "DataClass Object parent (sub folder). ");
-
     }
 
     private void createAndPopulateSampleType(String sampleTypeName, String path, String namePrefix, String descriptionPrefix)
@@ -206,7 +205,6 @@ public class SampleSetParentColumnTest extends BaseWebDriverTest
         {
             throw new RuntimeException(rethrow);
         }
-
     }
 
     private void checkAllRowsInDataRegion(String dataRegionName, String columnName, List<String> expectedValues)
@@ -463,7 +461,6 @@ public class SampleSetParentColumnTest extends BaseWebDriverTest
         checkAllRowsInDataRegion("parentMaterials", SAMPLE_TYPE_COLUMN_NAME, List.of(SAMPLE_TYPE_NAME, PARENT_CONTAINER_SAMPLE_TYPE_NAME));
 
         regexCheckRowInDataRegion("Runs", 0, "Name", "Derive sample from (?:S_11, SE_04|SE_04, S_11)");
-
     }
 
     /**

--- a/src/org/labkey/test/tests/SampleTypeRemoteAPITest.java
+++ b/src/org/labkey/test/tests/SampleTypeRemoteAPITest.java
@@ -65,8 +65,8 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DATA_REGION_NAME;
-import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DOMAIN_KIND;
+import static org.labkey.test.util.exp.SampleTypeAPIHelper.SAMPLE_TYPE_DATA_REGION_NAME;
+import static org.labkey.test.util.exp.SampleTypeAPIHelper.SAMPLE_TYPE_DOMAIN_KIND;
 
 @Category({DailyC.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 10)

--- a/src/org/labkey/test/tests/SampleTypeRemoteAPITest.java
+++ b/src/org/labkey/test/tests/SampleTypeRemoteAPITest.java
@@ -65,12 +65,12 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.labkey.test.tests.SampleSetTest.SAMPLE_TYPE_DATA_REGION_NAME;
-import static org.labkey.test.tests.SampleSetTest.SAMPLE_TYPE_DOMAIN_KIND;
+import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DATA_REGION_NAME;
+import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DOMAIN_KIND;
 
 @Category({DailyC.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 10)
-public class SampleSetRemoteAPITest extends BaseWebDriverTest
+public class SampleTypeRemoteAPITest extends BaseWebDriverTest
 {
     public final String FOLDER_NAME = "Samples";
     public final String LINEAGE_FOLDER = "LineageSamples";
@@ -84,7 +84,7 @@ public class SampleSetRemoteAPITest extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject()
     {
-        SampleSetRemoteAPITest init = (SampleSetRemoteAPITest) getCurrentTest();
+        SampleTypeRemoteAPITest init = (SampleTypeRemoteAPITest) getCurrentTest();
 
         init.doSetup();
     }

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -48,6 +48,7 @@ import org.labkey.test.util.ExcelHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
 import org.labkey.test.util.TestDataGenerator;
+import org.labkey.test.util.exp.SampleTypeAPIHelper;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -72,11 +73,6 @@ import static org.junit.Assert.assertTrue;
 @BaseWebDriverTest.ClassTimeout(minutes = 20)
 public class SampleTypeTest extends BaseWebDriverTest
 {
-    // Global constants to ease migration from "Sample Set" to "Sample Type"
-    public static final String SAMPLE_TYPE_DOMAIN_KIND = "SampleSet";
-    public static final String SAMPLE_TYPE_DATA_REGION_NAME = "SampleSet";
-    public static final String SAMPLE_TYPE_COLUMN_NAME = "Sample Set";
-
     private static final String PROJECT_NAME = "SampleTypeTestProject";
     private static final String FOLDER_NAME = "SampleTypeTestFolder";
     private static final String LOOKUP_FOLDER = "LookupSampleTypeFolder";
@@ -304,7 +300,7 @@ public class SampleTypeTest extends BaseWebDriverTest
                         new FieldDefinition("intData", ColumnType.Integer),
                         new FieldDefinition("floatData", ColumnType.Decimal)
                 ));
-        dgen.createDomain(createDefaultConnection(true), SAMPLE_TYPE_DOMAIN_KIND);
+        dgen.createDomain(createDefaultConnection(true), SampleTypeAPIHelper.SAMPLE_TYPE_DOMAIN_KIND);
         dgen.addCustomRow(Map.of("name", "A", "strData", "argy", "intData", 6, "floatData", 2.5));
         dgen.addCustomRow(Map.of("name", "B", "strData", "bargy","intData", 7, "floatData", 3.5));
         dgen.addCustomRow(Map.of("name", "C", "strData", "foofoo","intData", 8, "floatData", 4.5));
@@ -324,7 +320,7 @@ public class SampleTypeTest extends BaseWebDriverTest
                         new FieldDefinition("floatLooky", ColumnType.Decimal)
                                 .setLookup("exp.materials", "sampleData", lookupContainer)
                 ));
-        lookupDgen.createDomain(createDefaultConnection(true), SAMPLE_TYPE_DOMAIN_KIND);
+        lookupDgen.createDomain(createDefaultConnection(true), SampleTypeAPIHelper.SAMPLE_TYPE_DOMAIN_KIND);
         lookupDgen.addCustomRow(Map.of("name", "B"));
 
         // If this is to be a look-up to another sample type I believe the values should be the row index and not the name.
@@ -334,7 +330,7 @@ public class SampleTypeTest extends BaseWebDriverTest
         lookupDgen.insertRows(createDefaultConnection(true), dgen.getRows());
 
         refresh();
-        DataRegionTable.DataRegion(getDriver()).withName(SAMPLE_TYPE_DOMAIN_KIND).waitFor();
+        DataRegionTable.DataRegion(getDriver()).withName(SampleTypeAPIHelper.SAMPLE_TYPE_DOMAIN_KIND).waitFor();
         waitAndClick(Locator.linkWithText("sampleLookups"));
         DataRegionTable materialsList =  DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
 

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -70,7 +70,7 @@ import static org.junit.Assert.assertTrue;
 
 @Category({DailyC.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 20)
-public class SampleSetTest extends BaseWebDriverTest
+public class SampleTypeTest extends BaseWebDriverTest
 {
     // Global constants to ease migration from "Sample Set" to "Sample Type"
     public static final String SAMPLE_TYPE_DOMAIN_KIND = "SampleSet";
@@ -98,7 +98,7 @@ public class SampleSetTest extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject()
     {
-        SampleSetTest init = (SampleSetTest) getCurrentTest();
+        SampleTypeTest init = (SampleTypeTest) getCurrentTest();
 
         // Comment out this line (after you run once) it will make iterating on tests much easier.
         init.doSetup();
@@ -117,7 +117,6 @@ public class SampleSetTest extends BaseWebDriverTest
         _containerHelper.createSubfolder(PROJECT_NAME, LOOKUP_FOLDER, "Collaboration");
         portalHelper.addWebPart("Sample Types");
         portalHelper.exitAdminMode();
-
     }
 
     @Override
@@ -261,7 +260,7 @@ public class SampleSetTest extends BaseWebDriverTest
         log("Try to import overlapping data from file");
         drt.clickImportBulkData();
         click(Locator.tagWithText("h3", "Upload file (.xlsx, .xls, .csv, .txt)"));
-        setFormElement(Locator.tagWithName("input", "file"), TestFileUtils.getSampleData("simpleSampleSet.xls"));
+        setFormElement(Locator.tagWithName("input", "file"), TestFileUtils.getSampleData("simpleSampleType.xls"));
         clickButton("Submit", "duplicate key");
 
         log ("Switch to 'Insert and Replace'");
@@ -284,7 +283,6 @@ public class SampleSetTest extends BaseWebDriverTest
         assertTrue("Should have a row with the third sample name", index >= 0);
         rowData = drt.getRowDataAsMap(index);
         assertEquals(fieldNames.get(0) + " for sample 'Name' not as expected", "Dee", rowData.get(fieldNames.get(0)));
-
     }
 
     // I don't think this test is doing what was intended. I'm unclear if this is intended to be a lineage test or a
@@ -297,7 +295,7 @@ public class SampleSetTest extends BaseWebDriverTest
     @Ignore
     public void testSamplesWithLookups() throws IOException, CommandException
     {
-        // create a basic sampleset
+        // create a basic sample type
         navigateToFolder(getProjectName(), LOOKUP_FOLDER);
         TestDataGenerator dgen = new TestDataGenerator("exp.materials", "sampleData", getCurrentContainerPath())
                 .withColumns(List.of(
@@ -312,7 +310,7 @@ public class SampleSetTest extends BaseWebDriverTest
         dgen.addCustomRow(Map.of("name", "C", "strData", "foofoo","intData", 8, "floatData", 4.5));
         dgen.insertRows(createDefaultConnection(true), dgen.getRows());
 
-        // create the lookup sampleset in a different folder- configured to look to the first one
+        // create the lookup sample type in a different folder- configured to look to the first one
         String lookupContainer = getProjectName() + "/" + LOOKUP_FOLDER;
         navigateToFolder(getProjectName(), FOLDER_NAME);
         // create another with a lookup to it
@@ -1199,7 +1197,7 @@ public class SampleSetTest extends BaseWebDriverTest
     {
         SampleTypeHelper sampleHelper = new SampleTypeHelper(this);
 
-        // make sure we are case-sensitive when creating samplesets -- regression coverage for issue 33743
+        // make sure we are case-sensitive when creating sample types -- regression coverage for issue 33743
         clickProject(PROJECT_NAME);
         sampleHelper.createSampleType(new SampleTypeDefinition(CASE_INSENSITIVE_SAMPLE_TYPE));
 

--- a/src/org/labkey/test/util/SampleTypeHelper.java
+++ b/src/org/labkey/test/util/SampleTypeHelper.java
@@ -36,7 +36,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
-import static org.labkey.test.tests.SampleSetTest.SAMPLE_TYPE_DATA_REGION_NAME;
+import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DATA_REGION_NAME;
 
 /**
  * Helper methods for create Sample Types and import data into them through standard LabKey Server UI

--- a/src/org/labkey/test/util/SampleTypeHelper.java
+++ b/src/org/labkey/test/util/SampleTypeHelper.java
@@ -36,7 +36,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
-import static org.labkey.test.tests.SampleTypeTest.SAMPLE_TYPE_DATA_REGION_NAME;
+import static org.labkey.test.util.exp.SampleTypeAPIHelper.SAMPLE_TYPE_DATA_REGION_NAME;
 
 /**
  * Helper methods for create Sample Types and import data into them through standard LabKey Server UI

--- a/src/org/labkey/test/util/exp/SampleTypeAPIHelper.java
+++ b/src/org/labkey/test/util/exp/SampleTypeAPIHelper.java
@@ -19,6 +19,11 @@ import java.util.Set;
 
 public class SampleTypeAPIHelper
 {
+    // Global constants to ease migration from "Sample Set" to "Sample Type"
+    public static final String SAMPLE_TYPE_DOMAIN_KIND = "SampleSet";
+    public static final String SAMPLE_TYPE_DATA_REGION_NAME = "SampleSet";
+    public static final String SAMPLE_TYPE_COLUMN_NAME = "Sample Set";
+
     /**
      * Create a sample type in the specified container with the fields provided.
      *
@@ -85,5 +90,4 @@ public class SampleTypeAPIHelper
 
         return sampleIds;
     }
-
 }


### PR DESCRIPTION
#### Rationale
Now that the bulk of the SampleSet → SampleType changes have been made, it's time for the remaining tests to reflect the new name. Also need to fix SampleTypeFolderExportImportTest.

#### Related Pull Requests
* LabKey/sampleManagement#312
* LabKey/biologics#622
* LabKey/nihs#22
* LabKey/provenance#33

#### Changes
* Rename SampleSetTest, SampleSetParentColumnTest, and SampleSetRemoteAPITest
* Use dataregion name constant in SampleTypeFolderExportImportTest
* Use renamed sample data files
