### PR TITLE
Issue 39832: Fix admin settings pages' navtrails

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1586,9 +1586,29 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
     public void assertNavTrail(String... links)
     {
+        verifyNavTrail(true, links);
+    }
+
+    public boolean verifyNavTrail(boolean throwOnNoMatch, String... links)
+    {
+        Locator navTrailLocator = Locator.tagWithClass("ol", "breadcrumb");
+        boolean exists = navTrailLocator.existsIn(getDriver());
+
+        if (!exists)
+        {
+            if (throwOnNoMatch)
+                fail("NavTrail does not exist");
+            else
+                return false;
+        }
+
+        String navTrailText = navTrailLocator.findElement(getDriver()).getText();
         String expectedNavTrail = String.join("", links);
-        String navTrail = Locator.tagWithClass("ol", "breadcrumb").findElement(getDriver()).getText();
-        assertEquals("Wrong nav trail", expectedNavTrail, navTrail);
+
+        if (throwOnNoMatch)
+            assertEquals("Nav trail does not match", expectedNavTrail, navTrailText);
+
+        return expectedNavTrail.equals(navTrailText);
     }
 
     public void clickTab(String tabname)

--- a/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
@@ -31,10 +31,14 @@ public class AdminConsoleNavigationTest extends BaseWebDriverTest
         Set<String> ignoredLinks = Collections.newSetFromMap(new CaseInsensitiveHashMap<>());
         ignoredLinks.addAll(List.of(
             "LDAP Sync Admin",                  // An HTML view -- difficult to customize navtrail
+            "Authentication",                   // Slow to load
             "Change User Properties",           // Generic domain action -- difficult to customize navtrail
             "Site-Wide Terms of Use",           // Standard wiki action -- difficult to customize navtrail
+            "Puppeteer Service",                // An HTML view -- difficult to customize navtrail
             "Dump Heap",                        // Undesired consequences
+            "Memory Usage",                     // Slow to load
             "Reset Site Errors",                // Undesired consequences
+            "Running Threads",                  // Undesired consequences
             "View All Site Errors",             // No nav trail
             "View All Site Errors Since Reset", // No nav trail
             "View Primary Site Log File"        // No nav trail

--- a/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
@@ -7,6 +7,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.categories.BVT;
 import org.labkey.test.categories.Git;
 import org.labkey.test.pages.core.admin.ShowAdminPage;
 import org.labkey.test.util.TestLogger;
@@ -20,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-@Category({Git.class})
+@Category({Git.class, BVT.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
 public class AdminConsoleNavigationTest extends BaseWebDriverTest
 {

--- a/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
@@ -1,0 +1,75 @@
+package org.labkey.test.tests;
+
+import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
+import org.labkey.test.categories.Git;
+import org.labkey.test.pages.core.admin.ShowAdminPage;
+import org.labkey.test.util.TestLogger;
+import org.openqa.selenium.WebElement;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Category({Git.class})
+@BaseWebDriverTest.ClassTimeout(minutes = 3)
+public class AdminConsoleNavigationTest extends BaseWebDriverTest
+{
+    @Test
+    public void testAdminNavTrails()
+    {
+        Set<String> ignoredLinks = Collections.newSetFromMap(new CaseInsensitiveHashMap<>());
+        ignoredLinks.addAll(List.of("Dump Heap", "Reset Site Errors", "View All Site Errors", "View All Site Errors Since Reset", "View Primary Site Log File"));
+        ShowAdminPage.beginAt(this);
+        WebElement adminLinksContainer = Locator.id("links").findElement(getDriver()); // Maybe put this in 'ShowAdminPage'
+        List<WebElement> adminLinks = Locator.tag("a").findElements(adminLinksContainer);
+        Assert.assertTrue(String.format("Failed sanity check. Only found %s admin links. There should be more.", adminLinks.size()), adminLinks.size() > 10);
+        Map<String, String> linkHrefs = new HashMap<>();
+
+        for (WebElement link : adminLinks)
+        {
+            linkHrefs.put(link.getText(), link.getAttribute("href"));
+        }
+
+        List<String> pagesMissingNavTrail = new ArrayList<>();
+
+        for (Map.Entry<String, String> link : linkHrefs.entrySet())
+        {
+            if (ignoredLinks.contains(link.getKey()))
+            {
+                TestLogger.log("Skipping admin link: " + link.getKey());
+            }
+            else
+            {
+                TestLogger.log("Checking admin link: " + link.getKey());
+                beginAt(link.getValue());
+                if (!verifyNavTrail(false, "Admin Console"))
+                    pagesMissingNavTrail.add(link.getKey() + ": " + link.getValue());
+            }
+        }
+
+        pagesMissingNavTrail.sort(Comparator.naturalOrder());
+        Assert.assertTrue("The following " + pagesMissingNavTrail.size() + " pages are missing Admin Console navtrails:\n" + String.join("\n", pagesMissingNavTrail), pagesMissingNavTrail.isEmpty());
+    }
+
+    @Override
+    protected @Nullable String getProjectName()
+    {
+        return null;
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return null;
+    }
+}

--- a/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
@@ -29,7 +29,16 @@ public class AdminConsoleNavigationTest extends BaseWebDriverTest
     public void testAdminNavTrails()
     {
         Set<String> ignoredLinks = Collections.newSetFromMap(new CaseInsensitiveHashMap<>());
-        ignoredLinks.addAll(List.of("Dump Heap", "Reset Site Errors", "View All Site Errors", "View All Site Errors Since Reset", "View Primary Site Log File"));
+        ignoredLinks.addAll(List.of(
+            "LDAP Sync Admin",                  // An HTML view -- difficult to customize navtrail
+            "Change User Properties",           // Generic domain action -- difficult to customize navtrail
+            "Site-Wide Terms of Use",           // Standard wiki action -- difficult to customize navtrail
+            "Dump Heap",                        // Undesired consequences
+            "Reset Site Errors",                // Undesired consequences
+            "View All Site Errors",             // No nav trail
+            "View All Site Errors Since Reset", // No nav trail
+            "View Primary Site Log File"        // No nav trail
+        ));
         ShowAdminPage.beginAt(this);
         WebElement adminLinksContainer = Locator.id("links").findElement(getDriver()); // Maybe put this in 'ShowAdminPage'
         List<WebElement> adminLinks = Locator.tag("a").findElements(adminLinksContainer);

--- a/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-@Category({Git.class, BVT.class})
+@Category({Git.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
 public class AdminConsoleNavigationTest extends BaseWebDriverTest
 {

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -235,8 +235,8 @@ public class AdminConsoleTest extends BaseWebDriverTest
     @BeforeClass
     public static void doSetup() throws Exception
     {
-          AdminConsoleTest initTest = (AdminConsoleTest)getCurrentTest();
-          initTest.createTestUser();
+        AdminConsoleTest initTest = (AdminConsoleTest)getCurrentTest();
+        initTest.createTestUser();
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We want consistent navtrails for admin console pages. This test fails if any admin console link hits a page that lacks the expected navtrail.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1940