### PR TITLE
Fix NPE in AssayQCTest

### DIFF
--- a/src/org/labkey/test/pages/study/CreateStudyPage.java
+++ b/src/org/labkey/test/pages/study/CreateStudyPage.java
@@ -94,13 +94,13 @@ public class CreateStudyPage extends LabKeyPage<CreateStudyPage.Elements>
     public LabKeyPage createStudy()
     {
         clickAndWait(elementCache().createStudyButton);
-        return null;
+        return new LabKeyPage(this);
     }
 
     public LabKeyPage cancel()
     {
         clickAndWait(elementCache().backButton);
-        return null;
+        return new LabKeyPage(this);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
`AssayQCTest` chains off of the `LabKeyPage` returned by `CreateStudyPage.createStudy`.

#### Related Pull Requests
* #643 

#### Changes
* Revert change to return null from `createStudy` and `cancel`
