### PR TITLE
Item 8058: Domain designer related test fixes for Ontology Lookup data type support

### DIFF
--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -885,7 +885,7 @@ public class DomainDesignerTest extends BaseWebDriverTest
                 .setDescription("LookUp in same container")
                 .collapse();
 
-        assertEquals("Incorrect detail message", "Current Folder > lists > lookUpList1", lookUpRow.detailsMessage());
+        assertEquals("Incorrect detail message", "New Field. Current Folder > lists > lookUpList1", lookUpRow.detailsMessage());
 
         domainDesignerPage.clickFinish();
 
@@ -929,7 +929,7 @@ public class DomainDesignerTest extends BaseWebDriverTest
                 .setDescription("LookUp in same container")
                 .collapse();
 
-        assertEquals("Incorrect detail message", "Current Folder > lists > lookUpList", lookUpRow.detailsMessage());
+        assertEquals("Incorrect detail message", "New Field. Current Folder > lists > lookUpList", lookUpRow.detailsMessage());
         domainDesignerPage.clickFinish();
 
         DomainResponse domainResponse = dgen.getDomain(createDefaultConnection());


### PR DESCRIPTION
#### Rationale
The related PRs add domain designer support for a new Ontology Lookup data type. With it, there were some small updates to the domain row details message/text display. This PR fixes up related tests.

Issue [41838](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=41838): Ontology Lookup data type in domain designer

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/390
* https://github.com/LabKey/platform/pull/1709

#### Changes
* Fix DomainDesignerTest cases for minor text updates to domain row details message
