### PR TITLE
Test fix for app NavBar menu-section-header locator

### DIFF
--- a/src/org/labkey/test/components/ui/navigation/ProductMenu.java
+++ b/src/org/labkey/test/components/ui/navigation/ProductMenu.java
@@ -129,7 +129,7 @@ public class ProductMenu extends BaseBootstrapMenu
 
         WebElement menuSectionHeader(String headerText)
         {
-            return Locator.byClass("menu-section-header").findElement(menuSection(headerText));
+            return Locator.byClass("menu-section-header").childTag("a").findElement(menuSection(headerText));
         }
 
         WebElement menuSectionBody(String headerText)


### PR DESCRIPTION
#### Rationale
Several SM tests are failing with the following error: `Element <span class="menu-section-header"> could not be scrolled into view`
See related changes in https://github.com/LabKey/labkey-ui-components/pull/453

#### Changes
* Update locator for ProductMenu.menuSection
