### PR TITLE
Make etltest upgrade script compatible with SQL Server 2012

### DIFF
--- a/modules/ETLtest/resources/schemas/dbscripts/sqlserver/etltest-20.000-20.001.sql
+++ b/modules/ETLtest/resources/schemas/dbscripts/sqlserver/etltest-20.000-20.001.sql
@@ -1,5 +1,5 @@
 
-CREATE OR ALTER PROCEDURE etltest.etlTest
+ALTER PROCEDURE etltest.etlTest
 	@transformRunId int,
 	@containerId entityid = NULL OUTPUT,
 	@rowsInserted int = 0 OUTPUT,


### PR DESCRIPTION
#### Rationale
Running `etltest` module on SQL Server 2012 produces the following error during bootstrap:
`java.sql.SQLException: Incorrect syntax near the keyword 'OR'.`

#### Changes
* Make `etltest-20.000-20.001.sql` work on SQL Server 2012

---
[TeamCity verification](https://teamcity.labkey.org/viewLog.html?buildId=1103218&tab=buildResultsDiv&buildTypeId=LabKey_207Release_Internal_InternalSuites_OldDependenciesSqlserver)
