### PR TITLE
Back-port test fixes from develop to 20.7 branch.

### DIFF
--- a/src/org/labkey/test/selenium/LazyWebElement.java
+++ b/src/org/labkey/test/selenium/LazyWebElement.java
@@ -17,7 +17,9 @@ package org.labkey.test.selenium;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.test.Locator;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.FluentWait;
 
@@ -37,6 +39,19 @@ public class LazyWebElement<T extends LazyWebElement<T>> extends WebElementWrapp
     {
         _locator = locator;
         _searchContext = searchContext;
+    }
+
+    @Override
+    public boolean isDisplayed()
+    {
+        try
+        {
+            return super.isDisplayed();
+        }
+        catch (StaleElementReferenceException | NoSuchElementException ex)
+        {
+            return false;
+        }
     }
 
     public final T withTimeout(long ms)

--- a/src/org/labkey/test/selenium/LazyWebElement.java
+++ b/src/org/labkey/test/selenium/LazyWebElement.java
@@ -17,9 +17,7 @@ package org.labkey.test.selenium;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.test.Locator;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.SearchContext;
-import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.FluentWait;
 
@@ -39,19 +37,6 @@ public class LazyWebElement<T extends LazyWebElement<T>> extends WebElementWrapp
     {
         _locator = locator;
         _searchContext = searchContext;
-    }
-
-    @Override
-    public boolean isDisplayed()
-    {
-        try
-        {
-            return super.isDisplayed();
-        }
-        catch (StaleElementReferenceException | NoSuchElementException ex)
-        {
-            return false;
-        }
     }
 
     public final T withTimeout(long ms)

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -174,7 +174,9 @@ public class Crawler
             new ControllerActionId("assay", "assayDetailRedirect"),
             new ControllerActionId("assay", "designer"), // assay designer prompts to save design when navigating away
             new ControllerActionId("assay", "template"),
-            new ControllerActionId("core", "downloadFileLink"),
+            new ControllerActionId("cds", "exportTourDefinitions"), // Download action
+            new ControllerActionId("cds", "permissionsReportExport"),
+            new ControllerActionId("core", "downloadFileLink"), // Download action
             new ControllerActionId("dumbster", "begin"),
             new ControllerActionId("experiment", "exportProtocols"),
             new ControllerActionId("experiment", "exportRunFiles"),


### PR DESCRIPTION
#### Rationale
CDS development is done in the 20.7 branch. There were some changes to shared test code in the develop branch that would be useful in fixing /updating the CDS tests. I'd like to back port these two changes to the 20.7 branch.

#### Related Pull Requests
* None at this time.

#### Changes
* The change to Crawler.getDefaultExcludedActions that ignores two actions in CDS.
* The change to LazyWebElement.isDisplayed to return false if the element is not present on the page.
