### PR TITLE
Update crawler to encode curly braces in urls

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -1010,7 +1010,9 @@ public class Crawler
             {
                 long loadTime = _test.beginAt(relativeURL
                         .replace("[", "%5B")
-                        .replace("]", "%5D")); // Escape brackets to prevent 400 errors
+                        .replace("]", "%5D")
+                        .replace("{", "%7B")
+                        .replace("}", "%7D")); // Escape brackets to prevent 400 errors
                 _actionProfiler.updateActionProfile(relativeURL, loadTime);
             }
             catch (UnhandledAlertException alert)


### PR DESCRIPTION
#### Rationale
Unencoded curly braces in a url cause 400 invalid character errors in more recent versions of Tomcat.

#### Related Pull Requests
* n/a

#### Changes
* Add encodings for curly braces
