### PR TITLE
Rlabkey labkey.saveBatch regression test for assay with spaces in name

### DIFF
--- a/data/api/rlabkey-api-experiment.xml
+++ b/data/api/rlabkey-api-experiment.xml
@@ -53,4 +53,27 @@
             ]]>
         </response>
     </test>
+    <test name="labkey.saveBatch for assay with space in name" type="post">
+        <url>
+            <![CDATA[
+                library(Rlabkey)
+                labkey.saveBatch(baseUrl="%baseUrl%", folderPath="%projectName%", "Rlabkey GPAT Test", data.frame(SpecimenID=c(1,2,3)))
+            ]]>
+        </url>
+        <response>
+            <![CDATA[
+                $batch$runs[[1]]$dataRows[[1]]$SpecimenID
+                [1] "1"
+
+                $batch$runs[[1]]$dataRows[[2]]$SpecimenID
+                [1] "2"
+
+                $batch$runs[[1]]$dataRows[[3]]$SpecimenID
+                [1] "3"
+
+                $batch$runs[[1]]$schemaName
+                [1] "assay.General.Rlabkey GPAT Test"
+            ]]>
+        </response>
+    </test>
 </ApiTests>

--- a/src/org/labkey/test/tests/RlabkeyTest.java
+++ b/src/org/labkey/test/tests/RlabkeyTest.java
@@ -126,6 +126,13 @@ public class RlabkeyTest extends BaseWebDriverTest
         issuesHelper.addIssue(Maps.of("assignedTo", _userHelper.getDisplayNameForEmail(USER), "title", ISSUE_TITLE_2));
     }
 
+    private void setupAssays()
+    {
+        log("Create a GPAT assay design");
+        goToManageAssays();
+        _assayHelper.createAssayDesign("General", "Rlabkey GPAT Test").clickFinish();
+    }
+
     /**
      * Create a new issues list and override the default assigned to group
      */
@@ -153,6 +160,7 @@ public class RlabkeyTest extends BaseWebDriverTest
         // Dummy files for saveBatch API test
         _fileBrowserHelper.createFolder("data.tsv");
         _fileBrowserHelper.createFolder("result.txt");
+        setupAssays();
 
         doRLabkeyTest(RLABKEY_API_EXPERIMENT);
     }


### PR DESCRIPTION
#### Rationale
There was a regression with Rlabkey v2.4.0 when the labkey.saveBatch was changed from a GET to a POST. The assay name param was still being URLencoded even though we no longer what that for the post. This PR adds a test to the RlabkeyTest experiment API test cases for this scenario. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-r/pull/57

#### Changes
* Add RlabkeyTest.testRlabkeyExperimentApi test case for labkey.saveBatch using GPAT assay with space in name
