### PR TITLE
Update Pagination Selectors, rename QueryGridTest.java to GridPanelTest.java

### DIFF
--- a/src/org/labkey/test/components/react/DropdownButtonGroup.java
+++ b/src/org/labkey/test/components/react/DropdownButtonGroup.java
@@ -250,6 +250,11 @@ public class DropdownButtonGroup extends WebDriverComponent<DropdownButtonGroup.
         {
             return Locator.tagWithClass("div", "dropdown").withChild(Locators.toggleAnchor().withAttribute("id", Id));
         }
+
+        static public Locator.XPathLocator buttonGroupWithClass(String cls)
+        {
+            return Locator.tagWithClass("div", "dropdown").withChild(Locators.toggleAnchor().withClass(cls));
+        }
     }
 
     public static class DropdownButtonGroupFinder extends WebDriverComponentFinder<DropdownButtonGroup, DropdownButtonGroupFinder>
@@ -278,6 +283,12 @@ public class DropdownButtonGroup extends WebDriverComponent<DropdownButtonGroup.
         public DropdownButtonGroupFinder withButtonId(String Id)
         {
             _baseLocator = Locators.buttonGroupWithId(Id);
+            return this;
+        }
+
+        public DropdownButtonGroupFinder withButtonClass(String Id)
+        {
+            _baseLocator = Locators.buttonGroupWithClass(Id);
             return this;
         }
 

--- a/src/org/labkey/test/components/react/DropdownButtonGroup.java
+++ b/src/org/labkey/test/components/react/DropdownButtonGroup.java
@@ -286,9 +286,9 @@ public class DropdownButtonGroup extends WebDriverComponent<DropdownButtonGroup.
             return this;
         }
 
-        public DropdownButtonGroupFinder withButtonClass(String Id)
+        public DropdownButtonGroupFinder withButtonClass(String cls)
         {
-            _baseLocator = Locators.buttonGroupWithClass(Id);
+            _baseLocator = Locators.buttonGroupWithClass(cls);
             return this;
         }
 

--- a/src/org/labkey/test/components/react/Pager.java
+++ b/src/org/labkey/test/components/react/Pager.java
@@ -169,9 +169,9 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
     protected class ElementCache extends WebDriverComponent.ElementCache
     {
         DropdownButtonGroup jumpToDropdown = new DropdownButtonGroup.DropdownButtonGroupFinder(getDriver())
-                .withButtonId("current-page-drop-model").findWhenNeeded(this);
+                .withButtonClass("current-page-dropdown").findWhenNeeded(this);
         DropdownButtonGroup pageSizeDropdown = new DropdownButtonGroup.DropdownButtonGroupFinder(getDriver())
-                .withButtonId("page-size-drop-model").findWhenNeeded(this);
+                .withButtonClass("page-size-dropdown").findWhenNeeded(this);
 
         final Locator.XPathLocator queryGridModelPagingCounts = Locator.tag("span").withAttribute("data-min");
         final Locator.XPathLocator queryModelPagingCounts = Locator.tagWithClass("span", "pagination-info");
@@ -180,7 +180,8 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
         Optional<WebElement> prevButton()
         {
             return Locator.XPathLocator.union(
-                    Locator.tagWithClass("button", "pagination-buttons__prev"),     // used in gridPanel
+                    Locator.tagWithClass("button", "pagination-button--previous"),     // used in GridPanel
+                    Locator.tagWithClass("button", "pagination-buttons__prev"),     // used in ReportList
                     Locator.tag("button").withChild(Locator.tagWithClass("i", "fa fa-chevron-left"))) // used in QueryGridPanel, here for back-support
                     .findOptionalElement(this);
         }
@@ -188,7 +189,8 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
         Optional<WebElement> nextButton()
         {
             return Locator.XPathLocator.union(
-                    Locator.tagWithClass("button", "pagination-buttons__next"),
+                    Locator.tagWithClass("button", "pagination-button--next"), // used in GridPanel
+                    Locator.tagWithClass("button", "pagination-buttons__next"), // used in ReportList
                     Locator.tag("button").withChild(Locator.tagWithClass("i", "fa fa-chevron-right")))
                     .findOptionalElement(this);
         }

--- a/src/org/labkey/test/pages/test/CoreComponentsTestPage.java
+++ b/src/org/labkey/test/pages/test/CoreComponentsTestPage.java
@@ -38,7 +38,7 @@ public class CoreComponentsTestPage extends LabKeyPage<CoreComponentsTestPage.El
      * @param query
      * @return  a QueryGrid to wrap the GridPanel, once it is found
      */
-    public QueryGrid getQueryGrid(String schema, String query)
+    public QueryGrid getGridPanel(String schema, String query)
     {
         getComponentSelect().select("GridPanel");       // note: we use GridPanel now, not QueryGridPanel
         Input.Input(Locator.input("schemaName"), getDriver()).waitFor().set(schema);

--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -1,7 +1,6 @@
 package org.labkey.test.tests.component;
 
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
@@ -22,7 +21,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 @Category({DailyB.class})       // until we create a component suite, it's a daily
-public class QueryGridTest extends BaseWebDriverTest
+public class GridPanelTest extends BaseWebDriverTest
 {
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
@@ -33,7 +32,7 @@ public class QueryGridTest extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject()
     {
-        QueryGridTest init = (QueryGridTest) getCurrentTest();
+        GridPanelTest init = (GridPanelTest) getCurrentTest();
 
         init.doSetup();
     }
@@ -53,7 +52,7 @@ public class QueryGridTest extends BaseWebDriverTest
         sampleSetDataGenerator.insertRows();
 
         CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getQueryGrid("samples", "grid_paging_samples");
+        QueryGrid grid = testPage.getGridPanel("samples", "grid_paging_samples");
 
         assertThat(grid.getGridBar().pager().start(), is(1));
         assertThat(grid.getGridBar().pager().end(), is(20));
@@ -81,7 +80,7 @@ public class QueryGridTest extends BaseWebDriverTest
         sampleSetDataGenerator.insertRows();
 
         CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getQueryGrid("samples", "grid_page_size_samples");
+        QueryGrid grid = testPage.getGridPanel("samples", "grid_page_size_samples");
 
         // assume default page size is 20
         assertThat(grid.getGridBar().getCurrentPage(), is(1));
@@ -133,7 +132,7 @@ public class QueryGridTest extends BaseWebDriverTest
         sampleSetDataGenerator.insertRows();
 
         CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getQueryGrid("samples", "filtered_grid_selection_samples");
+        QueryGrid grid = testPage.getGridPanel("samples", "filtered_grid_selection_samples");
 
         // confirm that selectAll is limited to just the records in a filtered set
         grid.filterOn("Description", "=", "used to test issue 39011");
@@ -178,7 +177,7 @@ public class QueryGridTest extends BaseWebDriverTest
         sampleSetDataGenerator.insertRows();
 
         CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getQueryGrid("samples", "tiny_sampleset");
+        QueryGrid grid = testPage.getGridPanel("samples", "tiny_sampleset");
 
         grid.filterOn("description", "=", "used to test single-page filter selection");
         grid.selectAllRows();
@@ -207,7 +206,7 @@ public class QueryGridTest extends BaseWebDriverTest
         sampleSetDataGenerator.insertRows();
 
         CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getQueryGrid("samples", "filtered_grid_multipageselection_samples");
+        QueryGrid grid = testPage.getGridPanel("samples", "filtered_grid_multipageselection_samples");
 
         // confirm that selectAll is limited to just the records in a filtered set
         grid.filterOn("Description", "=", "used to test issue 39011");
@@ -246,7 +245,7 @@ public class QueryGridTest extends BaseWebDriverTest
         sampleSetDataGenerator.insertRows();
 
         CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getQueryGrid("samples", "search_for_description_expression");
+        QueryGrid grid = testPage.getGridPanel("samples", "search_for_description_expression");
 
         // prove we can filter on this criteria
         grid.filterOn("Description", "contains", "off-view");
@@ -273,7 +272,7 @@ public class QueryGridTest extends BaseWebDriverTest
         sampleSetDataGenerator.insertRows();
 
         CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getQueryGrid("samples", "empty_filter_test_set");
+        QueryGrid grid = testPage.getGridPanel("samples", "empty_filter_test_set");
 
         grid.filterOn("Description", "is blank", null);
         assertThat(grid.getGridBar().pager().summary(), is("1 - 20 of 30"));
@@ -315,7 +314,7 @@ public class QueryGridTest extends BaseWebDriverTest
         sampleSetDataGenerator.insertRows();
 
         CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getQueryGrid("samples", "deselect_one_page_set");
+        QueryGrid grid = testPage.getGridPanel("samples", "deselect_one_page_set");
 
         grid.selectAllRows();
         assertThat(grid.getGridBar().pager().summary(), is("1 - 20 of 35"));
@@ -350,7 +349,7 @@ public class QueryGridTest extends BaseWebDriverTest
         sampleSetDataGenerator.insertRows();
 
         CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getQueryGrid("samples", "remove_filters_with_selections_set");
+        QueryGrid grid = testPage.getGridPanel("samples", "remove_filters_with_selections_set");
 
         grid.filterOn("Int Column", "is not blank", null);
 
@@ -371,7 +370,6 @@ public class QueryGridTest extends BaseWebDriverTest
         sampleSetDataGenerator.deleteDomain(createDefaultConnection());
     }
 
-    @Ignore // https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41171
     @Test
     public void testDeselectRecordsWithFilter() throws Exception
     {
@@ -389,7 +387,7 @@ public class QueryGridTest extends BaseWebDriverTest
         sampleSetDataGenerator.insertRows();
 
         CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getQueryGrid("samples", "deselect_with_filter");
+        QueryGrid grid = testPage.getGridPanel("samples", "deselect_with_filter");
 
         grid.selectAllRows();
         grid.filterOn("String Column", "does not contain", "filtered_y");


### PR DESCRIPTION
#### Rationale
The QueryGridTest was not testing the QueryGridPanel at all, so I renamed it to GridPanelTest to better reflect what it is testing. I also added some new selectors to the pagination related components and updated the test code to use them.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/332
* https://github.com/LabKey/platform/pull/1538

#### Changes
* Rename QueryGridTest.java to GridPanelTest.java
* Update selectors for pagination components
