### PR TITLE
Add coverage for new SampleType export/import behavior

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -999,6 +999,11 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         beginAt(buildURL("project", projectName, "begin"));
     }
 
+    public void goToProjectFolder(String projectName, String subfolder)
+    {
+        beginAt(buildURL("project", projectName + "/" + subfolder, "begin"));
+    }
+
     /**
      * go to the project settings page of a project
      * @param project project name

--- a/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
@@ -431,18 +431,18 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
 
         // arrange - 2 sample types, one with samples derived from parents in the other (and also parents in the same one)
         List<FieldDefinition> testFields = SampleTypeAPIHelper.sampleTypeTestFields();
-        SampleTypeDefinition parentType = SampleTypeAPIHelper.sampleTypeDefinition(parentSampleType, testFields, null, null);
-        SampleTypeDefinition testSampleType = SampleTypeAPIHelper.sampleTypeDefinition(testSamples, testFields, null, null)
+        SampleTypeDefinition parentType = new SampleTypeDefinition(parentSampleType).setFields(testFields);
+        SampleTypeDefinition testSampleType = new SampleTypeDefinition(testSamples).setFields(testFields)
                 .addParentAlias("Parent", parentSampleType) // to derive from parent sampleType
                 .addParentAlias("SelfParent"); // to derive from samles in the current type
 
-        TestDataGenerator parentDgen = SampleTypeAPIHelper.createEmptySampleType(subfolderPath, parentType, null);
+        TestDataGenerator parentDgen = SampleTypeAPIHelper.createEmptySampleType(subfolderPath, parentType);
         parentDgen.addCustomRow(Map.of("Name", "Parent1", "intColumn", 1, "floatColumn", 1.1, "stringColumn", "one"));
         parentDgen.addCustomRow(Map.of("Name", "Parent2", "intColumn", 2, "floatColumn", 2.2, "stringColumn", "two"));
         parentDgen.addCustomRow(Map.of("Name", "Parent3", "intColumn", 3, "floatColumn", 3.3, "stringColumn", "three"));
         parentDgen.insertRows();
 
-        TestDataGenerator testDgen = SampleTypeAPIHelper.createEmptySampleType(subfolderPath, testSampleType, null);
+        TestDataGenerator testDgen = SampleTypeAPIHelper.createEmptySampleType(subfolderPath, testSampleType);
         testDgen.addCustomRow(Map.of("Name", "Child1", "intColumn", 1, "decimalColumn", 1.1, "stringColumn", "one",
                 "Parent", "Parent1"));
         testDgen.addCustomRow(Map.of("Name", "Child2", "intColumn", 2, "decimalColumn", 2.2, "stringColumn", "two",
@@ -543,10 +543,10 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
 
         // create a test sampleType
         List<FieldDefinition> testFields = SampleTypeAPIHelper.sampleTypeTestFields();
-        SampleTypeDefinition testSampleType = SampleTypeAPIHelper.sampleTypeDefinition(testSamples, testFields, null, null)
+        SampleTypeDefinition testSampleType = new SampleTypeDefinition(testSamples).setFields(testFields)
                 .addParentAlias("SelfParent"); // to derive from samles in the current type
 
-        TestDataGenerator parentDgen = SampleTypeAPIHelper.createEmptySampleType(subfolderPath, testSampleType, null);
+        TestDataGenerator parentDgen = SampleTypeAPIHelper.createEmptySampleType(subfolderPath, testSampleType);
         parentDgen.addCustomRow(Map.of("Name", "sample1", "intColumn", 1, "decimalColumn", 1.1, "stringColumn", "one"));
         parentDgen.addCustomRow(Map.of("Name", "sample2", "intColumn", 2, "decimalColumn", 2.2, "stringColumn", "two"));
         parentDgen.addCustomRow(Map.of("Name", "sample3", "intColumn", 3, "decimalColumn", 3.3, "stringColumn", "three"));

--- a/src/org/labkey/test/util/exp/SampleTypeAPIHelper.java
+++ b/src/org/labkey/test/util/exp/SampleTypeAPIHelper.java
@@ -1,6 +1,5 @@
 package org.labkey.test.util.exp;
 
-import org.apache.commons.lang3.time.DateUtils;
 import org.junit.Assert;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
@@ -13,7 +12,6 @@ import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.TestDataGenerator;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -26,20 +24,16 @@ public class SampleTypeAPIHelper
     public static final String SAMPLE_TYPE_DOMAIN_KIND = "SampleSet";
     public static final String SAMPLE_TYPE_DATA_REGION_NAME = "SampleSet";
     public static final String SAMPLE_TYPE_COLUMN_NAME = "Sample Set";
+    public static final String SAMPLE_NAME_EXPRESSION = "S-${now:date}-${dailySampleCount}";
 
     /**
      * Create a sample type in the specified container with the fields provided.
      *
      * @param containerPath Container in which to create the sample type.
-     * @param def domain properties for the new sample type.
+     * @param sampleTypeDefinition domain properties for the new sample type.
      * @return A TestDataGenerator for inserting rows into the created sample type.
      */
-    public static TestDataGenerator createEmptySampleType(String containerPath, SampleTypeDefinition def)
-    {
-        return createEmptySampleType(containerPath, def, null);
-    }
-
-    static public TestDataGenerator createEmptySampleType(String containerPath, SampleTypeDefinition sampleTypeDefinition, String dateFormatString)
+    static public TestDataGenerator createEmptySampleType(String containerPath, SampleTypeDefinition sampleTypeDefinition)
     {
         deleteDomain(new FieldDefinition.LookupInfo(containerPath, "samples", sampleTypeDefinition.getName()));
 
@@ -52,31 +46,13 @@ public class SampleTypeAPIHelper
         {
             throw new RuntimeException("Failed to create sample type.", e);
         }
-
-        if (null != dateFormatString)
-        {
-            dgen.addDataSupplier("DateColumn", () -> dgen.randomDateString(dateFormatString,
-                    DateUtils.addWeeks(new Date(), -39),
-                    new Date()));
-        }
         return dgen;
     }
 
-    static public SampleTypeDefinition sampleTypeDefinition(String sampleTypeName,
-                                                            List<FieldDefinition> fields,
-                                                            String parentAlias,
-                                                            String nameExpression)
-    {
-        SampleTypeDefinition def = new SampleTypeDefinition(sampleTypeName);
-        def.setFields(fields);
-        if (null != parentAlias)
-            def.addParentAlias(parentAlias);
-        if (null != nameExpression)
-            def.setNameExpression(nameExpression);
-
-        return def;
-    }
-
+    /**
+     * A set of FieldDefinition provided for convenience
+     * @return
+     */
     public static List<FieldDefinition> sampleTypeTestFields()
     {
         return Arrays.asList(
@@ -87,7 +63,11 @@ public class SampleTypeAPIHelper
                 new FieldDefinition("boolColumn", FieldDefinition.ColumnType.Boolean));
     }
 
-    static public void deleteDomain(FieldDefinition.LookupInfo targetDomain)
+    /**
+     * Removes the specified domain if it exists
+     * @param targetDomain
+     */
+    public static void deleteDomain(FieldDefinition.LookupInfo targetDomain)
     {
         try
         {

--- a/src/org/labkey/test/util/exp/SampleTypeAPIHelper.java
+++ b/src/org/labkey/test/util/exp/SampleTypeAPIHelper.java
@@ -36,15 +36,30 @@ public class SampleTypeAPIHelper
      */
     public static TestDataGenerator createEmptySampleType(String containerPath, SampleTypeDefinition def)
     {
+        return createEmptySampleType(containerPath, def, null);
+    }
+
+    static public TestDataGenerator createEmptySampleType(String containerPath, SampleTypeDefinition sampleTypeDefinition, String dateFormatString)
+    {
+        deleteDomain(new FieldDefinition.LookupInfo(containerPath, "samples", sampleTypeDefinition.getName()));
+
+        TestDataGenerator dgen;
         try
         {
-            return TestDataGenerator.createDomain(containerPath, def);
+            dgen = TestDataGenerator.createDomain(containerPath, sampleTypeDefinition);
         }
         catch (CommandException e)
         {
             throw new RuntimeException("Failed to create sample type.", e);
         }
 
+        if (null != dateFormatString)
+        {
+            dgen.addDataSupplier("DateColumn", () -> dgen.randomDateString(dateFormatString,
+                    DateUtils.addWeeks(new Date(), -39),
+                    new Date()));
+        }
+        return dgen;
     }
 
     static public SampleTypeDefinition sampleTypeDefinition(String sampleTypeName,
@@ -66,25 +81,10 @@ public class SampleTypeAPIHelper
     {
         return Arrays.asList(
                 new FieldDefinition("intColumn", FieldDefinition.ColumnType.Integer),
-                new FieldDefinition("floatColumn", FieldDefinition.ColumnType.Decimal),
+                new FieldDefinition("decimalColumn", FieldDefinition.ColumnType.Decimal),
                 new FieldDefinition("stringColumn", FieldDefinition.ColumnType.String),
                 new FieldDefinition("sampleDate", FieldDefinition.ColumnType.DateAndTime),
                 new FieldDefinition("boolColumn", FieldDefinition.ColumnType.Boolean));
-    }
-
-    static public TestDataGenerator makeSampleType(SampleTypeDefinition sampleTypeDefinition, String containerPath, String dateFormatString)
-    {
-        deleteDomain(new FieldDefinition.LookupInfo(containerPath, "samples", sampleTypeDefinition.getName()));
-
-        TestDataGenerator dgen = SampleTypeAPIHelper.createEmptySampleType(containerPath, sampleTypeDefinition);
-
-        if (null != dateFormatString)
-        {
-            dgen.addDataSupplier("DateColumn", () -> dgen.randomDateString(dateFormatString,
-                    DateUtils.addWeeks(new Date(), -39),
-                    new Date()));
-        }
-        return dgen;
     }
 
     static public void deleteDomain(FieldDefinition.LookupInfo targetDomain)


### PR DESCRIPTION
#### Rationale
This adds new test coverage for SampleType export and import, to provide coverage for derived and experiment run information

#### Related Pull Requests
N/A

#### Changes
adds test cases to SampleTypeFolderExportImportTest
adds functionality to SampleTypeAPIHelper
adds goToProjectFolder to LabkeySiteWrapper
