### PR TITLE
Issue 39629: Enable setting metadata on linked schema tables

### DIFF
--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -677,7 +677,9 @@ public class LinkedSchemaTest extends BaseWebDriverTest
         waitForElementToDisappear(Locator.id("status").withText("Saved"), WAIT_FOR_JAVASCRIPT);
 
         log("** Applying metadata to " + QUERY_NAME + " in linked schema container");
-        beginAt("/query/" + PROJECT_NAME + "/" + TARGET_FOLDER + "/sourceQuery.view?schemaName=" + A_PEOPLE_SCHEMA_NAME + "&query.queryName=" + QUERY_NAME + "#metadata");
+        beginAt("/query/" + PROJECT_NAME + "/" + TARGET_FOLDER + "/sourceQuery.view?schemaName=" + A_PEOPLE_SCHEMA_NAME + "&queryName=" + QUERY_NAME);
+        assertElementPresent(Locator.tagWithClass("div", "labkey-customview-message").withText("This query is not editable"));
+        _ext4Helper.clickExt4Tab("XML Metadata");
         setCodeEditorValue("metadataText", A_PEOPLE_QUERY_METADATA_OVERRIDE);
         clickButton("Save", 0);
         waitForElement(Locator.id("status").withText("Saved"), WAIT_FOR_JAVASCRIPT);


### PR DESCRIPTION
#### Rationale
Clean up handling of capabilities and permissions for custom query definition subclasses.  Disallow editing of custom query properties (name, description, inherit) for linked schema custom queries since they don't make sense.  Metadata for linked schemas was being persisted for wrapped custom queries but the saved metadata wasn't being threaded through to the editor.  The source and metadata xml editors will now display a message indicating why the editor is disabled instead of letting the user guess.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1672

#### Changes
- clean up capability and permission checks for custom queries and linked schema custom queries
- fixed loading of metadata for linked schema custom queries so saved metadata will appear in xml editor
- query editor now displays reason if source or metadata can't be modified
- ability to edit custom query properties (description, inherit, hidden) now requires canEdit permission
  since these properties are used for custom queries and not intended for built-in tables
