### PR TITLE
Upgrade AspectJ 1.9.5 -> 1.9.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,10 @@
-antContribVersion=1.0b3
+# Properties used by 'org.labkey.UiTest' Gradle plugin
+# suppress inspection "UnusedProperty"
 aspectjVersion=1.9.6
+# suppress inspection "UnusedProperty"
+reflectionsVersion=0.9.10
+
 lookfirstSardineVersion=5.7
 seleniumVersion=3.141.59
-reflectionsVersion=0.9.10
 mockserverVersion=5.5.1
-labkeySchemasTestVersion=20.3.2
+labkeySchemasTestVersion=20.7.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 antContribVersion=1.0b3
-aspectjVersion=1.9.5
+aspectjVersion=1.9.6
 lookfirstSardineVersion=5.7
 seleniumVersion=3.141.59
 reflectionsVersion=0.9.10


### PR DESCRIPTION
#### Rationale
AspectJ 1.9.6 upgrade supports Java 14 syntax