### PR TITLE
Update staleness checks and other fixes

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -934,13 +934,16 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                     getDriver().switchTo().window(failureWindow);
                 }
             }
-            catch (RuntimeException | Error e)
+            catch (RuntimeException e)
             {
                 log("Unable to dump screenshots");
                 System.err.println(e.getMessage());
             }
-            // Reset errors before next test and make it easier to view server-side errors that may have happened during the test.
-            checker().withScreenshot("serverErrors").wrapAssertion(this::checkErrors);
+            if (isTestRunningOnTeamCity()) // Don't risk modifying browser state when running locally
+            {
+                // Reset errors before next test and make it easier to view server-side errors that may have happened during the test.
+                checker().withScreenshot("serverErrors").wrapAssertion(this::checkErrors);
+            }
         }
         finally
         {

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -864,6 +864,8 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         }
     }
 
+    public static final Pattern ERROR_PATTERN = Pattern.compile("^ERROR", Pattern.MULTILINE);
+
     public void checkErrors()
     {
         if (isGuestModeTest())
@@ -873,6 +875,19 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         String serverErrors = getServerErrors();
         if (!serverErrors.isEmpty())
         {
+            Matcher errorMatcher = ERROR_PATTERN.matcher(serverErrors);
+            while (errorMatcher.find())
+            {
+                String[] errorLines = errorMatcher.group().split("\n");
+                TestLogger.error("Server error:");
+                TestLogger.increaseIndent();
+                for (int i = 0; i < 10 && i < errorLines.length; i++)
+                {
+                    TestLogger.error(errorLines[i]);
+                }
+                TestLogger.decreaseIndent();
+            }
+
             beginAt(buildURL("admin", "showErrorsSinceMark"));
             resetErrors();
             if (serverErrors.toLowerCase().contains(CLIENT_SIDE_ERROR.toLowerCase()))
@@ -909,8 +924,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
     protected int getServerErrorCount()
     {
         String text = getServerErrors();
-        Pattern errorPattern = Pattern.compile("^ERROR", Pattern.MULTILINE);
-        Matcher errorMatcher = errorPattern.matcher(text);
+        Matcher errorMatcher = ERROR_PATTERN.matcher(text);
         int count = 0;
         while (errorMatcher.find())
         {

--- a/src/org/labkey/test/aspects/ImpersonationLoggingAspect.java
+++ b/src/org/labkey/test/aspects/ImpersonationLoggingAspect.java
@@ -43,7 +43,7 @@ public class ImpersonationLoggingAspect
             _impersonating = impersonating;
             _startTime = System.currentTimeMillis();
         }
-        else
+        else if (!_impersonating.equals(impersonating))
         {
             TestLogger.decreaseIndent();
             TestLogger.log("><Switch Impersonation : " + _impersonating + TestLogger.formatElapsedTime(System.currentTimeMillis() - _startTime) + " -> " + impersonating);
@@ -57,7 +57,7 @@ public class ImpersonationLoggingAspect
     @AfterReturning(value = "stopImpersonation()")
     public void afterImpersonation()
     {
-        if (_startTime == null)
+        if (_startTime == null || _impersonating == null)
             return;
 
         String impersonating = _impersonating;

--- a/src/org/labkey/test/components/glassLibrary/components/MultiMenu.java
+++ b/src/org/labkey/test/components/glassLibrary/components/MultiMenu.java
@@ -99,7 +99,7 @@ public class MultiMenu extends BootstrapMenu
             {
                 // This happens in the time between the change of the menu content from containing "loading"
                 // to having data (like "sample types").
-                getComponentElement().isDisplayed(); // will throw an uncaught 'StaleReferenceException' if the entire menu went stale
+                getComponentElement().isEnabled(); // will throw an uncaught 'StaleReferenceException' if the entire menu went stale
                 stale = true;
             }
 

--- a/src/org/labkey/test/components/html/SiteNavBar.java
+++ b/src/org/labkey/test/components/html/SiteNavBar.java
@@ -273,7 +273,7 @@ public class SiteNavBar extends WebDriverComponent<SiteNavBar.Elements>
             {
                 clickSubMenu(false, "Impersonate", "User");
                 window = new ImpersonateUserWindow(getDriver());
-                window.getComponentElement().isDisplayed(); // force it to resolve
+                window.getComponentElement().isEnabled(); // force it to resolve
             }
             catch (NoSuchElementException notfound)
             {
@@ -298,7 +298,7 @@ public class SiteNavBar extends WebDriverComponent<SiteNavBar.Elements>
             {
                 clickSubMenu(false, "Impersonate", "Roles");
                 window = new ImpersonateRoleWindow(getDriver());
-                window.getComponentElement().isDisplayed(); // force it to find/resolve
+                window.getComponentElement().isEnabled(); // force it to find/resolve
             }
             catch (NoSuchElementException notFound)
             {
@@ -319,7 +319,7 @@ public class SiteNavBar extends WebDriverComponent<SiteNavBar.Elements>
             {
                 clickSubMenu(false, "Impersonate", "Group");
                 window = new ImpersonateGroupWindow(getDriver());
-                window.getComponentElement().isDisplayed(); // force it to resolve
+                window.getComponentElement().isEnabled(); // force it to resolve
             }
             catch (NoSuchElementException retry)
             {

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -1397,7 +1397,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
         assertTextNotPresent("Prius");
         try
         {
-            rootEl.isDisplayed();
+            rootEl.isEnabled();
         }
         catch (StaleElementReferenceException stale)
         {

--- a/src/org/labkey/test/tests/wiki/EmbeddedWebPartTest.java
+++ b/src/org/labkey/test/tests/wiki/EmbeddedWebPartTest.java
@@ -96,7 +96,7 @@ public class EmbeddedWebPartTest extends BaseWebDriverTest
 
         try
         {
-            el.isDisplayed();
+            el.isEnabled();
         }
         catch (NoSuchElementException fail)
         {

--- a/src/org/labkey/test/util/DataRegion.java
+++ b/src/org/labkey/test/util/DataRegion.java
@@ -93,7 +93,7 @@ public abstract class DataRegion extends WebDriverComponent<DataRegion.ElementCa
     @Override
     public ElementCache elementCache()
     {
-        getComponentElement().isDisplayed(); // Trigger cache reset
+        getComponentElement().isEnabled(); // Trigger cache reset
         return super.elementCache();
     }
 

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -459,7 +459,7 @@ public class DataRegionTable extends DataRegion
 
     public List<String> getColumnLabels()
     {
-        getComponentElement().isDisplayed(); // validate cached element
+        getComponentElement().isEnabled(); // validate cached element
 
         if (_columnLabels.isEmpty())
         {
@@ -473,7 +473,7 @@ public class DataRegionTable extends DataRegion
 
     public List<String> getColumnNames()
     {
-        getComponentElement().isDisplayed(); // validate cached element
+        getComponentElement().isEnabled(); // validate cached element
 
         if (_columnNames.isEmpty())
         {
@@ -628,7 +628,7 @@ public class DataRegionTable extends DataRegion
     {
         assertTrue("Need the selector checkboxes value to find row by pk", hasSelectors());
 
-        getComponentElement().isDisplayed(); // refresh cache
+        getComponentElement().isEnabled(); // refresh cache
 
         Integer cached = _mapRows.get(pk);
         if (cached != null)


### PR DESCRIPTION
#### Rationale
* Don't check server errors after tests when running locally
  * Doing so might need to stop impersonating, which will navigate away from the test failure.
* Don't double-log impersonation
  * `LKSW.impersonate` calls `SiteNavBar.UserMenu.impersonate`, and they would both would get logged
* Include partial server stack traces in test log
  * TeamCity discards artifacts (such as server logs) after a couple of weeks but the test logs stick around for much longer.
* Use 'isEnabled' to trigger staleness checks
  * `LazyWebElement.isDisplayed` won't throw `StaleElementReferenceException` or `NoSuchElementException` (#468). Need to call `isEnabled` instead.
