### PR TITLE
Update components for new notification behavior

### DIFF
--- a/src/org/labkey/test/components/ColumnChartRegion.java
+++ b/src/org/labkey/test/components/ColumnChartRegion.java
@@ -41,7 +41,7 @@ public class ColumnChartRegion extends WebDriverComponent
     }
 
     @Override
-    protected WebDriverWrapper getWrapper()
+    public WebDriverWrapper getWrapper()
     {
         return _dataRegionTable.getWrapper();
     }

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -81,7 +81,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
     }
 
     @Override
-    protected WebDriverWrapper getWrapper()
+    public WebDriverWrapper getWrapper()
     {
         return _driver;
     }

--- a/src/org/labkey/test/components/WebDriverComponent.java
+++ b/src/org/labkey/test/components/WebDriverComponent.java
@@ -33,7 +33,7 @@ import java.util.function.BiFunction;
 public abstract class WebDriverComponent<EC extends Component.ElementCache> extends Component<EC>
 {
     private WebDriverWrapper _dWrapper;
-    protected WebDriverWrapper getWrapper()
+    public WebDriverWrapper getWrapper()
     {
         if (_dWrapper == null)
             _dWrapper = new WebDriverWrapperImpl(getDriver());

--- a/src/org/labkey/test/components/WebPart.java
+++ b/src/org/labkey/test/components/WebPart.java
@@ -64,7 +64,7 @@ public abstract class WebPart<EC extends WebPart.ElementCache> extends WebPartPa
     }
 
     @Override
-    protected WebDriverWrapper getWrapper()
+    public WebDriverWrapper getWrapper()
     {
         return _wDriver;
     }

--- a/src/org/labkey/test/components/core/NotificationPanelItem.java
+++ b/src/org/labkey/test/components/core/NotificationPanelItem.java
@@ -77,19 +77,13 @@ public class NotificationPanelItem extends Component
         final int initialCount = _panel.getNotificationCount();
         final String notificationId = _el.getAttribute("id");
         _markAsRead.click();
-        try
-        {
-            waitFor(() -> ExpectedConditions.invisibilityOf(_el).apply(null)
-                && _panel.getNotificationCount() == initialCount - 1,
-                "Notification did not go away when marked as read: " + notificationId, 2000);
+        _panel.getWrapper().shortWait().until(ExpectedConditions.invisibilityOf(_el));
+        _panel.clearElementCache();
+        waitFor(() -> _panel.getNotificationCount() == initialCount - 1,
+            "Notification did not go away when marked as read: " + notificationId, 2000);
 
-            if (!_panel.isNotificationPanelVisible())
-                fail("Notification panel closed unexpectedly when marking a notification as read");
-        }
-        catch (StaleElementReferenceException stale)
-        {
-            fail("Unexpected navigation when marking a notification as read");
-        }
+        if (!_panel.isNotificationPanelVisible())
+            fail("Notification panel closed unexpectedly when marking a notification as read");
     }
 
     public void toggleExpand()

--- a/src/org/labkey/test/components/core/UserNotificationsPanel.java
+++ b/src/org/labkey/test/components/core/UserNotificationsPanel.java
@@ -49,6 +49,12 @@ public class UserNotificationsPanel extends WebDriverComponent<UserNotifications
         _notificationPanel = Locator.tagWithClass("div", "labkey-notification-panel").findElement(driver);
     }
 
+    @Override
+    protected void clearElementCache() // Notification panel items can trigger panel refresh
+    {
+        super.clearElementCache();
+    }
+
     public static int getInboxCount(BaseWebDriverTest test)
     {
         String s = test.getText(inboxCount);

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -1,25 +1,16 @@
 package org.labkey.test.components.domain;
 
 import org.apache.commons.lang3.StringUtils;
-import org.json.JSONObject;
-import org.json.simple.JSONArray;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
-import org.labkey.test.components.labkey.ui.core.Alert;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.selenium.WebElementWrapper;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/org/labkey/test/components/glassLibrary/heatmap/HeatMap.java
+++ b/src/org/labkey/test/components/glassLibrary/heatmap/HeatMap.java
@@ -10,8 +10,6 @@ import org.openqa.selenium.WebElement;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
 
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 import static org.labkey.test.util.TestLogger.log;


### PR DESCRIPTION
#### Rationale
Notification panel now goes stale when marking items read. Fixes the test failure in [`DataFinderTest.testNotifications`](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_LabkeyPremiumTrunk_GitModules_ImmportPostgres95/1224420)

#### Related Pull Requests
* LabKey/platform#1815

#### Changes
* Clear `NotificationPanel`'s element cache after marking items read
* Update visibility of some methods to give access to `NotificationPanelItem`
