### PR TITLE
Add Option Buttons for Derived or Pooled Sample Creation

### DIFF
--- a/src/org/labkey/test/components/glassLibrary/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/glassLibrary/grids/EditableGrid.java
@@ -119,6 +119,19 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         return this;
     }
 
+    public EditableGrid selectAll(boolean checked)
+    {
+        if(hasSelectColumn())
+        {
+            getWrapper().setCheckbox(elementCache().selectColumn.get(), checked);
+        }
+        else
+        {
+            throw new NoSuchElementException("There is no select checkbox for all rows.");
+        }
+        return this;
+    }
+
     private List<WebElement> getRows()
     {
         waitForLoaded();

--- a/src/org/labkey/test/components/ui/EntityBulkInsertDialog.java
+++ b/src/org/labkey/test/components/ui/EntityBulkInsertDialog.java
@@ -26,19 +26,45 @@ public class EntityBulkInsertDialog extends ModalDialog
         super(finder);
     }
 
+    /**
+     * Option at the top of the dialog to make the samples derive from the identified parents.
+     *
+     * @return A reference to this dialog.
+     */
     public EntityBulkInsertDialog selectDerivativesOption()
     {
         elementCache().derivativesOption.check();
         return this;
     }
 
+    /**
+     * Option at the top of the dialog to make the samples pool (aliquot) from the identified parents.
+     *
+     * @return A reference to this dialog.
+     */
     public EntityBulkInsertDialog selectPooledOption()
     {
         elementCache().poolOption.check();
         return this;
     }
 
-    public String getSelectedOption()
+    /**
+     * Check to see if the creation type options are displayed.
+     *
+     * @return True if either option is visible, false otherwise.
+     */
+    public boolean creationTypeOptionsVisible()
+    {
+        // Unlikely one option would be visible without the other.
+        return elementCache().poolOption.isDisplayed() || elementCache().derivativesOption.isDisplayed();
+    }
+
+    /**
+     * Get the text of the currently selected creation type. If the options are not present return an empty string.
+     *
+     * @return The text of the current selected creation type.
+     */
+    public String getCreationTypeSelected()
     {
         String option = "";
 
@@ -73,7 +99,12 @@ public class EntityBulkInsertDialog extends ModalDialog
         return getWrapper().getFormElement(elementCache().quantity);
     }
 
-    public String getQuanityLabel()
+    /**
+     * Get the label next to the quantity text box. This will change depending upon the creation option selected.
+     *
+     * @return The text of the label next to the quantity box.
+     */
+    public String getQuantityLabel()
     {
         return elementCache().quantityLabel.getText();
     }
@@ -114,7 +145,7 @@ public class EntityBulkInsertDialog extends ModalDialog
     public EntityBulkInsertDialog setSelectionField(String fieldCaption, List<String> selectValues)
     {
         FilteringReactSelect reactSelect = FilteringReactSelect.finder(getDriver()).followingLabelWithSpan(fieldCaption).find();
-        selectValues.forEach(s -> {reactSelect.filterSelect(s);});
+        selectValues.forEach(reactSelect::filterSelect);
         return this;
     }
 

--- a/src/org/labkey/test/components/ui/EntityBulkInsertDialog.java
+++ b/src/org/labkey/test/components/ui/EntityBulkInsertDialog.java
@@ -6,24 +6,55 @@ import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.components.glassLibrary.components.FilteringReactSelect;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
+import org.labkey.test.components.html.RadioButton;
 import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
 
 public class EntityBulkInsertDialog extends ModalDialog
 {
-    private EntityInsertPanel _panel;
 
-    public EntityBulkInsertDialog(EntityInsertPanel panel)
+    public EntityBulkInsertDialog(WebDriver driver)
     {
-        this(new ModalDialogFinder(panel.getDriver()).withTitle("Bulk Creation of"));
-        _panel = panel;
+        this(new ModalDialogFinder(driver).withTitle("Bulk Creation of"));
     }
 
     private EntityBulkInsertDialog(ModalDialogFinder finder)
     {
         super(finder);
+    }
+
+    public EntityBulkInsertDialog selectDerivativesOption()
+    {
+        elementCache().derivativesOption.check();
+        return this;
+    }
+
+    public EntityBulkInsertDialog selectPooledOption()
+    {
+        elementCache().poolOption.check();
+        return this;
+    }
+
+    public String getSelectedOption()
+    {
+        String option = "";
+
+        if(elementCache().derivativesOption.isDisplayed())
+        {
+            if(elementCache().derivativesOption.isChecked())
+            {
+                option = elementCache().derivativesOption.getComponentElement().getAttribute("value");
+            }
+            else
+            {
+                option = elementCache().poolOption.getComponentElement().getAttribute("value");
+            }
+        }
+
+        return option;
     }
 
     public EntityBulkInsertDialog setQuantity(int quantity)
@@ -40,6 +71,11 @@ public class EntityBulkInsertDialog extends ModalDialog
     public String getQuantity()
     {
         return getWrapper().getFormElement(elementCache().quantity);
+    }
+
+    public String getQuanityLabel()
+    {
+        return elementCache().quantityLabel.getText();
     }
 
     public EntityBulkInsertDialog setDescription(String description)
@@ -208,11 +244,19 @@ public class EntityBulkInsertDialog extends ModalDialog
         WebElement addRowsButton = Locator.tagWithClass("button", "test-loc-submit-for-edit-button")
                 .findWhenNeeded(getComponentElement());
 
+        WebElement quantityLabel = Locator.tagWithAttribute("label", "for", "numItems")
+                .findWhenNeeded(getComponentElement());
 
         WebElement quantity = Locator.tagWithId("input", "numItems")
                 .findWhenNeeded(getComponentElement());
 
         WebElement description = Locator.tagWithId("textarea", "Description")
+                .findWhenNeeded(getComponentElement());
+
+        RadioButton derivativesOption = new RadioButton.RadioButtonFinder().withNameAndValue("creationType", "Derivatives")
+                .findWhenNeeded(getComponentElement());
+
+        RadioButton poolOption = new RadioButton.RadioButtonFinder().withNameAndValue("creationType", "Pooled Samples")
                 .findWhenNeeded(getComponentElement());
 
         final Locator textInputLoc = Locator.tagWithAttribute("input", "type", "text");

--- a/src/org/labkey/test/components/ui/EntityBulkInsertDialog.java
+++ b/src/org/labkey/test/components/ui/EntityBulkInsertDialog.java
@@ -2,6 +2,7 @@ package org.labkey.test.components.ui;
 
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.components.glassLibrary.components.FilteringReactSelect;
 import org.labkey.test.components.html.Checkbox;
@@ -208,6 +209,19 @@ public class EntityBulkInsertDialog extends ModalDialog
         }
     }
 
+    /**
+     * Click the 'Add' button and wait for an alert (error) message to be shown on the dialog.
+     *
+     * @return The text displayed in the alert.
+     */
+    public String clickAddRowsExpectError()
+    {
+        elementCache().addRowsButton.click();
+        WebDriverWrapper.waitFor(()->elementCache().alert.isDisplayed(), "Expected alert error was not shown.", 500);
+
+        return elementCache().alert.getText();
+    }
+
     public void clickCancel()
     {
         elementCache().cancelButton.click();
@@ -288,6 +302,9 @@ public class EntityBulkInsertDialog extends ModalDialog
                 .findWhenNeeded(getComponentElement());
 
         RadioButton poolOption = new RadioButton.RadioButtonFinder().withNameAndValue("creationType", "Pooled Samples")
+                .findWhenNeeded(getComponentElement());
+
+        WebElement alert = Locator.tagWithClassContaining("div", "alert-danger")
                 .findWhenNeeded(getComponentElement());
 
         final Locator textInputLoc = Locator.tagWithAttribute("input", "type", "text");

--- a/src/org/labkey/test/components/ui/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/EntityInsertPanel.java
@@ -158,7 +158,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
     public EntityBulkInsertDialog clickBulkInsert()
     {
         elementCache().bulkInsert.click();
-        return new EntityBulkInsertDialog(this);
+        return new EntityBulkInsertDialog(getDriver());
     }
 
     public boolean isBulkInsertVisible()


### PR DESCRIPTION
#### Rationale
The bulk insert dialog has changed to have options when creating samples that have parents. The created samples can be derived (one sample per parent) or pooled (one sample multiple parents). These options are available to everyone but may not be turned on for everyone. Sample Manager will have them, Biologics does not have them yet.
<img width="1087" alt="Screen Shot 2021-02-17 at 10 01 58 AM" src="https://user-images.githubusercontent.com/12738200/108247673-cfcd9a80-7107-11eb-9aea-a81a1b771fa5.png">


#### Related Pull Requests
* None at this time.

#### Changes
* Added creation type option buttons and associated methods to the EntityBulkInsertDialog.
* Replaced parameter in EntityBulkInsertDialog constructor. Previous parameter was not used.
* Added a selectAll method to the editable grid. Used in SampleManager test for this feature.
