### PR TITLE
Data region fixes to load Ext4 library now that it isn't always on the page

### DIFF
--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -1148,18 +1148,22 @@ public class DataRegionTable extends DataRegion
 
     private void closePhiLoggingColumnMsg()
     {
-        // If Ext4 is not on the page when column Filter is clicked, this error will show as an Ext3 dialog
+        String title = "Error";
         String msg = "Cannot choose values from a column that requires logging.";
-        if (getWrapper().isElementPresent(ExtHelper.Locators.extDialog("Error")))
+        String btn = "OK";
+
+        // If Ext4 is not on the page when column Filter is clicked, this error will show as an Ext3 dialog
+        if (getWrapper().isElementPresent(ExtHelper.Locators.extDialog(title)))
         {
-            getWrapper().assertExtMsgBox("Error", msg, "OK");
-            getWrapper()._extHelper.waitForExtDialogToDisappear("Error");
+            assertTrue(getWrapper()._extHelper.getExtMsgBoxText(title).contains(msg));
+            getWrapper()._extHelper.clickExtButton(title, btn, 0);
+            getWrapper()._extHelper.waitForExtDialogToDisappear(title);
         }
         else
         {
-            Window confirmWindow = Window.Window(getDriver()).withTitle("Error").waitFor();
-            getWrapper().waitForText(msg);
-            confirmWindow.clickButton("OK", 0);
+            Window confirmWindow = Window.Window(getDriver()).withTitle(title).waitFor();
+            assertTrue(confirmWindow.getBody().contains(msg));
+            confirmWindow.clickButton(btn, 0);
             getWrapper()._ext4Helper.waitForMaskToDisappear();
         }
     }


### PR DESCRIPTION
#### Rationale
Recent changes in platform removed the Ext4 library from automatically being loaded for every DataRegion. This means that this Ext4 usage from some other actions/buttons will need to make sure the Ext4 library is loaded lazily for this use case.

#### Previously Merged Pull Requests
* https://github.com/LabKey/platform/pull/1868
* https://github.com/LabKey/platform/pull/1874

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1875
* https://github.com/LabKey/dataintegration/pull/81
* https://github.com/LabKey/testAutomation/pull/581

#### Changes
* Update a couple of DataRegion test cases that now need to check for non-Ext4 alert messages
