### PR TITLE
Fix staleness check for page signals

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1997,12 +1997,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
         if (previousElement != null)
         {
-            try
-            {
-                wait.until(ExpectedConditions.stalenessOf(previousElement));
-            }
-            // Firefox sometimes throws the wrong exception.
-            catch (NoSuchElementException ignore) { } // "NoSuchElementException: Web element reference not seen before"
+            wait.until(LabKeyExpectedConditions.stalenessOf(previousElement));
         }
 
         return wait.until(wd -> elementFinder.get());

--- a/src/org/labkey/test/util/LabKeyExpectedConditions.java
+++ b/src/org/labkey/test/util/LabKeyExpectedConditions.java
@@ -201,4 +201,40 @@ public class LabKeyExpectedConditions
         };
     }
 
+    /**
+     * Wraps {@link ExpectedConditions#stalenessOf(WebElement)}
+     * Firefox occasionally throws "NoSuchElementException: Web element reference not seen before"
+     * for short lived elements.
+     *
+     * @param element WebElement that should go stale.
+     * @return false if the element is still attached to the DOM, true otherwise.
+     */
+    public static ExpectedCondition<Boolean> stalenessOf(WebElement element)
+    {
+        return new ExpectedCondition<>()
+        {
+            final ExpectedCondition<Boolean> wrapped = ExpectedConditions.stalenessOf(element);
+
+            @Override
+            public Boolean apply(WebDriver driver)
+            {
+                try
+                {
+                    return wrapped.apply(driver);
+                }
+                catch (NoSuchElementException ignore)
+                {
+                    // Firefox sometimes throws the wrong exception.
+                    return true;
+                }
+            }
+
+            @Override
+            public String toString()
+            {
+                return wrapped.toString();
+            }
+        };
+    }
+
 }


### PR DESCRIPTION
#### Rationale
Firefox occasionally throws "NoSuchElementException: Web element reference not seen before" for stale elements. Previous fix attempt was incorrect because the exception doesn't escape the `wait.until` call.
This should fix the intermittent failure in `TrialShareExportTest.testTrialShareExportActionDefault`:
```
org.openqa.selenium.TimeoutException: Expected condition failed: element to refresh: css=#testSignals > div[name="file-list-updated"] (tried for 10 second(s) with 500 milliseconds interval)
  at org.openqa.selenium.support.ui.WebDriverWait.timeoutException(WebDriverWait.java:95)
  at org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:272)
  at org.labkey.test.WebDriverWrapper.doAndWaitForElementToRefresh(WebDriverWrapper.java:2002)
  at org.labkey.test.util.FileBrowserHelper.doAndWaitForFileListRefresh(FileBrowserHelper.java:178)
  at org.labkey.test.util.FileBrowserHelper.doAndWaitForFileListRefresh(FileBrowserHelper.java:172)
  at org.labkey.test.util.FileBrowserHelper.selectFolderTreeNode(FileBrowserHelper.java:166)
  at org.labkey.test.util.FileBrowserHelper.selectFileBrowserItem(FileBrowserHelper.java:138)
  at org.labkey.test.tests.trialshare.TrialShareExportTest.testTrialShareExportActionDefault(TrialShareExportTest.java:47)
```

#### Changes
* Catch `NoSuchElementException` where it might be thrown.
