### PR TITLE
Have 'isDisplayed' return false for stale or unfound WebElements

### DIFF
--- a/src/org/labkey/test/selenium/LazyWebElement.java
+++ b/src/org/labkey/test/selenium/LazyWebElement.java
@@ -17,7 +17,9 @@ package org.labkey.test.selenium;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.test.Locator;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.FluentWait;
 
@@ -37,6 +39,19 @@ public class LazyWebElement<T extends LazyWebElement<T>> extends WebElementWrapp
     {
         _locator = locator;
         _searchContext = searchContext;
+    }
+
+    @Override
+    public boolean isDisplayed()
+    {
+        try
+        {
+            return super.isDisplayed();
+        }
+        catch (StaleElementReferenceException | NoSuchElementException ex)
+        {
+            return false;
+        }
     }
 
     public final T withTimeout(long ms)


### PR DESCRIPTION
#### Rationale
We often check whether a component or page is ready by checking for the presence and visibility of particular element. e.g.:
```
try
{
    return elementCache().element.isDisplayed();
}
catch (NoSuchElementException nse)
{
    return false;
}
```
This update would allow us to remove the try/catch from such statements:
```
return elementCache().element.isDisplayed();
```

#### Changes
* Have 'isDisplayed' return false for stale or unfound `LazyWebElement`s

#### Alternate solutions
* Move this override up to `WebElementWrapper`.
  * More likely to introduce unexpected behavior to other tests but would make behavior more consistent.
* Create a new `WebElementWrapper` or `LazyWebElement` subclass to allow components to opt in to this behavior.
  * Won't risk breaking any existing tests but might be too cumbersome for people to bother with.
