### PR TITLE
Create a component test class for EditableGrid

### DIFF
--- a/src/org/labkey/test/components/glassLibrary/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/glassLibrary/grids/EditableGrid.java
@@ -495,6 +495,19 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
             return Locator.tagWithClass("div", "cell-warning").findElement(gridCell).getText();
     }
 
+    public String getCellPopoverText(int row, String column)
+    {
+        WebElement warnDiv = Locator.tagWithClass("div", "cellular-display").findElement(getCell(row, column));
+        getWrapper().mouseOver(warnDiv);   // cause the tooltip to be present
+        if (getWrapper().waitFor(()-> null != warnDiv.getAttribute("aria-describedby"), 1000))
+        {
+            String popoverId = warnDiv.getAttribute("aria-describedby");
+            return Locator.id(popoverId).findElement(getDriver()).getText();
+        }
+        else
+            return null;
+    }
+
     public List<WebElement> getCellErrors()
     {
         return Locator.tagWithClass("div", "cell-warning").findElements(this);

--- a/src/org/labkey/test/pages/test/CoreComponentsTestPage.java
+++ b/src/org/labkey/test/pages/test/CoreComponentsTestPage.java
@@ -4,6 +4,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.glassLibrary.components.ReactSelect;
+import org.labkey.test.components.glassLibrary.grids.EditableGrid;
 import org.labkey.test.components.glassLibrary.grids.QueryGrid;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.pages.LabKeyPage;
@@ -30,6 +31,12 @@ public class CoreComponentsTestPage extends LabKeyPage<CoreComponentsTestPage.El
     public ReactSelect getComponentSelect()
     {
         return ReactSelect.finder(getDriver()).waitFor();
+    }
+
+    public EditableGrid getEditableGrid()
+    {
+        getComponentSelect().select("EditableGridPanel");
+        return new EditableGrid.EditableGridFinder(getDriver()).waitFor();
     }
 
     /**

--- a/src/org/labkey/test/tests/component/EditableGridTest.java
+++ b/src/org/labkey/test/tests/component/EditableGridTest.java
@@ -17,7 +17,7 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@Category({DailyB.class})   // until there's a component suite
+@Category({DailyB.class})
 public class EditableGridTest extends BaseWebDriverTest
 {
     @Override

--- a/src/org/labkey/test/tests/component/EditableGridTest.java
+++ b/src/org/labkey/test/tests/component/EditableGridTest.java
@@ -13,9 +13,10 @@ import org.labkey.test.pages.test.CoreComponentsTestPage;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.everyItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 @Category({DailyB.class})
 public class EditableGridTest extends BaseWebDriverTest
@@ -56,6 +57,8 @@ public class EditableGridTest extends BaseWebDriverTest
         assertThat("Expect cell error to explain that paste cannot add columns",
                 testGrid.getCellPopoverText(0, "Description"),
                 is("Unable to paste. Cannot paste columns beyond the columns found in the grid."));
+        assertThat("Expect failed paste to leave data unchanged",
+                testGrid.getColumnData("LSID *"), everyItem(is("")));
     }
 
     @Test
@@ -74,9 +77,11 @@ public class EditableGridTest extends BaseWebDriverTest
 
         testGrid.pasteFromCell(0, "Description", tallShape);
         List<String> pastedColData = testGrid.getColumnData("Description");
+        List<String> unpastedColData = testGrid.getColumnData("LSID *");
 
-        assertThat(pastedColData, hasItems("42", "41", "40", "39", "38"));
-        assertThat(testGrid.getRowCount(), is(5));
+        assertEquals("Didn't get correct values", List.of("42", "41", "40", "39", "38"), pastedColData);
+        assertThat("expect other column to remain empty",
+                unpastedColData, everyItem(is("")));
     }
 
     @Override

--- a/src/org/labkey/test/tests/component/EditableGridTest.java
+++ b/src/org/labkey/test/tests/component/EditableGridTest.java
@@ -1,0 +1,99 @@
+package org.labkey.test.tests.component;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.TestTimeoutException;
+import org.labkey.test.categories.DailyB;
+import org.labkey.test.components.glassLibrary.grids.EditableGrid;
+import org.labkey.test.pages.test.CoreComponentsTestPage;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Category({DailyB.class})   // until there's a component suite
+public class EditableGridTest extends BaseWebDriverTest
+{
+    @Override
+    protected void doCleanup(boolean afterTest) throws TestTimeoutException
+    {
+        super.doCleanup(afterTest);
+    }
+
+    @BeforeClass
+    public static void setupProject()
+    {
+        EditableGridTest init = (EditableGridTest) getCurrentTest();
+
+        init.doSetup();
+    }
+
+    private void doSetup()
+    {
+        _containerHelper.createProject(getProjectName(), null);
+    }
+
+    @Before
+    public void preTest() throws Exception
+    {
+        goToProjectHome();
+    }
+
+    @Test
+    public void testTooWideErrorCase() throws Exception
+    {
+        CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
+        EditableGrid testGrid = testPage.getEditableGrid();
+        String wideShape = "Too wide\tACME\tthing\tanother\televen\toff the map\tMoar columns\n";
+
+        testGrid.pasteFromCell(0, "Description", wideShape);
+        assertThat("Expect cell error to explain that paste cannot add columns",
+                testGrid.getCellPopoverText(0, "Description"),
+                is("Unable to paste. Cannot paste columns beyond the columns found in the grid."));
+    }
+
+    @Test
+    public void testCanAddRowsWithTallShape()
+    {
+        CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
+        EditableGrid testGrid = testPage.getEditableGrid();
+        String tallShape = "42\n" +
+                "41\n" +
+                "40\n" +
+                "39\n" +
+                "38";
+
+        int initialRowCount = testGrid.getRowCount();
+        assertThat(initialRowCount, is(2));
+
+        testGrid.pasteFromCell(0, "Description", tallShape);
+        List<String> pastedColData = testGrid.getColumnData("Description");
+
+        assertThat(pastedColData, hasItems("42", "41", "40", "39", "38"));
+        assertThat(testGrid.getRowCount(), is(5));
+    }
+
+    @Override
+    protected BrowserType bestBrowser()
+    {
+        return BrowserType.CHROME;
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return "EditableGridTest Project";
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Arrays.asList();
+    }
+}

--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-@Category({DailyB.class})       // until we create a component suite, it's a daily
+@Category({DailyB.class})
 public class GridPanelTest extends BaseWebDriverTest
 {
     @Override


### PR DESCRIPTION
#### Rationale
This adds basic test coverage for component behavior of EditableGrid in core-components view.
To date, the only ways to test components like this has been to bloat scenario tests in Biologics or SM.
The test in BiologicsComponentTest.checkErrorCasesInEditableGrid sometimes fails because testing the second case in it collides with the (expected) prior error- creating this should replace that coverage, but more reliably.

For the nonce, the core-components.view does not support getting an EditableGrid for an arbitrary schema- [issue 41459](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41459) should address this.  Once this is possible we can add test coverage for cases like lookup field interactions

#### Related Pull Requests
n/a
(possibly, remove checkErrorCasesInEditableGrid from the Biologics suite)

#### Changes
add ability to get cell error text from its related popover

