### PR TITLE
Fix header locator in DataRegionTable

### DIFF
--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -26,12 +26,12 @@ import org.labkey.test.WebDriverWrapperImpl;
 import org.labkey.test.components.ColumnChartRegion;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.components.PagingWidget;
-import org.labkey.test.components.study.ViewPreferencesPage;
 import org.labkey.test.components.SummaryStatisticsDialog;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.study.DatasetFacetPanel;
+import org.labkey.test.components.study.ViewPreferencesPage;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.TimeChartWizard;
 import org.labkey.test.selenium.RefindingWebElement;
@@ -1382,7 +1382,7 @@ public class DataRegionTable extends DataRegion
 
         public static Locator.XPathLocator columnHeader(String regionName, String fieldName)
         {
-            return Locator.tagWithAttribute("th", "column-name", regionName + ":" + fieldName).childTag("div");
+            return Locator.tagWithAttribute("th", "column-name", regionName + ":" + fieldName);
         }
 
         public static Locator.XPathLocator floatingHeader()


### PR DESCRIPTION
#### Rationale
The actual header element contains attributes that some tests currently care about. The nested div is largely irrelevant.

#### Related Pull Requests
* #427

#### Changes
* Remove styling div from test locator
