### PR TITLE
Don't set passwords for users

### DIFF
--- a/src/org/labkey/test/tests/DataReportsTest.java
+++ b/src/org/labkey/test/tests/DataReportsTest.java
@@ -31,7 +31,6 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.DailyB;
 import org.labkey.test.categories.Reports;
 import org.labkey.test.components.html.BootstrapMenu;
-import org.labkey.test.util.APIUserHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
@@ -129,16 +128,13 @@ public class DataReportsTest extends ReportTest
 
     protected final static String R_USER = "r_editor@report.test";
     protected final static String AUTHOR_USER = "author_user@report.test";
-    protected final static String AUTHOR_USER_PW = "Password";
-    protected final static String READER_USER = "reader_user@report.test";
-    protected final static String READER_USER_PW = "Password";
 
     private final ApiPermissionsHelper _apiPermissionsHelper = new ApiPermissionsHelper(this);
 
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
-        _userHelper.deleteUsers(false, R_USER, AUTHOR_USER, READER_USER);
+        _userHelper.deleteUsers(false, R_USER, AUTHOR_USER);
         super.doCleanup(afterTest);
     }
 
@@ -160,18 +156,6 @@ public class DataReportsTest extends ReportTest
 
         // Make sure the Developers group has the Platform Developer role.
         initTest.addDeveloperGroupToPlatformDeveloperRole();
-
-        APIUserHelper apiUserHelper = new APIUserHelper(initTest);
-        ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(initTest);
-
-        // Create a site-developer that is an author in the project
-        initTest.createSiteDeveloper(AUTHOR_USER).addMemberToRole(AUTHOR_USER, "Author", PermissionsHelper.MemberType.user, initTest.getProjectName());
-        initTest.setInitialPassword(AUTHOR_USER, AUTHOR_USER_PW);
-
-        // Create a reader user
-        apiUserHelper.createUser(READER_USER, true, true);
-        initTest.setInitialPassword(READER_USER, READER_USER_PW);
-        apiPermissionsHelper.addMemberToRole(READER_USER, "Reader", PermissionsHelper.MemberType.user, initTest.getProjectName());
     }
 
     private void addDeveloperGroupToPlatformDeveloperRole()
@@ -430,13 +414,13 @@ public class DataReportsTest extends ReportTest
         if (!TestProperties.isPrimaryUserAppAdmin())
         {
             log("Test user permissions");
+            createSiteDeveloper(AUTHOR_USER).addMemberToRole(AUTHOR_USER, "Author", PermissionsHelper.MemberType.user, getProjectName());
             impersonate(AUTHOR_USER);
         }
         else
         {
             log("App Admin can't impersonate site roles. Just create report as primary test user.");
         }
-
         navigateToFolder(getProjectName(), getFolderName());
         clickAndWait(Locator.linkWithText(DATA_SET));
         createRReport(AUTHOR_REPORT, R_SCRIPT2(DATA_BASE_PREFIX, "mouseId"), true, true, new String[0]);
@@ -444,9 +428,6 @@ public class DataReportsTest extends ReportTest
         {
             stopImpersonating();
         }
-
-        signOut();
-        simpleSignIn();
 
         popLocation();
         log("Create second R script");
@@ -466,7 +447,6 @@ public class DataReportsTest extends ReportTest
         log("Check that background run works");
 
         _userHelper.createUser(R_USER);
-        setInitialPassword(R_USER, "Password");
         _apiPermissionsHelper.addUserToProjGroup(R_USER, getProjectName(), "Users");
         _apiPermissionsHelper.addMemberToRole("Users", "Editor", PermissionsHelper.MemberType.group, getProjectName());
 
@@ -547,8 +527,6 @@ public class DataReportsTest extends ReportTest
 
         impersonateRole("Reader");
         clickFolder(getFolderName());
-
-        navigateToFolder(getProjectName(), getFolderName());
         scrollIntoView(Locator.linkWithText(DATA_SET_APX1));
         clickAndWait(Locator.linkWithText(DATA_SET_APX1));
         DataRegionTable.DataRegion(getDriver()).find().goToReport( reportName);
@@ -558,7 +536,6 @@ public class DataReportsTest extends ReportTest
 
 
         log("Re-save report disabling showing the source tab to all users");
-        goToProjectHome();
         navigateToFolder(getProjectName(), getFolderName());
         scrollIntoView(Locator.linkWithText(DATA_SET_APX1));
         clickAndWait(Locator.linkWithText(DATA_SET_APX1));


### PR DESCRIPTION
#### Rationale
This test had been refactored to work against trial servers. This makes it work again. Trial servers don't have database authentication enabled, so we can't set user passwords there.

#### Related Pull Requests
* #546 

#### Changes
* Roll back most `DataReportsTest` changes from #525 
