### PR TITLE
ElisaAssayTest - make sure "ELISA Multi-plate" experimental feature is disabled

### DIFF
--- a/src/org/labkey/test/tests/elisa/ElisaAssayTest.java
+++ b/src/org/labkey/test/tests/elisa/ElisaAssayTest.java
@@ -26,6 +26,7 @@ import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.assay.plate.PlateDesignerPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.tests.AbstractAssayTest;
+import org.labkey.test.util.ExperimentalFeaturesHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.QCAssayScriptHelper;
 
@@ -70,6 +71,8 @@ public class ElisaAssayTest extends AbstractAssayTest
     @Test
     public void runUITests() throws Exception
     {
+        ExperimentalFeaturesHelper.disableExperimentalFeature(createDefaultConnection(), "elisaMultiPlateSupport");
+
         log("Starting ELISA Assay BVT Test");
 
         //revert to the admin user

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -562,7 +562,7 @@ public class NabAssayTest extends AbstractAssayTest
         wikiHelper.setWikiBody(TestFileUtils.getFileContents(TestFileUtils.getSampleData("api/nabApiTest.html")));
         wikiHelper.saveWikiPage();
         waitForElement(Locator.id(TEST_DIV_ID));
-        waitForElements(Locator.id(TEST_DIV_ID).child(Locator.tagWithText("div", "Success!")), 2);
+        waitForElements(Locator.id(TEST_DIV_ID).child(Locator.tagWithText("div", "Success!")), 2, WAIT_FOR_PAGE);
     }
 
     private void assertStudyData(int ptidCount)


### PR DESCRIPTION
#### Rationale
Looks like the ELISA multi-plate experimental feature flag is enabled occasionally (likely from ElisaMultiPlateAssayTest). This PR makes sure to disabled that flag before starting the ElisaAssayTest test case.

#### Changes
* Add call to disabled ELISA multi-plate experimental feature flag at beginning of test
