### PR TITLE
Update bulk insert dialog to allow titles not specific to Samples

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
@@ -20,12 +20,7 @@ public class EntityBulkInsertDialog extends ModalDialog
 
     public EntityBulkInsertDialog(WebDriver driver)
     {
-        this(new ModalDialogFinder(driver).withTitle("Bulk Creation of"));
-    }
-
-    public EntityBulkInsertDialog(WebDriver driver, String dialogTitle)
-    {
-        this(new ModalDialogFinder(driver).withTitle(dialogTitle));
+        this(new ModalDialogFinder(driver).withTitle("Bulk"));
     }
 
     private EntityBulkInsertDialog(ModalDialogFinder finder)

--- a/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
@@ -4,10 +4,10 @@ import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.bootstrap.ModalDialog;
-import org.labkey.test.components.react.FilteringReactSelect;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.html.RadioButton;
+import org.labkey.test.components.react.FilteringReactSelect;
 import org.labkey.test.components.react.ReactDatePicker;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
@@ -21,6 +21,11 @@ public class EntityBulkInsertDialog extends ModalDialog
     public EntityBulkInsertDialog(WebDriver driver)
     {
         this(new ModalDialogFinder(driver).withTitle("Bulk Creation of"));
+    }
+
+    public EntityBulkInsertDialog(WebDriver driver, String dialogTitle)
+    {
+        this(new ModalDialogFinder(driver).withTitle(dialogTitle));
     }
 
     private EntityBulkInsertDialog(ModalDialogFinder finder)

--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -155,10 +155,10 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
         return this;
     }
 
-    public EntityBulkInsertDialog clickBulkInsert(String insertDialogTitle)
+    public EntityBulkInsertDialog clickBulkInsert()
     {
         elementCache().bulkInsert.click();
-        return new EntityBulkInsertDialog(getDriver(), insertDialogTitle);
+        return new EntityBulkInsertDialog(getDriver());
     }
 
     public boolean isBulkInsertVisible()

--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -155,10 +155,10 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
         return this;
     }
 
-    public EntityBulkInsertDialog clickBulkInsert()
+    public EntityBulkInsertDialog clickBulkInsert(String insertDialogTitle)
     {
         elementCache().bulkInsert.click();
-        return new EntityBulkInsertDialog(getDriver());
+        return new EntityBulkInsertDialog(getDriver(), insertDialogTitle);
     }
 
     public boolean isBulkInsertVisible()


### PR DESCRIPTION
#### Rationale
To support entity bulk insert of assay run data, the EntityBulkInsertDialog can't have a hard-coded title specific to SampleTypes.  This parameterizes the title of this shared component wrapper, and calls for updating calling page classes.

#### Related Pull Requests
Biologics https://github.com/LabKey/biologics/pull/816
SampleManager https://github.com/LabKey/sampleManagement/pull/508

#### Changes
Allow the caller to specify the title of the EntityBulkInsertDialog
