### PR TITLE
Prevent line ending changes at checkout for SpectraMax tests' sample data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -48,3 +48,4 @@
 
 # LuceneSearchServiceImpl.TikaTestCase depends on exact file sizes. Do not normalize these files on checkout.
 data/fileTypes/* -text
+data/Nab/SpectraMax/* -text


### PR DESCRIPTION

#### Rationale
The plate reading tests are failing on Windows machines due to the sample data files being corrupted.

#### Changes
* exempt the SpectraMax from the automatic checkout normalization.
