### PR TITLE
Define `toString` for test components

### DIFF
--- a/src/org/labkey/test/components/Component.java
+++ b/src/org/labkey/test/components/Component.java
@@ -33,7 +33,7 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
     @Override
     public String toString()
     {
-        return getClass().getSimpleName() + "[" + getComponentElement() + "]";
+        return getClass().getSimpleName() + " " + getComponentElement();
     }
 
     @Override

--- a/src/org/labkey/test/components/Component.java
+++ b/src/org/labkey/test/components/Component.java
@@ -31,6 +31,12 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
     public abstract WebElement getComponentElement();
 
     @Override
+    public String toString()
+    {
+        return getClass().getSimpleName() + "[" + getComponentElement() + "]";
+    }
+
+    @Override
     public WebElement findElement(By by)
     {
         return getComponentElement().findElement(by);
@@ -73,6 +79,12 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
         public WebElement findElement(By by)
         {
             return getComponentElement().findElement(by);
+        }
+
+        @Override
+        public String toString()
+        {
+            return Component.this.toString();
         }
     }
 

--- a/src/org/labkey/test/pages/LabKeyPage.java
+++ b/src/org/labkey/test/pages/LabKeyPage.java
@@ -73,6 +73,12 @@ public class LabKeyPage<EC extends LabKeyPage.ElementCache> extends WebDriverWra
         waitForPage();
     }
 
+    @Override
+    public String toString()
+    {
+        return getClass().getName();
+    }
+
     protected EC elementCache()
     {
         if (null == _elementCache)
@@ -97,6 +103,12 @@ public class LabKeyPage<EC extends LabKeyPage.ElementCache> extends WebDriverWra
         public WebElement findElement(By by)
         {
             return getDriver().findElement(by);
+        }
+
+        @Override
+        public String toString()
+        {
+            return LabKeyPage.this.toString();
         }
 
         public WebElement headerBlock = Locators.headerContainer().findWhenNeeded(this);


### PR DESCRIPTION
#### Rationale
Generate better exception messages from within `ElementCache`s
Currently we get something like:
```
org.openqa.selenium.NoSuchElementException: Unable to find element: id=status-text
within: org.labkey.test.pages.pipeline.PipelineStatusDetailsPage$ElementCache@1d3bcb74
```
The `toString` method for `WebElement`s includes the locator used to find the element. We should pipe that value through `Component` and `Component.ElementCache`. Then we get something more like:
```
org.openqa.selenium.NoSuchElementException: Unable to find element: id=status-text
within: PipelineStatusTable [[FirefoxDriver: firefox on MAC (a42ebe26-dfcc-f74d-be38-1dd454d84d5c)] -> css selector: form[lk-region-form="StatusFiles"]]
```

#### Changes
* Override `toString` for test components and pages
