### PR TITLE
Conditionally apply new applyLicenses plugin

### DIFF
--- a/distributions/teamcity/build.gradle
+++ b/distributions/teamcity/build.gradle
@@ -9,6 +9,9 @@ plugins {
     id 'org.labkey.build.distribution'
 }
 
+if (!BuildUtils.isOpenSource(project))
+    apply plugin: 'org.labkey.build.applyLicenses'
+
 dist.description = "Distribution that includes all modules, for use in the continuous integration LabKey Server instance"
 
 project.task(


### PR DESCRIPTION
#### Rationale
We separated the distribution into two plugins so we can add the `patchApiModule` task only when needed.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/117

#### Changes
* Conditionally apply new `applyLicenses` plugin
