### PR TITLE
Rename 'External Tool Settings' to 'External Tool Access'.

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -1013,7 +1013,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
 
     public void goToExternalToolPage()
     {
-        clickUserMenuItem("External Tool Settings");
+        clickUserMenuItem("External Tool Access");
         waitForText("API keys are used to authorize");
     }
 

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -1014,7 +1014,6 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
     public void goToExternalToolPage()
     {
         clickUserMenuItem("External Tool Access");
-        waitForText("API keys are used to authorize");
     }
 
     protected WebElement openMenu(String menuText)

--- a/src/org/labkey/test/tests/ApiKeyTest.java
+++ b/src/org/labkey/test/tests/ApiKeyTest.java
@@ -280,6 +280,7 @@ public class ApiKeyTest extends BaseWebDriverTest
     private String generateSessionKey()
     {
         goToExternalToolPage();
+        waitForText("API keys are used to authorize");
         clickButton("Generate session key", "session|");
         return Locator.inputById("session-token").findElement(getDriver()).getAttribute("value");
     }


### PR DESCRIPTION
#### Rationale
Rename 'External Tool Settings' to 'External Tool Access' to avoid confusion with the Settings part (since users are not Setting any configurations, but only retrieving it)

#### Related Pull Requests
https://github.com/LabKey/connectors/pull/38
https://github.com/LabKey/platform/pull/1380