### PR TITLE
Fix test heap dump trigger

### DIFF
--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -126,7 +126,7 @@ public abstract class TestProperties
 
     public static boolean isHeapDumpCollectionEnabled()
     {
-        return "true".equals(System.getProperty("enable.heap.dump"));
+        return "true".equals(System.getProperty("webtest.enable.heap.dump"));
     }
 
     public static boolean isRunWebDriverHeadless()

--- a/src/org/labkey/test/util/ArtifactCollector.java
+++ b/src/org/labkey/test/util/ArtifactCollector.java
@@ -165,7 +165,7 @@ public class ArtifactCollector
         if (_dumpedHeap || // Only one heap dump per suite (don't want to overload TeamCity)
             !isLocalServer() ||
             _test.isGuestModeTest() ||
-            isHeapDumpCollectionEnabled()
+            !isHeapDumpCollectionEnabled()
         )
         {
             return;

--- a/src/org/labkey/test/util/ArtifactCollector.java
+++ b/src/org/labkey/test/util/ArtifactCollector.java
@@ -176,7 +176,14 @@ public class ArtifactCollector
         // Use dumpHeapAction rather that touching file so that we can get file name and publish artifact.
         _driver.beginAt("/admin/dumpHeap.view");
         String dumpMsg = Locators.bodyPanel().childTag("div").findElement(_driver.getDriver()).getText();
-        String filename = dumpMsg.replace("Heap dumped to ", "");
+        String filePrefix = "Heap dumped to ";
+        int prefixIndex = dumpMsg.indexOf(filePrefix);
+        if (prefixIndex < 0)
+        {
+            _test.checker().error("Unable to extract filename from page body. Update test or disable heap dump.\n" + dumpMsg);
+            return;
+        }
+        String filename = dumpMsg.substring(prefixIndex + filePrefix.length());
         File heapDump = new File(filename);
         File destFile = new File(ensureDumpDir(), heapDump.getName());
         try

--- a/src/org/labkey/test/util/ArtifactCollector.java
+++ b/src/org/labkey/test/util/ArtifactCollector.java
@@ -180,7 +180,7 @@ public class ArtifactCollector
         int prefixIndex = dumpMsg.indexOf(filePrefix);
         if (prefixIndex < 0)
         {
-            _test.checker().error("Unable to extract filename from page body. Update test or disable heap dump.\n" + dumpMsg);
+            _test.checker().error("Unable to extract heap dump filename from page body. 'ArtifactCollector.dumpHeap' may need to be updated.\n" + dumpMsg);
             return;
         }
         String filename = dumpMsg.substring(prefixIndex + filePrefix.length());

--- a/src/org/labkey/test/util/ArtifactCollector.java
+++ b/src/org/labkey/test/util/ArtifactCollector.java
@@ -62,6 +62,7 @@ public class ArtifactCollector
     // Use CopyOnWriteArrayList to avoid ConcurrentModificationException
     private static List<Pair<File, FileFilter>> pipelineDirs = new CopyOnWriteArrayList<>();
     private static long _testStart;
+    private static boolean _dumpedHeap = false;
 
     public ArtifactCollector(BaseWebDriverTest test)
     {
@@ -161,26 +162,28 @@ public class ArtifactCollector
 
     public void dumpHeap()
     {
-        if (!isLocalServer())
+        if (_dumpedHeap || // Only one heap dump per suite (don't want to overload TeamCity)
+            !isLocalServer() ||
+            _test.isGuestModeTest() ||
+            isHeapDumpCollectionEnabled()
+        )
+        {
             return;
-        if ( _test.isGuestModeTest() )
-            return;
-        if (!isHeapDumpCollectionEnabled())
-            return;
+        }
 
         _driver.pushLocation();
 
         // Use dumpHeapAction rather that touching file so that we can get file name and publish artifact.
         _driver.beginAt("/admin/dumpHeap.view");
-        File destDir = ensureDumpDir();
         String dumpMsg = Locators.bodyPanel().childTag("div").findElement(_driver.getDriver()).getText();
-        String filename = dumpMsg.substring(dumpMsg.indexOf("HeapDump_"));
-        File heapDump = new File(TestFileUtils.getLabKeyRoot() + "/build/deploy", filename);
-        File destFile = new File(destDir, filename);
+        String filename = dumpMsg.replace("Heap dumped to ", "");
+        File heapDump = new File(filename);
+        File destFile = new File(ensureDumpDir(), heapDump.getName());
         try
         {
             Files.move(heapDump.toPath(), destFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
             publishArtifact(destFile);
+            _dumpedHeap = true;
         }
         catch (IOException e)
         {


### PR DESCRIPTION
#### Rationale
The heap dumping mechanism was created when our build was done in 'ant'. Gradle handles TeamCity properties differently, so '`enable.heap.dump`' was not getting passed through when running tests on TeamCity. Prepending "webtest." tells our Gradle plugin to pass the parameter through.

#### Changes
* Enable heap dumps with `webtest.enable.heap.dump`
* Add flag to prevent collection of more than one heap dump per test run
