### PR TITLE
Even test code loves to invoke ExtJS3's date.format function

### DIFF
--- a/src/org/labkey/test/util/ext4cmp/Ext4FieldRef.java
+++ b/src/org/labkey/test/util/ext4cmp/Ext4FieldRef.java
@@ -127,7 +127,7 @@ public class Ext4FieldRef extends Ext4CmpRef
     {
         try
         {
-            String val = (String)getFnEval("return this.getValue() ? this.getValue().format('c') : null");
+            String val = (String)getFnEval("return this.getValue() ? Ext4.Date.format(this.getValue(), 'c') : null");
             SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
             return val == null ? null : dateFormat.parse(val);
         }


### PR DESCRIPTION
#### Rationale
ExtJS3 injected a format function into the JS date prototype object. We shouldn't rely on it being present anymore

#### Changes
* Update to ExtJS4 format function