### PR TITLE
Fix race condition for tests logging in.

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -331,7 +331,6 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
     public void signIn(String email, String password)
     {
         attemptSignIn(email, password);
-        waitForElementToDisappear(Locator.id("password"));
         Assert.assertEquals("Logged in as wrong user", email, getCurrentUser());
         WebTestHelper.saveSession(email, getDriver());
     }
@@ -359,7 +358,12 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         assertElementPresent(Locator.tagWithName("form", "login"));
         setFormElement(Locator.id("email"), email);
         setFormElement(Locator.id("password"), password);
+        WebElement signInButton = Locator.lkButton("Sign In").findElement(getDriver());
         clickButton("Sign In", 0);
+        shortWait().until(ExpectedConditions.invisibilityOfElementLocated(Locator.byClass("signing-in-msg")));
+        shortWait().until(ExpectedConditions.or(
+                ExpectedConditions.stalenessOf(signInButton), // Successful login
+                ExpectedConditions.presenceOfElementLocated(Locators.labkeyError.withText()))); // Error during sign-in
     }
 
     public void signInShouldFail(String email, String password, String... expectedMessages)

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -359,7 +359,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         setFormElement(Locator.id("email"), email);
         setFormElement(Locator.id("password"), password);
         WebElement signInButton = Locator.lkButton("Sign In").findElement(getDriver());
-        clickButton("Sign In", 0);
+        signInButton.click();
         shortWait().until(ExpectedConditions.invisibilityOfElementLocated(Locator.byClass("signing-in-msg")));
         shortWait().until(ExpectedConditions.or(
                 ExpectedConditions.stalenessOf(signInButton), // Successful login

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -331,7 +331,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
     public void signIn(String email, String password)
     {
         attemptSignIn(email, password);
-        waitForElementToDisappear(Locator.lkButton("Sign In"));
+        waitForElementToDisappear(Locator.id("password"));
         Assert.assertEquals("Logged in as wrong user", email, getCurrentUser());
         WebTestHelper.saveSession(email, getDriver());
     }


### PR DESCRIPTION
#### Rationale
Login page behavior has changed slightly. Text on the "Sign In" button changes after clicking, effectively "disappearing", causing callers to interact with the page before sign in has completed. This was causing LDAP tests to fail because LDAP authentication takes a bit longer.

#### Changes
* Have 'attemptSignIn' wait for success and error states. 

#### Issue
* https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40791