### PR TITLE
Issue 42496: Lingering General/GPAT terminology in UI after rename

### DIFF
--- a/src/org/labkey/test/AssayAPITest.java
+++ b/src/org/labkey/test/AssayAPITest.java
@@ -509,7 +509,7 @@ public class AssayAPITest extends BaseWebDriverTest
     {
         PlateDesignerPage.PlateDesignerParams params = new PlateDesignerPage.PlateDesignerParams(8, 12);
         params.setTemplateType("blank");
-        params.setAssayType("GPAT (General)");
+        params.setAssayType("Standard");
         PlateDesignerPage plateDesigner = PlateDesignerPage.beginAt(this,params);
 
         // create the sample well groups

--- a/src/org/labkey/test/tests/GpatAssayTest.java
+++ b/src/org/labkey/test/tests/GpatAssayTest.java
@@ -230,7 +230,7 @@ public class GpatAssayTest extends BaseWebDriverTest
         log("Create GPAT assay from " + dataFile.getName());
         _uploadHelper.uploadFile(dataFile);
         beginAt(WebTestHelper.buildURL("pipeline", getProjectName(), "browse"));
-        _fileBrowserHelper.importFile(dataFile.getName(), "Create New General Assay Design");
+        _fileBrowserHelper.importFile(dataFile.getName(), "Create New Standard Assay Design");
         waitForText(WAIT_FOR_JAVASCRIPT, "SpecimenID");
         if (assayName != null)
         {

--- a/src/org/labkey/test/tests/GpatPlateTemplateTest.java
+++ b/src/org/labkey/test/tests/GpatPlateTemplateTest.java
@@ -42,7 +42,7 @@ public class GpatPlateTemplateTest extends BaseWebDriverTest
         goToProjectHome();
         APIAssayHelper assayHelper = new APIAssayHelper(this);
         assayHelper.createAssayWithPlateSupport(ASSAY_NAME);
-        createPlateTemplate(templateName, "blank", "GPAT (General)");
+        createPlateTemplate(templateName, "blank", "Standard");
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We've renamed General assay to be Standard assay, and there are lingering references to the old name in the UI.

Since we want this for 21.3 I'll retarget before merging but this will get some test coverage underway

#### Related Pull Requests
https://github.com/LabKey/platform/pull/2045

#### Changes
* Introduce label for assay providers
* Use the label in a handful of UI text generating places
* Update some comments and metadata