### PR TITLE
Fix AuditLogTest

### DIFF
--- a/src/org/labkey/test/components/html/SiteNavBar.java
+++ b/src/org/labkey/test/components/html/SiteNavBar.java
@@ -335,6 +335,11 @@ public class SiteNavBar extends WebDriverComponent<SiteNavBar.Elements>
             window.clickImpersonate();
         }
 
+        public void signOut()
+        {
+            clickSubMenu(true, "Sign Out");
+        }
+
         @Override
         public UserMenu withExpandRetries(int retries)
         {

--- a/src/org/labkey/test/tests/AuditLogTest.java
+++ b/src/org/labkey/test/tests/AuditLogTest.java
@@ -46,6 +46,7 @@ import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.core.admin.logger.ManagerPage.LoggingLevel;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.util.AuditLogHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.Log4jUtils;
@@ -59,6 +60,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -155,7 +157,7 @@ public class AuditLogTest extends BaseWebDriverTest
     }
 
     @Test
-    public void testSteps() throws IOException
+    public void testSteps() throws IOException, CommandException
     {
         turnOnAuditLogFile();
 
@@ -295,7 +297,8 @@ public class AuditLogTest extends BaseWebDriverTest
         expectedLogValues.add(AUDIT_TEST_USER + "fail failed to login: user does not exist");
         expectedLogValues.add(AUDIT_TEST_USER + " was deleted from the system");
 
-        for (String msg : expectedLogValues)
+        Collections.reverse(expectedLogValues);
+        for (int i = 0; i < expectedLogValues.size(); i++)
         {
             verifyAuditEvent(this, USER_AUDIT_EVENT, COMMENT_COLUMN, msg, 20);
         }
@@ -490,17 +493,7 @@ public class AuditLogTest extends BaseWebDriverTest
 
     public static void goToAuditEventView(BaseWebDriverTest instance, String eventType)
     {
-        if (!instance.isTextPresent("Audit Log"))
-        {
-            instance.ensureAdminMode();
-
-            instance.goToAdminConsole().clickAuditLog();
-        }
-
-        if (!instance.getSelectedOptionText(Locator.name("view")).equals(eventType))
-        {
-            instance.doAndWaitForPageToLoad(() -> instance.selectOptionByText(Locator.name("view"), eventType));
-        }
+        new AuditLogHelper(instance).goToAuditEventView(eventType);
     }
 
     public static void verifyAuditEvent(BaseWebDriverTest instance, String eventType, String column, String msg, int rowsToSearch)

--- a/src/org/labkey/test/tests/AuditLogTest.java
+++ b/src/org/labkey/test/tests/AuditLogTest.java
@@ -69,6 +69,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.labkey.test.util.PasswordUtil.getUsername;
 
 @Category({DailyA.class, Hosting.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 9)
@@ -272,28 +273,28 @@ public class AuditLogTest extends BaseWebDriverTest
         expectedLogValues.add(AUDIT_TEST_USER + " was added to the system and the administrator chose not to send a verification email.");
 
         impersonate(AUDIT_TEST_USER);
-        expectedLogValues.add(getCurrentUser() + " impersonated " + AUDIT_TEST_USER);
-        expectedLogValues.add(AUDIT_TEST_USER + " was impersonated by " + getCurrentUser());
+        expectedLogValues.add(getUsername() + " impersonated " + AUDIT_TEST_USER);
+        expectedLogValues.add(AUDIT_TEST_USER + " was impersonated by " + getUsername());
 
         stopImpersonating();
-        expectedLogValues.add(AUDIT_TEST_USER + " was no longer impersonated by " + getCurrentUser());
-        expectedLogValues.add(getCurrentUser() + " stopped impersonating " + AUDIT_TEST_USER);
+        expectedLogValues.add(AUDIT_TEST_USER + " was no longer impersonated by " + getUsername());
+        expectedLogValues.add(getUsername() + " stopped impersonating " + AUDIT_TEST_USER);
 
         impersonateRoles(PROJECT_ADMIN_ROLE, AUTHOR_ROLE);
-        expectedLogValues.add(getCurrentUser() + " impersonated roles: " + PROJECT_ADMIN_ROLE + "," + AUTHOR_ROLE);
+        expectedLogValues.add(getUsername() + " impersonated roles: " + PROJECT_ADMIN_ROLE + "," + AUTHOR_ROLE);
 
         stopImpersonating();
-        expectedLogValues.add(getCurrentUser() + " stopped impersonating roles: " + PROJECT_ADMIN_ROLE + "," + AUTHOR_ROLE);
+        expectedLogValues.add(getUsername() + " stopped impersonating roles: " + PROJECT_ADMIN_ROLE + "," + AUTHOR_ROLE);
 
         String adminGroup = "Administrator";
         impersonateGroup(adminGroup, true);
-        expectedLogValues.add(getCurrentUser() + " impersonated group: " + adminGroup);
+        expectedLogValues.add(getUsername() + " impersonated group: " + adminGroup);
 
         stopImpersonating();
-        expectedLogValues.add(getCurrentUser() + " stopped impersonating group: " + adminGroup);
+        expectedLogValues.add(getUsername() + " stopped impersonating group: " + adminGroup);
 
         navBar().userMenu().signOut();
-        expectedLogValues.add(getCurrentUser() + " logged out.");
+        expectedLogValues.add(getUsername() + " logged out.");
 
         signInShouldFail(AUDIT_TEST_USER, "asdf"); // Bad login.  Existing User
         expectedLogValues.add(AUDIT_TEST_USER + " failed to login: incorrect password");
@@ -302,7 +303,7 @@ public class AuditLogTest extends BaseWebDriverTest
         expectedLogValues.add(AUDIT_TEST_USER + "fail failed to login: user does not exist");
 
         simpleSignIn();
-        expectedLogValues.add(getCurrentUser() + " logged in successfully via the \"Standard database authentication\" configuration.");
+        expectedLogValues.add(getUsername() + " logged in successfully via the \"Standard database authentication\" configuration.");
 
         userHelper.deleteUsers(true, AUDIT_TEST_USER);
         expectedLogValues.add(AUDIT_TEST_USER + " was deleted from the system");

--- a/src/org/labkey/test/util/AuditLogHelper.java
+++ b/src/org/labkey/test/util/AuditLogHelper.java
@@ -1,0 +1,59 @@
+package org.labkey.test.util;
+
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.query.SelectRowsCommand;
+import org.labkey.remoteapi.query.SelectRowsResponse;
+import org.labkey.remoteapi.query.Sort;
+import org.labkey.test.LabKeySiteWrapper;
+import org.labkey.test.Locator;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class AuditLogHelper
+{
+    private final LabKeySiteWrapper _wrapper;
+
+    public AuditLogHelper(LabKeySiteWrapper wrapper)
+    {
+        _wrapper = wrapper;
+    }
+
+    public Integer getLatestAuditRowId(String auditTable, String containerPath) throws IOException, CommandException
+    {
+        String rowId = "rowId";
+
+        SelectRowsCommand selectRows = new SelectRowsCommand("auditLog", auditTable);
+        selectRows.setColumns(List.of(rowId));
+        selectRows.setSorts(List.of(new Sort(rowId, Sort.Direction.DESCENDING)));
+        selectRows.setMaxRows(1);
+
+        SelectRowsResponse response = selectRows.execute(_wrapper.createDefaultConnection(), containerPath);
+        List<Map<String, Object>> rows = response.getRows();
+        if (rows.isEmpty())
+        {
+            return -1;
+        }
+        return (Integer) rows.get(0).get(rowId);
+    }
+
+    public Integer getLatestAuditRowId(String auditTable) throws IOException, CommandException
+    {
+        return getLatestAuditRowId(auditTable, "/");
+    }
+
+    public DataRegionTable goToAuditEventView(String eventType)
+    {
+        if (!_wrapper.isTextPresent("Audit Log"))
+        {
+            _wrapper.goToAdminConsole().clickAuditLog();
+        }
+
+        if (!_wrapper.getSelectedOptionText(Locator.name("view")).equals(eventType))
+        {
+            _wrapper.doAndWaitForPageToLoad(() -> _wrapper.selectOptionByText(Locator.name("view"), eventType));
+        }
+        return new DataRegionTable("query", _wrapper);
+    }
+}


### PR DESCRIPTION
#### Rationale
Among other things, the test does a "Sign In" -> "Sign Out" -> "Sign In" and the final "Sign In" doesn't appear in the audit log.
We don't log repeated, identical authentication events from a given user+IP combination. For some reason, when the test signs out via HTTP (as the test was doing), the server sees the IPv6 address; then sees two identical "Sign In" messages and doesn't log the second.

#### Changes
* Sign Out using the user menu
