### PR TITLE
Make getBooleanField like the setter.

### DIFF
--- a/src/org/labkey/test/components/glassLibrary/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/glassLibrary/grids/DetailTableEdit.java
@@ -152,7 +152,13 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
      **/
     public boolean getBooleanField(String fieldCaption)
     {
-        return new Checkbox(Locator.tagWithName("input", fieldCaption.toLowerCase()).findElement(getComponentElement())).isChecked();
+        // The text used in the field caption and the value of the name attribute in the checkbox don't always have the same case.
+        WebElement editableElement = Locator.tagWithAttributeIgnoreCase("input", "name", fieldCaption).findElement(getComponentElement());
+        String elementType = editableElement.getAttribute("type").toLowerCase().trim();
+
+        Assert.assertEquals(String.format("Field '%s' is not a checkbox. Cannot be get true/false value.", fieldCaption), "checkbox", elementType);
+
+        return new Checkbox(editableElement).isChecked();
     }
 
     /**


### PR DESCRIPTION
#### Rationale
Make getBooleanField like the setter. Remove the toLower call when getting the value of the name attribute.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/622 (already merged)

#### Changes
* Made the getter like the setter.
* Removed the call to lowercase the value of the name attribute.
