### PR TITLE
remove un-used method in dropdownButtonGroup

### DIFF
--- a/src/org/labkey/test/components/react/DropdownButtonGroup.java
+++ b/src/org/labkey/test/components/react/DropdownButtonGroup.java
@@ -19,7 +19,6 @@ public class DropdownButtonGroup extends WebDriverComponent<DropdownButtonGroup.
 {
     final WebElement _el;
     final WebDriver _driver;
-    private Integer _expandRetries = 1;
 
     /* componentElement should contain the toggle anchor *and* the UL containing list items */
     public DropdownButtonGroup(WebDriver driver, WebElement componentElement)
@@ -43,12 +42,6 @@ public class DropdownButtonGroup extends WebDriverComponent<DropdownButtonGroup.
     public WebDriver getDriver()
     {
         return _driver;
-    }
-
-    public DropdownButtonGroup withExpandRetries(Integer expandRetries)
-    {
-        _expandRetries = expandRetries;
-        return this;
     }
 
     public boolean isExpanded()


### PR DESCRIPTION
#### Rationale
This removes an un-used method in the DropDownButtonGroup component wrapper; 

#### Related Pull Requests
n/a

#### Changes
removes withExpandRetries, which could be (but isn't) used to configure this wrapper to re-try opening 
