### PR TITLE
Feature Request 41549: Time chart automated test fixes for visit-based display property addition

### DIFF
--- a/src/org/labkey/test/components/ChartTypeDialog.java
+++ b/src/org/labkey/test/components/ChartTypeDialog.java
@@ -403,7 +403,7 @@ public class ChartTypeDialog extends ChartWizardDialog<ChartTypeDialog.ElementCa
 
         if(text.length() == 0)
         {
-            // If the lenght is 0 see if the drag and drop text is visible.
+            // If the length is 0 see if the drag and drop text is visible.
             if(dragAndDropElement.isDisplayed())
                 text = dragAndDropElement.getText();
             else
@@ -427,13 +427,9 @@ public class ChartTypeDialog extends ChartWizardDialog<ChartTypeDialog.ElementCa
         {
             case Date:
                 getWrapper().click(elementCache().timeAxisDateBasedRadioButton);
-                getWrapper().waitForElementToDisappear(elementCache().disabledTimeInterval);
-                getWrapper().assertElementNotPresent(elementCache().disabledIntervalStartDate);
                 break;
             case Visit:
                 getWrapper().click(elementCache().timeAxisVisitBasedRadioButton);
-                getWrapper().waitForElement(elementCache().disabledTimeInterval);
-                getWrapper().assertElementPresent(elementCache().disabledIntervalStartDate);
                 break;
         }
         return this;
@@ -608,8 +604,6 @@ public class ChartTypeDialog extends ChartWizardDialog<ChartTypeDialog.ElementCa
         public Locator.XPathLocator studyQueryCombo = Locator.xpath("//tr["+Locator.NOT_HIDDEN+" and ./td/input[@placeholder='Select a query']]");
         public Locator timeAxisDateBasedRadioButton = Locator.xpath("//label[text()='Date-Based']/preceding-sibling::input[@type='button']");
         public Locator timeAxisVisitBasedRadioButton = Locator.xpath("//label[text()='Visit-Based']/preceding-sibling::input[@type='button']");
-        public Locator disabledTimeInterval = Locator.xpath("//table[//label[text() = 'Time Interval:'] and contains(@class, 'x4-item-disabled')]");
-        public Locator disabledIntervalStartDate = Locator.xpath("//table[//label[text() = 'Interval Start Date:'] and contains(@class, 'x4-item-disabled')]");
     }
 
     public enum ChartType


### PR DESCRIPTION
#### Rationale
The Time Chart wizard allows for study dataset measures to be plotted with a time based x-axis. Currently, the time chart x-axis options are to allow for date based plots or visit based plots. When visit based is selected, the chart will show the x-axis as visit labels in ascending order with fixed intervals between visits. This makes it hard to see the visit relationship when the visits start spreading out over time (i.e. if the visits are something like Day 1, Day 2, Week 1, 6 Months, 2 years).

This PR fixes a time chart automated test because of the changes to the display options.
https://www.labkey.org/RVC/Feature%20Requests/issues-details.view?issueId=41549

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1636

#### Changes
* ChartTypeDialog changes for fixing TimeChartVisitBasedTest
