### PR TITLE
attempt to wait after pasting to grid

### DIFF
--- a/src/org/labkey/test/components/glassLibrary/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/glassLibrary/grids/EditableGrid.java
@@ -314,10 +314,17 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
      */
     public EditableGrid pasteFromCell(int row, String columnName, String pasteText)
     {
+        int initialRowCount = getRowCount();
         WebElement gridCell = getCell(row, columnName);
+        String indexValue = gridCell.getText();
         selectCell(gridCell);
 
         getWrapper().actionPaste(null, pasteText);
+
+        // wait for the cell value to change or the rowcount to change, and the target cell to go into highlight,
+        // ... or for a second and a half
+        getWrapper().waitFor(()-> (getRowCount() > initialRowCount || !indexValue.equals(gridCell.getText())) &&
+                        isInSelection(gridCell), 1500);
         return this;
     }
 


### PR DESCRIPTION
#### Rationale
Some of our tests paste data into an editable grid component, and submit the contents immediately.
Sometimes, tests can fail if the submit occurs before the grid component can bind the contents to the form state.
This attempts to prevent that from occurring, by waiting briefly after pasting

#### Related Pull Requests

#### Changes
wait, after paste into the grid, for value change/selection/more rows - or else, for 1.5 seconds
