### PR TITLE
handle errors thrown when reading pipeline status log file

### DIFF
--- a/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
+++ b/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
@@ -3,6 +3,7 @@ package org.labkey.test.pages.pipeline;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
@@ -26,7 +27,8 @@ import static org.junit.Assert.assertNotNull;
 
 public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsPage.ElementCache>
 {
-    private final Set<String> FINISHED_STATES = new CaseInsensitiveHashSet("COMPLETE", "ERROR", "CANCELLED");
+    private static final Set<String> FINISHED_STATES = new CaseInsensitiveHashSet("COMPLETE", "ERROR", "CANCELLED");
+    private static final int DEFAULT_PIPELINE_WAIT = BaseWebDriverTest.MAX_WAIT_SECONDS * 1000;
 
     public static PipelineStatusDetailsPage beginAt(WebDriverWrapper driver, int rowId)
     {
@@ -109,7 +111,7 @@ public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsP
     @LogMethod
     public PipelineStatusDetailsPage waitForStatus(String status)
     {
-        return waitForStatus(status, defaultWaitForPage);
+        return waitForStatus(status, DEFAULT_PIPELINE_WAIT);
     }
 
     @LogMethod
@@ -135,7 +137,7 @@ public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsP
      */
     public PipelineStatusDetailsPage waitForFinish()
     {
-        waitForStatus(FINISHED_STATES, defaultWaitForPage);
+        waitForStatus(FINISHED_STATES, DEFAULT_PIPELINE_WAIT);
         return this;
     }
 
@@ -149,7 +151,7 @@ public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsP
     /** Wait for COMPLETE job status */
     public PipelineStatusDetailsPage waitForComplete()
     {
-        return waitForComplete(defaultWaitForPage);
+        return waitForComplete(DEFAULT_PIPELINE_WAIT);
     }
 
     /** Wait for COMPLETE job status */

--- a/src/org/labkey/test/tests/flow/FlowTest.java
+++ b/src/org/labkey/test/tests/flow/FlowTest.java
@@ -31,6 +31,7 @@ import org.labkey.test.components.flow.FlowReportsWebpart;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.pages.flow.reports.QCReportEditorPage;
 import org.labkey.test.pages.flow.reports.ReportEditorPage;
+import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.tests.AuditLogTest;
 import org.labkey.test.util.DataRegion;
@@ -706,6 +707,7 @@ public class FlowTest extends BaseFlowTest
         clickButton("Next");
         waitForText("Import Analysis: Confirm");
         clickButton("Finish");
+        new PipelineStatusDetailsPage(getDriver()).waitForComplete();
         waitForElement(Locator.tagWithClass("div", "alert alert-warning").containing("Ignoring filter/sort"), defaultWaitForPage);
         DataRegionTable query = new DataRegionTable("query", getDriver());
         List<String> names = query.getColumnDataAsText("Name");


### PR DESCRIPTION
#### Rationale
Handle IOException thrown when reading pipeline status file as seen on TeamCity running the flow tests.

```java
java.nio.charset.MalformedInputException: Input length = 1
       at java.base/java.nio.charset.CoderResult.throwException(CoderResult.java:274)
       at java.base/sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:352)
       at java.base/sun.nio.cs.StreamDecoder.read(StreamDecoder.java:188)
       at java.base/java.io.InputStreamReader.read(InputStreamReader.java:181)
       at java.base/java.io.BufferedReader.read1(BufferedReader.java:210)
       at java.base/java.io.BufferedReader.read(BufferedReader.java:287)
       at java.base/java.io.Reader.transferTo(Reader.java:384)
       at org.labkey.pipeline.status.StatusDetailsBean.transferTo(StatusDetailsBean.java:162)
       at org.labkey.pipeline.status.StatusDetailsBean.create(StatusDetailsBean.java:113)
       at org.labkey.pipeline.status.StatusController$DetailsAction.getView(StatusController.java:482)
       at org.labkey.pipeline.status.StatusController$DetailsAction.getView(StatusController.java:441)
```

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1438

#### Changes
- report errors reading pipeline status log file to client
- increase default wait time for pipeline in tests

