### PR TITLE
DomainDesigner field import/export testing

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -314,6 +314,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
                                     "application/x-gzip," +
                                     "application/x-zip-compressed," +
                                     "application/xml," +
+                                    "application/json" +
                                     "image/png," +
                                     "image/tiff," +
                                     "text/html," +

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -1,16 +1,25 @@
 package org.labkey.test.components.domain;
 
 import org.apache.commons.lang3.StringUtils;
+import org.json.JSONObject;
+import org.json.simple.JSONArray;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.components.labkey.ui.core.Alert;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.selenium.WebElementWrapper;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -198,6 +207,15 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
         return this;
     }
 
+    public File clickExportFields() throws Exception
+    {
+        getWrapper().scrollIntoView(elementCache().exportFieldsButton);
+        File[] exportFiles =  getWrapper().doAndWaitForDownload(()-> {
+            elementCache().exportFieldsButton.click();
+        }, 1);
+        return exportFiles[0];
+    }
+
     public DomainFormPanel setInferFieldFile(File file)
     {
         getWrapper().setFormElement(elementCache().fileUploadInput, file);
@@ -287,6 +305,9 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
                 }, "New field didn't appear", 10000);
             }
         };
+
+        protected WebElement exportFieldsButton = Locator.tagWithClass("div", "domain-toolbar-export-btn")
+                .findWhenNeeded(this);
 
         protected void clearFieldCache()
         {


### PR DESCRIPTION
#### Rationale
this adds test coverage for the new field export/import functionality in the domain designer

#### Related Pull Requests
n/a

#### Changes
update domainFieldRow page class to download fields exported as json
update webDriverWrapper to cause firefox to automatically download application/json content