### PR TITLE
Add test property to customize startup timeout

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -103,7 +103,7 @@ import static org.labkey.test.WebTestHelper.logToServer;
  */
 public abstract class LabKeySiteWrapper extends WebDriverWrapper
 {
-    private static final int MAX_SERVER_STARTUP_WAIT_SECONDS = 60;
+    private static final int MAX_SERVER_STARTUP_WAIT_SECONDS = TestProperties.getServerStartupTimeout();
     private static final String CLIENT_SIDE_ERROR = "Client exception detected";
     public AbstractUserHelper _userHelper = new APIUserHelper(this);
 

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -198,6 +198,24 @@ public abstract class TestProperties
         return "true".equals(System.getProperty("webtest.server.trial"));
     }
 
+    /**
+     * Parses system property 'webtest.server.startup.timeout' to determine maximum allowed server startup time.
+     * If property is not defined or is not an integer, it defaults to 60 seconds.
+     * @return Maximum number of seconds to wait for server startup
+     */
+    public static int getServerStartupTimeout()
+    {
+        String property = System.getProperty("webtest.server.startup.timeout");
+        try
+        {
+            return Integer.parseInt(property);
+        }
+        catch (NumberFormatException nfe)
+        {
+            return 60;
+        }
+    }
+
     public static String ensureGeckodriverExeProperty()
     {
         final String key = GECKO_DRIVER_EXE_PROPERTY;


### PR DESCRIPTION
#### Rationale
Servers sometimes take longer than a minute to startup. Particularly trial servers.

#### Changes
* Add test property: `webtest.server.startup.timeout`
