### PR TITLE
use case-insensitive text compare to await assay type button update

### DIFF
--- a/src/org/labkey/test/pages/assay/ChooseAssayTypePage.java
+++ b/src/org/labkey/test/pages/assay/ChooseAssayTypePage.java
@@ -62,8 +62,9 @@ public class ChooseAssayTypePage extends LabKeyPage<ChooseAssayTypePage.ElementC
         waitForElementToBeVisible(elementCache().specialtySelectLocator);
         selectOptionByText(elementCache().specialtySelect, name);
 
-        waitFor(()-> elementCache().selectButton.getText().toLowerCase().contains(name.toLowerCase()),
-            "took too long for the select button text to contain the assay name", 2000);
+        waitFor(()->
+           elementCache().selectButton.getText().toLowerCase().contains(name.toLowerCase()),
+            String.format("took too long for the select button text to contain the assay name [%s].", name), 2000);
 
         clickSelectButton();
         return new ReactAssayDesignerPage(getDriver());

--- a/src/org/labkey/test/pages/assay/ChooseAssayTypePage.java
+++ b/src/org/labkey/test/pages/assay/ChooseAssayTypePage.java
@@ -62,8 +62,8 @@ public class ChooseAssayTypePage extends LabKeyPage<ChooseAssayTypePage.ElementC
         waitForElementToBeVisible(elementCache().specialtySelectLocator);
         selectOptionByText(elementCache().specialtySelect, name);
 
-        waitFor(()-> elementCache().selectButton.getText().toLowerCase().contains(name),
-            "took too long to update", 2000);
+        waitFor(()-> elementCache().selectButton.getText().toLowerCase().contains(name.toLowerCase()),
+            "took too long for the select button text to contain the assay name", 2000);
 
         clickSelectButton();
         return new ReactAssayDesignerPage(getDriver());


### PR DESCRIPTION
#### Rationale
A recent change to ChooseAssayPage caused it to wait for the select assay type button to contain the name of the assay before clicking it, but erroneously did the text comparison in a case-sensitive manner.  This caused multiple test failures. This change updates that behavior to disregard case, but still wait for the button's update.

#### Related Pull Requests


#### Changes

