### PR TITLE
Fail faster if pipeline job doesn't hit expected state

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -2058,25 +2058,32 @@ public abstract class WebDriverWrapper implements WrapsDriver
         return checker.get();
     }
 
-    public void waitForEquals(String message, Supplier expected, Supplier actual, int wait)
+    public static void waitForEquals(String message, Supplier<?> expected, Supplier<?> actual, int wait)
     {
-        waitFor(() -> Objects.equals(expected.get(), actual.get()), wait);
-
-        assertEquals(message, expected.get(), actual.get());
+        if (!waitFor(() -> Objects.equals(expected.get(), actual.get()), wait))
+        {
+            assertEquals(message, expected.get(), actual.get());
+        }
     }
 
-    public void waitForNotEquals(String message, Supplier expected, Supplier actual, int wait)
+    public static void waitForNotEquals(String message, Supplier<?> expected, Supplier<?> actual, int wait)
     {
-        waitFor(() -> !Objects.equals(expected.get(), actual.get()), wait);
-
-        assertNotEquals(message, expected.get(), actual.get());
+        if (!waitFor(() -> !Objects.equals(expected.get(), actual.get()), wait))
+        {
+            assertNotEquals(message, expected.get(), actual.get());
+        }
     }
 
     public static void waitFor(Supplier<Boolean> checker, String failMessage, int wait)
     {
+        waitFor(checker, () -> failMessage, wait);
+    }
+
+    public static void waitFor(Supplier<Boolean> checker, Supplier<String> failMessage, int wait)
+    {
         if (!waitFor(checker, wait))
         {
-            throw new TimeoutException(failMessage + TestLogger.formatElapsedTime(wait));
+            throw new TimeoutException(failMessage.get() + TestLogger.formatElapsedTime(wait));
         }
     }
 

--- a/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
+++ b/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
@@ -117,18 +117,8 @@ public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsP
     @LogMethod
     public PipelineStatusDetailsPage waitForStatus(String status, int wait)
     {
-        waitFor(() -> status.equals(getStatus()),
-                "Expected status '" + status + "', but was '" + getStatus() + "'",
-                wait);
-        return this;
-    }
-
-    @LogMethod
-    public PipelineStatusDetailsPage waitForStatus(Set<String> status, int wait)
-    {
-        waitFor(() -> status.contains(getStatus()),
-                "Expected status to be one of '" + StringUtils.join(status, "', '") + "'",
-                wait);
+        waitForFinish(wait);
+        assertStatus(status);
         return this;
     }
 
@@ -137,7 +127,15 @@ public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsP
      */
     public PipelineStatusDetailsPage waitForFinish()
     {
-        waitForStatus(FINISHED_STATES, DEFAULT_PIPELINE_WAIT);
+        return waitForFinish(DEFAULT_PIPELINE_WAIT);
+    }
+
+    /**
+     * Wait for job to finish: status is either COMPLETE, ERROR, or CANCELLED
+     */
+    public PipelineStatusDetailsPage waitForFinish(int timoutMs)
+    {
+        waitFor(() -> FINISHED_STATES.contains(getStatus()), () -> "Pipeline job did not finish. Final state: " + getStatus(), timoutMs);
         return this;
     }
 


### PR DESCRIPTION
#### Rationale
`PipelineStatusDetailsPage` can wait for a job to reach particular state but we only really want to wait for terminal states (`COMPLETE`, `ERROR`, `CANCELLED`). Otherwise, tests might wait in vain for a job that has already finished with an unwanted status.

#### Changes
* Make `PipelineStatusDetailsPage. waitForStatus` stop waiting as soon as a terminal status has been reached.
* Add `waitFor` method that takes an error message supplier so that error messages can be generated at the time of failure.
