### PR TITLE
Add missing module dependencies and move dependencies declarations out of module.properties files

### DIFF
--- a/modules/ETLtest/build.gradle
+++ b/modules/ETLtest/build.gradle
@@ -1,0 +1,4 @@
+import org.labkey.gradle.util.BuildUtils
+
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "pipeline"), depProjectConfig: "published", depExtension: "module")
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"), depProjectConfig: "published", depExtension: "module")

--- a/modules/ETLtest/module.properties
+++ b/modules/ETLtest/module.properties
@@ -1,3 +1,2 @@
 Name: ETLtest
 SchemaVersion: 20.001
-ModuleDependencies: Pipeline, Experiment

--- a/modules/simpletest/build.gradle
+++ b/modules/simpletest/build.gradle
@@ -1,0 +1,4 @@
+import org.labkey.gradle.util.BuildUtils
+
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "pipeline"), depProjectConfig: "published", depExtension: "module")
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"), depProjectConfig: "published", depExtension: "module")

--- a/modules/simpletest/module.properties
+++ b/modules/simpletest/module.properties
@@ -1,3 +1,2 @@
 Name: simpletest
 SchemaVersion: 20.000
-ModuleDependencies: Pipeline, Experiment


### PR DESCRIPTION
#### Rationale
We have also deprecated the declaration of module dependencies in the `module.properties` file in favor of declaration in the `build.gradle` file.

#### Changes
* Move module dependency declarations from `module.properties` files to `build.gradle` files
