### PR TITLE
Leave the miniprofiler disabled on TeamCity

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1047,7 +1047,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             checkLeaks();
         }
 
-        if (reenableMiniProfiler)
+        if (reenableMiniProfiler && !TestProperties.isTestRunningOnTeamCity())
             setMiniProfilerEnabled(true);
 
         resetExperimentalFlags();


### PR DESCRIPTION
#### Rationale
Re-enabling it is intended to leave a dev server configured as it was before a test ran. On TeamCity, it serves no purpose other than leaving a short window for the miniprofiler to cause test failures.

Failures such as:
```
ERROR AdminController          2020-11-19T18:56:27,324     http-nio-8111-exec-5 : Client exception detected:
http://localhost:8111/labkey/home/project-begin.view?
http://localhost:8111/labkey/home/project-begin.view?
Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
teamcity@labkey.test
TypeError: document.body is null
  initPopupView (http://localhost:8111/labkey/internal/MiniProfiler/miniprofiler.js:1031:13)
  doInit (http://localhost:8111/labkey/internal/MiniProfiler/miniprofiler.js:1129:13)
  deferInit (http://localhost:8111/labkey/internal/MiniProfiler/miniprofiler.js:1141:17)
  _init (http://localhost:8111/labkey/internal/MiniProfiler/miniprofiler.js:1145:9)
  init (http://localhost:8111/labkey/internal/MiniProfiler/miniprofiler.js:1164:13)
  http://localhost:8111/labkey/home/project-begin.view?:62:30
```
