### PR TITLE
Backport : Retry failed Firefox startup (#401)

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -351,13 +351,23 @@ public abstract class WebDriverWrapper implements WrapsDriver
                         binary.addCommandLineOptions("--headless");
                     }
                     capabilities.setCapability(FirefoxDriver.BINARY, binary);
+                    FirefoxOptions firefoxOptions = new FirefoxOptions(capabilities);
                     try
                     {
-                        newWebDriver = new FirefoxDriver(new FirefoxOptions(capabilities));
+                        newWebDriver = new FirefoxDriver(firefoxOptions);
                     }
-                    catch (WebDriverException rethrow)
+                    catch (WebDriverException retry)
                     {
-                        throw new WebDriverException("ERROR: Failed to initialize FirefoxDriver. Ensure that you are using Firefox 62 or newer.", rethrow);
+                        try
+                        {
+                            retry.printStackTrace(System.err);
+                            sleep(10000);
+                            newWebDriver = new FirefoxDriver(firefoxOptions);
+                        }
+                        catch (WebDriverException rethrow)
+                        {
+                            throw new WebDriverException("ERROR: Failed to initialize FirefoxDriver. Ensure that you are using Firefox 62 or newer.", rethrow);
+                        }
                     }
                 }
                 break;
@@ -999,6 +1009,15 @@ public abstract class WebDriverWrapper implements WrapsDriver
         }
 
         return connection;
+    }
+
+    /**
+     * @deprecated Copying the browser session is preferred unless tests have specific needs otherwise.
+     */
+    @Deprecated
+    public Connection createDefaultConnection(boolean reuseSession)
+    {
+        return createDefaultConnection();
     }
 
     public long beginAt(String relativeURL)

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1011,15 +1011,6 @@ public abstract class WebDriverWrapper implements WrapsDriver
         return connection;
     }
 
-    /**
-     * @deprecated Copying the browser session is preferred unless tests have specific needs otherwise.
-     */
-    @Deprecated
-    public Connection createDefaultConnection(boolean reuseSession)
-    {
-        return createDefaultConnection();
-    }
-
     public long beginAt(String relativeURL)
     {
         return beginAt(relativeURL, defaultWaitForPage);


### PR DESCRIPTION
#### Rationale
Seeing a lot of noise from Firefox startup errors. Backporting fix from develop.

#### Changes
* Backport #401
