### PR TITLE
Add datafinder-begin to exclusion list.

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -257,6 +257,7 @@ public class Crawler
                 new ControllerActionId("reagent", "begin"),
                 new ControllerActionId("su2c", "begin"),
                 new ControllerActionId("trialshare", "begin"),
+                new ControllerActionId("datafinder", "begin"),
                 new ControllerActionId("ehr_compliancedb", "requirementDetails"),
                 new ControllerActionId("onprc_billingpublic", "begin"),
                 new ControllerActionId("hdrl", "begin")


### PR DESCRIPTION
#### Rationale
Add datafinder-begin to the exclusion list used by the crawler. Should prevent "noise" in the crawlerresults.

#### Related Pull Requests
* None.

#### Changes
* Added datafinder-begin to the exclusion list.
* Ran tests on TC, did not see the crawler complain.
