### PR TITLE
Fix post-failure error screenshot

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -314,8 +314,16 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         SingletonWebDriver.getInstance().tearDown(closeWindow || isTestRunningOnTeamCity());
     }
 
+    private void clearLastPageInfo()
+    {
+        _lastPageTitle = null;
+        _lastPageURL = null;
+        _lastPageText = null;
+    }
+
     private void populateLastPageInfo()
     {
+        clearLastPageInfo();
         _lastPageTitle = getLastPageTitle();
         _lastPageURL = getLastPageURL();
         _lastPageText = getLastPageText();
@@ -968,6 +976,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             }
             if (isTestRunningOnTeamCity()) // Don't risk modifying browser state when running locally
             {
+                clearLastPageInfo(); // Make sure server error screenshot doesn't reuse cached page text
                 // Reset errors before next test and make it easier to view server-side errors that may have happened during the test.
                 checker().withScreenshot(testName + "_serverErrors").wrapAssertion(this::checkErrors);
             }


### PR DESCRIPTION
#### Rationale
We cache the page text when handling test failure do avoid doing so multiple times. That cached text is used erroneously during the final check for server errors, resulting in a PNG screenshot of the error log but HTML from the initial test failure.

#### Changes
* Clear cached page source before checking for server errors 
