### PR TITLE
Scroll button on the grid into view.

### DIFF
--- a/src/org/labkey/test/components/glassLibrary/grids/GridBar.java
+++ b/src/org/labkey/test/components/glassLibrary/grids/GridBar.java
@@ -223,6 +223,7 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
         if(!button.findOptionalElement(this).isEmpty())
         {
             WebElement btn = button.waitForElement(this, 5_000);
+            getWrapper().scrollIntoView(btn);
             btn.click();
 
             if(doAction != null)


### PR DESCRIPTION
#### Rationale
Sometimes the top of the grid will scroll under the page's header bar. Make sure a button on the top of the grid is clickable before trying to click it.

#### Related Pull Requests
* None

#### Changes
* Added ScrollIntoView call in the buttonClick method for the gridBar
