### PR TITLE
Support selecting a grid row by partial map of column, text values

### DIFF
--- a/src/org/labkey/test/components/glassLibrary/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/glassLibrary/grids/ResponsiveGrid.java
@@ -147,9 +147,12 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
      * @param checked       the desired checkbox state
      * @return
      */
-    public ResponsiveGrid selectRow(Map partialMap, boolean checked)
+    public ResponsiveGrid selectRow(Map<String, String> partialMap, boolean checked)
     {
-        getRow(partialMap).select(checked);
+        GridRow row = getRow(partialMap);
+        selectRowAndVerifyCheckedCounts(row, checked);
+        getWrapper().log("Row described by map ["+partialMap+"] selection state set to + ["+row.isSelected()+"]");
+
         return getThis();
     }
 
@@ -162,10 +165,18 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
      */
     public ResponsiveGrid selectRow(String columnLabel, String text, boolean checked)
     {
+        GridRow row = getRow(columnLabel, text);
+        selectRowAndVerifyCheckedCounts(row, checked);
+        getWrapper().log("Row at column ["+columnLabel+"] with text ["+text+"] selection state set to + ["+row.isSelected()+"]");
+
+        return getThis();
+    }
+
+    private void selectRowAndVerifyCheckedCounts(GridRow row, boolean checked)
+    {
         Locator selectedCheckboxes = Locator.css("tr td input:checked[type='checkbox']");
         int initialCount = selectedCheckboxes.findElements(this).size();
         int increment = 0;
-        GridRow row = getRow(columnLabel, text);
 
         if (checked && !row.isSelected())
             increment++;
@@ -177,8 +188,6 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
         int finalIncrement = increment;
         int subsequentCount = selectedCheckboxes.findElements(this).size();
         waitFor(()-> subsequentCount == initialCount + finalIncrement, 1000);
-        getWrapper().log("Row at column ["+columnLabel+"] with text ["+text+"] selection state set to + ["+row.isSelected()+"]");
-        return getThis();
     }
 
     /**

--- a/src/org/labkey/test/components/glassLibrary/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/glassLibrary/grids/ResponsiveGrid.java
@@ -142,6 +142,18 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
     }
 
     /**
+     * Finds the first row with the specified texts in the specified columns, and sets its checkbox
+     * @param partialMap    key-column, value-text in that column
+     * @param checked       the desired checkbox state
+     * @return
+     */
+    public ResponsiveGrid selectRow(Map partialMap, boolean checked)
+    {
+        getRow(partialMap).select(checked);
+        return getThis();
+    }
+
+    /**
      * Finds the first row with the specified text in the specified column and sets its checkbox
      * @param columnLabel    header text of the specified column
      * @param text          Text to be found in the specified column


### PR DESCRIPTION
#### Rationale
This adds support for selecting a row in a QueryGrid based on values it might have in more than one column.
The grid already supports finding a row by passing in a partialMap (of column, text).

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/697

#### Changes
New overload for `selectRow()`
