### PR TITLE
Allow enabling troubleshooting stacktraces on TeamCity

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.json.simple.JSONObject;
 import org.junit.Assume;
 import org.junit.AssumptionViolatedException;
 import org.junit.ClassRule;
@@ -42,6 +43,7 @@ import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.PostCommand;
 import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.labkey.remoteapi.query.ContainerFilter;
 import org.labkey.remoteapi.query.DeleteRowsCommand;
@@ -588,6 +590,10 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             _checkedLeaksAndErrors = true;
         }
 
+        if (TestProperties.isTroubleshootingStacktracesEnabled())
+        {
+            enableTroubleshootingStacktraces();
+        }
         setServerDebugLogging();
         setExperimentalFlags();
 
@@ -610,6 +616,29 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         }
 
         cleanup(false);
+    }
+
+    private void enableTroubleshootingStacktraces()
+    {
+        if (TestProperties.isPrimaryUserAppAdmin())
+        {
+            return; // app admin can't enable stack traces
+        }
+        Connection cn = createDefaultConnection();
+        PostCommand command = new PostCommand("mini-profiler", "enableTroubleshootingStacktraces");
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("enabled", true);
+        command.setJsonObject(jsonObject);
+        try
+        {
+            CommandResponse r = command.execute(cn, null);
+            Map<String, Object> response = r.getParsedData();
+            log("Troubleshooting stacktraces state updated: " + response.get("data"));
+        }
+        catch (IOException | CommandException e)
+        {
+            throw new RuntimeException("Failed to enable troubleshooting stacktraces", e);
+        }
     }
 
     private void setServerDebugLogging()

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -173,6 +173,11 @@ public abstract class TestProperties
         return "true".equals(System.getProperty("webtest.webdriver.logging"));
     }
 
+    public static boolean isTroubleshootingStacktracesEnabled()
+    {
+        return "true".equals(System.getProperty("webtest.troubleshooting.stacktraces"));
+    }
+
     public static boolean isDebugLoggingEnabled()
     {
         return "true".equals(System.getProperty("webtest.logging.debug"));


### PR DESCRIPTION
#### Rationale
We encounter occasional memory leaks on TeamCity. Being able to quickly enable stacktraces would be useful for debugging such failures.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1620

#### Changes
* Test property to enable troubleshooting stacktraces
