### PR TITLE
Make experimental feature properties work on TeamCity

### DIFF
--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -286,9 +286,10 @@ public abstract class TestProperties
                     ? (Boolean)entry.getValue()
                     : Boolean.valueOf(String.valueOf(entry.getValue()));
 
-            if (key.startsWith("experimental.") && value != null)
+            String prefix = "webtest.experimental.";
+            if (key.startsWith(prefix))
             {
-                String feature = key.substring("experimental.".length());
+                String feature = key.substring(prefix.length());
                 features.put(feature, value);
             }
         }

--- a/src/org/labkey/test/util/ExperimentalFeaturesHelper.java
+++ b/src/org/labkey/test/util/ExperimentalFeaturesHelper.java
@@ -19,7 +19,6 @@ import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.PostCommand;
-import org.labkey.test.LabKeySiteWrapper;
 import org.labkey.test.TestProperties;
 
 import java.io.IOException;
@@ -28,57 +27,20 @@ import java.util.Map;
 
 public class ExperimentalFeaturesHelper
 {
-    private static Map<String, Boolean> _originalFeatureFlags = new HashMap<>();
-
-    public static void enableExperimentalFeature(Connection cn, String feature)
+    public static Boolean enableExperimentalFeature(Connection cn, String feature)
     {
-        setFeature(cn, feature, true);
+        return setExperimentalFeature(cn, feature, true);
     }
 
-    public static void disableExperimentalFeature(Connection cn, String feature)
+    public static Boolean disableExperimentalFeature(Connection cn, String feature)
     {
-        setFeature(cn, feature, false);
+        return setExperimentalFeature(cn, feature, false);
     }
 
-    public static void setExperimentalFeature(Connection cn, String feature, boolean enable)
-    {
-        setFeature(cn, feature, enable);
-    }
-
-    public static void setFeatures(LabKeySiteWrapper test, Map<String, Boolean> flags)
-    {
-        if (flags == null || flags.isEmpty())
-            return;
-
-        TestLogger.log("Setting experimental flags for duration of the test:");
-
-        Connection cn = test.createDefaultConnection();
-        for (Map.Entry<String, Boolean> flag : flags.entrySet())
-        {
-            setFeature(cn, flag.getKey(), flag.getValue());
-        }
-    }
-
-    public static void resetFeatures(LabKeySiteWrapper test)
-    {
-        if (_originalFeatureFlags.isEmpty())
-            return;
-
-        TestLogger.log("Resetting experimental flags to their original value:");
-
-        Connection cn = test.createDefaultConnection();
-        for (Map.Entry<String, Boolean> features : _originalFeatureFlags.entrySet())
-        {
-            setExperimentalFeature(cn, features.getKey(), features.getValue());
-        }
-
-        _originalFeatureFlags = new HashMap<>();
-    }
-
-    private static void setFeature(Connection cn, String feature, boolean enable)
+    public static Boolean setExperimentalFeature(Connection cn, String feature, boolean enable)
     {
         if (TestProperties.isPrimaryUserAppAdmin())
-            return; // App admin can't enable/disable experimental features
+            return null; // App admin can't enable/disable experimental features
 
         TestLogger.log((enable ? "Enabling" : "Disabling") + " experimental feature " + feature);
 
@@ -93,12 +55,7 @@ public class ExperimentalFeaturesHelper
             CommandResponse r = command.execute(cn, null);
             Map<String, Object> response = r.getParsedData();
 
-            // When setting a feature flag the first time, remember the previous setting
-            if (!_originalFeatureFlags.containsKey(feature) && response.containsKey("previouslyEnabled"))
-            {
-                Boolean previouslyEnabled = (Boolean)response.get("previouslyEnabled");
-                _originalFeatureFlags.put(feature, previouslyEnabled.booleanValue());
-            }
+            return (Boolean)response.get("previouslyEnabled");
         }
         catch (IOException e)
         {

--- a/test.properties
+++ b/test.properties
@@ -39,4 +39,4 @@ webtest.without.test.modules=
 webtest.primary.app.admin=
 
 # Enable/Disable experimental features
-#experimental.legacy-lineage=false
+#webtest.experimental.legacy-lineage=false


### PR DESCRIPTION
#### Rationale
When defined as system properties on TeamCity, Gradle does not pass the `experimental.*` flags to the test harness. It does, however pass any property that starts with `webtest`.
We will use this feature to incrementally enable strict JSP validation to prevent backsliding as Adam and Matt work their way through the test suites.

#### Related
* https://github.com/LabKey/platform/pull/1425

#### Changes
* Use `webtest.experimental.*` properties to set experimental features
* Move `set/resetExperimentalFlags` out of `ExperimentalFeaturesHelper` to isolate features enabled via property from features enabled otherwise
* Don't reset experimental features between tests on TeamCity. The property isn't going to change.
