### PR TITLE
Create and publish a labkey-api-selenium jar with just the classes from this module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,12 @@
 apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'org.labkey.testRunner'
+apply plugin: 'maven-publish'
 
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.PomFileHelper
+
+project.group = "org.labkey.test"
 
 project.dependencies {
     implementation "org.slf4j:slf4j-log4j12:${slf4jLog4j12Version}" // Suppresses unwanted logging from remoteapi and webdriver
@@ -21,7 +26,12 @@ project.dependencies {
     implementation "org.apache.xmlbeans:xmlbeans:${xmlbeansVersion}"
     implementation "org.bouncycastle:bcpg-jdk15on:${bouncycastleVersion}"
     implementation "org.jetbrains:annotations:${annotationsVersion}"
-    implementation "org.mock-server:mockserver-netty:${mockserverVersion}"
+    api "org.mock-server:mockserver-netty:${mockserverVersion}"
+    api "org.seleniumhq.selenium:selenium-server:${seleniumVersion}"
+    runtimeOnly "org.aspectj:aspectjrt:${aspectjVersion}"
+    implementation "org.aspectj:aspectjtools:${aspectjVersion}"
+    implementation "org.reflections:reflections:${reflectionsVersion}"
+    uiTestRuntimeOnly "org.aspectj:aspectjrt:${aspectjVersion}"
 
     if (project.hasProperty("teamcity") || project.findProject(BuildUtils.getApiProjectPath(project.gradle)) == null)
     {
@@ -53,6 +63,13 @@ BuildUtils.addLabKeyDependency(
         depProjectConfig: 'runtimeElements',
         depVersion: project.labkeyClientApiVersion)
 
+BuildUtils.addLabKeyDependency(
+        project: project,
+        config: 'api',
+        depProjectPath: BuildUtils.getRemoteApiProjectPath(gradle),
+        depProjectConfig: 'runtimeElements',
+        depVersion: project.labkeyClientApiVersion)
+
 if (project.findProject(":remoteapi:labkey-api-jdbc") != null)
 {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":remoteapi:labkey-api-jdbc")
@@ -61,4 +78,74 @@ if (project.findProject(":remoteapi:labkey-api-jdbc") != null)
 if (project.hasProperty("teamcity"))
 {
     apply plugin: 'org.labkey.teamCity'
+}
+
+project.sourceSets {
+    main {
+        java {
+            srcDirs = ["src"]
+        }
+    }
+}
+
+
+project.afterEvaluate {
+    PomFileHelper pomUtil = new PomFileHelper(project)
+    project.publishing {
+        publications {
+            libs(MavenPublication) {
+                groupId = project.group
+                artifact project.tasks.jar
+                pom {
+                    name = "LabKey Test Automation Classes"
+                    description = "Library of classes and utilities for Selenium testing of LabKey Server components"
+                    url = PomFileHelper.LABKEY_ORG_URL
+                    developers PomFileHelper.getLabKeyTeamDevelopers()
+                    licenses PomFileHelper.getApacheLicense()
+                    organization PomFileHelper.getLabKeyOrganization()
+                    scm {
+                        connection = 'scm:git:https://github.com/LabKey/testAutomation'
+                        developerConnection = 'scm:git:https://github.com/LabKey/testAutomation'
+                        url = 'scm:git:https://github.com/LabKey/testAutomation'
+                    }
+                    withXml {
+                        pomUtil.getDependencyClosure(asNode(), false)
+                    }
+                }
+            }
+        }
+
+        if (project.hasProperty('doPublishing'))
+        {
+            apply plugin: 'com.jfrog.artifactory'
+            artifactory {
+                contextUrl = "${artifactory_contextUrl}"   //The base Artifactory URL if not overridden by the publisher/resolver
+                publish {
+                    repository {
+                        repoKey = BuildUtils.getRepositoryKey(project)
+                        if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
+                        {
+                            username = artifactory_user
+                            password = artifactory_password
+                        }
+                        maven = true
+                    }
+                    defaults
+                            {
+                                publishPom = true
+                                publishIvy = false
+                            }
+                }
+            }
+
+            project.artifactoryPublish {
+                publications('libs')
+            }
+        }
+    }
+    project.model {
+        tasks.publishLibsPublicationToMavenLocal {
+            enabled = false
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,8 @@ apply plugin: 'maven-publish'
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.PomFileHelper
 
-project.group = "org.labkey.test"
+project.group = "org.labkey.api"
+def apiArtifactName = "labkey-api-selenium"
 
 project.configurations {
     aspectj
@@ -84,68 +85,79 @@ project.sourceSets {
     main {
         java {
             srcDirs = ["src"]
+            exclude "test/tests/**"
         }
     }
 }
+project.tasks.jar {
+    Jar jar ->
+        jar.archiveBaseName.set(apiArtifactName)
+        jar.setGroup('org.labkey.api')
+}
 
 
-project.afterEvaluate {
-    PomFileHelper pomUtil = new PomFileHelper(project)
-    project.publishing {
-        publications {
-            libs(MavenPublication) {
-                groupId = project.group
-                artifact project.tasks.jar
-                pom {
-                    name = "LabKey Test Automation Classes"
-                    description = "Library of classes and utilities for Selenium testing of LabKey Server components"
-                    url = PomFileHelper.LABKEY_ORG_URL
-                    developers PomFileHelper.getLabKeyTeamDevelopers()
-                    licenses PomFileHelper.getApacheLicense()
-                    organization PomFileHelper.getLabKeyOrganization()
-                    scm {
-                        connection = 'scm:git:https://github.com/LabKey/testAutomation'
-                        developerConnection = 'scm:git:https://github.com/LabKey/testAutomation'
-                        url = 'scm:git:https://github.com/LabKey/testAutomation'
-                    }
-                    withXml {
-                        pomUtil.getDependencyClosure(asNode(), false)
-                    }
-                }
-            }
-        }
-
-        if (project.hasProperty('doPublishing'))
-        {
-            apply plugin: 'com.jfrog.artifactory'
-            artifactory {
-                contextUrl = "${artifactory_contextUrl}"   //The base Artifactory URL if not overridden by the publisher/resolver
-                publish {
-                    repository {
-                        repoKey = BuildUtils.getRepositoryKey(project)
-                        if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
-                        {
-                            username = artifactory_user
-                            password = artifactory_password
+if (project.hasProperty('doPublishing'))
+{
+    project.afterEvaluate {
+        PomFileHelper pomUtil = new PomFileHelper(project)
+        project.publishing {
+            publications {
+                libs(MavenPublication) {
+                    groupId = project.group
+                    artifactId = apiArtifactName
+                    artifact project.tasks.jar
+                    pom {
+                        name = "LabKey Test Automation Classes"
+                        description = "Library of classes and utilities for Selenium testing of LabKey Server components"
+                        url = PomFileHelper.LABKEY_ORG_URL
+                        developers PomFileHelper.getLabKeyTeamDevelopers()
+                        licenses PomFileHelper.getApacheLicense()
+                        organization PomFileHelper.getLabKeyOrganization()
+                        scm {
+                            connection = 'scm:git:https://github.com/LabKey/testAutomation'
+                            developerConnection = 'scm:git:https://github.com/LabKey/testAutomation'
+                            url = 'scm:git:https://github.com/LabKey/testAutomation'
                         }
-                        maven = true
+                        withXml {
+                            pomUtil.getDependencyClosure(asNode(), false)
+                        }
                     }
-                    defaults
-                            {
-                                publishPom = true
-                                publishIvy = false
-                            }
                 }
             }
 
-            project.artifactoryPublish {
-                publications('libs')
+            if (project.hasProperty('doPublishing'))
+            {
+                apply plugin: 'com.jfrog.artifactory'
+                artifactory {
+                    contextUrl = "${artifactory_contextUrl}"
+                    //The base Artifactory URL if not overridden by the publisher/resolver
+                    publish {
+                        repository {
+                            repoKey = BuildUtils.getRepositoryKey(project)
+                            if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password'))
+                            {
+                                username = artifactory_user
+                                password = artifactory_password
+                            }
+                            maven = true
+                        }
+                        defaults
+                                {
+                                    publishPom = true
+                                    publishIvy = false
+                                }
+                    }
+                }
+
+                project.artifactoryPublish {
+                    publications('libs')
+                }
             }
         }
-    }
-    project.model {
-        tasks.publishLibsPublicationToMavenLocal {
-            enabled = false
+        project.model {
+            tasks.publishLibsPublicationToMavenLocal {
+                enabled = false
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,12 @@ import org.labkey.gradle.util.PomFileHelper
 
 project.group = "org.labkey.test"
 
+project.configurations {
+    aspectj
+}
+
 project.dependencies {
+    aspectj "org.aspectj:aspectjtools:${aspectjVersion}"
     implementation "org.slf4j:slf4j-log4j12:${slf4jLog4j12Version}" // Suppresses unwanted logging from remoteapi and webdriver
     implementation "com.github.lookfirst:sardine:${project.lookfirstSardineVersion}"
     implementation "com.googlecode.json-simple:json-simple:${jsonSimpleVersion}"
@@ -58,13 +63,6 @@ project.dependencies {
 
 BuildUtils.addLabKeyDependency(
         project: project,
-        config: 'uiTestImplementation',
-        depProjectPath: BuildUtils.getRemoteApiProjectPath(gradle),
-        depProjectConfig: 'runtimeElements',
-        depVersion: project.labkeyClientApiVersion)
-
-BuildUtils.addLabKeyDependency(
-        project: project,
         config: 'api',
         depProjectPath: BuildUtils.getRemoteApiProjectPath(gradle),
         depProjectConfig: 'runtimeElements',
@@ -80,6 +78,8 @@ if (project.hasProperty("teamcity"))
     apply plugin: 'org.labkey.teamCity'
 }
 
+// the jar file that contains just the classes from this project, not all other
+// projects with src/test directories
 project.sourceSets {
     main {
         java {

--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ if (project.hasProperty('doPublishing'))
                         scm {
                             connection = 'scm:git:https://github.com/LabKey/testAutomation'
                             developerConnection = 'scm:git:https://github.com/LabKey/testAutomation'
-                            url = 'scm:git:https://github.com/LabKey/testAutomation'
+                            url = 'https://github.com/LabKey/testAutomation'
                         }
                         withXml {
                             pomUtil.getDependencyClosure(asNode(), false)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,3 @@
-buildFromSource=false
-
 aspectjVersion=1.9.6
 reflectionsVersion=0.9.10
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
-# Properties used by 'org.labkey.UiTest' Gradle plugin
-# suppress inspection "UnusedProperty"
+buildFromSource=false
+
 aspectjVersion=1.9.6
-# suppress inspection "UnusedProperty"
 reflectionsVersion=0.9.10
 
 lookfirstSardineVersion=5.7


### PR DESCRIPTION
#### Rationale
Currently the default jar file for this package is empty because the source code is not in the default location for the Gradle java plugin.  This causes a problem when trying to run the `moduleUiTests` task that declares a dependency on the default output of the test project.  We had been producing a `testJar` artifact from the Gradle plugins containing all of the test classes from all modules as well as this module.  This is more than is needed for running individual module tests, so we scale back on the classes included in the jar and publish it to Artifactory to get us closer to being able to have developers use this test api jar without a need for an enlistment in this repository. (We're not quite there yet because of some need for the `test.properties` file that lives in this repository, but this gets us pretty close.)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1498

#### Changes
* Specify the custom `src` directory for the default java source set so the `jar` (or `build`) command produces a jar file with classes for use in writing Selenium tests
* Set up publishing for the default jar file to `org.labkey.api:labkey-api-selinim`
* Move configuration and dependency declarations out of the Gradle plugins and into here for easier maintenance

