### PR TITLE
Fix intermittent EntityInsertPanel find parent select after clicking add

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -42,7 +42,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     public ReactSelect getEntityTypeSelect(String labelText)
     {
-        return ReactSelect.finder(getDriver()).followingLabelWithSpan(labelText).waitFor();
+        return ReactSelect.finder(getDriver()).followingLabelWithSpan(labelText).waitFor(getDriver());
     }
 
     public EntityInsertPanel addParent(String label, String parentType)

--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -42,12 +42,13 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     public ReactSelect getEntityTypeSelect(String labelText)
     {
-        return ReactSelect.finder(getDriver()).followingLabelWithSpan(labelText).waitFor(getDriver());
+        return ReactSelect.finder(getDriver()).followingLabelWithSpan(labelText).findWhenNeeded(getDriver());
     }
 
     public EntityInsertPanel addParent(String label, String parentType)
     {
         elementCache().addParent.click();
+        getWrapper().waitForElement(Locator.tag("label").withChild(Locator.tagWithText("span", label)));
         getEntityTypeSelect(label).select(parentType);
         return this;
     }


### PR DESCRIPTION
#### Rationale
The related PRs fixed a few 21.4 issues for LKSM and LKB related to creating samples from various places in the apps. The existing automated tests had some intermittent issues with using the sample parent type dropdown.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/527
* https://github.com/LabKey/biologics/pull/840
* https://github.com/LabKey/labkey-ui-components/pull/483
* https://github.com/LabKey/testAutomation/pull/681

#### Changes
* EntityInsertPanel test component update to add a wait for the parent type label before selecting from it
