### PR TITLE
Fix JavDoc Build Breaks in TestAutomation

### DIFF
--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -13,6 +13,8 @@ import org.openqa.selenium.WebElement;
 
 import java.util.List;
 
+// Replacing the @see org.labkey.test.pages.samplemanagement.... for now. The javadoc compiler cannot resolve the
+// reference to the module. Don't have time to investigate a fix for this pr.
 /**
  * <p>
  * This is a base class for the edit lineage panels that are shown on the sample overview page. Samples can have two
@@ -23,11 +25,10 @@ import java.util.List;
  * <p>
  *  It is not intended that this base class to be exposed directly from a page. Rather the derived classes
  *  EditParentsPanel and EditSourcesPanel are the classes that should be exposed on the form.
- * @see org.labkey.test.pages.samplemanagement.samples.EditParentsPanel
- * @see org.labkey.test.pages.samplemanagement.samples.EditSourcesPanel
+ *  </p>
+ * <p>see org.labkey.test.pages.samplemanagement.samples.EditParentsPanel</p>
+ * <p>see org.labkey.test.pages.samplemanagement.samples.EditSourcesPanel</p>
  * @see <a href="https://github.com/LabKey/labkey-ui-components/blob/master/packages/components/src/components/entities/ParentEntityEditPanel.tsx">ParentEntityEditPanel.tsx</a>
- *
- * </p>
  */
 public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPanel.ElementCache>
 {

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -433,7 +433,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
 
     /**
      *
-     * @return  a List<String> containing the text of each column header
+     * @return a List&#60;String&#62; containing the text of each column header
      */
     public List getColumnNames()
     {
@@ -480,7 +480,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
 
     /**
      *
-     * @return a list of Map<String, String> containing keys and values for each row
+     * @return a list of Map&#60;String, String&#62; containing keys and values for each row
      */
     public List<Map<String, String>> getRowMaps()
     {

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -560,13 +560,15 @@ public class FieldDefinition extends PropertyDescriptor
             return json;
         }
 
+        // Even with the <pre> tag the & needs to be escaped for a javadoc compile.
+        // "expression": "~gt=34&~lt=99", & -> &#38;
         /**
          * JSON for a field validator looks something like this:
          * <pre>
          * {
          *   "description": "description",
          *   "errorMessage": "error message",
-         *   "expression": "~gt=34&~lt=99",
+         *   "expression": "~gt=34&#38;~lt=99",
          *   "name": "V range 1",
          *   "new": true,
          *   "properties": {

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -479,7 +479,6 @@ public class TestDataGenerator
      * @param schema The schema of the domain. For example for sample types it would be 'exp.data'.
      * @param queryName The name of the query to look for. For example for a sample type it would be its name.
      * @return True if it exists in the given container false otherwise.
-     * @throws IOException Thrown if there is an issue while looking for the domain.
      */
     public static boolean doesDomainExists(final String containerPath, final String schema,
                                                 final String queryName)


### PR DESCRIPTION
#### Rationale
No real rationale other than there were compile errors in the javadoc comments for testAutomation. If you run `gradlew :server:test:javadoc` it will generate the JavaDocs for testAutomation, you can find them under the build/modules/testAutomation/docs/javadocs folder. There are several warnings but they should build now.

I haven't gotten the javadocs to build for other modules yet. 

#### Related Pull Requests
* none

#### Changes
* Escaped some <, > and &
* Removed a bogus `@return` reference
* Removed two `@see` references to docs in other modules that have yet to be built.
