### PR TITLE
use PipelineStatusDetailsPage to check for expected status log text

### DIFF
--- a/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
+++ b/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
@@ -293,6 +293,19 @@ public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsP
         return this;
     }
 
+    public PipelineStatusDetailsPage assertLogTextNotContains(Collection<String> texts)
+    {
+        return assertLogTextNotContains(texts.toArray(new String[0]));
+    }
+
+    @LogMethod
+    public PipelineStatusDetailsPage assertLogTextNotContains(String... texts)
+    {
+        assertTextNotPresent(new TextSearcher(getLogText()), texts);
+        log("Log text not present: " + StringUtils.join(texts, ", "));
+        return this;
+    }
+
     @LogMethod
     public PipelineStatusTable clickShowGrid()
     {


### PR DESCRIPTION
#### Rationale
Use the PipelineStatusDetailPage test helper to check for the expected status log text.  The html of the log format changed in PR #https://github.com/LabKey/platform/pull/1511 causing test failures in InvokePipeAnalysisTest and StudyVisitManagementTest.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1519
* https://github.com/LabKey/medImmune/pull/74