### PR TITLE
Item 8335: App test fixes for removal of "Switch to LabKey" from the UserMenu

### DIFF
--- a/src/org/labkey/test/components/glassLibrary/navigation/UserMenu.java
+++ b/src/org/labkey/test/components/glassLibrary/navigation/UserMenu.java
@@ -26,12 +26,6 @@ public abstract class UserMenu extends BootstrapMenu
         return new MultiMenu.MultiMenuFinder(driver).withButtonId(MENU_ID).wrap(factory);
     }
 
-    protected LabKeyPage<?> switchToLabkey()
-    {
-        clickSubMenu(true, "Switch to LabKey");
-        return new LabKeyPage<>(getDriver());
-    }
-
     // TODO: Placeholder for product update
     protected LabKeyPage<?> login()
     {


### PR DESCRIPTION
#### Rationale
As part of the related PRs to add the LabKey product navigation header icon and menu, we are removing the "Switch to LabKey" menu item from the app navigation bar UserMenu component.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/88
* https://github.com/LabKey/labkey-ui-components/pull/447
* https://github.com/LabKey/biologics/pull/792
* https://github.com/LabKey/sampleManagement/pull/488
* https://github.com/LabKey/inventory/pull/190
* https://github.com/LabKey/platform/pull/2001
* https://github.com/LabKey/testAutomation/pull/638

#### Changes
* Remove UserMenu.switchToLabKey()
