### PR TITLE
Fix RlabkeyTest

### DIFF
--- a/data/api/rlabkey-api-query.xml
+++ b/data/api/rlabkey-api-query.xml
@@ -150,7 +150,7 @@
                 s<-getSession(baseUrl=labkey.url.base, folderPath="/%projectName%")
                 scobj <- getSchema(s, "lists")
                 lucols <- getLookups(s, scobj$AllTypes$Category)  # can add fields from related queries
-                cols <- c(names(scobj$AllTypes)[9:13], names(lucols)[8:10])
+                cols <- c(names(scobj$AllTypes)[10:14], names(lucols)[9:11])
                 simpledf <- getRows(s, scobj$AllTypes, colSelect=paste(cols, sep=","), colNameOpt="caption")
                 simpledf
             ]]>

--- a/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
+++ b/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
@@ -22,6 +22,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.DailyA;
 import org.labkey.test.categories.Flow;
+import org.labkey.test.categories.Specimen;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PipelineStatusTable;
@@ -32,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * This test checks the flow specimen foreign key behavior from flow.FCSFiles and flow.FCSAnalyses.
  */
-@Category({DailyA.class, Flow.class})
+@Category({DailyA.class, Flow.class, Specimen.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 8)
 public class FlowSpecimenTest extends BaseFlowTest
 {


### PR DESCRIPTION
#### Rationale
`RlabkeyTest.testRlabkeyQueryApi()` started failing because of the new diImportHash column. The test creates an R report that queries list metadata, outputs specific columns, and checks expectations. A new column appearing meant we no longer met its expectations. Just need to bump the R script column indexes by one.
