### PR TITLE
Fb fix pager

### DIFF
--- a/src/org/labkey/test/components/react/Pager.java
+++ b/src/org/labkey/test/components/react/Pager.java
@@ -94,7 +94,7 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
             return false;
 
         String nextBtnClass = elementCache().nextButton().get().getAttribute("class");
-        if (nextBtnClass.contains("pagination_buttons__next"))
+        if (nextBtnClass.contains("pagination-buttons__next"))
             return !elementCache().nextButton().get().getAttribute("disabled").equals("true");
         else
             return !nextBtnClass.contains("disabled-button");

--- a/src/org/labkey/test/components/react/ReactCheckBox.java
+++ b/src/org/labkey/test/components/react/ReactCheckBox.java
@@ -105,11 +105,11 @@ public class ReactCheckBox extends Checkbox
                     break;
                 case Indeterminate:
                     WebDriverWrapper.waitFor(() -> isIndeterminate(),
-                            "", 1000);
+                            "Expected checkbox to be in an indeterminate state", 1000);
                     break;
                 case Unchecked:
                     WebDriverWrapper.waitFor(() -> !isChecked() && !isIndeterminate(),
-                            "Expected", 1000);
+                            "Failed to uncheck checkbox", 1000);
                     break;
             }
         }


### PR DESCRIPTION
#### Rationale
This fixes the pager's 'isNextEnabled' method to correctly support biologics' ReportList (mis-matching the expected class caused a [test failure](https://teamcity.labkey.org/viewLog.html?buildId=1095630&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsBPostgres&fromExperimentalUI=true#testNameId-3591195710326300759))

#### Related Pull Requests
n/a

#### Changes
also adds error messages to explain why (if it happens) a checkbox wasn't in its expected state after being set
