### PR TITLE
Fix test expectation now that we're not double-logging errors

### DIFF
--- a/src/org/labkey/test/tests/flow/FlowTest.java
+++ b/src/org/labkey/test/tests/flow/FlowTest.java
@@ -788,7 +788,7 @@ public class FlowTest extends BaseFlowTest
 
         assertTitleContains(reportName);
         assertTextPresent(errorText);
-        checkExpectedErrors(2);
+        checkExpectedErrors(1);
 
         // Subsequent tests expect there to be no ERRORs in pipeline. Delete errored pipeline job
         PipelineStatusTable pipelineStatusTable = PipelineStatusTable.viewJobsForContainer(this, getContainerPath());


### PR DESCRIPTION
#### Rationale
In improving the behavior of RReportJob.Task, we're no longer double-logging the exception

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2029

#### Changes
* Only expect one error in the main log file