### PR TITLE
Remove unnecessary navigation from BaseFlowTest

### DIFF
--- a/src/org/labkey/test/tests/flow/BaseFlowTest.java
+++ b/src/org/labkey/test/tests/flow/BaseFlowTest.java
@@ -174,16 +174,10 @@ abstract public class BaseFlowTest extends BaseWebDriverTest
     //Issue 12597: Need to delete exp.data objects when deleting a flow run
     protected void deleteAllRuns()
     {
-        if (!isElementPresent(Locator.linkWithText(getProjectName())))
-            goToHome();
-        if (!isElementPresent(Locator.linkWithText(getProjectName())))
+        if (!_containerHelper.doesContainerExist(getContainerPath()))
+        {
             return;
-
-        clickProject(getProjectName());
-        if (!isElementPresent(Locator.linkWithText(getFolderName())))
-            return;
-
-        clickFolder(getFolderName());
+        }
 
         beginAt("/query/" + getProjectName() + "/" + getFolderName() + "/executeQuery.view?schemaName=exp&query.queryName=Runs");
         DataRegionTable table = new DataRegionTable("query", this);

--- a/src/org/labkey/test/tests/flow/BaseFlowTest.java
+++ b/src/org/labkey/test/tests/flow/BaseFlowTest.java
@@ -185,11 +185,7 @@ abstract public class BaseFlowTest extends BaseWebDriverTest
         {
             // Delete all runs
             table.checkAllOnPage();
-            doAndWaitForPageToLoad(() ->
-            {
-                clickButton("Delete", 0);
-                assertAlertContains("Are you sure you want to delete the selected row");
-            });
+            table.deleteSelectedRows();
             assertEquals("Expected all experiment Runs to be deleted", 0, table.getDataRowCount());
 
             // Check all DataInputs were deleted


### PR DESCRIPTION
#### Rationale
This method is called by `doCleanup`. If the crawler ends on a particular action, this method will attempt to open a project menu that doesn't exist.
The test does a bunch of navigation just to check if a folder exists. If we use the container helper to check for the folder we don't need the project menu to be present.
_Note: This code predates our current project menu and might not function as expected at all._

#### Changes
* Use `APIContainerHelper` to check for folder
