### PR TITLE
Fix race condition in moderator review tests

### DIFF
--- a/src/org/labkey/test/pages/announcements/ModeratorReviewPage.java
+++ b/src/org/labkey/test/pages/announcements/ModeratorReviewPage.java
@@ -48,16 +48,18 @@ public class ModeratorReviewPage extends LabKeyPage<ModeratorReviewPage.ElementC
     public ModeratorReviewPage review(String title, boolean approve)
     {
         elementCache()._dataRegionTable.checkCheckbox(elementCache()._dataRegionTable.getRowIndex("Title", title));
-        if (approve)
-        {
-            elementCache().approveButton.click();
-            assertAlertContains("approve");
-        }
-        else
-        {
-            elementCache().spamButton.click();
-            assertAlertContains("spam");
-        }
+        doAndWaitForPageToLoad(() -> {
+            if (approve)
+            {
+                elementCache().approveButton.click();
+                assertAlertContains("approve");
+            }
+            else
+            {
+                elementCache().spamButton.click();
+                assertAlertContains("spam");
+            }
+        });
 
         return new ModeratorReviewPage(getDriver());
     }


### PR DESCRIPTION
#### Rationale
Attempting to navigate without waiting for the page to load after dismissing the approve/spam dialog can cause failures.

#### Changes
* Wait for page to load after reviewing message board posts
