### PR TITLE
Improve timing of R report helper

### DIFF
--- a/src/org/labkey/test/tests/AbstractKnitrReportTest.java
+++ b/src/org/labkey/test/tests/AbstractKnitrReportTest.java
@@ -19,6 +19,7 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.Locators;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestProperties;
 import org.labkey.test.pages.reports.ManageViewsPage;
@@ -117,6 +118,10 @@ public abstract class AbstractKnitrReportTest extends BaseWebDriverTest
 
         // Regression test: Issue #18602
         _rReportHelper.clickReportTab();
+        if (isElementPresent(Locators.labkeyError))
+        {
+            refresh(); // Sometimes doesn't render on the first try.
+        }
         _rReportHelper.assertKnitrReportContents(reportContains, reportNotContains);
 
         _rReportHelper.clickSourceTab();

--- a/src/org/labkey/test/tests/AbstractKnitrReportTest.java
+++ b/src/org/labkey/test/tests/AbstractKnitrReportTest.java
@@ -19,7 +19,6 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
-import org.labkey.test.Locators;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestProperties;
 import org.labkey.test.pages.reports.ManageViewsPage;
@@ -118,10 +117,6 @@ public abstract class AbstractKnitrReportTest extends BaseWebDriverTest
 
         // Regression test: Issue #18602
         _rReportHelper.clickReportTab();
-        if (isElementPresent(Locators.labkeyError))
-        {
-            refresh(); // Sometimes doesn't render on the first try.
-        }
         _rReportHelper.assertKnitrReportContents(reportContains, reportNotContains);
 
         _rReportHelper.clickSourceTab();

--- a/src/org/labkey/test/util/RReportHelper.java
+++ b/src/org/labkey/test/util/RReportHelper.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.Locators;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestProperties;
 import org.labkey.test.components.ext4.Checkbox;
@@ -526,7 +527,9 @@ public class RReportHelper
     public void clickReportTab()
     {
         _test.waitAndClick(Ext4Helper.Locators.tab("Report"));
-        _test.waitForElement(Locator.tagWithClass("div", "reportView").notHidden().withPredicate("not(ancestor-or-self::*[contains(@class,'mask')])"), WAIT_FOR_PAGE);
+        Locator.XPathLocator reportLoc = Locator.tagWithClass("div", "reportView").notHidden().withPredicate("not(ancestor-or-self::*[contains(@class,'mask')])");
+        Locator.waitForAnyElement(_test.longWait(), reportLoc, Locators.labkeyError);
+        _test.waitForElement(reportLoc, WAIT_FOR_PAGE);
     }
 
     public void clickSourceTab()

--- a/src/org/labkey/test/util/RReportHelper.java
+++ b/src/org/labkey/test/util/RReportHelper.java
@@ -529,7 +529,6 @@ public class RReportHelper
         _test.waitAndClick(Ext4Helper.Locators.tab("Report"));
         Locator.XPathLocator reportLoc = Locator.tagWithClass("div", "reportView").notHidden().withPredicate("not(ancestor-or-self::*[contains(@class,'mask')])");
         Locator.waitForAnyElement(_test.longWait(), reportLoc, Locators.labkeyError);
-        _test.waitForElement(reportLoc, WAIT_FOR_PAGE);
     }
 
     public void clickSourceTab()

--- a/src/org/labkey/test/util/RReportHelper.java
+++ b/src/org/labkey/test/util/RReportHelper.java
@@ -38,6 +38,7 @@ import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.WebDriverWrapper.WAIT_FOR_PAGE;
 import static org.labkey.test.components.ext4.Checkbox.Ext4Checkbox;
 import static org.labkey.test.components.ext4.RadioButton.RadioButton;
 import static org.labkey.test.util.DataRegionTable.DataRegion;
@@ -464,18 +465,24 @@ public class RReportHelper
 
     public void saveReportWithName(String name, boolean isSaveAs, boolean isExternal)
     {
-        String windowTitle = isExternal ? "Create New Report" : isSaveAs ? "Save Report As" : "Save Report";
-        Locator locator = Ext4Helper.Locators.window(windowTitle).append(Locator.xpath("//input[contains(@class, 'x4-form-field')]"));
-        _test.waitForElement(locator);
-        if (_test.isElementPresent(locator))
+        String windowTitle;
+        if (isExternal)
         {
-            _test.setFormElement(locator, name);
-            Window window = new Window(windowTitle, _test.getWrappedDriver());
-            if (isExternal)
-                window.clickButton("OK", 0);
-            else
-                window.clickButton("OK");
+            windowTitle = "Create New Report";
         }
+        else
+        {
+            windowTitle = isSaveAs ? "Save Report As" : "Save Report";
+        }
+
+        Window<?> window = new Window<>(windowTitle, _test.getWrappedDriver());
+        WebElement nameInput = Locator.xpath("//input[contains(@class, 'x4-form-field')]").findElement(window);
+        _test.setFormElement(nameInput, name);
+        _test.waitForFormElementToEqual(nameInput, name); // Make sure it sticks
+        if (isExternal)
+            window.clickButton("OK", 0);
+        else
+            window.clickButton("OK");
     }
 
     public void saveReport(String name)
@@ -519,13 +526,13 @@ public class RReportHelper
     public void clickReportTab()
     {
         _test.waitAndClick(Ext4Helper.Locators.tab("Report"));
-        _test.waitForElement(Locator.tagWithClass("div", "reportView").notHidden().withPredicate("not(ancestor-or-self::*[contains(@class,'mask')])"), BaseWebDriverTest.WAIT_FOR_PAGE);
+        _test.waitForElement(Locator.tagWithClass("div", "reportView").notHidden().withPredicate("not(ancestor-or-self::*[contains(@class,'mask')])"), WAIT_FOR_PAGE);
     }
 
     public void clickSourceTab()
     {
         _test.waitAndClick(Ext4Helper.Locators.tab("Source"));
-        _test.waitForElement(Locator.tagWithClass("div", "reportSource").notHidden(), BaseWebDriverTest.WAIT_FOR_PAGE);
+        _test.waitForElement(Locator.tagWithClass("div", "reportSource").notHidden(), WAIT_FOR_PAGE);
     }
 
     public void ensureFieldSetExpanded(String name)
@@ -605,11 +612,11 @@ public class RReportHelper
      */
     public WebElement assertKnitrReportContents(Locator[] reportContains, String[] reportNotContains)
     {
-        WebElement reportDiv = _test.waitForElement(Locator.css("div.reportView > div.labkey-knitr"), BaseWebDriverTest.WAIT_FOR_PAGE);
+        WebElement reportDiv = _test.waitForElement(Locator.css("div.reportView > div.labkey-knitr"), WAIT_FOR_PAGE);
 
         for (Locator contains : reportContains)
         {
-            contains.waitForElement(reportDiv, BaseWebDriverTest.WAIT_FOR_PAGE);
+            contains.waitForElement(reportDiv, WAIT_FOR_PAGE);
         }
 
         if (reportNotContains != null)


### PR DESCRIPTION
#### Rationale
RStudio tests have been unreliable on TeamCity since a recent update to the Linux agents. They occasionally pass but usually do not.
I've made some minor test timing changes to get the tests passing for me locally but they still usually fail on TeamCity.

#### Related Pull Requests
* LabKey/docker#44
* LabKey/rstudio#73

#### Changes
* Minor test timing improvements and linting
