### PR TITLE
Updates the test to no longer specify a public name on schema query l…

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1987,16 +1987,6 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         waitForElement(Locator.tagWithClass("div", "lk-qd-name").startsWith(schemaName + "." + queryName), 30000);
     }
 
-    public void selectQuery(String schemaName, String queryName, String publicName)
-    {
-        log("Selecting query " + schemaName + "." + queryName + " in the schema browser...");
-        selectSchema(schemaName);
-        WebElement queryLink = Locator.tagWithClass("table", "lk-qd-coltable").append(Locator.tagWithClass("span", "labkey-link")).withText(queryName).notHidden().waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT);
-        mouseOver(Locator.byClass(".x4-tab-button")); // Move away from schema tree to dismiss tooltip
-        queryLink.click();
-        waitForElement(Locator.tagWithClass("div", "lk-qd-name").startsWith(schemaName + "." + publicName), 30000);
-    }
-
     public void clickFkExpando(String schemaName, String queryName, String columnName)
     {
         click(Locator.tagWithClass("img", "lk-qd-expando").withAttribute("lkqdfieldkey", columnName));
@@ -2004,25 +1994,13 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
     public DataRegionTable viewQueryData(String schemaName, String queryName)
     {
-        return viewQueryData(schemaName, queryName, null, null);
+        return viewQueryData(schemaName, queryName, null);
     }
 
     public DataRegionTable viewQueryData(String schemaName, String queryName, @Nullable String moduleName)
     {
-        return viewQueryData(schemaName, queryName, moduleName, null);
-    }
-
-    public DataRegionTable viewQueryData(String schemaName, String queryName, @Nullable String moduleName, @Nullable String publicName)
-    {
-        if (publicName != null)
-        {
-            selectQuery(schemaName, queryName, publicName);
-        }
-        else
-        {
-            selectQuery(schemaName, queryName);
-        }
-        Locator loc = Locator.xpath("//div[contains(@class,'lk-qd-name')]//a[contains(text(),'" + schemaName + "." + (publicName != null?publicName:queryName) + "')]");
+        selectQuery(schemaName, queryName);
+        Locator loc = Locator.xpath("//div[contains(@class,'lk-qd-name')]//a[contains(text(),'" + schemaName + "." + queryName + "')]");
         waitForElement(loc, WAIT_FOR_JAVASCRIPT);
         String href = getAttribute(loc, "href");
         if (moduleName != null) // 12474

--- a/src/org/labkey/test/tests/microarray/ExpressionMatrixAssayTest.java
+++ b/src/org/labkey/test/tests/microarray/ExpressionMatrixAssayTest.java
@@ -98,7 +98,7 @@ public class ExpressionMatrixAssayTest extends BaseExpressionMatrixTest
                 resultTable.getColumnDataAsText("Run"));
 
         goToSchemaBrowser();
-        selectQuery("assay.ExpressionMatrix." + ASSAY_NAME, "FeatureDataBySample", "ctq");
+        selectQuery("assay.ExpressionMatrix." + ASSAY_NAME, "FeatureDataBySample");
     }
 
     @Test
@@ -135,7 +135,7 @@ public class ExpressionMatrixAssayTest extends BaseExpressionMatrixTest
         assertEquals(0, resultTable.getDataRowCount());
 
         goToSchemaBrowser();
-        selectQuery("assay.ExpressionMatrix." + ASSAY_NAME, "FeatureDataBySample", "ctq");
+        selectQuery("assay.ExpressionMatrix." + ASSAY_NAME, "FeatureDataBySample");
     }
 
     @Test

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -511,7 +511,7 @@ public class NabAssayTest extends AbstractAssayTest
         navigateToFolder(getProjectName(), TEST_ASSAY_FLDR_NAB);
         clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));
         goToSchemaBrowser();
-        selectQuery("assay.NAb.TestAssayNab", "Data", "NAbSpecimen");
+        selectQuery("assay.NAb.TestAssayNab", QUERY_NAME);
         createNewQuery("assay.NAb.TestAssayNab");
         setFormElement(Locator.name("ff_newQueryName"), "New NabQuery");
         clickAndWait(Locator.lkButton("Create and Edit Source"));


### PR DESCRIPTION


#### Rationale
This changes the test to no longer expect 'ctq' as the public name of the query.  This test was failing because the text of the link appears to have changed.

#### Related Pull Requests
n/a

#### Changes
don't expect the schema query link text to contain schema, query, and public name- schema and query are enough.
