### PR TITLE
Update the rangeURI of decimal to 'double'

### DIFF
--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -318,7 +318,7 @@ public class FieldDefinition extends PropertyDescriptor
         DateAndTime("Date Time", "dateTime"),
         Boolean("Boolean", "boolean"),
         Double("Number (Double)", "float"),
-        Decimal("Decimal (floating point)", "float"),
+        Decimal("Decimal (floating point)", "double"),
         File("File", "fileLink"),
         AutoInteger("Auto-Increment Integer", "int"),
         Flag("Flag", "string", "http://www.labkey.org/exp/xml#flag", null),


### PR DESCRIPTION
#### Rationale
This updates the rangeURI type for Decimal to 'double', to better align test code to product behavior.
This change enables export/import of sampleTypes generated by remoteAPI tests

#### Related Pull Requests
https://github.com/LabKey/testAutomation/commit/bc9116550ea93abcadea6d1a38e2cfc5a41aa7c9

#### Changes

