### PR TITLE
Increase timeout for knitr report

### DIFF
--- a/src/org/labkey/test/tests/AbstractKnitrReportTest.java
+++ b/src/org/labkey/test/tests/AbstractKnitrReportTest.java
@@ -200,7 +200,7 @@ public abstract class AbstractKnitrReportTest extends BaseWebDriverTest
         clickProject(getProjectName());
         _ext4Helper.waitForMaskToDisappear();
         waitAndClickAndWait(Locator.linkWithText("kable"));
-        _ext4Helper.waitForMaskToDisappear(2 * BaseWebDriverTest.WAIT_FOR_JAVASCRIPT);
+        _ext4Helper.waitForMaskToDisappear(3 * BaseWebDriverTest.WAIT_FOR_JAVASCRIPT);
         waitForElement(Locator.id("mtcars_table_wrapper"));
     }
 }


### PR DESCRIPTION
#### Rationale
Knitr just needs a little extra time to render reports sometimes.

#### Changes
* Increase timeout for knitr report
