### PR TITLE
Fix SpecimenTest failure

### DIFF
--- a/src/org/labkey/test/pages/study/specimen/ManageNotificationsPage.java
+++ b/src/org/labkey/test/pages/study/specimen/ManageNotificationsPage.java
@@ -108,6 +108,16 @@ public class ManageNotificationsPage extends LabKeyPage<ManageNotificationsPage.
 
     public void clickSave()
     {
+        // Wait for auto-complete text areas to render
+        if (elementCache().newRequestNotifyCheckbox.isChecked())
+        {
+            shortWait().until(ExpectedConditions.visibilityOf(elementCache().newRequestNotifyInput.getComponentElement()));
+        }
+        if (elementCache().ccCheckbox.isChecked())
+        {
+            shortWait().until(ExpectedConditions.visibilityOf(elementCache().ccInput.getComponentElement()));
+        }
+
         clickAndWait(elementCache().saveButton);
     }
 


### PR DESCRIPTION
#### Rationale
`SpecimenTest` reconfigures notification settings a couple of times but sometimes it doesn't stick. This is due to the way the form on this page works. There is a fancy input on the page that takes a moment to render. If the test clicks save before the input is there, it submits an empty value, which produces the error below. Waiting for the input to render before clicking save should remedy this.

#### Changes
* Wait for form to render before clicking "Save"

![image](https://user-images.githubusercontent.com/5263798/110718848-9d700400-81c0-11eb-9025-ca8fe9c6413d.png)
