### PR TITLE
Exclude core-downloadFileLink from crawler

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -177,6 +177,7 @@ public class Crawler
             new ControllerActionId("assay", "downloadSampleQCData"),
             new ControllerActionId("assay", "template"),
             new ControllerActionId("cds", "exportTourDefinitions"), // Download action
+            new ControllerActionId("core", "downloadFileLink"), // Download action
             new ControllerActionId("dumbster", "begin"),
             new ControllerActionId("experiment", "exportProtocols"),
             new ControllerActionId("experiment", "exportRunFiles"),


### PR DESCRIPTION
#### Rationale
Crawler should skip download actions

#### Changes
* Exclude `CoreController.DownloadFileLinkAction` from crawler
