### PR TITLE
Check for leaks after running server-side tests

### DIFF
--- a/src/org/labkey/test/util/JUnitFooter.java
+++ b/src/org/labkey/test/util/JUnitFooter.java
@@ -65,6 +65,12 @@ public class JUnitFooter extends BaseWebDriverTest
         // Skip normal check. Server-side tests might generate expected errors.
     }
 
+    @Override
+    protected void checkLeaks(Long leakCutoffTime)
+    {
+        super.checkLeaks(JUnitHeader.startTime);
+    }
+
     @Override public BrowserType bestBrowser()
     {
         return BrowserType.CHROME;

--- a/src/org/labkey/test/util/JUnitHeader.java
+++ b/src/org/labkey/test/util/JUnitHeader.java
@@ -27,6 +27,9 @@ import static org.labkey.test.WebTestHelper.logToServer;
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
 public class JUnitHeader extends BaseWebDriverTest
 {
+    // Used by 'JUnitFooter' to check for leaks from server-side tests
+    static Long startTime = null;
+
     @Override
     public List<String> getAssociatedModules()
     {
@@ -76,6 +79,7 @@ public class JUnitHeader extends BaseWebDriverTest
     @AfterClass
     public static void logStart()
     {
+        startTime = System.currentTimeMillis();
         logToServer("=== Starting Server-side JUnit Tests ===");
     }
 


### PR DESCRIPTION
#### Rationale
The test harness doesn't check for memory leaks after running the server-side JUnit tests. Because of that, we almost missed a leak from the TargetedMS module (see the BVT failure on this branch). This change makes the leak check from `JUnitFooter` (which always runs after the server-side tests) able to catch leaks that happened during the server-side tests.

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/303
