### PR TITLE
Somehow the change to restore the default toggle locator didn't make …

### DIFF
--- a/src/org/labkey/test/components/html/BootstrapMenu.java
+++ b/src/org/labkey/test/components/html/BootstrapMenu.java
@@ -167,9 +167,7 @@ public class BootstrapMenu extends BaseBootstrapMenu
     {
         public static Locator.XPathLocator toggleAnchor()
         {
-            return Locator.XPathLocator.union(
-                    Locator.tagWithAttribute("*", "data-toggle", "dropdown"),
-                    Locator.tagWithClass("a", "dropdown-toggle"));
+            return Locator.tagWithAttribute("*", "data-toggle", "dropdown");
         }
 
         public static Locator.XPathLocator menuItem(String text)


### PR DESCRIPTION
…it into a previous push or merge, this is an attempt at getting it in finally

#### Rationale
The last attempt to fix this issue somehow didn't get the original locator, which is 
 return Locator.tagWithAttribute("*", "data-toggle", "dropdown");

#### Related Pull Requests
n/a

#### Changes

