### PR TITLE
Move PuppeteerHelper to testAutomation

### DIFF
--- a/src/org/labkey/remoteapi/puppeteer/PuppeteerSettings.java
+++ b/src/org/labkey/remoteapi/puppeteer/PuppeteerSettings.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.labkey.remoteapi.puppeteer;
 
 import org.json.JSONObject;

--- a/src/org/labkey/remoteapi/puppeteer/PuppeteerSettings.java
+++ b/src/org/labkey/remoteapi/puppeteer/PuppeteerSettings.java
@@ -1,0 +1,111 @@
+package org.labkey.remoteapi.puppeteer;
+
+import org.json.JSONObject;
+import org.labkey.remoteapi.CommandResponse;
+
+public class PuppeteerSettings
+{
+    private Boolean _enabled;
+    private String _mode;
+    private String _dockerImage;
+    private Integer _dockerPort;
+    private String _remoteUrl;
+
+    public PuppeteerSettings()
+    {
+    }
+
+    public PuppeteerSettings(JSONObject json)
+    {
+        this();
+        _enabled = json.getBoolean("enabled");
+        _mode = json.getString("mode");
+        _dockerImage = json.getString("docker.image");
+
+        try
+        {
+            _dockerPort = Integer.parseInt(json.getString("docker.port"));
+        }
+        catch (NumberFormatException ignored)
+        {
+        }
+
+        _remoteUrl = json.getString("remote.url");
+    }
+
+    public PuppeteerSettings(CommandResponse response)
+    {
+        this(new JSONObject(response.getParsedData().get("data")));
+    }
+
+    public Boolean getEnabled()
+    {
+        return _enabled;
+    }
+
+    public void setEnabled(Boolean enabled)
+    {
+        _enabled = enabled;
+    }
+
+    public String getMode()
+    {
+        return _mode;
+    }
+
+    public void setMode(String mode)
+    {
+        _mode = mode;
+    }
+
+    public String getDockerImage()
+    {
+        return _dockerImage;
+    }
+
+    public void setDockerImage(String dockerImage)
+    {
+        _dockerImage = dockerImage;
+    }
+
+    public Integer getDockerPort()
+    {
+        return _dockerPort;
+    }
+
+    public void setDockerPort(Integer dockerPort)
+    {
+        _dockerPort = dockerPort;
+    }
+
+    public String getRemoteUrl()
+    {
+        return _remoteUrl;
+    }
+
+    public void setRemoteUrl(String remoteUrl)
+    {
+        _remoteUrl = remoteUrl;
+    }
+
+    public org.json.simple.JSONObject toJSON()
+    {
+        var settings = new org.json.simple.JSONObject();
+
+        if (getEnabled() != null)
+            settings.put("enabled", getEnabled());
+        if (getMode() != null)
+            settings.put("mode", getMode());
+        if (getDockerImage() != null)
+            settings.put("docker.image", getDockerImage());
+        if (getDockerPort() != null)
+            settings.put("docker.port", getDockerPort());
+        if (getRemoteUrl() != null)
+            settings.put("remote.url", getRemoteUrl());
+
+        var payload = new org.json.simple.JSONObject();
+        payload.put("settings", settings);
+
+        return payload;
+    }
+}

--- a/src/org/labkey/remoteapi/puppeteer/PuppeteerStatus.java
+++ b/src/org/labkey/remoteapi/puppeteer/PuppeteerStatus.java
@@ -1,6 +1,17 @@
 /*
- * Copyright (c) 2020 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
- * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
+ * Copyright (c) 2020 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.labkey.remoteapi.puppeteer;
 

--- a/src/org/labkey/remoteapi/puppeteer/PuppeteerStatus.java
+++ b/src/org/labkey/remoteapi/puppeteer/PuppeteerStatus.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
+ * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
+ */
+package org.labkey.remoteapi.puppeteer;
+
+import org.json.JSONObject;
+import org.labkey.remoteapi.CommandResponse;
+
+public class PuppeteerStatus
+{
+    final private boolean _isAvailable;
+    final private boolean _pingSuccess;
+    final private JSONObject _service;
+
+    public PuppeteerStatus(JSONObject payload)
+    {
+        _isAvailable = payload.getBoolean("isAvailable");
+        _pingSuccess = payload.getBoolean("pingSuccess");
+        _service = new JSONObject(payload.get("service"));
+    }
+
+    public PuppeteerStatus(CommandResponse response)
+    {
+        this(new JSONObject(response.getParsedData().get("data")));
+    }
+
+    public boolean isAvailable()
+    {
+        return _isAvailable;
+    }
+
+    public boolean isPingSuccess()
+    {
+        return _pingSuccess;
+    }
+
+    public JSONObject getService()
+    {
+        return _service;
+    }
+}

--- a/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
+++ b/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
@@ -1,0 +1,44 @@
+package org.labkey.test.util.puppeteer;
+
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.PostCommand;
+import org.labkey.test.WebTestHelper;
+import org.labkey.remoteapi.puppeteer.PuppeteerSettings;
+import org.labkey.remoteapi.puppeteer.PuppeteerStatus;
+
+import java.io.IOException;
+
+public class PuppeteerHelper
+{
+    public static void enableRemoteService(Connection connection) throws IOException, CommandException
+    {
+        var puppeteerSettings = new PuppeteerSettings();
+        puppeteerSettings.setEnabled(true);
+        puppeteerSettings.setMode("remote");
+        puppeteerSettings.setRemoteUrl(getRemoteServiceURL());
+
+        updateSettings(connection, puppeteerSettings);
+    }
+
+    public static String getRemoteServiceURL()
+    {
+        return WebTestHelper.getTargetServer() + ":3031";
+    }
+
+    public static PuppeteerStatus getStatus(Connection connection) throws IOException, CommandException
+    {
+        var statusCmd = new PostCommand<>("puppeteer", "status.api");
+        var response = statusCmd.execute(connection, "/");
+        return new PuppeteerStatus(response);
+    }
+
+    public static PuppeteerSettings updateSettings(Connection connection, PuppeteerSettings settings) throws IOException, CommandException
+    {
+        var updateCmd = new PostCommand<>("puppeteer", "updateSettings.api");
+        updateCmd.setRequiredVersion(0);
+        updateCmd.setJsonObject(settings.toJSON());
+        var response = updateCmd.execute(connection, "/");
+        return new PuppeteerSettings(response);
+    }
+}

--- a/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
+++ b/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.labkey.test.util.puppeteer;
 
 import org.labkey.remoteapi.CommandException;


### PR DESCRIPTION
#### Rationale
This PR moves the `PuppeteerHelper` and associated `remoteapi` test utility classes to testAutomation to allow compilation of tests without the presence of the `puppeteer` module locally. These utilities also do not require the presence of the `puppeteer` module as they interact with the module via remote API.

#### Related Pull Requests
* https://github.com/LabKey/puppeteer/pull/7
* https://github.com/LabKey/biologics/pull/760

#### Changes
* Move `PuppeteerHelper`, `PuppeteerSettings`, and `PuppeteerStatus` test utility classes to the testAutomation package.
