### PR TITLE
Avoid SQL Server deadlock exception during end of TargetedMSQCGuideSetTest

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1125,7 +1125,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                         + (GC_ATTEMPT_LIMIT - attempt) + " attempt(s) remaining.)");
 
                 // If another thread (e.g., SearchService) is doing work then give it 10 seconds before trying again
-                if (isElementPresent(Locators.labkeyError.containing("Active thread(s) may have objects in use:")))
+                if (isRequestThreadActive())
                 {
                     log("Pausing 10 seconds to wait for active thread");
                     sleep(10000);
@@ -1164,6 +1164,12 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         }
         else
             log("Found " + leakCount + " in-use objects.  This is within the expected number of " + MAX_LEAK_LIMIT + ".");
+    }
+
+    /** Assuming you're on the Admin Console's memory usage page, checks for text indicating there's an active thread processing an HTTP request. */
+    protected boolean isRequestThreadActive()
+    {
+        return isElementPresent(Locators.labkeyError.containing("Active thread(s) may have objects in use:"));
     }
 
     @LogMethod


### PR DESCRIPTION
#### Rationale
We're hitting periodic failures in TargetedMSQCGuideSetTest on SQL Server. The crawler is visiting pages and not waiting for all of the AJAX requests to complete. One API call is taking a few seconds, and before it's done the crawler has finished and the test has started deleting the project. That causes a SQL Server deadlock exception.

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/256

#### Changes
* Method to check if a request is still running