### PR TITLE
Make toggleLocator settable

### DIFF
--- a/src/org/labkey/test/components/html/BootstrapMenu.java
+++ b/src/org/labkey/test/components/html/BootstrapMenu.java
@@ -26,6 +26,8 @@ import java.util.List;
 
 public class BootstrapMenu extends BaseBootstrapMenu
 {
+    private Locator _toggleLocator;
+
     /* componentElement should contain the toggle anchor *and* the UL containing list items */
     public BootstrapMenu(WebDriver driver, WebElement componentElement)
     {
@@ -110,7 +112,16 @@ public class BootstrapMenu extends BaseBootstrapMenu
     @Override
     protected Locator getToggleLocator()
     {
-        return Locators.toggleAnchor();
+        if (_toggleLocator != null)
+            return _toggleLocator;
+        else
+            return Locators.toggleAnchor();
+    }
+
+    public BootstrapMenu setToggleLocator(Locator toggleLocator)
+    {
+        _toggleLocator = toggleLocator;
+        return this;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
A previous change modified the BootstrapMenu's toggleAnchor locator to be the union of 2 possible locators, but this broke some tests.  This restores the old locator as the default, but makes that locator settable in situations where that will make the BootstrapMenu component wrapper work for menus that define their toggle element differently

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/709

#### Changes
revert the original change to leave the default locator how it was
add a setter for an optional locator which if defined will be used instead of the default
