### PR TITLE
Issue 42386: Don't show reserved fields as inferred fields

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -317,6 +317,11 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
         return getPanelAlertWebElement().getText();
     }
 
+    public String getPanelAlertText(int index)
+    {
+        return getPanelAlertWebElement(index).getText();
+    }
+
     /**
      * There may be an element in the alert that a test will need to interact with so return the alert element and let
      * the test find the control it needs.
@@ -324,12 +329,19 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
      */
     public WebElement getPanelAlertWebElement()
     {
+        return getPanelAlertWebElement(0);
+    }
+
+    public WebElement getPanelAlertWebElement(int index)
+    {
+
         getWrapper().waitFor(()-> BootstrapLocators.infoBanner.existsIn(getDriver()),
                 "the info alert did not appear as expected", 1000);
 
         // It would be better to not return a raw WebElement but who knows what the future holds, different alerts
         // may show different controls.
-        return BootstrapLocators.infoBanner.existsIn(getDriver()) ? BootstrapLocators.infoBanner.findElement(getDriver()) : null;
+        return BootstrapLocators.infoBanner.existsIn(getDriver()) ?
+                BootstrapLocators.infoBanner.findElements(getDriver()).get(index) : null;
     }
 
     @Override

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -334,14 +334,12 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
 
     public WebElement getPanelAlertWebElement(int index)
     {
-
         getWrapper().waitFor(()-> BootstrapLocators.infoBanner.existsIn(getDriver()),
                 "the info alert did not appear as expected", 1000);
 
         // It would be better to not return a raw WebElement but who knows what the future holds, different alerts
         // may show different controls.
-        return BootstrapLocators.infoBanner.existsIn(getDriver()) ?
-                BootstrapLocators.infoBanner.findElements(getDriver()).get(index) : null;
+        return BootstrapLocators.infoBanner.index(index).findOptionalElement(this).orElse(null);
     }
 
     @Override

--- a/src/org/labkey/test/tests/DataClassTest.java
+++ b/src/org/labkey/test/tests/DataClassTest.java
@@ -160,7 +160,6 @@ public class DataClassTest extends BaseWebDriverTest
         createPage.clickSave();
         DataRegionTable drt = DataRegion(getDriver()).find();
         checker().verifyTrue("Data class not found in list of data classes", drt.getColumnDataAsText("Name").contains(name));
-        log("End of test.");
     }
 
     @Test

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -68,6 +68,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.DataRegionTable.DataRegion;
 
 @Category({DailyC.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 20)
@@ -1241,6 +1242,42 @@ public class SampleTypeTest extends BaseWebDriverTest
                 Arrays.asList("The SampleId field name is reserved for imported or generated sample ids."),
                 createPage.clickSaveExpectingErrors());
         domainFormPanel.removeAllFields(false);
+    }
+
+    @Test
+    public void testIgnoreReservedFieldNames()
+    {
+        final String expectedInfoMsg = "Reserved fields found in your file are not shown below. " +
+                "These fields are already used by LabKey to support this sample type: " +
+                "Name, Created, createdBy, Modified, modifiedBy, container, created, createdby, modified, modifiedBy, Container, SampleId, SampleID.";
+
+        List<String> lines = new ArrayList<>();
+        lines.add("Name,TextField1,DecField1,DateField1,Created,createdBy,Modified,modifiedBy,container,SampleId,created,createdby,modified,modifiedBy,Container,SampleID");
+
+        if (!TestFileUtils.getTestTempDir().exists())
+            TestFileUtils.getTestTempDir().mkdirs();
+        File inferenceFile = TestFileUtils.saveFile(TestFileUtils.getTestTempDir(), "InferFieldsForSampleType.csv", String.join(System.lineSeparator(), lines));
+
+        log("Create a Sample Type.");
+        SampleTypeHelper sampleHelper = new SampleTypeHelper(this);
+
+        clickProject(PROJECT_NAME);
+        String name = "Infer Fields";
+        CreateSampleTypePage createPage = sampleHelper
+                .goToCreateNewSampleType()
+                .setName(name);
+
+        log("Infer fields from a file that contains some reserved fields.");
+
+        DomainFormPanel domainForm = createPage
+                .getFieldsPanel()
+                .setInferFieldFile(inferenceFile);
+        checker().verifyEquals("Reserved field warning not as expected",  expectedInfoMsg, domainForm.getPanelAlertText());
+        createPage.clickSave();
+        DataRegionTable drt = DataRegion(getDriver()).find();
+        checker().verifyTrue("Sample type not found in list of sample types", drt.getColumnDataAsText("Name").contains(name));
+
+        log("End of test.");
     }
 
     @Test

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -958,6 +958,38 @@ public class ListTest extends BaseWebDriverTest
         listDefinitionPage.clickSave();
     }
 
+    @Test
+    public void testIgnoreReservedFieldNames()
+    {
+        final String expectedInfoMsg = "Reserved fields found in your file are not shown below. " +
+                "These fields are already used by LabKey: " +
+                "Created, createdBy, Modified, modifiedBy, container, created, createdby, modified, modifiedBy, Container.";
+
+        List<String> lines = new ArrayList<>();
+        lines.add("Name,TextField1,DecField1,DateField1,Created,createdBy,Modified,modifiedBy,container,created,createdby,modified,modifiedBy,Container,SampleID");
+
+        if (!TestFileUtils.getTestTempDir().exists())
+            TestFileUtils.getTestTempDir().mkdirs();
+        File inferenceFile = TestFileUtils.saveFile(TestFileUtils.getTestTempDir(), "InferFieldsForList.csv", String.join(System.lineSeparator(), lines));
+
+        goToProjectHome();
+
+        String name = "Ignore Reserved Fields List";
+
+        log("Infer fields from a file that contains some reserved fields.");
+        EditListDefinitionPage listEditPage = _listHelper.beginCreateList(PROJECT_VERIFY, name);
+        DomainFormPanel domainForm = listEditPage.getFieldsPanel()
+                .setInferFieldFile(inferenceFile);
+
+        checker().verifyEquals("Reserved field warning not as expected",  expectedInfoMsg, domainForm.getPanelAlertText(1));
+        listEditPage.selectAutoIntegerKeyField();
+        listEditPage.clickSave();
+        goToProjectHome();
+        checker().verifyTrue("Link to new list not present", Locator.linkWithText(name).existsIn(getDriver()));
+
+        log("End of test.");
+    }
+
     @LogMethod
     private void customFormattingTest()
     {

--- a/src/org/labkey/test/util/ListHelper.java
+++ b/src/org/labkey/test/util/ListHelper.java
@@ -298,18 +298,22 @@ public class ListHelper extends LabKeySiteWrapper
 
     public void createListFromFile(String containerPath, String listName, File inputFile)
     {
+        inferFieldsFromFile(containerPath, listName, inputFile)
+                .clickSave(); // assumes we intend to import from file
+    }
+
+    public EditListDefinitionPage inferFieldsFromFile(String containerPath, String listName, File inputFile)
+    {
         EditListDefinitionPage listEditPage = beginCreateList(containerPath, listName);
         listEditPage.getFieldsPanel()
-            .setInferFieldFile(inputFile);
+                .setInferFieldFile(inputFile);
 
         // assumes we intend to key on auto-integer
         DomainFieldRow keyRow = listEditPage.getFieldsPanel().getField("Key");
         if (keyRow != null)
             keyRow.clickRemoveField(false);
         listEditPage.selectAutoIntegerKeyField();
-
-        // assumes we intend to import from file
-        listEditPage.clickSave();
+        return listEditPage;
     }
 
     /**


### PR DESCRIPTION
#### Rationale
When inferring fields from an uploaded file, the file may reasonably contain some of the fields that are reserved and will already be created for a particular domain.  Currently, the user has to remove these fields manually after the server infers the full set of fields.  We change this so we will display a message indicating that some fields in the file were recognized as reserved and thus not included in the field listing.  Thus a user has a better chance of creating (or updating) a domain successfully the first time through.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2064
* https://github.com/LabKey/labkey-ui-components/pull/463
* https://github.com/LabKey/sampleManagement/pull/506

#### Changes
* Add test for list, sample type, and data class that assure we are ignoring reserved fields when inferring from a file for each of these domains.  
* Assay result domain is covered by a test in Sample Manager.  See the related PR.
