### PR TITLE
Fix intermittent test issues

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3457,10 +3457,11 @@ public abstract class WebDriverWrapper implements WrapsDriver
         RadioButton radioButton = RadioButton(radioButtonLocator).find(getDriver());
         radioButton.check();
 
+        // TODO: Should review this code, and understand why it was written.
         // I'm not sure this code is doing what was intended, or is the correct thing to do.
         // I think this may be exposing a bug in the RadioButton finder. Look at baseWebDriverTest.prepareForFolderExport (line 1448).
         // The locator sent into this function is a table, which will find the input element, but it makes the base
-        // element table which never returns true for checked.
+        // element the table as well which will never returns true for checked.
         if (!waitFor(()-> radioButton.isChecked(), 250))
             radioButton.check();
         return radioButton;

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3456,6 +3456,11 @@ public abstract class WebDriverWrapper implements WrapsDriver
     {
         RadioButton radioButton = RadioButton(radioButtonLocator).find(getDriver());
         radioButton.check();
+
+        // I'm not sure this code is doing what was intended, or is the correct thing to do.
+        // I think this may be exposing a bug in the RadioButton finder. Look at baseWebDriverTest.prepareForFolderExport (line 1448).
+        // The locator sent into this function is a table, which will find the input element, but it makes the base
+        // element table which never returns true for checked.
         if (!waitFor(()-> radioButton.isChecked(), 250))
             radioButton.check();
         return radioButton;

--- a/src/org/labkey/test/components/html/Checkbox.java
+++ b/src/org/labkey/test/components/html/Checkbox.java
@@ -78,15 +78,6 @@ public class Checkbox extends Component implements FormItem<Boolean>
     {
         if (checked != isChecked())
             toggle();
-
-        // There are checkbox/radio buttons that have problems here. Sometimes the component element is
-        // not an input but the container element used to find it. In BaseWebDriverTest.prepareForFolderExport
-        // the wrapping table element used to find the radio button is what _el is set to.
-        if(getComponentElement().getTagName().toLowerCase().equals("input"))
-        {
-            Assert.assertEquals("Checkbox/Radio Button state is not as expected.", checked, isChecked());
-        }
-
     }
 
     public void toggle()

--- a/src/org/labkey/test/components/html/Checkbox.java
+++ b/src/org/labkey/test/components/html/Checkbox.java
@@ -78,6 +78,15 @@ public class Checkbox extends Component implements FormItem<Boolean>
     {
         if (checked != isChecked())
             toggle();
+
+        // There are checkbox/radio buttons that have problems here. Sometimes the component element is
+        // not an input but the container element used to find it. In BaseWebDriverTest.prepareForFolderExport
+        // the wrapping table element used to find the radio button is what _el is set to.
+        if(getComponentElement().getTagName().toLowerCase().equals("input"))
+        {
+            Assert.assertEquals("Checkbox/Radio Button state is not as expected.", checked, isChecked());
+        }
+
     }
 
     public void toggle()

--- a/src/org/labkey/test/components/html/RadioButton.java
+++ b/src/org/labkey/test/components/html/RadioButton.java
@@ -20,9 +20,7 @@ import org.labkey.test.Locator;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebElement;
 
-// TODO: We may want to revisit this inheritance. Specifically I have run into problems being able to check if a
-//  radio button is checked or not. It doesn't look like their status (checked/unchecked) is always stored as an
-//  attribute of the input control. Sometimes it is stored as an attribute in one of it's ancestor tags.
+// TODO: We may want to revisit this inheritance, not sure we are getting what we want from it.
 public class RadioButton extends Checkbox
 {
     public RadioButton(WebElement element)

--- a/src/org/labkey/test/components/html/RadioButton.java
+++ b/src/org/labkey/test/components/html/RadioButton.java
@@ -20,6 +20,9 @@ import org.labkey.test.Locator;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebElement;
 
+// TODO: We may want to revisit this inheritance. Specifically I have run into problems being able to check if a
+//  radio button is checked or not. It doesn't look like their status (checked/unchecked) is always stored as an
+//  attribute of the input control. Sometimes it is stored as an attribute in one of it's ancestor tags.
 public class RadioButton extends Checkbox
 {
     public RadioButton(WebElement element)

--- a/src/org/labkey/test/components/html/Table.java
+++ b/src/org/labkey/test/components/html/Table.java
@@ -86,7 +86,7 @@ public class Table extends WebDriverComponent<Table.Elements>
      */
     public List<String> getTableHeaderTexts()
     {
-        List<WebElement> headerEls = Locator.xpath("//thead//th").findElements(this);
+        List<WebElement> headerEls = Locator.xpath("./thead/th").findElements(this);
         List<String> columnHeaders = new ArrayList<>();
         for(WebElement headerEl : headerEls){columnHeaders.add(headerEl.getText());}
         return columnHeaders;
@@ -100,9 +100,7 @@ public class Table extends WebDriverComponent<Table.Elements>
         return columnHeaders;
     }
 
-    // TODO: This finder makes a bad assumption that the column headers will be in a tr in the tbody. In a well formed
-    //  html table that is not the case the column headers could be in a th in a thead, which is outside the tbody.
-    // The problem is compounded because some of the other functions, like getDataAsText(int row, String columnName), build on this assumption.
+    // TODO: This finder makes an assumption that the column headers will be in a tr in the tbody, that is not always the case.
     // Maybe a possible solution would be to remove "./tbody" from the locator, but that is a thread I am not willing to pull at this time.
     private List<WebElement> getColumnHeaderElements(int headerRow)
     {

--- a/src/org/labkey/test/components/html/Table.java
+++ b/src/org/labkey/test/components/html/Table.java
@@ -79,6 +79,19 @@ public class Table extends WebDriverComponent<Table.Elements>
         return elementCache().getRows().size();
     }
 
+    /**
+     * For a well formed html table get the text from the th elements in the thead.
+     *
+     * @return A list of the text values contained in the th tags in the thead.
+     */
+    public List<String> getTableHeaderTexts()
+    {
+        List<WebElement> headerEls = Locator.xpath("//thead//th").findElements(this);
+        List<String> columnHeaders = new ArrayList<>();
+        for(WebElement headerEl : headerEls){columnHeaders.add(headerEl.getText());}
+        return columnHeaders;
+    }
+
     public List<String> getColumnHeaders(int headerRow)
     {
         List<WebElement> headerEls = getColumnHeaderElements(headerRow);
@@ -87,6 +100,10 @@ public class Table extends WebDriverComponent<Table.Elements>
         return columnHeaders;
     }
 
+    // TODO: This finder makes a bad assumption that the column headers will be in a tr in the tbody. In a well formed
+    //  html table that is not the case the column headers could be in a th in a thead, which is outside the tbody.
+    // The problem is compounded because some of the other functions, like getDataAsText(int row, String columnName), build on this assumption.
+    // Maybe a possible solution would be to remove "./tbody" from the locator, but that is a thread I am not willing to pull at this time.
     private List<WebElement> getColumnHeaderElements(int headerRow)
     {
         return getComponentElement().findElements(By.xpath("./tbody/tr["+ headerRow +"]/*[(name()='TH' or name()='TD' or name()='th' or name()='td')]"));

--- a/src/org/labkey/test/components/html/Table.java
+++ b/src/org/labkey/test/components/html/Table.java
@@ -86,7 +86,7 @@ public class Table extends WebDriverComponent<Table.Elements>
      */
     public List<String> getTableHeaderTexts()
     {
-        List<WebElement> headerEls = Locator.xpath("./thead/th").findElements(this);
+        List<WebElement> headerEls = Locator.xpath("//thead//th").findElements(this);
         List<String> columnHeaders = new ArrayList<>();
         for(WebElement headerEl : headerEls){columnHeaders.add(headerEl.getText());}
         return columnHeaders;

--- a/src/org/labkey/test/tests/ReportThumbnailTest.java
+++ b/src/org/labkey/test/tests/ReportThumbnailTest.java
@@ -351,11 +351,11 @@ public class ReportThumbnailTest extends BaseWebDriverTest
     {
         goToDataViews();
         waitForElement(Locator.xpath("//a[text()='"+chart+"']"));
+        sleep(500);
         mouseOver(Locator.xpath("//a[text()='"+chart+"']"));
         Locator.XPathLocator thumbnail = Locator.xpath("//div[@class='thumbnail']/img").notHidden();
         waitForElement(thumbnail);
         // Trying to protect against a possible race condition when icon is there but thumbnail has not yet been generated.
-        sleep(500);
         String thumbnailData;
         thumbnailData = WebTestHelper.getHttpResponse(getAttribute(thumbnail, "src")).getResponseBody();
 

--- a/src/org/labkey/test/tests/ReportThumbnailTest.java
+++ b/src/org/labkey/test/tests/ReportThumbnailTest.java
@@ -354,6 +354,8 @@ public class ReportThumbnailTest extends BaseWebDriverTest
         mouseOver(Locator.xpath("//a[text()='"+chart+"']"));
         Locator.XPathLocator thumbnail = Locator.xpath("//div[@class='thumbnail']/img").notHidden();
         waitForElement(thumbnail);
+        // Trying to protect against a possible race condition when icon is there but thumbnail has not yet been generated.
+        sleep(500);
         String thumbnailData;
         thumbnailData = WebTestHelper.getHttpResponse(getAttribute(thumbnail, "src")).getResponseBody();
 


### PR DESCRIPTION
#### Rationale
Trying to fix long running intermittent test issues with [ReportThumbnailTest.testSteps](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailySqlserverb/1121712?buildTab=tests&name=ReportThumbnail&pager.currentPage=1) and [VocabularyViewSupportTest.testSampleSetViewSupport](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyCPostgres/1121786?buildTab=tests&name=Vocabulary&pager.currentPage=1).

#### Related Pull Requests
* [Change in platform module](https://github.com/LabKey/platform/pull/1584).

#### Changes
* Added a better check to the vocabulary test to validate a table as a map object and not as a string.
* Added a sleep to wait for the thumbnail graph to get generated

Tried to add a validation to the checkbox control to assert that it is set as expected. However this proved to be unreliable for radio buttons which inherit from the checkbox. So I removed that change but added comments to various other test libraries calling out some of the issues I ran into.