### PR TITLE
Date time domain fields should have dateTime RangeURI

### DIFF
--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -301,7 +301,7 @@ public class FieldDefinition extends PropertyDescriptor
         Integer("Integer", "int"),
         String("Text", "string"),
         Subject("Subject/Participant", "string", "http://cpas.labkey.com/Study#ParticipantId", null),
-        DateAndTime("Date Time", "date"),
+        DateAndTime("Date Time", "dateTime"),
         Boolean("Boolean", "boolean"),
         Double("Number (Double)", "float"),
         Decimal("Decimal (floating point)", "float"),

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -228,6 +228,7 @@ public class TestDataGenerator
             case "boolean":
                 return () -> randomBoolean();
             case "date":
+            case "datetime":
                 return () -> randomDateString(DateUtils.addWeeks(new Date(), -39), new Date());
             default:
                 throw new IllegalArgumentException("ColumnType " + columnType + " isn't implemented yet");


### PR DESCRIPTION
#### Rationale
Domain editor has Date Time option.  This should create a DateTime RangeURI, not Date.

#### Changes
- Update Field Definitions and Test Data Generator to use DateTime RangeURI instead of Date.
