### PR TITLE
When syncing in IntelliJ, don't reconfigure the default jar file task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,19 +81,19 @@ if (project.hasProperty("teamcity"))
 
 // the jar file that contains just the classes from this project, not all other
 // projects with src/test directories
-project.sourceSets {
-    main {
-        java {
-            srcDirs = ["src"]
-            exclude "test/tests/**"
-        }
-    }
-}
-project.tasks.jar {
-    Jar jar ->
-        jar.archiveBaseName.set(apiArtifactName)
-        jar.setGroup('org.labkey.api')
-}
+//project.sourceSets {
+//    main {
+//        java {
+//            srcDirs = ["src"]
+//            exclude "test/tests/**"
+//        }
+//    }
+//}
+//project.tasks.jar {
+//    Jar jar ->
+//        jar.archiveBaseName.set(apiArtifactName)
+//        jar.setGroup('org.labkey.api')
+//}
 
 
 if (project.hasProperty('doPublishing'))

--- a/build.gradle
+++ b/build.gradle
@@ -79,21 +79,25 @@ if (project.hasProperty("teamcity"))
     apply plugin: 'org.labkey.teamCity'
 }
 
-// the jar file that contains just the classes from this project, not all other
-// projects with src/test directories
-//project.sourceSets {
-//    main {
-//        java {
-//            srcDirs = ["src"]
-//            exclude "test/tests/**"
-//        }
-//    }
-//}
-//project.tasks.jar {
-//    Jar jar ->
-//        jar.archiveBaseName.set(apiArtifactName)
-//        jar.setGroup('org.labkey.api')
-//}
+// If this configuration for the default jar file is included when synching with IntelliJ
+// the classes in other modules that reference classes here will not resolve properly.
+if (!BuildUtils.isIntellij())  {
+    // the jar file that contains just the classes from this project, not all other
+    // projects with src/test directories
+    project.sourceSets {
+        main {
+            java {
+                srcDirs = ["src"]
+                exclude "test/tests/**"
+            }
+        }
+    }
+    project.tasks.jar {
+        Jar jar ->
+            jar.archiveBaseName.set(apiArtifactName)
+            jar.setGroup('org.labkey.api')
+    }
+}
 
 
 if (project.hasProperty('doPublishing'))


### PR DESCRIPTION
#### Rationale
When syncing in IntelliJ, if the new default jar configuration is used, the classes in modules outside of `testAutomation` that refer to classes in this module do not resolve properly.   I'm not entirely sure why this causes a problem since without this configuration, the default jar file has no classes in it at all.  When the errors are present, IntelliJ suggests adding a dependency to the testAutomation project, and that does seem to fix things (until the next time you do a gradle refesh), but I don't think we actually want that sort of dependency declared.

In my testing, making the configuration of the jar file conditional on whether in IntelliJ or not does seem to work, but I hope this is a temporary fix.

#### Related Pull Requests
* #433 

#### Changes
* Conditionalize configuration of default jar file
