### PR TITLE
Issue 42420: Support source query filter via ETL XML

### DIFF
--- a/modules/ETLtest/resources/ETLs/SourceToTarget2WithFilter.xml
+++ b/modules/ETLtest/resources/ETLs/SourceToTarget2WithFilter.xml
@@ -1,26 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <etl xmlns="http://labkey.org/etl/xml" transactDestinationSchema="etltest">
-<name>Source to target with sourceFilter</name>
-<description>append rows from source to target with a sourceFilter</description>
-<transforms>
-    <transform id="step1" type="org.labkey.di.pipeline.TransformTask">
-        <description>Copy to target</description>
-        <source schemaName="etltest" queryName="source">
-            <sourceFilters>
-                <sourceFilter column="name" value="shouldEtl" operator="eq"/>
-            </sourceFilters>
-        </source>
-        <destination schemaName="etltest" queryName="target" />
-    </transform>
-    <transform id="step2" type="org.labkey.di.pipeline.TransformTask">
-        <description>Copy to target2</description>
-        <source schemaName="etltest" queryName="source" />
-        <destination schemaName="etltest" queryName="target2" />
-    </transform>
-</transforms>
-<!--<incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified">-->
-    <!--&lt;!&ndash;<deletedRowsSource schemaName="etltest" queryName="delete" deletedSourceKeyColumnName="id" timestampColumnName="rowversion" targetKeyColumnName="id"/>&ndash;&gt;-->
-<!--</incrementalFilter>-->
+    <name>Source to target with sourceFilter</name>
+    <description>append rows from source to target with a sourceFilter</description>
+    <transforms>
+        <transform id="step1" type="org.labkey.di.pipeline.TransformTask">
+            <description>Copy to target</description>
+            <source schemaName="etltest" queryName="source">
+                <sourceFilters>
+                    <sourceFilter column="name" value="Filter1" operator="eq"/>
+                </sourceFilters>
+            </source>
+            <destination schemaName="etltest" queryName="target" targetOption="merge">
+                <alternateKeys>
+                    <column name="id"/>
+                </alternateKeys>
+            </destination>
+        </transform>
+        <transform id="step2" type="org.labkey.di.pipeline.TransformTask">
+            <description>Copy to target2</description>
+            <source schemaName="etltest" queryName="source">
+                <sourceFilters>
+                    <sourceFilter column="name" value="Filter1;Filter2" operator="in" />
+                </sourceFilters>
+            </source>
+            <destination schemaName="etltest" queryName="target2" targetOption="merge">
+                <alternateKeys>
+                    <column name="id"/>
+                </alternateKeys>
+            </destination>
+        </transform>
+    </transforms>
+    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified" />
     <schedule>
         <poll interval="15s" />
     </schedule>

--- a/modules/ETLtest/resources/ETLs/SourceToTarget2WithFilter.xml
+++ b/modules/ETLtest/resources/ETLs/SourceToTarget2WithFilter.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml" transactDestinationSchema="etltest">
+<name>Source to target with sourceFilter</name>
+<description>append rows from source to target with a sourceFilter</description>
+<transforms>
+    <transform id="step1" type="org.labkey.di.pipeline.TransformTask">
+        <description>Copy to target</description>
+        <source schemaName="etltest" queryName="source">
+            <sourceFilters>
+                <sourceFilter column="name" value="shouldEtl" operator="eq"/>
+            </sourceFilters>
+        </source>
+        <destination schemaName="etltest" queryName="target" />
+    </transform>
+    <transform id="step2" type="org.labkey.di.pipeline.TransformTask">
+        <description>Copy to target2</description>
+        <source schemaName="etltest" queryName="source" />
+        <destination schemaName="etltest" queryName="target2" />
+    </transform>
+</transforms>
+<!--<incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified">-->
+    <!--&lt;!&ndash;<deletedRowsSource schemaName="etltest" queryName="delete" deletedSourceKeyColumnName="id" timestampColumnName="rowversion" targetKeyColumnName="id"/>&ndash;&gt;-->
+<!--</incrementalFilter>-->
+    <schedule>
+        <poll interval="15s" />
+    </schedule>
+</etl>

--- a/modules/ETLtest/resources/ETLs/remoteConnectionTargetMergeWithFilter.xml
+++ b/modules/ETLtest/resources/ETLs/remoteConnectionTargetMergeWithFilter.xml
@@ -1,0 +1,19 @@
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>Remote connection with target option and sourceFilter</name>
+    <description>User Defined ETL With Filter</description>
+    <transforms>
+        <transform id="step1forEditTest" type="org.labkey.di.pipeline.TransformTask">
+            <description>Copy to target via remote connection</description>
+            <source queryName="source" remoteSource="EtlTest_RemoteConnection" schemaName="etltest">
+                <sourceFilters>
+                    <sourceFilter column="name" operator="neqornull" value="Patient 17"/>
+                </sourceFilters>
+            </source>
+            <destination queryName="target2" schemaName="etltest" targetOption="merge"/>
+        </transform>
+    </transforms>
+    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified"/>
+    <schedule>
+        <poll interval="5s"/>
+    </schedule>
+</etl>


### PR DESCRIPTION
#### Rationale
To make it easier to create ETLs that run against a remote server where the ETL developer may not have permission to create custom queries, it's more convenient to allow the ETL definition to add filters to the source table/query.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1979
* https://github.com/LabKey/dataintegration/pull/90

#### Changes
* Add filters to ETL XSD
* Parse and propagate them
* Apply them when fetching the source data