### PR TITLE
sample type MV column test fixes

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
@@ -204,14 +204,7 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         final String REQUIRED_FIELD_DISPLAY_NAME = "Field01";
         final String MISSING_FIELD_NAME = "field02";
         final String MISSING_FIELD_DISPLAY_NAME = "Field02";
-        String INDICATOR_FIELD_NAME;
-
-        // Unfortunately Postgres and MSSQL case the missing indicator field differently. This causes issues when
-        // getting the data by a db query and validating it against expected values.
-        if(WebTestHelper.getDatabaseType().equals(WebTestHelper.DatabaseType.MicrosoftSQLServer))
-            INDICATOR_FIELD_NAME = MISSING_FIELD_NAME + "_MVIndicator";
-        else
-            INDICATOR_FIELD_NAME = MISSING_FIELD_NAME + "_mvindicator";
+        final String INDICATOR_FIELD_NAME = MISSING_FIELD_NAME + "MVIndicator";
 
         StringBuilder errorLog = new StringBuilder();
 

--- a/src/org/labkey/test/tests/SampleTypeRemoteAPITest.java
+++ b/src/org/labkey/test/tests/SampleTypeRemoteAPITest.java
@@ -275,8 +275,7 @@ public class SampleTypeRemoteAPITest extends BaseWebDriverTest
         assertEquals("cell should reflect literal value", "updatedValue", dCell.getText());
 
         // now update rows via the UI
-        String mvIndicatorColName = WebTestHelper.getDatabaseType().equals(WebTestHelper.DatabaseType.MicrosoftSQLServer) ?
-                "mvStringData_MVIndicator" : "mvstringdata_mvindicator";
+        String mvIndicatorColName = "mvStringDataMVIndicator";
         materialsList.updateRow(dIndex, Map.of("mvStringData", "reallyUpdatedValue", mvIndicatorColName, "Q"));  // update the underlying value but set it mv-Q
         materialsList.clickEditRow(eIndex);
         selectOptionByText(Locator.name("quf_"+mvIndicatorColName), "");    // clear the mv value, reveal underlying value
@@ -425,22 +424,14 @@ public class SampleTypeRemoteAPITest extends BaseWebDriverTest
         materialsList.clickEditRow(0);
         setFormElement(Locator.input("quf_mvStringData"), "testValue");
 
-        /* SQL and PG handle casing differently- and labkey passes the differently-cased field names straight through.
-        * Until we figure out a way to do case-insensitive matching over xpath, fork in the test code based on which DB we're running */
-        if(WebTestHelper.getDatabaseType().equals(WebTestHelper.DatabaseType.MicrosoftSQLServer))
-            selectOptionByText(Locator.tagWithAttribute("select", "name", "quf_mvStringData_MVIndicator"), "Q");
-        else
-            selectOptionByText(Locator.tagWithAttribute("select", "name", "quf_mvstringdata_mvindicator"), "Q");
+        selectOptionByText(Locator.tagWithAttribute("select", "name", "quf_mvStringDataMVIndicator"), "Q");
         clickButton("Submit");
 
         materialsList =  DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
 
         materialsList.clickEditRow(1);
         setFormElement(Locator.input("quf_mvStringData"), "otherValue");
-        if(WebTestHelper.getDatabaseType().equals(WebTestHelper.DatabaseType.MicrosoftSQLServer))
-            selectOptionByText(Locator.tagWithAttribute("select", "name", "quf_mvStringData_MVIndicator"), "N");
-        else
-            selectOptionByText(Locator.tagWithAttribute("select", "name", "quf_mvstringdata_mvindicator"), "N");
+        selectOptionByText(Locator.tagWithAttribute("select", "name", "quf_mvStringDataMVIndicator"), "N");
         clickButton("Submit");
         materialsList =  DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
 

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -904,14 +904,7 @@ public class SampleTypeTest extends BaseWebDriverTest
 
         final String REQUIRED_FIELD_NAME = "field01";
         final String MISSING_FIELD_NAME = "field02";
-        String INDICATOR_FIELD_NAME;
-
-        // Unfortunately Postgres and MSSQL case the missing indicator field differently. This causes issues when
-        // getting the data by a db query and validating it against expected values.
-        if(WebTestHelper.getDatabaseType().equals(WebTestHelper.DatabaseType.MicrosoftSQLServer))
-            INDICATOR_FIELD_NAME = MISSING_FIELD_NAME + "_MVIndicator";
-        else
-            INDICATOR_FIELD_NAME = MISSING_FIELD_NAME + "_mvindicator";
+        final String INDICATOR_FIELD_NAME = MISSING_FIELD_NAME + "MVIndicator";
 
         log("Validate missing values and required fields in a Sample Type.");
 


### PR DESCRIPTION
#### Rationale
Now that sample type MV columns are properly aliased in the virtual table we don't need to rely on the provisioned column names that will be case sensitive depending on the dialect.

If there are other places in the automation code that rely on the case sensitivity, please let me know and I'll get those fixed as well.

#### Changes
- Remove the conditional logic on the test cases for the indicator column name.