### PR TITLE
Update plugin id syntax

### DIFF
--- a/distributions/teamcity/build.gradle
+++ b/distributions/teamcity/build.gradle
@@ -5,7 +5,7 @@ import org.labkey.gradle.util.ModuleFinder
 import org.labkey.gradle.plugin.Distribution
 import org.labkey.gradle.plugin.FileModule
 
-apply plugin: 'org.labkey.distribution'
+apply plugin: 'org.labkey.build.distribution'
 
 dist.description = "Distribution that includes all modules, for use in the continuous integration LabKey Server instance"
 
@@ -20,6 +20,7 @@ project.task(
             dist.embeddedArchiveType="tar.gz"
             dist.extraFileIdentifier='-test'
             dist.versionPrefix='Test'
+            dist.isOpenSource=true
         }
 )
 

--- a/distributions/teamcity/build.gradle
+++ b/distributions/teamcity/build.gradle
@@ -22,7 +22,6 @@ project.task(
             dist.embeddedArchiveType="tar.gz"
             dist.extraFileIdentifier='-test'
             dist.versionPrefix='Test'
-            dist.isOpenSource=true
         }
 )
 

--- a/distributions/teamcity/build.gradle
+++ b/distributions/teamcity/build.gradle
@@ -5,7 +5,9 @@ import org.labkey.gradle.util.ModuleFinder
 import org.labkey.gradle.plugin.Distribution
 import org.labkey.gradle.plugin.FileModule
 
-apply plugin: 'org.labkey.build.distribution'
+plugins {
+    id 'org.labkey.build.distribution'
+}
 
 dist.description = "Distribution that includes all modules, for use in the continuous integration LabKey Server instance"
 

--- a/distributions/teamcity/gradle.properties
+++ b/distributions/teamcity/gradle.properties
@@ -1,1 +1,1 @@
-isOpenSource
+isOpenSource=false

--- a/distributions/teamcity/gradle.properties
+++ b/distributions/teamcity/gradle.properties
@@ -1,0 +1,1 @@
+isOpenSource

--- a/distributions/teamcity/gradle.properties
+++ b/distributions/teamcity/gradle.properties
@@ -1,1 +1,0 @@
-isOpenSource=false


### PR DESCRIPTION
#### Rationale
The TeamCity distribution should be built using open source versions of the extJS libraries as the commercial versions require credentials, which we don't use for the community build.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/114

#### Changes
* Mark distribution as isOpenSource
