### PR TITLE
Back-port crawler fix for two CDS action from develop into 20.7.

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -174,6 +174,8 @@ public class Crawler
             new ControllerActionId("assay", "assayDetailRedirect"),
             new ControllerActionId("assay", "designer"), // assay designer prompts to save design when navigating away
             new ControllerActionId("assay", "template"),
+            new ControllerActionId("cds", "exportTourDefinitions"), // Download action
+            new ControllerActionId("cds", "permissionsReportExport"),
             new ControllerActionId("core", "downloadFileLink"),
             new ControllerActionId("dumbster", "begin"),
             new ControllerActionId("experiment", "exportProtocols"),


### PR DESCRIPTION
#### Rationale
Adding two CDS actions to the "ignore list" for the crawler. These changes were done in develop, but since CDS work is done in 20.7 these are useful to have here as well. 

#### Related Pull Requests
* None

#### Changes
* Added exportTourDefinitions & permissionsReportExport for cds to crawler.getDefaultExcludedActions.
