### PR TITLE
Update entity insert components

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
@@ -14,6 +14,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
+import java.util.Optional;
 
 public class EntityBulkInsertDialog extends ModalDialog
 {
@@ -192,6 +193,18 @@ public class EntityBulkInsertDialog extends ModalDialog
         return elementCache().checkBox(fieldKey).get();
     }
 
+    public Optional<WebElement> validationMessage()
+    {
+        return elementCache().validationMessage.findOptionalElement(this);
+    }
+
+    public String waitForValidationError()
+    {
+        WebDriverWrapper.waitFor(()-> validationMessage().isPresent(),
+                "Field validation error did not appear", 2000);
+        return validationMessage().get().getText();
+    }
+
     public void clickAddRows()
     {
         elementCache().addRowsButton.click();
@@ -253,6 +266,8 @@ public class EntityBulkInsertDialog extends ModalDialog
 
     protected class ElementCache extends ModalDialog.ElementCache
     {
+        public Locator validationMessage = Locator.tagWithClass("span", "validation-message");
+
         public WebElement formRow(String fieldKey)
         {
             return Locator.tagWithClass("div", "row")

--- a/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
@@ -193,11 +193,20 @@ public class EntityBulkInsertDialog extends ModalDialog
         return elementCache().checkBox(fieldKey).get();
     }
 
+    /**
+     * Finds a validation/error message in the dialog, if one exists.
+     * @return
+     */
     public Optional<WebElement> validationMessage()
     {
         return elementCache().validationMessage.findOptionalElement(this);
     }
 
+    /**
+     * Gets the text value of an error/warning message in the dialog, if it exists within 2 seconds.
+     * Treats non-existence of the error message as a failure
+     * @return
+     */
     public String waitForValidationError()
     {
         WebDriverWrapper.waitFor(()-> validationMessage().isPresent(),

--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -8,9 +8,12 @@ import org.labkey.test.components.ui.grids.EditableGrid;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.List;
 import java.util.Map;
+
+import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 
 /**
  * This class automates the UI component defined in <a href="https://github.com/LabKey/labkey-ui-components/blob/master/packages/components/src/components/entities/EntityInsertPanel.tsx">components/entities/EntityInsertPanel.tsx</a>
@@ -47,6 +50,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     public EntityInsertPanel addParent(String label, String parentType)
     {
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().addParent));
         elementCache().addParent.click();
         getEntityTypeSelect(label).select(parentType);
         return this;
@@ -157,6 +161,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     public EntityBulkInsertDialog clickBulkInsert()
     {
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().bulkInsert));
         elementCache().bulkInsert.click();
         return new EntityBulkInsertDialog(getDriver());
     }
@@ -211,7 +216,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
         WebElement bulkInsert = Locator.button("Bulk Insert").findWhenNeeded(this);
         WebElement bulkUpdate = Locator.button("Bulk update").findWhenNeeded(this);
         WebElement deleteRows = deleteRowsBtnLoc.findWhenNeeded(this);
-        EditableGrid grid = new EditableGrid.EditableGridFinder(_driver).findWhenNeeded();
+        EditableGrid grid = new EditableGrid.EditableGridFinder(_driver).timeout(WAIT_FOR_JAVASCRIPT).findWhenNeeded();
         WebElement addRowsTxtBox = Locator.tagWithName("input", "addCount").findWhenNeeded(this);
         WebElement addRowsButton = Locator.buttonContainingText("Add").findWhenNeeded(this);
 


### PR DESCRIPTION
#### Rationale
This updates `EntityInsertPanel `to wait to be loaded while instantiating, and hopefully surfaces the fileUpload panel for that mode of its function.  It also adds a finder/wait to the BulkInsertDialog to support finding error/warning messages

#### Related Pull Requests
https://github.com/LabKey/biologics/tree/fb_bio_media_sample_crud
This is a product feature branch that migrates Biologics to use the FileUpload components for rawMaterials (like it does Samples) and retire its older sampleTypeUploadPage.
![image](https://user-images.githubusercontent.com/16809856/110973829-9eb14600-8312-11eb-9e6f-ad6c3b9b881d.png)


#### Changes
Promote Grid getter to be a class function vs. being a member of the elementCache- having it outside of the cache allows us to use cache initialization as the gate to make the component waitforLoaded

Some past iteration of the component appears to have dropped support for the FileUpload mode of its operation, this will hopefully restore that.  This introduces the notion of selecting the input operational mode (grid, or file) and surfacing the fileUploadPanel as a subcomponent 
![image](https://user-images.githubusercontent.com/16809856/110973748-7cb7c380-8312-11eb-8e17-a276d7ed7947.png)


Adds the ability for Bulk Insert dialog to report when it has an input warning: 
![image](https://user-images.githubusercontent.com/16809856/110973590-47ab7100-8312-11eb-8cd5-81b12842abd7.png)
