### PR TITLE
Issue 40482: Prefer using apiKey replacement parameter

### DIFF
--- a/src/org/labkey/test/tests/DataReportsTest.java
+++ b/src/org/labkey/test/tests/DataReportsTest.java
@@ -31,6 +31,7 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.DailyB;
 import org.labkey.test.categories.Reports;
 import org.labkey.test.components.html.BootstrapMenu;
+import org.labkey.test.util.APIUserHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
@@ -128,13 +129,16 @@ public class DataReportsTest extends ReportTest
 
     protected final static String R_USER = "r_editor@report.test";
     protected final static String AUTHOR_USER = "author_user@report.test";
+    protected final static String AUTHOR_USER_PW = "Password";
+    protected final static String READER_USER = "reader_user@report.test";
+    protected final static String READER_USER_PW = "Password";
 
     private final ApiPermissionsHelper _apiPermissionsHelper = new ApiPermissionsHelper(this);
 
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
-        _userHelper.deleteUsers(false, R_USER, AUTHOR_USER);
+        _userHelper.deleteUsers(false, R_USER, AUTHOR_USER, READER_USER);
         super.doCleanup(afterTest);
     }
 
@@ -156,6 +160,19 @@ public class DataReportsTest extends ReportTest
 
         // Make sure the Developers group has the Platform Developer role.
         initTest.addDeveloperGroupToPlatformDeveloperRole();
+
+        APIUserHelper apiUserHelper = new APIUserHelper(initTest);
+        ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(initTest);
+
+        // Create a author user
+        apiUserHelper.createUser(AUTHOR_USER, true, true);
+        initTest.setInitialPassword(AUTHOR_USER, AUTHOR_USER_PW);
+        apiPermissionsHelper.addMemberToRole(AUTHOR_USER, "Author", PermissionsHelper.MemberType.user, initTest.getProjectName());
+
+        // Create a reader user
+        apiUserHelper.createUser(READER_USER, true, true);
+        initTest.setInitialPassword(READER_USER, READER_USER_PW);
+        apiPermissionsHelper.addMemberToRole(READER_USER, "Reader", PermissionsHelper.MemberType.user, initTest.getProjectName());
     }
 
     private void addDeveloperGroupToPlatformDeveloperRole()
@@ -170,8 +187,7 @@ public class DataReportsTest extends ReportTest
     @Before
     public void preTest()
     {
-        goToProjectHome();
-        clickFolder(getFolderName());
+        navigateToFolder(getProjectName(), getFolderName());
     }
 
     @Override @Ignore // Mask base StudyTest test method
@@ -412,23 +428,15 @@ public class DataReportsTest extends ReportTest
         popLocation();
         pushLocation();
 
-        if (!TestProperties.isPrimaryUserAppAdmin())
-        {
-            log("Test user permissions");
-            createSiteDeveloper(AUTHOR_USER).addMemberToRole(AUTHOR_USER, "Author", PermissionsHelper.MemberType.user, getProjectName());
-            impersonate(AUTHOR_USER);
-        }
-        else
-        {
-            log("App Admin can't impersonate site roles. Just create report as primary test user.");
-        }
+        signOut();
+        signIn(AUTHOR_USER, AUTHOR_USER_PW);
+
         navigateToFolder(getProjectName(), getFolderName());
         clickAndWait(Locator.linkWithText(DATA_SET));
         createRReport(AUTHOR_REPORT, R_SCRIPT2(DATA_BASE_PREFIX, "mouseId"), true, true, new String[0]);
-        if (!TestProperties.isPrimaryUserAppAdmin())
-        {
-            stopImpersonating();
-        }
+
+        signOut();
+        simpleSignIn();
 
         popLocation();
         log("Create second R script");
@@ -448,11 +456,13 @@ public class DataReportsTest extends ReportTest
         log("Check that background run works");
 
         _userHelper.createUser(R_USER);
+        setInitialPassword(R_USER, "Password");
         _apiPermissionsHelper.addUserToProjGroup(R_USER, getProjectName(), "Users");
         _apiPermissionsHelper.addMemberToRole("Users", "Editor", PermissionsHelper.MemberType.group, getProjectName());
 
         //create R report with dev
-        impersonate(R_USER);
+        signOut();
+        signIn(R_USER, "Password");
 
         log("Access shared R script");
         navigateToFolder(getProjectName(), getFolderName());
@@ -464,8 +474,10 @@ public class DataReportsTest extends ReportTest
         DataRegionTable.DataRegion(getDriver()).find().goToReport(AUTHOR_REPORT);
 
         popLocation();
+        signOut();
+        simpleSignIn();
+
         log("Change user permission");
-        stopImpersonating();
         _apiPermissionsHelper.addMemberToRole("Users", "Project Administrator", PermissionsHelper.MemberType.group, getProjectName());
 
         log("Create a new R script that uses other R scripts");
@@ -525,18 +537,21 @@ public class DataReportsTest extends ReportTest
         log("Test showing the source tab to all users");
         createRReport(reportName, R_SCRIPT, true, true, new String[0]);
 
-        impersonateRole("Reader");
-        clickFolder(getFolderName());
+        simpleSignOut();
+        signIn(READER_USER, READER_USER_PW);
+
+        navigateToFolder(getProjectName(), getFolderName());
         scrollIntoView(Locator.linkWithText(DATA_SET_APX1));
         clickAndWait(Locator.linkWithText(DATA_SET_APX1));
         DataRegionTable.DataRegion(getDriver()).find().goToReport( reportName);
         waitForText(WAIT_FOR_PAGE, "Console output");
         assertElementVisible(Ext4Helper.Locators.tab("Source"));
-        stopImpersonating();
+
+        signOut();
+        simpleSignIn();
 
         log("Re-save report disabling showing the source tab to all users");
-        goToProjectHome();
-        clickFolder(getFolderName());
+        navigateToFolder(getProjectName(), getFolderName());
         scrollIntoView(Locator.linkWithText(DATA_SET_APX1));
         clickAndWait(Locator.linkWithText(DATA_SET_APX1));
         DataRegionTable.DataRegion(getDriver()).find().goToReport( reportName);
@@ -545,14 +560,19 @@ public class DataReportsTest extends ReportTest
         _rReportHelper.clearOption(RReportHelper.ReportOption.showSourceTab);
         resaveReport();
 
-        impersonateRole("Reader");
-        clickFolder(getFolderName());
+        signOut();
+        signIn(READER_USER, READER_USER_PW);
+
+        navigateToFolder(getProjectName(), getFolderName());
         scrollIntoView(Locator.linkWithText(DATA_SET_APX1));
         clickAndWait(Locator.linkWithText(DATA_SET_APX1));
         DataRegionTable.DataRegion(getDriver()).find().goToReport( reportName);
         waitForText(WAIT_FOR_PAGE, "Console output");
         assertElementNotVisible(Ext4Helper.Locators.tab("Source"));
-        stopImpersonating();
+
+        signOut();
+        simpleSignIn();
+
         goToProjectHome();
     }
 

--- a/src/org/labkey/test/tests/DataReportsTest.java
+++ b/src/org/labkey/test/tests/DataReportsTest.java
@@ -164,10 +164,9 @@ public class DataReportsTest extends ReportTest
         APIUserHelper apiUserHelper = new APIUserHelper(initTest);
         ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(initTest);
 
-        // Create a author user
-        apiUserHelper.createUser(AUTHOR_USER, true, true);
+        // Create a site-developer that is an author in the project
+        initTest.createSiteDeveloper(AUTHOR_USER).addMemberToRole(AUTHOR_USER, "Author", PermissionsHelper.MemberType.user, initTest.getProjectName());
         initTest.setInitialPassword(AUTHOR_USER, AUTHOR_USER_PW);
-        apiPermissionsHelper.addMemberToRole(AUTHOR_USER, "Author", PermissionsHelper.MemberType.user, initTest.getProjectName());
 
         // Create a reader user
         apiUserHelper.createUser(READER_USER, true, true);


### PR DESCRIPTION
#### Rationale
As of LabKey/platform#1699 we now generate a temporary apikey when executing an R report.  Unfortunately, we disallow generating apikey when impersonating so the DataReportsTest needs to be updated to use real user accounts.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1699

#### Changes
- not allowed to generate 'apikey' when impersonating so use real user accounts
