### PR TITLE
Don't include modules that are not meant to be built in the teamCity distribution

### DIFF
--- a/distributions/teamcity/build.gradle
+++ b/distributions/teamcity/build.gradle
@@ -52,8 +52,7 @@ else
     List pathList = []
     project.rootProject.allprojects.each {
         Project otherProject ->
-            if (otherProject != project && otherProject.getPlugins().findPlugin(Distribution.class) == null
-                && ModuleFinder.isPotentialModule(otherProject) && FileModule.shouldDoBuild(otherProject, true))
+            if (otherProject != project && ModuleFinder.isPotentialModule(otherProject) && FileModule.shouldDoBuild(otherProject, false))
             {
                 project.evaluationDependsOn(otherProject.path)
                 if (otherProject.plugins.hasPlugin('org.labkey.module') || 

--- a/distributions/teamcity/build.gradle
+++ b/distributions/teamcity/build.gradle
@@ -1,6 +1,7 @@
 import org.labkey.gradle.task.ModuleDistribution
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
+import org.labkey.gradle.util.ModuleFinder
 import org.labkey.gradle.plugin.Distribution
 import org.labkey.gradle.plugin.FileModule
 
@@ -52,7 +53,7 @@ else
     project.rootProject.allprojects.each {
         Project otherProject ->
             if (otherProject != project && otherProject.getPlugins().findPlugin(Distribution.class) == null
-                && FileModule.shouldDoBuild(project, true))
+                && ModuleFinder.isPotentialModule(otherProject) && FileModule.shouldDoBuild(otherProject, true))
             {
                 project.evaluationDependsOn(otherProject.path)
                 if (otherProject.plugins.hasPlugin('org.labkey.module') || 

--- a/distributions/teamcity/build.gradle
+++ b/distributions/teamcity/build.gradle
@@ -2,6 +2,7 @@ import org.labkey.gradle.task.ModuleDistribution
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.plugin.Distribution
+import org.labkey.gradle.plugin.FileModule
 
 apply plugin: 'org.labkey.distribution'
 
@@ -50,7 +51,8 @@ else
     List pathList = []
     project.rootProject.allprojects.each {
         Project otherProject ->
-            if (otherProject != project && otherProject.getPlugins().findPlugin(Distribution.class) == null)
+            if (otherProject != project && otherProject.getPlugins().findPlugin(Distribution.class) == null
+                && FileModule.shouldDoBuild(project, true))
             {
                 project.evaluationDependsOn(otherProject.path)
                 if (otherProject.plugins.hasPlugin('org.labkey.module') || 


### PR DESCRIPTION
#### Rationale
Now that we correctly skip over building modules that are not meant to be built, we need to exclude them from the teamCity distribution as well

#### Related Pull Requests
* https://github.com/LabKey/server/pull/18
* https://github.com/LabKey/gradlePlugin/pull/105

#### Changes
* Check for build viability before adding to distribution