### PR TITLE
support more than one menu-section per column

### DIFF
--- a/src/org/labkey/test/components/ui/navigation/ProductMenu.java
+++ b/src/org/labkey/test/components/ui/navigation/ProductMenu.java
@@ -5,8 +5,8 @@
 package org.labkey.test.components.ui.navigation;
 
 import org.labkey.test.Locator;
-import org.labkey.test.components.react.MultiMenu;
 import org.labkey.test.components.html.BaseBootstrapMenu;
+import org.labkey.test.components.react.MultiMenu;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -15,11 +15,11 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ProductMenu extends BaseBootstrapMenu
 {
-    private final static Locator MENU_CONTENT_LOC = Locator.tagWithClass("div", "product-menu-content");
-    private final static Locator MENU_SECTION_LOC = Locator.byClass("menu-section");
+    private final static Locator MENU_SECTION_HEADER_LOC = Locator.byClass("menu-section-header");
     private int expectedSectionCount = 1;
 
     protected ProductMenu(WebElement element, WebDriver driver)
@@ -35,11 +35,22 @@ public class ProductMenu extends BaseBootstrapMenu
     @Override
     protected boolean isExpanded()
     {
-        return super.isExpanded()
-                && elementCache().menuContent.isDisplayed()
-                && MENU_SECTION_LOC.findElements(this).size() >= getExpectedSectionCount();
+        boolean ariaExpanded = super.isExpanded();
+        boolean menuContentDisplayed = elementCache().menuContent.isDisplayed();
+        int headerSectionCount =  MENU_SECTION_HEADER_LOC.findElements(this).size();
+        int expectedHeaderSecionCount = getExpectedSectionCount();
+        getWrapper().log(String.format("product menu expansion state: aria-expanded is %b, menuContentDisplayed is %b, %d of %d expected header sections are present",
+                ariaExpanded, menuContentDisplayed, headerSectionCount, expectedHeaderSecionCount));
+
+        return  ariaExpanded && menuContentDisplayed && headerSectionCount >= expectedHeaderSecionCount;
     }
 
+    /**
+     * the number of menu sections is how many sections (not just columns) this menu will wait for before reporting
+     * that it is fully open
+     * @param expectedSectionCount the number of sections to expect
+     * @return the current instance
+     */
     public ProductMenu setExpectedSectionCount(int expectedSectionCount)
     {
         this.expectedSectionCount = expectedSectionCount;
@@ -55,7 +66,7 @@ public class ProductMenu extends BaseBootstrapMenu
     {
         expand();
         List<WebElement> headersElements = Locator.tagWithClass("span", "menu-section-header").findElements(this);
-        return getWrapper().getTexts(headersElements);
+        return getWrapper().getTexts(headersElements).stream().map(String::trim).collect(Collectors.toList());
     }
 
     public void clickMenuColumnHeader(String headerText)
@@ -120,31 +131,31 @@ public class ProductMenu extends BaseBootstrapMenu
         private final WebElement menuContent = Locator.tagWithClass("div", "product-menu-content").findWhenNeeded(this);
 
         private final Map<String, WebElement> menuSections = new HashMap<>();
-        WebElement menuSection(String headerText)
+        Locator.XPathLocator menuSectionHeaderLoc(String headerText)
         {
             return Locator.tagWithClass("div", "menu-section")
-                    .withChild(Locator.tagWithClass("span", "menu-section-header").withText(Locator.NBSP + headerText))
-                    .findElement(menuContent);
+                    .child(Locator.tagWithClass("span", "menu-section-header").withText(Locator.NBSP + headerText));
         }
 
         WebElement menuSectionHeader(String headerText)
         {
-            return Locator.byClass("menu-section-header").childTag("a").findElement(menuSection(headerText));
+            return menuSectionHeaderLoc(headerText).child(Locator.linkWithText(Locator.NBSP + headerText)).findElement(elementCache().menuContent);
         }
 
         WebElement menuSectionBody(String headerText)
         {
-            return Locator.xpath("./ul").findElement(menuSection(headerText));
+            return menuSectionHeaderLoc(headerText).followingSibling("ul").findElement(elementCache().menuContent);
         }
 
         WebElement menuSectionLink(String headerText, String linkText)
         {
-            return Locator.linkWithText(linkText).findElement(menuSection(headerText));
+            return Locator.linkWithText(linkText).findElement(menuSectionBody(headerText));
         }
 
         WebElement overFlowLink(String headerText)
         {
-            return Locator.byClass("overflow-link").findElement(menuSection(headerText));
+            return menuSectionHeaderLoc(headerText)
+                    .followingSibling("span").withClass("overflow-link").findElement(elementCache().menuContent);
         }
     }
 }


### PR DESCRIPTION
#### Rationale
This updates the productMenu component wrapper to correctly locate menu-sections (and their headers, and section contents) when there are more than one per menu column.  Biologics stacks its Workflow, Media, and Notebook sections in the far-right column and without this change, prior behavior found the "Workflow" element (or its children) whenever media or notebook were requested.

This enables regular ProductMenu methods to get section items and headers by name, when they share the same column:
![image](https://user-images.githubusercontent.com/16809856/109557208-a3f9cf80-7a8c-11eb-82cf-4ec17eb67c50.png)


#### Related Pull Requests
n/a

#### Changes
add logging to isExpanded to explain why it returns the status it does
update locators to distinguish menu-section-headers from menu columns
trim text contents of section-header element texts
