### PR TITLE
Wait for triggered page load to finish

### DIFF
--- a/src/org/labkey/test/tests/StudySurveyTest.java
+++ b/src/org/labkey/test/tests/StudySurveyTest.java
@@ -91,9 +91,11 @@ public class StudySurveyTest extends BaseWebDriverTest
         setFormElement(Locator.name("_surveyLabel_"), surveyLabel);
         setFormElement(Locator.name("participantid"), "1");
         setFormElement(Locator.name("date"), getDate(0));
-        clickButton("Submit completed form", 0);
-        _extHelper.waitForExtDialog("Success");
-        _extHelper.waitForExtDialogToDisappear("Success");
+        doAndWaitForPageToLoad(() ->
+        {
+            clickButton("Submit completed form", 0);
+            _extHelper.waitForExtDialog("Success");
+        });
 
         String newDate = getDate(2);
         goToProjectHome();


### PR DESCRIPTION
#### Rationale
When tests don't wait for page loads that happen, tests can start interacting with the page just before it navigates and fail when the page state changes out from under it.

#### Changes
* Wait for page to load
