### PR TITLE
Use existing components to create linked schema

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -2061,13 +2061,15 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     }
 
     // Careful: If baseQueryName isn't provided, the first table in the schema will be used as the base query.
-    public void createNewQuery(@NotNull String schemaName, @Nullable String baseQueryName)
+    public NewQueryPage createNewQuery(@NotNull String schemaName, @Nullable String baseQueryName)
     {
         if (baseQueryName != null)
             selectQuery(schemaName, baseQueryName);
         else
             selectSchema(schemaName);
         clickAndWait(Locator.xpath("//a[contains(@class, 'x4-btn')]//span[contains(text(), 'Create New Query')]"));
+
+        return new NewQueryPage(getDriver());
     }
 
 

--- a/src/org/labkey/test/pages/query/SourceQueryPage.java
+++ b/src/org/labkey/test/pages/query/SourceQueryPage.java
@@ -82,6 +82,12 @@ public class SourceQueryPage extends LabKeyPage<SourceQueryPage.ElementCache>
         return this;
     }
 
+    public ExecuteQueryPage clickSaveAndFinish()
+    {
+        clickAndWait(Ext4Helper.Locators.ext4Button("Save & Finish").findElement(getDriver()));
+        return new ExecuteQueryPage(getDriver());
+    }
+
     @Override
     protected ElementCache newElementCache()
     {

--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -898,16 +898,11 @@ public class LinkedSchemaTest extends BaseWebDriverTest
 
         goToSchemaBrowser();
 
-        createNewQuery(schemaName, tableName);
-
-        waitForElement(Locator.xpath("//input[@name='ff_newQueryName']"));
-        setFormElement(Locator.xpath("//input[@name='ff_newQueryName']"), queryName);
-        click(Locator.xpath("//select[@name='ff_baseTableName']"));
-
-        clickButton("Create and Edit Source");
-        Locator saveAndFinishBtn = Locator.tagWithClass("span", "x4-btn-button").withChild(Locator.tagWithText("span", "Save & Finish"));
-        waitForElement(saveAndFinishBtn);
-        clickAndWait(saveAndFinishBtn);
+        createNewQuery(schemaName, tableName)
+            .setName(queryName)
+            .setBaseTable(tableName)
+            .clickCreate()
+            .clickSaveAndFinish();
     }
 
 }


### PR DESCRIPTION
#### Rationale
`LinkedSchemaTest` was hitting some intermittent failures. There are existing test components for the actions that it was failing on.

#### Changes
* Update `LinkedSchemaTest` use existing components to create linked schema
