### PR TITLE
Improve crawler error message and exclude download action

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -193,6 +193,7 @@ public class Crawler
             new ControllerActionId("login", "setPassword"),
             new ControllerActionId("login", "verifyToken"), // returns XML, which WDW.waitForPageToLoad can't handle
             new ControllerActionId("luminex", "exportDefaultValues"), // download action
+            new ControllerActionId("ms2", "exportProteinCoverageMap"),
             new ControllerActionId("ms2", "pepSearch"), // TODO: 36995: Check for SQL injection in StatementWrapper is not precise enough
             new ControllerActionId("ms2", "showList"),
             new ControllerActionId("ms2", "showParamsFile"),
@@ -1098,7 +1099,9 @@ public class Crawler
             if (rethrow instanceof AssertionError)
                 throw rethrow; // AssertionErrors already contain page and origin information.
             else
-                throw new RuntimeException(relativeURL + "\nTriggered an exception." + originMessage, rethrow);
+                throw new RuntimeException("Crawler triggered " + rethrow.getClass().getSimpleName() + ".\n" +
+                    "Target page: " + relativeURL + "\n" +
+                    originMessage, rethrow);
         }
 
         if (currentPageUrl != null && urlToCheck.isInjectableURL() && _injectionCheckEnabled)

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -1099,7 +1099,7 @@ public class Crawler
             if (rethrow instanceof AssertionError)
                 throw rethrow; // AssertionErrors already contain page and origin information.
             else
-                throw new RuntimeException("Crawler triggered " + rethrow.getClass().getSimpleName() + ".\n" +
+                throw new RuntimeException("Crawler threw " + rethrow.getClass().getSimpleName() + ".\n" +
                     "Target page: " + relativeURL + "\n" +
                     originMessage, rethrow);
         }


### PR DESCRIPTION
#### Rationale
The old error message was not clear that the error was thrown by the test, not a product-side error.

#### Changes
* Clarify the source of errors thrown within the crawler itself
* Exclude `ms2-exportProteinCoverageMap` from crawler
