### PR TITLE
Fix timeout in 'testInsertLargeLineageGraph'

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeLimitsTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLimitsTest.java
@@ -199,9 +199,6 @@ public class SampleTypeLimitsTest extends BaseWebDriverTest
             generationDepth++;
         }
         assertEquals("Expect lineage depth to be" +intendedGenerationDepth, intendedGenerationDepth, generationDepth);
-
-        // clean up the sampleset on success
-        dgen.deleteDomain(createDefaultConnection());
     }
 
 }


### PR DESCRIPTION
#### Rationale
It regularly causes timeout failures and isn't providing interesting test coverage. Hopefully deleting the entire container at the end of the test is more reliable.

#### Changes
* Don't delete domain at end of test.
