### PR TITLE
Fixes for test refactors

### DIFF
--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -939,7 +939,7 @@ public abstract class Locator extends By
 
     public static String cq(String value)
     {
-        return "\"" + value.replace("\\\\", "\\\\\\\\").replace("\"", "\\\\\"") + "\"";
+        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
     }
 
     private static class XPathCSSLocator extends XPathLocator

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1800,7 +1800,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
                     {
                         return false;
                     }
-                }), "App didn't seem to load. No visible content. " + app.toString(), 5000);
+                }), "App didn't seem to load. No visible content. " + app.toString(), 10000);
         }
         mouseOut();
         _testTimeout = false;

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -26,7 +26,6 @@ import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.ExtraSiteWrapper;
 import org.labkey.test.Locator;
-import org.labkey.test.Locators;
 import org.labkey.test.TestProperties;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
@@ -1311,7 +1310,7 @@ public class Crawler
             }
             catch (Exception ex)
             {
-                throw new AssertionError("Injection error from " + actionId.toString() + "\n" +
+                throw new AssertionError("Non-injection error while attempting script injection on " + actionId.toString() + "\n" +
                         "param: " + paramMalicious + "\n" +
                         "URL: " + urlMalicious, ex);
             }


### PR DESCRIPTION
#### Rationale
Error pages sometimes take more than 5 seconds to render. The performance of these pages seems fine in reality and the failures on TeamCity are probably a side-effect of hammering so many links so rapidly.
This also includes a Locator fix and a better error message when the crawler hits certain errors when attempting script injection; these are usually just the server not handling the bad input well, not any actual vulnerability.

#### Related Pull Requests
* #499 

#### Changes
* Increase timeout for app loading
* Properly escape backslashes in `Locator.cq` (previous refactor was incorrect)
* Give a less misleading error message for non-injection crawler errors
