### PR TITLE
Fix ClientAPITest failure - slightly adjust logging and test too

### DIFF
--- a/src/org/labkey/test/tests/ClientAPITest.java
+++ b/src/org/labkey/test/tests/ClientAPITest.java
@@ -1232,7 +1232,7 @@ public class ClientAPITest extends BaseWebDriverTest
                     executeEmailScript(EMAIL_NO_LOGIN, EMAIL_SUBJECT_FROM_NEW_USER, new String[]{EMAIL_RECIPIENT1}, null, EMAIL_BODY_HTML));
         }
         stopImpersonating();
-        assertTrue("We should have recorded a server side error if no recipients are present.", getServerErrors().contains("Error sending email: No recipient addresses"));
+        assertTrue("We should have recorded a server side error if no recipients are present.", getServerErrors().contains("No recipient addresses"));
         checkExpectedErrors(count + 1);
 
         signOut();


### PR DESCRIPTION
#### Rationale
We're avoiding double-logging this error now, and need to adjust the test slightly for the expected text

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1526