### PR TITLE
41986: Remove experimental feature to use clientapi_core.lib.xml

### DIFF
--- a/src/org/labkey/test/tests/ResourceEncodingTest.java
+++ b/src/org/labkey/test/tests/ResourceEncodingTest.java
@@ -92,7 +92,7 @@ public class ResourceEncodingTest extends BaseWebDriverTest
     {
         List<String> baseFileNames = Arrays.asList(
                 "clientapi",
-                "clientapi_core",
+                "clientapi/labkey-api-js-core",
                 "internal"
         );
 


### PR DESCRIPTION
#### Rationale
Updated expected asset after changes from fixing [Issue 41986](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41986). See related platform PR for more information.

Verified on TC with personal build: https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyPostgres/1193151?buildTab=tests&status=passed

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1760

#### Changes
* Expect `clientapi/labkey-api-js-core` (.min.js) as declared by `labkey_api_js.lib.xml`.
