### PR TITLE
Update AdminConsoleTest now that app admins can't see the Environment…

### DIFF
--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -130,13 +130,11 @@ public class AdminConsoleTest extends BaseWebDriverTest
                 "credits",
                 "data sources",
                 "dump heap",
-                "environment variables",
                 "memory usage",
                 "queries",
                 "reset site errors",
                 "running threads",
                 "site validation",
-                "system properties",
                 "view all site errors",
                 "view all site errors since reset",
                 "view primary site log file"));
@@ -147,8 +145,19 @@ public class AdminConsoleTest extends BaseWebDriverTest
         assertTrue("Missing expected admin console links: " + expectedLinkTexts, expectedLinkTexts.isEmpty());
 
         // confirm that NONE of the following are visible to AppAdmin:
-        List<String> notShownLinks = Arrays.asList("files","flow cytometry","experimental features","mascot server",
-                "ldap sync admin","notification service","ms2", "check database", "loggers", "sql scripts");
+        List<String> notShownLinks = Arrays.asList(
+                "files",
+                "flow cytometry",
+                "experimental features",
+                "mascot server",
+                "ldap sync admin",
+                "notification service",
+                "ms2",
+                "check database",
+                "loggers",
+                "sql scripts",
+                "environment variables",
+                "system properties");
         for (String linkText: notShownLinks)
         {
             assertElementNotPresent(Locator.linkWithText(linkText));


### PR DESCRIPTION
… Variables or System Properties pages

#### Rationale
We changed these pages so that only Site Admins can see them for security reasons and updated one test but not this one

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2030

#### Changes
* Make sure App Admins can't see the links