### PR TITLE
Add report and ETL to exercise 'RunReportTask'

### DIFF
--- a/modules/ETLtest/resources/ETLs/runReport.xml
+++ b/modules/ETLtest/resources/ETLs/runReport.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>Report ETL</name>
+    <description>run scheduled report</description>
+    <transforms>
+        <transform id="step1" type="TaskRefTransformStep">
+            <taskref ref="org.labkey.di.pipeline.RunReportTask">
+                <settings>
+                    <setting name="reportId" value="module:ETLtest/etlReport.R"/>
+                    <setting name="greeter" value="ETL"/>
+                </settings>
+            </taskref>
+        </transform>
+    </transforms>
+</etl>

--- a/modules/ETLtest/resources/reports/schemas/etlReport.R
+++ b/modules/ETLtest/resources/reports/schemas/etlReport.R
@@ -1,0 +1,1 @@
+cat('Hello, ', labkey.url.params$greeter, '!\n', sep='')


### PR DESCRIPTION
#### Rationale
This module is where all of the test ETLs live. The actual test will live in dataintegration.

#### Related Pull Requests
* LabKey/dataintegration#87
* LabKey/platform#1924

#### Changes
* Add `RunReportTask` ETL
