### PR TITLE
Bootstrap modal delete close button wait

### DIFF
--- a/src/org/labkey/test/components/bootstrap/ModalDialog.java
+++ b/src/org/labkey/test/components/bootstrap/ModalDialog.java
@@ -91,7 +91,10 @@ public class ModalDialog extends WebDriverComponent<ModalDialog.ElementCache>
 
     public void dismiss()
     {
-        Locator.tagWithClass("button", "close").findElement(getComponentElement()).click();
+        WebElement button = Locator.tagWithClass("button", "close").findElement(getComponentElement());
+        new WebDriverWait(getDriver(), WAIT_FOR_JAVASCRIPT)
+                .until(ExpectedConditions.elementToBeClickable(button));
+        button.click();
         waitForClose();
     }
 


### PR DESCRIPTION
#### Rationale
This modal transitions in so adding a wait for clickable to the close button before trying to close

#### Changes
- Add elementToBeClickable wait to modal dismiss
