### PR TITLE
set runInBackground=true

### DIFF
--- a/modules/ETLtest/resources/reports/schemas/etlReport.report.xml
+++ b/modules/ETLtest/resources/reports/schemas/etlReport.report.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ReportDescriptor descriptorType="rReportDescriptor" reportName="etlReport" xmlns="http://labkey.org/query/xml">
+    <Properties>
+        <Prop name="runInBackground">true</Prop>
+    </Properties>
+    <tags/>
+</ReportDescriptor>


### PR DESCRIPTION
#### Rationale
ETL RunReport now requires that runInBackground property is set to true.

#### Related PR
https://github.com/LabKey/commonAssays/pull/297
https://github.com/LabKey/dataintegration/pull/87
https://github.com/LabKey/platform/pull/1924
https://github.com/LabKey/testAutomation/pull/625
