### PR TITLE
add pipeline status details page test helper

### DIFF
--- a/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
+++ b/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
@@ -230,6 +230,13 @@ public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsP
         return "ERROR".equalsIgnoreCase(getStatus());
     }
 
+    /** Return true if the log status file was found (the log data element is present.) */
+    public PipelineStatusDetailsPage waitForLogPresent()
+    {
+        waitForElement(elementCache().logDataId);
+        return this;
+    }
+
     public boolean isShowingLogSummary()
     {
         String details = elementCache().showFullLogLink.getAttribute("data-details");
@@ -237,17 +244,21 @@ public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsP
         return "false".equals(details);
     }
 
+    @LogMethod
     public PipelineStatusDetailsPage showLogSummary()
     {
         if (!isShowingLogSummary())
             elementCache().showFullLogLink.click();
+        waitForElement(Locator.linkWithText("Show full log file"));
         return this;
     }
 
+    @LogMethod
     public PipelineStatusDetailsPage showLogDetails()
     {
         if (isShowingLogSummary())
             elementCache().showFullLogLink.click();
+        waitForElement(Locator.linkWithText("Show summary"));
         return this;
     }
 
@@ -415,6 +426,8 @@ public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsP
         protected WebElement retryButton = Locator.id("retry-btn").findWhenNeeded(this);
 
         protected WebElement showFullLogLink = Locator.id("show-full-log").findWhenNeeded(this);
-        protected WebElement logData = Locator.id("log-data").findWhenNeeded(this);
+        protected WebElement logContainer = Locator.id("log-container").findWhenNeeded(this);
+        protected Locator logDataId = Locator.id("log-data");
+        protected WebElement logData = logDataId.findWhenNeeded(this);
     }
 }

--- a/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
+++ b/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
@@ -1,0 +1,420 @@
+package org.labkey.test.pages.pipeline;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.pages.LabKeyPage;
+import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.PipelineStatusTable;
+import org.labkey.test.util.TextSearcher;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsPage.ElementCache>
+{
+    private final Set<String> FINISHED_STATES = new CaseInsensitiveHashSet("COMPLETE", "ERROR", "CANCELLED");
+
+    public static PipelineStatusDetailsPage beginAt(WebDriverWrapper driver, int rowId)
+    {
+        driver.beginAt(WebTestHelper.buildURL("pipeline-status", driver.getCurrentContainerPath(), "details", Map.of("rowId", String.valueOf(rowId))));
+        return new PipelineStatusDetailsPage(driver);
+    }
+
+    public PipelineStatusDetailsPage(WebDriver driver)
+    {
+        super(driver);
+    }
+
+    public PipelineStatusDetailsPage(WebDriverWrapper driver)
+    {
+        super(driver);
+    }
+
+    public String getErrorList()
+    {
+        return elementCache().errorList.getText();
+    }
+
+    public String getCreated()
+    {
+        return elementCache().created.getText();
+    }
+
+    public String getModified()
+    {
+        return elementCache().modified.getText();
+    }
+
+    public String getEmail()
+    {
+        return elementCache().email.getText();
+    }
+
+    public String getStatus()
+    {
+        return elementCache().statusText.getText();
+    }
+
+    public String getDescription()
+    {
+        return elementCache().description.getText();
+    }
+
+    public String getInfo()
+    {
+        return elementCache().info.getText();
+    }
+
+    public String getFilePath()
+    {
+        return elementCache().filePath.getText();
+    }
+
+    public List<WebElement> getFileLinks()
+    {
+        return elementCache().filesList.findElements(By.tagName("A"));
+    }
+
+    public List<WebElement> getRunLinks()
+    {
+        return elementCache().runsList.findElements(By.tagName("A"));
+    }
+
+    public String getLogText()
+    {
+        return elementCache().logData.getText();
+    }
+
+    @LogMethod
+    public PipelineStatusDetailsPage assertStatus(String status)
+    {
+        assertEquals("Incorrect job status", status, getStatus());
+        return this;
+    }
+
+    @LogMethod
+    public PipelineStatusDetailsPage waitForStatus(String status)
+    {
+        return waitForStatus(status, defaultWaitForPage);
+    }
+
+    @LogMethod
+    public PipelineStatusDetailsPage waitForStatus(String status, int wait)
+    {
+        waitFor(() -> status.equals(getStatus()),
+                "Expected status '" + status + "', but was '" + getStatus() + "'",
+                wait);
+        return this;
+    }
+
+    @LogMethod
+    public PipelineStatusDetailsPage waitForStatus(Set<String> status, int wait)
+    {
+        waitFor(() -> status.contains(getStatus()),
+                "Expected status to be one of '" + StringUtils.join(status, "', '") + "'",
+                wait);
+        return this;
+    }
+
+    /**
+     * Wait for job to finish: status is either COMPLETE, ERROR, or CANCELLED
+     */
+    public PipelineStatusDetailsPage waitForFinish()
+    {
+        waitForStatus(FINISHED_STATES, defaultWaitForPage);
+        return this;
+    }
+
+    /** Wait for CANCELLED job status */
+    public PipelineStatusDetailsPage waitForCancelled()
+    {
+        waitForStatus("CANCELLED");
+        return this;
+    }
+
+    /** Wait for COMPLETE job status */
+    public PipelineStatusDetailsPage waitForComplete()
+    {
+        return waitForComplete(defaultWaitForPage);
+    }
+
+    /** Wait for COMPLETE job status */
+    @LogMethod
+    public PipelineStatusDetailsPage waitForComplete(int wait)
+    {
+        // flow signals it would like to redirect when COMPLETED by using a URL parameter.
+        boolean expectRedirect = getUrlParam("redirect") != null;
+        if (expectRedirect)
+            log("Expecting redirect when complete");
+
+        waitForStatus("COMPLETE", wait);
+
+        if (expectRedirect)
+        {
+            // The click does nothing, but we want to wait for the redirect before continuing
+            clickAndWait(elementCache().statusText);
+            log("Redirected on success as expected");
+        }
+
+        return this;
+    }
+
+    /** Wait for ERROR job status */
+    public PipelineStatusDetailsPage waitForError()
+    {
+        return waitForError(List.of());
+    }
+
+    /** Wait for ERROR job status and expected errors in the log text. */
+    public PipelineStatusDetailsPage waitForError(String expectedError)
+    {
+        return waitForError(List.of(expectedError));
+    }
+
+    /** Wait for ERROR job status and expected errors in the log text. */
+    public PipelineStatusDetailsPage waitForError(List<String> expectedErrors)
+    {
+        waitForStatus("ERROR");
+        if (!expectedErrors.isEmpty())
+        {
+            log("Checking for expected errors");
+            assertLogTextContains(expectedErrors);
+        }
+        return this;
+    }
+
+    /**
+     * Returns true if the job is in the queue waiting to run or is running.
+     * See <code>{@link PipelineJob.TaskStatus#isActive()}</code>
+     */
+    public boolean isActive()
+    {
+        return isWaiting() || !isFinished();
+    }
+
+    /**
+     * Returns true if the job is COMPLETED, ERROR, or CANCELLED
+     */
+    public boolean isFinished()
+    {
+        String status = getStatus();
+        return FINISHED_STATES.contains(status);
+    }
+
+    /**
+     * Return true if the job is WAITING
+     */
+    public boolean isWaiting()
+    {
+        String status = getStatus();
+        return "WAITING".equalsIgnoreCase(status) || status.toLowerCase().endsWith("waiting");
+    }
+
+    public boolean isErrored()
+    {
+        return "ERROR".equalsIgnoreCase(getStatus());
+    }
+
+    public boolean isShowingLogSummary()
+    {
+        String details = elementCache().showFullLogLink.getAttribute("data-details");
+        assertNotNull("Expected 'data-details' attribute on 'show-full-log' link", details);
+        return "false".equals(details);
+    }
+
+    public PipelineStatusDetailsPage showLogSummary()
+    {
+        if (!isShowingLogSummary())
+            elementCache().showFullLogLink.click();
+        return this;
+    }
+
+    public PipelineStatusDetailsPage showLogDetails()
+    {
+        if (isShowingLogSummary())
+            elementCache().showFullLogLink.click();
+        return this;
+    }
+
+    public PipelineStatusDetailsPage waitForLogText(String logText)
+    {
+        waitForLogText(logText, defaultWaitForPage);
+        log("Found log text: " + logText);
+        return this;
+    }
+
+    @LogMethod
+    public PipelineStatusDetailsPage waitForLogText(String logText, int wait)
+    {
+        // log text is updated on page without having to refresh
+        waitFor(() -> elementCache().logData.getText().contains(logText), "Expected '" + logText + "' in log data", wait);
+        log("Found log text: " + logText);
+        return this;
+    }
+
+    public PipelineStatusDetailsPage assertLogTextContains(Collection<String> texts)
+    {
+        return assertLogTextContains(texts.toArray(new String[0]));
+    }
+
+    @LogMethod
+    public PipelineStatusDetailsPage assertLogTextContains(String... texts)
+    {
+        assertTextPresent(new TextSearcher(getLogText()), texts);
+        log("Found log text: " + StringUtils.join(texts, ", "));
+        return this;
+    }
+
+    @LogMethod
+    public PipelineStatusTable clickShowGrid()
+    {
+        clickAndWait(elementCache().showGridButton);
+        return new PipelineStatusTable(getDriver());
+    }
+
+    public List<WebElement> getSplitJobLinks()
+    {
+        return elementCache().splitJobsTableBody.findElements(By.tagName("A"));
+    }
+
+    public void forEachSplitJobLink(Consumer<PipelineStatusDetailsPage> action)
+    {
+        List<WebElement> splitJobLinks = getSplitJobLinks();
+        int count = splitJobLinks.size();
+        log("Found " + count + " split jobs");
+
+        for (int i = 0; i < count; i++)
+        {
+            pushLocation();
+            action.accept(clickSplitJobLink(i));
+            popLocation();
+            // NOTE: force refetching the split jobs links after navigating
+            clearCache();
+        }
+    }
+
+    public PipelineStatusDetailsPage clickSplitJobLink(int i)
+    {
+        WebElement link = getSplitJobLinks().get(i);
+        log("Clicking link: " + link.getText());
+        clickAndWait(link);
+        return new PipelineStatusDetailsPage(getDriver());
+    }
+
+
+    public WebElement getParentJobLink()
+    {
+        return elementCache().parentJobTableBody.findElement(By.tagName("A"));
+    }
+
+    /**
+     * Click the first run link.
+     */
+    @LogMethod
+    public void clickRunLink()
+    {
+        List<WebElement> runLinks = getRunLinks();
+        assertFalse("Expected at least one run link", runLinks.isEmpty());
+        WebElement runLink = runLinks.get(0);
+        log("clicking run link '" + runLink.getText() + "' with URL: " + runLink.getAttribute("href"));
+    }
+
+    /**
+     * Click the run link with the given name.
+     * @param runName
+     */
+    @LogMethod
+    public void clickRunLink(@Nullable String runName)
+    {
+        List<WebElement> runLinks = getRunLinks();
+        assertFalse("Expected at least one run link", runLinks.isEmpty());
+        for (WebElement runLink : runLinks)
+        {
+            if (runName.equals(runLink.getText()))
+            {
+                log("clicking run link '" + runLink.getText() + "' with URL: " + runLink.getAttribute("href"));
+                runLink.click();
+            }
+        }
+    }
+
+    /**
+     * Data button will be hidden if job is not yet complete or there is no dataUrl for the job.
+     * @return true if the data button is clicked
+     */
+    @LogMethod
+    public boolean clickDataLink()
+    {
+        if (elementCache().showDataButton.isDisplayed())
+        {
+            elementCache().showDataButton.click();
+            log("Clicked 'Data' link");
+            return true;
+        }
+
+        return false;
+    }
+
+    @LogMethod
+    public PipelineStatusDetailsPage clickRetry()
+    {
+        clickAndWait(elementCache().retryButton);
+        return new PipelineStatusDetailsPage(getDriver());
+    }
+
+    @LogMethod
+    public PipelineStatusDetailsPage clickCancel()
+    {
+        elementCache().cancelButton.click();
+        waitForLogText("Attempting to cancel");
+        waitForCancelled();
+        return this;
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends LabKeyPage.ElementCache
+    {
+        protected WebElement errorList = Locator.id("error-list").findWhenNeeded(this);
+        protected WebElement created = Locator.id("created").findWhenNeeded(this);
+        protected WebElement modified = Locator.id("modified").findWhenNeeded(this);
+        protected WebElement email = Locator.id("email").findWhenNeeded(this);
+        protected WebElement statusSpinner = Locator.id("status-spinner").findWhenNeeded(this);
+        protected WebElement statusText = Locator.id("status-text").findWhenNeeded(this);
+        protected WebElement info = Locator.id("info").findWhenNeeded(this);
+        protected WebElement description = Locator.id("description").findWhenNeeded(this);
+        protected WebElement filePath = Locator.id("file-path").findWhenNeeded(this);
+        protected WebElement filesList = Locator.id("files-list").findWhenNeeded(this);
+        protected WebElement parentJobTableBody = Locator.id("parent-job-table-body").findWhenNeeded(this);
+        protected WebElement splitJobsTableBody = Locator.id("split-jobs-table-body").findWhenNeeded(this);
+        protected WebElement runsList = Locator.id("runs-list").findWhenNeeded(this);
+
+        protected WebElement showGridButton = Locator.lkButton("Show Grid").findWhenNeeded(this);
+        protected WebElement showDataButton = Locator.id("show-data-btn").findWhenNeeded(this);
+        protected WebElement browseFilesButton = Locator.lkButton("Browse Files").findWhenNeeded(this);
+        protected WebElement cancelButton = Locator.id("cancel-btn").findWhenNeeded(this);
+        protected WebElement retryButton = Locator.id("retry-btn").findWhenNeeded(this);
+
+        protected WebElement showFullLogLink = Locator.id("show-full-log").findWhenNeeded(this);
+        protected WebElement logData = Locator.id("log-data").findWhenNeeded(this);
+    }
+}

--- a/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
+++ b/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
@@ -3,7 +3,6 @@ package org.labkey.test.pages.pipeline;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
-import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
@@ -200,7 +199,7 @@ public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsP
 
     /**
      * Returns true if the job is in the queue waiting to run or is running.
-     * See <code>{@link PipelineJob.TaskStatus#isActive()}</code>
+     * See <code>{@link org.labkey.api.pipeline.PipelineJob.TaskStatus#isActive()}</code>
      */
     public boolean isActive()
     {
@@ -405,29 +404,29 @@ public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsP
 
     protected class ElementCache extends LabKeyPage.ElementCache
     {
-        protected WebElement errorList = Locator.id("error-list").findWhenNeeded(this);
-        protected WebElement created = Locator.id("created").findWhenNeeded(this);
-        protected WebElement modified = Locator.id("modified").findWhenNeeded(this);
-        protected WebElement email = Locator.id("email").findWhenNeeded(this);
-        protected WebElement statusSpinner = Locator.id("status-spinner").findWhenNeeded(this);
-        protected WebElement statusText = Locator.id("status-text").findWhenNeeded(this);
-        protected WebElement info = Locator.id("info").findWhenNeeded(this);
-        protected WebElement description = Locator.id("description").findWhenNeeded(this);
-        protected WebElement filePath = Locator.id("file-path").findWhenNeeded(this);
-        protected WebElement filesList = Locator.id("files-list").findWhenNeeded(this);
-        protected WebElement parentJobTableBody = Locator.id("parent-job-table-body").findWhenNeeded(this);
-        protected WebElement splitJobsTableBody = Locator.id("split-jobs-table-body").findWhenNeeded(this);
-        protected WebElement runsList = Locator.id("runs-list").findWhenNeeded(this);
+        protected final WebElement errorList = Locator.id("error-list").findWhenNeeded(this);
+        protected final WebElement created = Locator.id("created").findWhenNeeded(this);
+        protected final WebElement modified = Locator.id("modified").findWhenNeeded(this);
+        protected final WebElement email = Locator.id("email").findWhenNeeded(this);
+        protected final WebElement statusSpinner = Locator.id("status-spinner").findWhenNeeded(this);
+        protected final WebElement statusText = Locator.id("status-text").findWhenNeeded(this);
+        protected final WebElement info = Locator.id("info").findWhenNeeded(this);
+        protected final WebElement description = Locator.id("description").findWhenNeeded(this);
+        protected final WebElement filePath = Locator.id("file-path").findWhenNeeded(this);
+        protected final WebElement filesList = Locator.id("files-list").findWhenNeeded(this);
+        protected final WebElement parentJobTableBody = Locator.id("parent-job-table-body").findWhenNeeded(this);
+        protected final WebElement splitJobsTableBody = Locator.id("split-jobs-table-body").findWhenNeeded(this);
+        protected final WebElement runsList = Locator.id("runs-list").findWhenNeeded(this);
 
-        protected WebElement showGridButton = Locator.lkButton("Show Grid").findWhenNeeded(this);
-        protected WebElement showDataButton = Locator.id("show-data-btn").findWhenNeeded(this);
-        protected WebElement browseFilesButton = Locator.lkButton("Browse Files").findWhenNeeded(this);
-        protected WebElement cancelButton = Locator.id("cancel-btn").findWhenNeeded(this);
-        protected WebElement retryButton = Locator.id("retry-btn").findWhenNeeded(this);
+        protected final WebElement showGridButton = Locator.lkButton("Show Grid").findWhenNeeded(this);
+        protected final WebElement showDataButton = Locator.id("show-data-btn").findWhenNeeded(this);
+        protected final WebElement browseFilesButton = Locator.lkButton("Browse Files").findWhenNeeded(this);
+        protected final WebElement cancelButton = Locator.id("cancel-btn").findWhenNeeded(this);
+        protected final WebElement retryButton = Locator.id("retry-btn").findWhenNeeded(this);
 
-        protected WebElement showFullLogLink = Locator.id("show-full-log").findWhenNeeded(this);
-        protected WebElement logContainer = Locator.id("log-container").findWhenNeeded(this);
-        protected Locator logDataId = Locator.id("log-data");
-        protected WebElement logData = logDataId.findWhenNeeded(this);
+        protected final WebElement showFullLogLink = Locator.id("show-full-log").findWhenNeeded(this);
+        protected final WebElement logContainer = Locator.id("log-container").findWhenNeeded(this);
+        protected final Locator logDataId = Locator.id("log-data");
+        protected final WebElement logData = logDataId.findWhenNeeded(this);
     }
 }

--- a/src/org/labkey/test/pipeline/AbstractPipelineTestParams.java
+++ b/src/org/labkey/test/pipeline/AbstractPipelineTestParams.java
@@ -21,6 +21,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.dumbster.EmailRecordTable;
+import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.labkey.test.util.ExperimentRunTable;
 import org.labkey.test.util.PasswordUtil;
 import org.openqa.selenium.NoSuchElementException;
@@ -292,7 +293,6 @@ abstract public class AbstractPipelineTestParams implements PipelineTestParams
     
     private void validateExperiment()
     {
-        _test.clickButton("Data");
         ExperimentGraph graph = new ExperimentGraph(_test);
         graph.validate(this);
     }
@@ -304,23 +304,18 @@ abstract public class AbstractPipelineTestParams implements PipelineTestParams
         validateEmail("COMPLETE", getDirStatusDesciption(), _mailSettings.isNotifyOnSuccess(),
                 _mailSettings.getNotifyUsersOnSuccess());
 
-        // Data button will be hidden if the pipeline job isn't complete yet
-        WebElement el = _test.findButton("Data");
-        if (el.isDisplayed())
+        // Data button will be hidden if the pipeline job isn't complete yet or there is no dataUrl
+        PipelineStatusDetailsPage detailsPage = new PipelineStatusDetailsPage(_test.getDriver());
+        if (detailsPage.clickDataLink())
         {
             validateExperiment();
         }
         else
         {
-            int split = 1;
-            while (_test.isElementPresent(Locator.linkWithText("COMPLETE").index(split)))
-            {
-                _test.pushLocation();
-                Integer index = split++;
-                _test.clickAndWait(Locator.linkWithText("COMPLETE").index(index));
+            detailsPage.forEachSplitJobLink(splitDetailsPage -> {
+                splitDetailsPage.clickDataLink();
                 validateExperiment();
-                _test.popLocation();
-            }
+            });
         }
     }
 

--- a/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
+++ b/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
@@ -28,6 +28,7 @@ import org.labkey.test.categories.DailyB;
 import org.labkey.test.categories.DailyC;
 import org.labkey.test.categories.Git;
 import org.labkey.test.io.Grep;
+import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.labkey.test.util.Maps;
 import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.PipelineStatusTable;
@@ -61,10 +62,9 @@ public class DatabaseDiagnosticsTest extends BaseWebDriverTest
         click(Locator.linkWithText("Validate"));
 
         PipelineStatusTable statusTable = new PipelineStatusTable(this);
-        statusTable.clickStatusLink(0);
-
-        waitForText(300000, "Check complete");
-        assertTextPresent("Check complete, 0 errors found");
+        statusTable.clickStatusLink(0)
+                .waitForComplete(300_000)
+                .assertLogTextContains("Check complete, 0 errors found");
     }
 
     @Test

--- a/src/org/labkey/test/tests/PipelineCancelTest.java
+++ b/src/org/labkey/test/tests/PipelineCancelTest.java
@@ -20,6 +20,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.DailyB;
+import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.labkey.test.util.PipelineStatusTable;
 
 import java.io.File;
@@ -44,14 +45,7 @@ public class PipelineCancelTest  extends BaseWebDriverTest
         startImportStudyFromZip(STUDY_ZIP);
 
         log("Cancel import");
-        PipelineStatusTable pipelineStatusTable = new PipelineStatusTable(this);
-        pipelineStatusTable.clickStatusLink(0);
-        clickButton("Cancel");
-
-        log("Verify cancel succeeded");
-        waitForText("Attempting to cancel");
-        // status should be updated on page without having to refresh
-        waitForText(defaultWaitForPage, "CANCELLED");
+        new PipelineStatusTable(this).clickStatusLink(0).clickCancel();
 
         goToProjectHome();
         assertTextPresent("This folder does not contain a study."); //part of the import will be done, but it shouldn't have gotten to participants.

--- a/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
+++ b/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
@@ -32,9 +32,11 @@ import org.labkey.test.components.CustomizeView;
 import org.labkey.test.components.PlateSummary;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.assay.plate.PlateDesignerPage;
+import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.labkey.test.tests.AbstractAssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.PipelineStatusTable;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.QCAssayScriptHelper;
 import org.openqa.selenium.NoSuchElementException;
@@ -545,8 +547,9 @@ public class ElispotAssayTest extends AbstractAssayTest
         runTable.checkAllOnPage();
         clickButton("Subtract Background");
 
-        // status should be updated on page without having to refresh
-        waitForText(WAIT_FOR_PAGE, "COMPLETE");
+        new PipelineStatusTable(getDriver())
+                .clickStatusLink(0)
+                .waitForComplete();
 
         // Check well counts for TEST_ASSAY_ELISPOT_FILE4
         clickProject(TEST_ASSAY_PRJ_ELISPOT);

--- a/src/org/labkey/test/tests/filecontent/FileRootMigrationTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileRootMigrationTest.java
@@ -27,9 +27,11 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.DailyA;
 import org.labkey.test.pages.admin.FileRootsManagementPage;
+import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PipelineStatusTable;
 import org.labkey.test.util.PortalHelper;
+import org.labkey.test.util.TextSearcher;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,6 +40,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @Category({DailyA.class})
@@ -128,16 +131,19 @@ public class FileRootMigrationTest extends BaseWebDriverTest
                 .saveAndMoveFiles();
         pipelineStatusTable.setContainerFilter(DataRegionTable.ContainerFilterType.CURRENT_AND_SUBFOLDERS);
         waitForPipelineJobsToComplete(1, "Copy Files for File Root Change", false);
-        clickAndWait(Locator.linkWithText("COMPLETE"));
 
-        assertTextPresent("Container: /" + getProjectName() + "/" + FOLDER,
-                projFile1.getName(),
-                projFile2.getName(),
-                folderFile1.getName(),
-                folderFile2.getName());
-        boolean hasUploadLogs = isTextPresent(".upload.log");
-        assertTextPresent("Copying file", hasUploadLogs ? 6 : 4);
-        assertTextPresent("Copying directory", 4);
+        PipelineStatusDetailsPage detailsPage = new PipelineStatusTable(getDriver())
+                .clickStatusLink(0)
+                .assertLogTextContains("Container: /" + getProjectName() + "/" + FOLDER,
+                        projFile1.getName(),
+                        projFile2.getName(),
+                        folderFile1.getName(),
+                        folderFile2.getName());
+
+        String logText = detailsPage.getLogText();
+        boolean hasUploadLogs = logText.contains(".upload.log");
+        assertTextPresent(new TextSearcher(logText), "Copying file", hasUploadLogs ? 6 : 4);
+        assertTextPresent(new TextSearcher(logText), "Copying directory", 4);
 
         log("Verify that all files are still present");
         clickProject(getProjectName());
@@ -189,16 +195,19 @@ public class FileRootMigrationTest extends BaseWebDriverTest
                 .saveAndCopyFiles();
         pipelineStatusTable.setContainerFilter(DataRegionTable.ContainerFilterType.CURRENT_AND_SUBFOLDERS);
         waitForPipelineJobsToComplete(1, "Copy Files for File Root Change", false);
-        clickAndWait(Locator.linkWithText("COMPLETE"));
 
-        assertTextPresent("Container: /" + getProjectName() + "/" + FOLDER,
-                projFile1.getName(),
-                projFile2.getName(),
-                folderFile1.getName(),
-                folderFile2.getName());
-        boolean hasUploadLogs = isTextPresent(".upload.log");
-        assertTextPresent("Copying file", hasUploadLogs ? 6 : 4);
-        assertTextPresent("Copying directory", 4);
+        PipelineStatusDetailsPage detailsPage = new PipelineStatusTable(getDriver())
+                .clickStatusLink(0)
+                .assertLogTextContains("Container: /" + getProjectName() + "/" + FOLDER,
+                        projFile1.getName(),
+                        projFile2.getName(),
+                        folderFile1.getName(),
+                        folderFile2.getName());
+
+        String logText = detailsPage.getLogText();
+        boolean hasUploadLogs = logText.contains(".upload.log");
+        assertTextPresent(new TextSearcher(logText), "Copying file", hasUploadLogs ? 6 : 4);
+        assertTextPresent(new TextSearcher(logText), "Copying directory", 4);
 
         log("Verify that all files are still present");
         clickProject(getProjectName());

--- a/src/org/labkey/test/tests/flow/BaseFlowTest.java
+++ b/src/org/labkey/test/tests/flow/BaseFlowTest.java
@@ -25,12 +25,11 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.components.BodyWebPart;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.experiment.CreateSampleTypePage;
+import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
-import org.labkey.test.util.TextSearcher;
 import org.openqa.selenium.WebDriverException;
-import org.openqa.selenium.WebElement;
 
 import java.io.File;
 import java.io.IOException;
@@ -145,37 +144,15 @@ abstract public class BaseFlowTest extends BaseWebDriverTest
 
     protected void waitForPipelineError(List<String> expectedErrors)
     {
-        waitForPipelineStatus("ERROR");
-
-        log("Checking for errors after importing");
-        String logText = Locator.id("log-data").findElement(getDriver()).getText();
-        assertTextPresent(new TextSearcher(logText), expectedErrors.toArray(new String[0]));
+        new PipelineStatusDetailsPage(getDriver()).waitForError(expectedErrors);
     }
 
     protected void waitForPipelineComplete()
     {
-        // flow signals it would like to redirect when COMPLETED by using a URL parameter.
-        boolean expectRedirect = getUrlParam("redirect") != null;
-        if (expectRedirect)
-            log("Expecting redirect when complete");
-
-        waitForPipelineStatus("COMPLETE");
-
-        if (expectRedirect)
-        {
-            // The click does nothing, but we want to wait for the redirect before continuing
-            clickAndWait(Locator.id("status-text"));
-            log("Redirected on success as expected");
-        }
+        new PipelineStatusDetailsPage(getDriver()).waitForComplete();
 
         log("Checking for errors after importing");
         checkErrors();
-    }
-
-    @LogMethod
-    private void waitForPipelineStatus(String status)
-    {
-        waitForElementText(Locator.id("status-text"), status, MAX_WAIT_SECONDS * 1000);
     }
 
     @Override

--- a/src/org/labkey/test/util/PipelineStatusTable.java
+++ b/src/org/labkey/test/util/PipelineStatusTable.java
@@ -19,6 +19,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.pages.LabKeyPage;
+import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -36,6 +37,11 @@ public class PipelineStatusTable extends DataRegionTable
     public PipelineStatusTable(WebDriverWrapper test)
     {
         super(REGION_NAME, test);
+    }
+
+    public PipelineStatusTable(WebDriver driver)
+    {
+        super(REGION_NAME, driver);
     }
 
     private PipelineStatusTable(WebElement el, WebDriver driver)
@@ -153,14 +159,15 @@ public class PipelineStatusTable extends DataRegionTable
         return getDataAsText(row, getDescriptionColumnIndex());
     }
 
-    public void clickStatusLink(String description)
+    public PipelineStatusDetailsPage clickStatusLink(String description)
     {
-        clickStatusLink(getExpectedJobRow(description));
+        return clickStatusLink(getExpectedJobRow(description));
     }
 
-    public void clickStatusLink(int row)
+    public PipelineStatusDetailsPage clickStatusLink(int row)
     {
         getWrapper().clickAndWait(link(row, getStatusColumnIndex()));
+        return new PipelineStatusDetailsPage(getDriver());
     }
 
     public LabKeyPage clickSetup()


### PR DESCRIPTION
#### Rationale
- fix S3FileRootMigrationTest: support s3 cloud status files in StatusDetailsBean
- fix RedCapTest: find expected errors in log text

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1431
* https://github.com/LabKey/redcap/pull/29
* https://github.com/LabKey/cloud/pull/74
* https://github.com/LabKey/dataintegration/pull/58
