### PR TITLE
Fix 'rangeUri' for multi-line text fields

### DIFF
--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -311,7 +311,7 @@ public class FieldDefinition extends PropertyDescriptor
 
     public enum ColumnType
     {
-        MultiLine("Multi-Line Text", "string"),
+        MultiLine("Multi-Line Text", "multiLine"),
         Integer("Integer", "int"),
         String("Text", "string"),
         Subject("Subject/Participant", "string", "http://cpas.labkey.com/Study#ParticipantId", null),


### PR DESCRIPTION
#### Rationale
The 'rangeUri' for `FieldDefinition.ColumnType.MultiLine` was defined incorrectly and does not function correctly for creating multi-line text fields via API

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Use correct `rangeUri` for `FieldDefinition.ColumnType.MultiLine`
