### PR TITLE
Fix expected value for exported Java script

### DIFF
--- a/src/org/labkey/test/tests/AbstractExportTest.java
+++ b/src/org/labkey/test/tests/AbstractExportTest.java
@@ -443,7 +443,7 @@ public abstract class AbstractExportTest extends BaseWebDriverTest
     {
         assertTrue("Script is missing SelectRowsCommand", javaScript.contains("SelectRowsCommand cmd = new SelectRowsCommand(\"" + getDataRegionSchemaName() + "\", \"" + getDataRegionQueryName() + "\");"));
         if (null != filterColumn)
-            assertTrue("Script is missing addFilter()", javaScript.contains("cmd.addFilter(\"" + filterColumn + "\", \"foo\", Filter.Operator.EQUAL);"));
+            assertTrue("Script is missing addFilter()", javaScript.contains("cmd.addFilter(\"" + filterColumn + "\", \"foo\", Filter.Operator.getOperator(\"EQUAL\"));"));
     }
 
     protected final void assertJavaScriptScriptContents(String javaScriptScript, String filterColumn)


### PR DESCRIPTION
#### Rationale
Java export tests failing after fix for [40753: Exported Java client API script uses wrong constant for Blank/Not Blank filters](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40753)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1369

#### Changes
* Update expected script content
