### PR TITLE
Have tests wait for app content

### DIFF
--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -939,7 +939,7 @@ public abstract class Locator extends By
 
     public static String cq(String value)
     {
-        return "\"" + value.replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\"") + "\"";
+        return "\"" + value.replace("\\\\", "\\\\\\\\").replace("\"", "\\\\\"") + "\"";
     }
 
     private static class XPathCSSLocator extends XPathLocator
@@ -1338,7 +1338,7 @@ public abstract class Locator extends By
 
         public XPathLocator attributeStartsWith(String attribute, String text)
         {
-            return this.withPredicate(String.format("starts-with(@%s, "+xq(text)+")", attribute));
+            return this.withPredicate(String.format("starts-with(@%s, %s)", attribute, xq(text)));
         }
 
         public XPathLocator attributeEndsWith(String attribute, String substring)
@@ -1498,6 +1498,10 @@ public abstract class Locator extends By
         {
             super(Locator.xpath("//*").withAttribute("id", id), CssLocator.forId(id));
             _id = id.contains(" ") ? null : id;
+            if (_id == null)
+            {
+                TestLogger.warn(String.format("Element has an invalid ID: '%s'", id));
+            }
         }
 
         @Override

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1800,7 +1800,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
                     {
                         return false;
                     }
-                }), "App didn't seem to load. No visible content. " + app.toString(), 1000);
+                }), "App didn't seem to load. No visible content. " + app.toString(), 5000);
         }
         mouseOut();
         _testTimeout = false;

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1783,9 +1783,14 @@ public abstract class WebDriverWrapper implements WrapsDriver
         waitForOnReady("Ext");
         waitForOnReady("Ext4");
         waitForOnReady("LABKEY.Utils");
-        if (Locator.id("app").existsIn(getDriver()))
+
+        List<WebElement> apps = Locator.findElements(getDriver(),
+            Locator.tagWithAttributeContaining("div", "id", "error-handler-app"), // from errorView.jsp
+            Locator.id("app")); // Most other apps start with an empty '<div id="app"></div>'
+        for (WebElement app : apps)
         {
-            waitFor(() -> executeScript("return LABKEY.App.__app__.isDOMContentLoaded;", Boolean.class), "App didn't render.", 10000);
+            waitFor(() -> Locator.xpath("./*").findElements(app).stream()
+                .anyMatch(WebElement::isDisplayed), "App didn't seem to load. No visible content. " + app.toString(), 1000);
         }
         mouseOut();
         _testTimeout = false;

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1783,6 +1783,10 @@ public abstract class WebDriverWrapper implements WrapsDriver
         waitForOnReady("Ext");
         waitForOnReady("Ext4");
         waitForOnReady("LABKEY.Utils");
+        if (Locator.id("app").existsIn(getDriver()))
+        {
+            waitFor(() -> executeScript("return LABKEY.App.__app__.isDOMContentLoaded;", Boolean.class), "App didn't render.", 10000);
+        }
         mouseOut();
         _testTimeout = false;
     }

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1790,7 +1790,17 @@ public abstract class WebDriverWrapper implements WrapsDriver
         for (WebElement app : apps)
         {
             waitFor(() -> Locator.xpath("./*").findElements(app).stream()
-                .anyMatch(WebElement::isDisplayed), "App didn't seem to load. No visible content. " + app.toString(), 1000);
+                .anyMatch(webElement ->
+                {
+                    try
+                    {
+                        return webElement.isDisplayed();
+                    }
+                    catch (StaleElementReferenceException stale)
+                    {
+                        return false;
+                    }
+                }), "App didn't seem to load. No visible content. " + app.toString(), 1000);
         }
         mouseOut();
         _testTimeout = false;


### PR DESCRIPTION
#### Rationale
Now that error pages are a special single-page app, tests need to know how to wait for them to load. Several tests have been failing because an expected error wasn't present soon enough. Waiting for such errors on a case-by-case basis isn't a viable solution because we need to notice them when they aren't expected (especially in the Crawler).

#### Changes
* If a single page app container is present after a page load, wait for it to contain something.
