### PR TITLE
Issue 26192: FlowTest fix for flag icon updates

### DIFF
--- a/src/org/labkey/test/tests/flow/FlowTest.java
+++ b/src/org/labkey/test/tests/flow/FlowTest.java
@@ -299,7 +299,7 @@ public class FlowTest extends BaseFlowTest
         setSelectedFields(getContainerPath(), "flow", "FCSFiles", null, new String[]{"Keyword/ExperimentName", "Keyword/Stim", "Keyword/Comp", "Keyword/PLATE NAME", "Flag", "Name", "RowId"});
         assertTextPresent("PerCP-Cy5.5 CD8");
 
-        assertElementNotPresent(Locator.linkWithImage("/flagFCSFile.gif"));
+        assertElementNotPresent(Locator.tagWithClass("i", "lk-flag-enabled"));
         pushLocation();
         clickAndWait(Locator.linkWithText("91761.fcs"));
         waitForText(FCS_FILE_1);
@@ -312,7 +312,7 @@ public class FlowTest extends BaseFlowTest
         setFormElement(locPlateName, "FlowTest Keyword Plate Name");
         clickButton("update");
         popLocation();
-        assertElementPresent(Locator.linkWithImage("/flagFCSFile.gif"));
+        assertElementPresent(Locator.tagWithClass("i", "lk-flag-enabled"));
         assertElementNotPresent(Locator.linkWithText("91761.fcs"));
         assertElementPresent(Locator.linkWithText("FlowTest New Name"));
         assertTextPresent("FlowTest Keyword Plate Name");


### PR DESCRIPTION
#### Rationale
Issue [26192](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=26192): experiment flag icons look dated

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1832
* https://github.com/LabKey/commonAssays/pull/277

#### Changes
* FlowTest fix for flag/comment related check
