### PR TITLE
Fix filter for finding enabled options

### DIFF
--- a/src/org/labkey/test/pages/admin/RConfigurationPage.java
+++ b/src/org/labkey/test/pages/admin/RConfigurationPage.java
@@ -103,7 +103,10 @@ public class RConfigurationPage extends FolderManagementPage
     @NotNull
     private List<String> getEnabledOptions(List<WebElement> options)
     {
-        return options.stream().filter(WebElement::isEnabled).map(WebElement::getText).collect(Collectors.toList());
+        return options.stream()
+            .filter(el -> el.getAttribute("disabled") == null) // 'isEnabled' is false if parent <select> is disabled
+            .map(WebElement::getText)
+            .collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
`RConfigTest` attempts to verify the available options without actually modifying the configuration. The `select` that these `option`s are in is disabled, causing `isEnabled` to return false, which isn't the behavior we want.

#### Related Pull Requests
* #604 (instigating change)

#### Changes
* Filter select options by their `disabled` attribute instead of `WebElement.isEnabled`
