### PR TITLE
Issue 40442: LinkedSchema should throw handled exception

### DIFF
--- a/src/org/labkey/test/params/list/IntListDefinition.java
+++ b/src/org/labkey/test/params/list/IntListDefinition.java
@@ -1,10 +1,32 @@
 package org.labkey.test.params.list;
 
+import org.jetbrains.annotations.NotNull;
+import org.labkey.test.params.FieldDefinition;
+
+import java.util.List;
+
 public class IntListDefinition extends ListDefinition
 {
+    private static final String AUTO_INCREMENT_DOMAIN_KIND = "IntList";
+
     public IntListDefinition(String name, String autoIncrementKeyName)
     {
         super(name);
-        setAutoIncrementKeyName(autoIncrementKeyName);
+        setKeyName(autoIncrementKeyName);
+    }
+
+    @Override
+    public List<FieldDefinition> getFields()
+    {
+        List<FieldDefinition> fields = super.getFields();
+        fields.add(0, new FieldDefinition(getKeyName(), FieldDefinition.ColumnType.Integer).setPrimaryKey(true));
+        return fields;
+    }
+
+    @NotNull
+    @Override
+    protected String getKind()
+    {
+        return AUTO_INCREMENT_DOMAIN_KIND;
     }
 }

--- a/src/org/labkey/test/params/list/ListDefinition.java
+++ b/src/org/labkey/test/params/list/ListDefinition.java
@@ -2,7 +2,6 @@ package org.labkey.test.params.list;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.remoteapi.domain.Domain;
-import org.labkey.remoteapi.domain.PropertyDescriptor;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.property.DomainProps;
 
@@ -11,29 +10,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- * TODO: Expand stub list definition and refactor list helpers to use it
- */
 public class ListDefinition extends DomainProps
 {
-    private static final String AUTO_INCREMENT_DOMAIN_KIND = "IntList";
     private static final String DOMAIN_KIND = "VarList";
 
     private String _name;
     private String _description;
     private List<FieldDefinition> _fields = new ArrayList<>();
-    private String _autoIncrementKey = null;
     private String _keyName;
 
     public ListDefinition(String name)
     {
         _name = name;
-    }
-
-    public ListDefinition setAutoIncrementKeyName(String keyName)
-    {
-        _autoIncrementKey = keyName;
-        return this;
     }
 
     public String getName()
@@ -71,7 +59,7 @@ public class ListDefinition extends DomainProps
 
     public List<FieldDefinition> getFields()
     {
-        return _fields;
+        return new ArrayList<>(_fields); // return a copy
     }
 
     public ListDefinition setFields(List<FieldDefinition> fields)
@@ -95,12 +83,7 @@ public class ListDefinition extends DomainProps
     protected Domain getDomainDesign()
     {
         Domain domain = new Domain(getName());
-        ArrayList<PropertyDescriptor> fields = new ArrayList<>(getFields());
-        if (_autoIncrementKey != null)
-        {
-            fields.add(new FieldDefinition(_autoIncrementKey, FieldDefinition.ColumnType.Integer).setPrimaryKey(true));
-        }
-        domain.setFields(fields);
+        domain.setFields(new ArrayList<>(getFields()));
         domain.setDescription(getDescription());
         return domain;
     }
@@ -109,7 +92,7 @@ public class ListDefinition extends DomainProps
     @Override
     protected String getKind()
     {
-        return _autoIncrementKey != null ? AUTO_INCREMENT_DOMAIN_KIND : DOMAIN_KIND;
+        return DOMAIN_KIND;
     }
 
     @NotNull

--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -18,6 +18,7 @@ package org.labkey.test.tests;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.CommandException;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.SortDirection;
@@ -29,14 +30,16 @@ import org.labkey.test.components.CustomizeView;
 import org.labkey.test.components.QueryMetadataEditorPage;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.list.IntListDefinition;
+import org.labkey.test.params.list.ListDefinition;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.LogMethod;
-import org.labkey.test.util.RelativeUrl;
 import org.labkey.test.util.SchemaHelper;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -525,12 +528,13 @@ public class LinkedSchemaTest extends BaseWebDriverTest
         log("Update the filter to use the wrapped field. Because the field is only wrapped and there is no foreign key it should error.");
         updatedMetaData = updatedMetaData.replace("ParticipantId/Study", "Pid2Consent/Study");
         _schemaHelper.updateLinkedSchema(getProjectName(), TARGET_FOLDER, STUDY_SCHEMA_NAME, sourceContainerPath, null, null, null, updatedMetaData);
-        RelativeUrl queryURL = new RelativeUrl("query", "begin");
-        queryURL.setContainerPath(getCurrentContainerPath());
-        queryURL.addParameter("schemaName", "CommonData");
-        queryURL.navigate(this);
 
-        assertExt4MsgBox("An error occurred trying to load: Column Pid2Consent.Study not found in column map.", "OK");
+        beginAt("/" + PROJECT_NAME + "/" + TARGET_FOLDER + "/query-begin.view?schemaName=CommonData&queryName=Demographics");
+        assertElementContains(Locator.tagWithClass("div", "lk-qd-error"),
+                "Error creating linked schema table 'Demographics': Column Pid2Consent.Study not found in column map.");
+
+        beginAt("/" + PROJECT_NAME + "/" + TARGET_FOLDER + "/query-executeQuery.view?schemaName=CommonData&queryName=Demographics");
+        assertTextPresent("Error creating linked schema table 'Demographics': Column Pid2Consent.Study not found in column map.");
 
         log("Looks good, going home.");
         goToProjectHome();
@@ -613,27 +617,29 @@ public class LinkedSchemaTest extends BaseWebDriverTest
     }
 
     @LogMethod
-    void createList()
+    void createList() throws IOException, CommandException
     {
-        log("** Importing some data...");
-        _listHelper.createList(getProjectName() + "/" + SOURCE_FOLDER, LIST_NAME,
-                ListHelper.ListColumnType.AutoInteger, "Key",
-                new ListHelper.ListColumn("Name", "Name", ListHelper.ListColumnType.String, "Name"),
-                new ListHelper.ListColumn("Age", "Age", ListHelper.ListColumnType.Integer, "Age"),
-                new ListHelper.ListColumn("Crazy", "Crazy", ListHelper.ListColumnType.Boolean, "Crazy?"),
-                new ListHelper.ListColumn("P", LIST_DEF_TITLE + " P", ListHelper.ListColumnType.String, null, null, null, null, "fake/" + LIST_DEF_URL),
-                new ListHelper.ListColumn("Q", LIST_DEF_TITLE + " Q", ListHelper.ListColumnType.String, null, null, null, null, "fake/" + LIST_DEF_URL),
-                new ListHelper.ListColumn("R", LIST_DEF_TITLE + " R", ListHelper.ListColumnType.String, null, null, null, null, "fake/" + LIST_DEF_URL),
-                new ListHelper.ListColumn("S", LIST_DEF_TITLE + " S", ListHelper.ListColumnType.String, null, null, null, null, "fake/" + LIST_DEF_URL),
-                new ListHelper.ListColumn("T", LIST_DEF_TITLE + " T", ListHelper.ListColumnType.String, null, null, null, null, "fake/" + LIST_DEF_URL),
-                new ListHelper.ListColumn("U", LIST_DEF_TITLE + " U", ListHelper.ListColumnType.String, null, null, null, null, "fake/" + LIST_DEF_URL),
-                new ListHelper.ListColumn("V", LIST_DEF_TITLE + " V", ListHelper.ListColumnType.String, null, null, null, null, "fake/" + LIST_DEF_URL),
-                new ListHelper.ListColumn("W", LIST_DEF_TITLE + " W", ListHelper.ListColumnType.String, null, null, null, null, "fake/" + LIST_DEF_URL),
-                new ListHelper.ListColumn("X", LIST_DEF_TITLE + " X", ListHelper.ListColumnType.String, null, null, null, null, "fake/" + LIST_DEF_URL),
-                new ListHelper.ListColumn("Y", LIST_DEF_TITLE + " Y", ListHelper.ListColumnType.String, null, null, null, null, "fake/" + LIST_DEF_URL),
-                new ListHelper.ListColumn("Z", LIST_DEF_TITLE + " Z", ListHelper.ListColumnType.String, null, null, null, null, "fake/" + LIST_DEF_URL));
+        log("** Creating list via API...");
+        ListDefinition listDef = new IntListDefinition(LIST_NAME, "Key")
+                .setKeyName("Key")
+                .addField(new FieldDefinition("Name", FieldDefinition.ColumnType.String).setLabel("Name").setDescription("Name"))
+                .addField(new FieldDefinition("Age", FieldDefinition.ColumnType.Integer).setLabel("Age").setDescription("Age"))
+                .addField(new FieldDefinition("Crazy", FieldDefinition.ColumnType.Boolean).setLabel("Crazy").setDescription("Crazy?"))
+                .addField(new FieldDefinition("P", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " P").setURL("fake/" + LIST_DEF_URL))
+                .addField(new FieldDefinition("Q", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " Q").setURL("fake/" + LIST_DEF_URL))
+                .addField(new FieldDefinition("R", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " R").setURL("fake/" + LIST_DEF_URL))
+                .addField(new FieldDefinition("S", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " S").setURL("fake/" + LIST_DEF_URL))
+                .addField(new FieldDefinition("T", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " T").setURL("fake/" + LIST_DEF_URL))
+                .addField(new FieldDefinition("U", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " U").setURL("fake/" + LIST_DEF_URL))
+                .addField(new FieldDefinition("V", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " V").setURL("fake/" + LIST_DEF_URL))
+                .addField(new FieldDefinition("W", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " W").setURL("fake/" + LIST_DEF_URL))
+                .addField(new FieldDefinition("X", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " X").setURL("fake/" + LIST_DEF_URL))
+                .addField(new FieldDefinition("Y", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " Y").setURL("fake/" + LIST_DEF_URL))
+                .addField(new FieldDefinition("Z", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " Z").setURL("fake/" + LIST_DEF_URL));
+        listDef.getCreateCommand().execute(createDefaultConnection(), getProjectName() + "/" + SOURCE_FOLDER);
 
         log("** Importing some data...");
+        beginAt("/" + PROJECT_NAME + "/" + SOURCE_FOLDER + "/list-begin.view");
         _listHelper.goToList(LIST_NAME);
         _listHelper.clickImportData();
         _listHelper.submitTsvData(LIST_DATA);

--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -621,7 +621,6 @@ public class LinkedSchemaTest extends BaseWebDriverTest
     {
         log("** Creating list via API...");
         ListDefinition listDef = new IntListDefinition(LIST_NAME, "Key")
-                .setKeyName("Key")
                 .addField(new FieldDefinition("Name", FieldDefinition.ColumnType.String).setLabel("Name").setDescription("Name"))
                 .addField(new FieldDefinition("Age", FieldDefinition.ColumnType.Integer).setLabel("Age").setDescription("Age"))
                 .addField(new FieldDefinition("Crazy", FieldDefinition.ColumnType.Boolean).setLabel("Crazy").setDescription("Crazy?"))


### PR DESCRIPTION
#### Rationale
Slightly better handling of a bad LinkedSchema configuration.  Instead of showing an error page, throw QueryParseException which is more gracefully handled in the schema browser and query-executeQuery.view action.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1659

#### Changes
- update expected error
