### PR TITLE
add support for slightly different toggle locator

### DIFF
--- a/src/org/labkey/test/components/html/BootstrapMenu.java
+++ b/src/org/labkey/test/components/html/BootstrapMenu.java
@@ -156,7 +156,9 @@ public class BootstrapMenu extends BaseBootstrapMenu
     {
         public static Locator.XPathLocator toggleAnchor()
         {
-            return Locator.tagWithAttribute("*", "data-toggle", "dropdown");
+            return Locator.XPathLocator.union(
+                    Locator.tagWithAttribute("*", "data-toggle", "dropdown"),
+                    Locator.tagWithClass("a", "dropdown-toggle"));
         }
 
         public static Locator.XPathLocator menuItem(String text)


### PR DESCRIPTION
#### Rationale
This change adds a locator to find a slightly different toggle than the standard one, to support the archive-action menu in notebook entry editor

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/709

#### Changes
updates the toggle locator to also support a.dropdown-toggle 
