### PR TITLE
Update ListArchiveImportTest

### DIFF
--- a/data/lists/bad_archive.lists/People.tsv
+++ b/data/lists/bad_archive.lists/People.tsv
@@ -1,0 +1,13 @@
+Key	First	Last	Age	Appearance	Sex	Height	File	Notes
+1	Fred	Flintstone	37	1960-09-30 00:00:00.0	1	1.8		
+2	Wilma	Flintstone	35	1960-09-30 00:00:00.0	2	1.6		
+3	Barney	Rubble	36	1960-09-30 00:00:00.0	1	1.7		
+4	Betty	Rubble	34	1960-09-30 00:00:00.0	2	1.6		
+5	Dino	Flintstone	5	1960-09-30 00:00:00.0	1	1.0		
+6	Hoppy	Rubble	3	1964-09-30 00:00:00.0	1	0.8		
+7	Baby Puss	Flintstone	4	1960-09-30 00:00:00.0	2	1.2		
+8	The Great	Gazoo		1965-10-26 00:00:00.0	1	0.7		
+9	Sam	Slate	52		1	1.3		
+10	ümlaut!	Schmidt	27					
+23	Carly	Rauch	1				People.xls	
+32	Adam	Flintstone	51			2.0		

--- a/data/lists/bad_archive.lists/lists.xml
+++ b/data/lists/bad_archive.lists/lists.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Exported from PostgreSQL 18.1 at http://localhost:8080/labkey/home/project-begin.view by adam on Tue Jan 02 09:26:45 PST 2018-->
+<tables xmlns="http://labkey.org/data/xml">
+  <table tableName="People" tableDbType="TABLE">
+    <description>This is my description</description>
+    <columns>
+      <column columnName="Key">
+        <datatype>integer</datatype>
+        <columnTitle>Key</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#int</rangeURI>
+        <nullable>false</nullable>
+        <isHidden>true</isHidden>
+        <isKeyField>true</isKeyField>
+        <isAutoInc>true</isAutoInc>
+      </column>
+      <column columnName="First">
+        <datatype>varchar</datatype>
+        <columnTitle>First</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+        <required>true</required>
+        <defaultValueType>FIXED_EDITABLE</defaultValueType>
+        <scale>100</scale>
+      </column>
+      <column columnName="Last">
+        <datatype>varchar</datatype>
+        <columnTitle>Last</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+        <required>true</required>
+        <defaultValue>Flintstone</defaultValue>
+        <validators>
+          <validator>
+            <name>No Lums!</name>
+            <description>Don't allow anyone named Lum</description>
+            <typeURI>urn:lsid:labkey.com:PropertyValidator:regex</typeURI>
+            <expression>Lum</expression>
+            <errorMessage>No Lums allowed!</errorMessage>
+            <property>
+              <name>failOnMatch</name>
+              <value>true</value>
+            </property>
+          </validator>
+        </validators>
+        <scale>200</scale>
+      </column>
+      <column columnName="Age">
+        <datatype>integer</datatype>
+        <columnTitle>Age</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#int</rangeURI>
+        <measure>false</measure>
+        <formatString><![CDATA[0.0 "''>--><'script>alert(''8('');</script>']]></formatString>
+        <defaultValueType>LAST_ENTERED</defaultValueType>
+        <validators>
+          <validator>
+            <name>Age out of range</name>
+            <description>The age is ridiculous</description>
+            <typeURI>urn:lsid:labkey.com:PropertyValidator:range</typeURI>
+            <expression><![CDATA[~gte=0&~lt=130]]></expression>
+            <errorMessage>That's out of range, you dork!</errorMessage>
+          </validator>
+          <validator>
+            <name>Some regex</name>
+            <description>Supposed to be good for you</description>
+            <typeURI>urn:lsid:labkey.com:PropertyValidator:regex</typeURI>
+            <expression>[0-8]+</expression>
+            <errorMessage>Doesn't match, dummy!</errorMessage>
+          </validator>
+        </validators>
+      </column>
+      <column columnName="Appearance">
+        <datatype>timestamp</datatype>
+        <columnTitle>Appearance</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#dateTime</rangeURI>
+      </column>
+      <column columnName="Sex">
+        <datatype>integer</datatype>
+        <columnTitle>Sex</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#int</rangeURI>
+        <fk>
+          <fkDbSchema>lists</fkDbSchema>
+          <fkTable>Gender</fkTable>
+          <fkColumnName>Key</fkColumnName>
+        </fk>
+        <validators>
+          <validator>
+            <name>Lookup validator</name>
+            <typeURI>urn:lsid:labkey.com:PropertyValidator:lookup</typeURI>
+          </validator>
+        </validators>
+      </column>
+      <column columnName="Height">
+        <datatype>double</datatype>
+        <columnTitle>Height</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+        <measure>false</measure>
+        <defaultValue>2.0</defaultValue>
+        <conditionalFormats>
+          <conditionalFormat>
+            <filters>
+              <filter operator="gt" value="2.0"/>
+            </filters>
+            <textColor>FF00FF</textColor>
+          </conditionalFormat>
+        </conditionalFormats>
+      </column>
+      <column columnName="File">
+        <datatype>varchar</datatype>
+        <columnTitle>File</columnTitle>
+        <rangeURI>http://www.labkey.org/exp/xml#attachment</rangeURI>
+        <url replaceMissing="blankValue"><![CDATA[/labkey/home/list-download.view?listId=11&entityId=${EntityId}&name=${File}]]></url>
+        <phi>Limited</phi>
+        <scale>4000</scale>
+      </column>
+      <column columnName="Notes">
+        <datatype>varchar</datatype>
+        <columnTitle>Notes</columnTitle>
+        <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+        <defaultValueType>FIXED_EDITABLE</defaultValueType>
+        <scale>2147483647</scale>
+      </column>
+    </columns>
+    <pkColumnName>Key</pkColumnName>
+  </table>
+</tables>

--- a/data/lists/bad_archive.lists/settings.xml
+++ b/data/lists/bad_archive.lists/settings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lists xmlns="http://labkey.org/list/xml">
+  <list name="People" id="11" discussions="1" eachItemIndex="true" entireListIndex="true" entireListIndexSetting="2"/>
+</lists>

--- a/src/org/labkey/test/components/list/ManageListsGrid.java
+++ b/src/org/labkey/test/components/list/ManageListsGrid.java
@@ -16,9 +16,14 @@
 package org.labkey.test.components.list;
 
 import org.labkey.test.pages.LabKeyPage;
+import org.labkey.test.pages.list.BeginPage;
+import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.pages.list.ImportListArchivePage;
 import org.labkey.test.util.DataRegionTable;
 import org.openqa.selenium.WebDriver;
+
+import java.io.File;
+import java.util.List;
 
 public class ManageListsGrid extends DataRegionTable
 {
@@ -33,29 +38,39 @@ public class ManageListsGrid extends DataRegionTable
         return new ImportListArchivePage(getDriver());
     }
 
-    public LabKeyPage clickCreateList()
+    public EditListDefinitionPage clickCreateList()
     {
         clickHeaderButtonAndWait("Create New List");
-        return new LabKeyPage(getDriver());
+        return new EditListDefinitionPage(getDriver());
     }
 
-    public LabKeyPage exportSelectedLists()
+    public File exportSelectedLists()
     {
-        clickHeaderButtonAndWait("Export List Archive");
-        return new LabKeyPage(getDriver());
+        return getWrapper().doAndWaitForDownload(() ->
+            clickHeaderButton("Export List Archive"));
     }
 
-    public LabKeyPage deleteSelectedLists()
+    public BeginPage deleteSelectedLists()
     {
         deleteSelectedRows();
-        return new LabKeyPage(getDriver());
+        return new BeginPage(getDriver());
     }
 
-    public LabKeyPage viewListDesign(String listName)
+    public List<String> getListNames()
     {
+        return getColumnDataAsText("Name");
+    }
 
+    public DataRegionTable viewListData(String listName)
+    {
+        getWrapper().clickAndWait(link(getRowIndex("Name", listName), getColumnIndex("Name")));
+        return new DataRegionTable("query", getDriver());
+    }
+
+    public EditListDefinitionPage viewListDesign(String listName)
+    {
         getWrapper().clickAndWait(link(getRowIndex("Name", listName), 0));
-        return null;
+        return new EditListDefinitionPage(getDriver());
     }
 
     public LabKeyPage viewListHistory(String listName)

--- a/src/org/labkey/test/tests/ListArchiveImportTest.java
+++ b/src/org/labkey/test/tests/ListArchiveImportTest.java
@@ -19,38 +19,25 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import static org.junit.Assert.assertEquals;
-
-import org.labkey.remoteapi.CommandException;
-import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.query.Filter;
-import org.labkey.remoteapi.query.InsertRowsCommand;
-import org.labkey.remoteapi.query.SelectRowsCommand;
-import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.BaseWebDriverTest;
-import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.DailyB;
 import org.labkey.test.categories.Hosting;
-import org.labkey.test.util.ListHelper;
-import org.labkey.test.util.PortalHelper;
+import org.labkey.test.components.list.ManageListsGrid;
+import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.ZipUtil;
+import org.openqa.selenium.WebElement;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.assertTrue;
 
 @Category({DailyB.class, Hosting.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
 public class ListArchiveImportTest extends BaseWebDriverTest
 {
-    private static final File LIST_ARCHIVE = TestFileUtils.getSampleData("lists/ListOfPeople.lists.zip");
 
     @Override
     protected @Nullable String getProjectName()
@@ -65,82 +52,39 @@ public class ListArchiveImportTest extends BaseWebDriverTest
     }
 
     @BeforeClass
-    public static void doSetup() throws Exception
+    public static void doSetup()
     {
         ListArchiveImportTest initTest = (ListArchiveImportTest) getCurrentTest();
         initTest._containerHelper.createProject(initTest.getProjectName(), null);
     }
 
     @Test
-    public void ImportListArchiveWithValidationTest() throws IOException, CommandException
+    public void testImportListArchiveWithError() throws IOException
     {
+        final File listArchive = TestFileUtils.getSampleData("lists/bad_archive.lists");
+        final String listName = "People";
+
         log("Import list and test for expected validation error");
-        importListArchiveWithError();
         clickFolder(getProjectName());
 
-        log("Fix validation error by creating lookup target list.gender table and inserting expected rows");
-        ListHelper.ListColumn genderTypeCol = new ListHelper.ListColumn("GenderType", "Gender", ListHelper.ListColumnType.String,null,null,null,null,null, null);
-        _listHelper.createList(getProjectName(), "Gender", ListHelper.ListColumnType.AutoInteger, "Key", genderTypeCol);
+        goToManageLists().importListArchive(new ZipUtil(listArchive).tempZip());
 
-        InsertRowsCommand insertRowsCommand = new InsertRowsCommand("lists", "Gender");
-        Connection cn = createDefaultConnection();
-        Map<String, Object> row = new HashMap<>();
-        row.put("GenderType", "Male");
-        insertRowsCommand.addRow(row);
+        String expectedError = "File: Could not find referenced file People.xls";
+        String actualError = Locators.labkeyError.findOptionalElement(getDriver()).map(WebElement::getText).orElse(null);
+        checker().verifyEquals("Wrong error message after attempting to import bad list archive.", expectedError, actualError);
 
-        row = new HashMap<>();
-        row.put("GenderType", "Female");
-        insertRowsCommand.addRow(row);
-        insertRowsCommand.execute(cn, getProjectName());
-
-        log("Import list again, this time it should import without errors.");
-        _listHelper.importListArchive(getProjectName(), LIST_ARCHIVE);
-
-        log("Verify five rows were inserted successfully.");
-        cn = createDefaultConnection();
-        SelectRowsCommand selectCmd = new SelectRowsCommand("lists", "People");
-        SelectRowsResponse rowsResponse = selectCmd.execute(cn, getProjectName());
-        assertEquals("Expected 5 rows in list.People.", 5, rowsResponse.getRows().size());
-
-        log("Insert sixth row in lists.People");
-        InsertRowsCommand insertRowsCommand2 = new InsertRowsCommand("lists", "People");
-        cn = createDefaultConnection();
-        Map<String, Object> newRow = new HashMap<>();
-        newRow.put("First", "Kitty");
-        newRow.put("Last", "Schmitty");
-        newRow.put("Age", "4");
-        newRow.put("Sex", 2);
-        newRow.put("Height", "0.5");
-        insertRowsCommand2.addRow(newRow);
-        insertRowsCommand2.execute(cn, getProjectName());
-
-        log("Validate the sequence for Key identity column.");
-        selectCmd = new SelectRowsCommand("lists", "People");
-        selectCmd.addFilter(new Filter("Key", "6"));
-        rowsResponse = selectCmd.execute(cn, getProjectName());
-        assertEquals("Expected identity column 'Key' value to be '6' for the last insert.", 6, rowsResponse.getRows().get(0).get("Key"));
-    }
-
-    private void importListArchiveWithError()
-    {
-        clickFolder(getProjectName());
-        assertTrue("Unable to locate input file: " + LIST_ARCHIVE, LIST_ARCHIVE.exists());
-
-        if (!isElementPresent(Locator.linkWithText("Lists")))
+        ManageListsGrid listsGrid = goToManageLists().getGrid();
+        if (checker().verifyEquals("Found list after import error.",
+            List.of(listName), listsGrid.getListNames()))
         {
-            PortalHelper portalHelper = new PortalHelper(getDriver());
-            portalHelper.addWebPart("Lists");
+            DataRegionTable people = listsGrid.viewListData(listName);
+            checker().verifyEquals("Shouldn't be any rows after import error.", 0, people.getDataRowCount());
         }
-
-        goToManageLists().importListArchive(LIST_ARCHIVE);
-        assertElementPresent(Locators.labkeyError);
-        assertTextPresent("Sex: Could not find the lookup's target query ('Gender') for field 'Sex'");
     }
 
     @Override
-    protected void doCleanup(boolean afterTest) throws TestTimeoutException
+    protected void doCleanup(boolean afterTest)
     {
         _containerHelper.deleteProject(getProjectName(), afterTest);
     }
-
 }

--- a/src/org/labkey/test/tests/ListArchiveImportTest.java
+++ b/src/org/labkey/test/tests/ListArchiveImportTest.java
@@ -58,6 +58,10 @@ public class ListArchiveImportTest extends BaseWebDriverTest
         initTest._containerHelper.createProject(initTest.getProjectName(), null);
     }
 
+    /**
+     * Regression test:
+     * Issue 32667: Errors during list import leave Connection in bad state
+     */
     @Test
     public void testImportListArchiveWithError() throws IOException
     {

--- a/src/org/labkey/test/util/ZipUtil.java
+++ b/src/org/labkey/test/util/ZipUtil.java
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package org.labkey.test.util;
+import org.labkey.test.TestFileUtils;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -33,27 +35,33 @@ public class ZipUtil
         _source = source;
     }
 
+    public File tempZip() throws IOException
+    {
+        TestFileUtils.getTestTempDir();
+        return zipInto(TestFileUtils.getTestTempDir());
+    }
+
     public File zipInto(File destDir) throws IOException
     {
         return zipIt(new File(destDir, _source.getName() + ".zip"));
     }
 
-    public File zipIt(File _dest) throws IOException
+    public File zipIt(File destZip) throws IOException
     {
         List<File> fileList = generateFileList(_source, new ArrayList<>());
 
-        TestLogger.log("Output to Zip : " + _dest.toString());
-        Files.createDirectories(_dest.getParentFile().toPath());
-        if (_dest.exists())
+        TestLogger.log("Output to Zip : " + destZip.toString());
+        Files.createDirectories(destZip.getParentFile().toPath());
+        if (destZip.exists())
         {
-            Files.delete(_dest.toPath());
+            Files.delete(destZip.toPath());
         }
-        Files.createFile(_dest.toPath());
+        Files.createFile(destZip.toPath());
 
         byte[] buffer = new byte[1024];
 
         try(
-                FileOutputStream fos = new FileOutputStream(_dest);
+                FileOutputStream fos = new FileOutputStream(destZip);
                 ZipOutputStream zos = new ZipOutputStream(fos)
         )
         {
@@ -77,7 +85,7 @@ public class ZipUtil
             TestLogger.log(String.format("Zipped %d files", fileList.size()));
         }
 
-        return _dest;
+        return destZip;
     }
 
     private List<File> generateFileList(File node, List<File> fileList)


### PR DESCRIPTION
#### Rationale
Validators are now applied _after_ data is imported from a list archive, so can't cause the import to fail. This test needs a different way of triggering an import error. This does so by using an archive where a list record references a missing file.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1410

#### Changes
* Update `ListArchiveImportTest` to work for new import behavior
* Add functionality to some test helpers
* Some SonarLint fixes
