### PR TITLE
Remove FCSExpress module from distribution lists

### DIFF
--- a/buildTestModules/communityArtifacts/build.gradle
+++ b/buildTestModules/communityArtifacts/build.gradle
@@ -30,9 +30,6 @@ dependencies {
     modules ("org.labkey.module:elispotassay:${labkeyVersion}@module") {
         transitive = true
     }
-    modules ("org.labkey.module:fcsexpress:${labkeyVersion}@module") {
-        transitive = true
-    }
     modules ("org.labkey.module:flow:${labkeyVersion}@module") {
         transitive = true
     }

--- a/buildTestModules/starterArtifacts/build.gradle
+++ b/buildTestModules/starterArtifacts/build.gradle
@@ -30,9 +30,6 @@ dependencies {
     modules ("org.labkey.module:elispotassay:${labkeyVersion}@module") {
         transitive = true
     }
-    modules ("org.labkey.module:fcsexpress:${labkeyVersion}@module") {
-        transitive = true
-    }
     modules ("org.labkey.module:flow:${labkeyVersion}@module") {
         transitive = true
     }


### PR DESCRIPTION
#### Rationale
We don't see any usage of the FCSExpress module via our metrics, and our doc page indicates that it's been broken since 18.3. It's time to let it go.

#### Related Pull Requests
* https://github.com/LabKey/distributions/pull/134

#### Changes
* Remove defunct module