### PR TITLE
Move the getOmniBox method from GridBar to QueryGrid

### DIFF
--- a/src/org/labkey/test/components/glassLibrary/components/OmniBox.java
+++ b/src/org/labkey/test/components/glassLibrary/components/OmniBox.java
@@ -195,7 +195,7 @@ public class OmniBox extends WebDriverComponent<OmniBox.ElementCache>
 
     private static abstract class Locators
     {
-        static final Locator.XPathLocator omniBoxControl = Locator.tagWithClass("div", "OmniBox-control");
+        static final Locator.CssLocator omniBoxControl = Locator.css("div.OmniBox-control");
         static final Locator.CssLocator omniBoxInput = Locator.css("div.OmniBox-input > input");
         static final Locator.XPathLocator values = Locator.tagWithClass("div", "OmniBox-value").childTag("span");
         static final Locator.XPathLocator editingValue = Locator.tagWithClass("div", "OmniBox-input")

--- a/src/org/labkey/test/components/glassLibrary/grids/GridBar.java
+++ b/src/org/labkey/test/components/glassLibrary/grids/GridBar.java
@@ -306,15 +306,22 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
     {
         static public Locator.XPathLocator gridBar()
         {
-            return Locator.tagWithClass("div", "query-grid-bar");
+            // QueryGridModel grid uses query-grid-bar, QueryModel grid uses grid-panel__button-bar
+            return Locator.XPathLocator.union(Locator.tagWithClassContaining("div", "query-grid-bar"),
+                    Locator.tagWithClassContaining("div", "grid-panel__button-bar"));
         }
 
-        static final Locator pgRightButton = Locator.tagWithClassContaining("span", "paging")
+        // QueryGridModel grid uses class names with the word "paging", QueryModel version uses class names with the
+        // word "pagination", so selectors look for class names containing "pagin".
+        static final Locator pgRightButton = Locator.tagWithClassContaining("span", "pagin")
                 .descendant(Locator.tag("button").withChild(Locator.tagWithClass("i", "fa fa-chevron-right")));
-        static final Locator pgLeftButton =Locator.tagWithClassContaining("span", "paging")
+        static final Locator pgLeftButton =Locator.tagWithClassContaining("span", "pagin")
                 .descendant(Locator.tag("button").withChild(Locator.tagWithClass("i", "fa fa-chevron-left")));
 
-        static final Locator pagingCountsSpan = Locator.xpath("//span[contains(@class, 'paging')]/span[@data-min]");
+        static final Locator.XPathLocator queryGridModelPagingCounts = Locator.xpath("//span[contains(@class, 'paging')]/span[@data-min]");
+        static final Locator.XPathLocator queryModelPagingCounts = Locator.xpath("//span[contains(@class, 'pagination-info')]");
+        static final Locator pagingCountsSpan = Locator.XPathLocator.union(queryGridModelPagingCounts, queryModelPagingCounts);
+
         static final Locator.XPathLocator viewSelectorButtonGroup = Locator.tagWithClass("div", "dropdown")
                 .withChild(Locator.button("Grid Views"));
         static final Locator.XPathLocator viewSelectorToggleButton = Locator.button("Grid Views");

--- a/src/org/labkey/test/components/glassLibrary/grids/GridBar.java
+++ b/src/org/labkey/test/components/glassLibrary/grids/GridBar.java
@@ -202,11 +202,6 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
 
     }
 
-    public OmniBox getOmniBox()
-    {
-        return elementCache().omniBox;
-    }
-
     public void doMenuAction(String buttonText, List<String> menuActions)
     {
         MultiMenu multiMenu = null;
@@ -295,7 +290,6 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
     protected class ElementCache extends Component<?>.ElementCache
     {
 
-        public OmniBox omniBox = new OmniBox.OmniBoxFinder(_driver).findWhenNeeded(this);
         private final Map<String, MultiMenu> menus = new HashMap<>();
         protected MultiMenu findMenu(String buttonText)
         {

--- a/src/org/labkey/test/components/glassLibrary/grids/GridBar.java
+++ b/src/org/labkey/test/components/glassLibrary/grids/GridBar.java
@@ -60,7 +60,11 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
 
         downloadBtn.click();
 
-        WebElement exportButton = Locator.css("li > a > span").withClass(exportType.buttonCssClass()).findElement(this);
+        // QueryGridPanel (deprecated)
+        Locator.CssLocator queryGridButton = Locator.css("li > a > span").withClass(exportType.buttonCssClass());
+        // GridPanel
+        Locator.CssLocator gridPanelButton = Locator.css("span.export-menu-icon").withClass(exportType.buttonCssClass());
+        WebElement exportButton = Locator.CssLocator.union(queryGridButton, gridPanelButton).findElement(this);
         return getWrapper().doAndWaitForDownload(()->exportButton.click());
     }
 

--- a/src/org/labkey/test/components/glassLibrary/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/glassLibrary/grids/QueryGrid.java
@@ -7,6 +7,7 @@ package org.labkey.test.components.glassLibrary.grids;
 import org.labkey.test.Locator;
 import org.labkey.test.SortDirection;
 import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.components.glassLibrary.components.OmniBox;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -142,6 +143,11 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         return elementCache()._gridBar;
     }
 
+    public OmniBox getOmniBox()
+    {
+        return elementCache().omniBox;
+    }
+
     public GridTabBar getGridTabBar()
     {
         return elementCache().gridTabBar().orElseThrow();
@@ -175,8 +181,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
      */
     public QueryGrid search(String searchTerm)
     {
-        doAndWaitForUpdate(()->
-                getGridBar().getOmniBox().setSearch(searchTerm));
+        doAndWaitForUpdate(()-> getOmniBox().setSearch(searchTerm));
         return this;
     }
 
@@ -188,8 +193,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
      */
     public QueryGrid sortOn(String column, SortDirection direction)
     {
-        doAndWaitForUpdate(()->
-                getGridBar().getOmniBox().setSort(column, direction));
+        doAndWaitForUpdate(()-> getOmniBox().setSort(column, direction));
         return this;
     }
 
@@ -202,8 +206,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
      */
     public QueryGrid filterOn(String columnName, String operator, String value)
     {
-        doAndWaitForUpdate(()->
-                getGridBar().getOmniBox().setFilter(columnName, operator, value));
+        doAndWaitForUpdate(()-> getOmniBox().setFilter(columnName, operator, value));
         return this;
     }
 
@@ -213,8 +216,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
      */
     public QueryGrid clearSortsAndFilters()
     {
-        doAndWaitForUpdate(()->
-                getGridBar().getOmniBox().clearAll());
+        doAndWaitForUpdate(()-> getOmniBox().clearAll());
         return this;
     }
 
@@ -261,6 +263,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
     {
         ResponsiveGrid _responsiveGrid = new ResponsiveGrid.ResponsiveGridFinder(_driver).findWhenNeeded(_queryGridPanel);
         GridBar _gridBar = new GridBar.GridBarFinder(_driver, _queryGridPanel, _responsiveGrid).findWhenNeeded();
+        OmniBox omniBox = new OmniBox.OmniBoxFinder(_driver).findWhenNeeded(this);
         Optional<GridTabBar> gridTabBar()
         {
             return new GridTabBar.GridTabBarFinder(_driver, _responsiveGrid).findOptional(_queryGridPanel);


### PR DESCRIPTION
#### Rationale
I moved the getOmniBox method from GridBar.java to QueryGrid.java because the QueryModel version does not render the OmniBox inside of the grid bar div.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/642
* https://github.com/LabKey/sampleManagement/pull/334

#### Changes
* Move the getOmniBox method from GridBar to QueryGrid
