### PR TITLE
Add case insensitive locator for attribute value.

### DIFF
--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -547,6 +547,11 @@ public abstract class Locator extends By
         return tag(tag).withAttributeContaining(attrName, attrVal);
     }
 
+    public static XPathLocator tagWithAttributeIgnoreCase(String tag, String attrName, String attrVal)
+    {
+        return tag(tag).withAttributeIgnoreCase(attrName, attrVal);
+    }
+
     public static XPathLocator tagWithClass(String tag, String cssClass)
     {
         return tag(tag).withClass(cssClass);
@@ -1411,6 +1416,13 @@ public abstract class Locator extends By
         public XPathLocator withAttributeContaining(String attrName, String partialAttrVal)
         {
             return this.withPredicate("contains(@" + attrName + ", " + xq(partialAttrVal) + ")");
+        }
+
+        public XPathLocator withAttributeIgnoreCase(String attrName, String attrVal)
+        {
+            return this.withPredicate(
+                    String.format("translate(@%s, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')=%s",
+                            attrName, xq(attrVal.toLowerCase())));
         }
 
         public XPathLocator withoutAttribute(String attrName, String attrVal)

--- a/src/org/labkey/test/components/glassLibrary/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/glassLibrary/grids/DetailTableEdit.java
@@ -1,6 +1,6 @@
 package org.labkey.test.components.glassLibrary.grids;
 
-import org.eclipse.core.runtime.Assert;
+import org.junit.Assert;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.components.Component;
@@ -166,24 +166,17 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     {
 
         WebElement fieldValueElement = elementCache().fieldValue(fieldCaption).findElement(getComponentElement());
-        Assert.isTrue(isEditableField(fieldValueElement), String.format("Field '%s' is not editable, and cannot be set.", fieldCaption));
+        Assert.assertTrue(String.format("Field '%s' is not editable and cannot be set.", fieldCaption), isEditableField(fieldValueElement));
 
         // The text used in the field caption and the value of the name attribute in the checkbox don't always have the same case.
         WebElement editableElement = fieldValueElement.findElement(Locator.tagWithAttributeIgnoreCase("input", "name", fieldCaption));
         String elementType = editableElement.getAttribute("type").toLowerCase().trim();
 
-        Assert.isTrue(elementType.equals("checkbox"), String.format("Field '%s' is not a checkbox, cannot be set to true/false.", fieldCaption));
+        Assert.assertEquals(String.format("Field '%s' is not a checkbox. Cannot be set to true/false.", fieldCaption), "checkbox", elementType);
 
         Checkbox checkbox = new Checkbox(editableElement);
 
-        if(!value)
-        {
-            checkbox.uncheck();
-        }
-        else
-        {
-            checkbox.check();
-        }
+        checkbox.set(value);
 
         return this;
     }

--- a/src/org/labkey/test/components/glassLibrary/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/glassLibrary/grids/DetailTableEdit.java
@@ -1,5 +1,6 @@
 package org.labkey.test.components.glassLibrary.grids;
 
+import org.eclipse.core.runtime.Assert;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.components.Component;
@@ -164,38 +165,24 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     public DetailTableEdit setBooleanField(String fieldCaption, boolean value)
     {
 
-        if(isFieldEditable(fieldCaption))
+        WebElement fieldValueElement = elementCache().fieldValue(fieldCaption).findElement(getComponentElement());
+        Assert.isTrue(isEditableField(fieldValueElement), String.format("Field '%s' is not editable, and cannot be set.", fieldCaption));
+
+        // The text used in the field caption and the value of the name attribute in the checkbox don't always have the same case.
+        WebElement editableElement = fieldValueElement.findElement(Locator.tagWithAttributeIgnoreCase("input", "name", fieldCaption));
+        String elementType = editableElement.getAttribute("type").toLowerCase().trim();
+
+        Assert.isTrue(elementType.equals("checkbox"), String.format("Field '%s' is not a checkbox, cannot be set to true/false.", fieldCaption));
+
+        Checkbox checkbox = new Checkbox(editableElement);
+
+        if(!value)
         {
-
-            WebElement fieldValueElement = elementCache().fieldValue(fieldCaption).findElement(getComponentElement());
-
-            WebElement editableElement = fieldValueElement.findElement(Locator.tagWithName("input", fieldCaption.toLowerCase()));
-            String elementType = editableElement.getAttribute("type").toLowerCase().trim();
-
-            if(elementType.equals("checkbox"))
-            {
-                Checkbox checkbox = new Checkbox(editableElement);
-
-                if(checkbox.isChecked() && !value)
-                {
-                    // If value is false and the checkbox is checked, uncheck it.
-                    checkbox.check();
-                }
-                else if(!checkbox.isChecked() && value)
-                {
-                    // If value is true and the checkbox is not checked, check it.
-                    checkbox.check();
-                }
-
-            }
-            else
-            {
-                throw new NoSuchElementException("Field '" + fieldCaption + "' is not a checkbox, cannot be set to true/false.");
-            }
+            checkbox.uncheck();
         }
         else
         {
-            throw new IllegalArgumentException("Field with caption '" + fieldCaption + "' is read-only. This field can not be set.");
+            checkbox.check();
         }
 
         return this;


### PR DESCRIPTION
#### Rationale
Added a slightly less strict locator that will check an attribute value but ignore the case. Sometimes this can happen when a field (column) has a display name that is a different case from the column name (Field_1 vs. field_1). 

#### Related Pull Requests
* None

#### Changes
* Added a locator that ignores the case of an attribute value.
* Used the locator in the DetailTableEdit.setBooleanField.
* Cleaned up some other code in setBooleanField.
