### PR TITLE
Add Firefox startup retry

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -355,13 +355,23 @@ public abstract class WebDriverWrapper implements WrapsDriver
                         binary.addCommandLineOptions("--headless");
                     }
                     capabilities.setCapability(FirefoxDriver.BINARY, binary);
+                    FirefoxOptions firefoxOptions = new FirefoxOptions(capabilities);
                     try
                     {
-                        newWebDriver = new FirefoxDriver(new FirefoxOptions(capabilities));
+                        newWebDriver = new FirefoxDriver(firefoxOptions);
                     }
-                    catch (WebDriverException rethrow)
+                    catch (WebDriverException retry)
                     {
-                        throw new WebDriverException("ERROR: Failed to initialize FirefoxDriver. Ensure that you are using Firefox 62 or newer.", rethrow);
+                        try
+                        {
+                            retry.printStackTrace(System.err);
+                            sleep(10000);
+                            newWebDriver = new FirefoxDriver(firefoxOptions);
+                        }
+                        catch (WebDriverException rethrow)
+                        {
+                            throw new WebDriverException("ERROR: Failed to initialize FirefoxDriver. Ensure that you are using Firefox 62 or newer.", rethrow);
+                        }
                     }
                 }
                 break;
@@ -990,6 +1000,10 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
     /**
      * @deprecated Copying the browser session is preferred unless tests have specific needs otherwise.
+     * Use {@link WebTestHelper#getRemoteApiConnection(boolean)} to get a fresh Connection.
+     *
+     * @param reuseSession ignored
+     * @return A new remoteapi connection matching the current browser session
      */
     @Deprecated
     public Connection createDefaultConnection(boolean reuseSession)


### PR DESCRIPTION
#### Rationale
Tests on TeamCity frequently fail when attempting to launch Firefox.
```
org.openqa.selenium.WebDriverException: invalid argument: can't kill an exited process
	[...]
remote stacktrace: 
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	[...]
	at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:131)
	at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:147)
	at org.labkey.test.WebDriverWrapper.createNewWebDriver(WebDriverWrapper.java:360)
```
Subsequent tests are unaffected so a wait and retry should be an effective solution.

#### Changes
* Wait 10s and retry if there is an exception when creating a new `FirefoxDriver`
