### PR TITLE
Make sure test is on correct page

### DIFF
--- a/src/org/labkey/test/tests/StudySurveyTest.java
+++ b/src/org/labkey/test/tests/StudySurveyTest.java
@@ -66,6 +66,7 @@ public class StudySurveyTest extends BaseWebDriverTest
     @Test
     public void testUpdateSurveyDatasetDate()
     {
+        goToProjectHome();
         String surveyLabel = "Study Survey";
 
         log("Creating a new dataset");


### PR DESCRIPTION
#### Rationale
Browser is on 'Home' project when `StudySurveyTest.testUpdateSurveyDatasetDate` starts. Not sure why this just started failing.

#### Changes
* `goToProjectHome` at start of test.
