### PR TITLE
Issue41828: External Specimen Importer Interstitial Page Text

### DIFF
--- a/src/org/labkey/test/pages/study/ConfigureImporterPage.java
+++ b/src/org/labkey/test/pages/study/ConfigureImporterPage.java
@@ -35,7 +35,7 @@ public class ConfigureImporterPage extends LabKeyPage<ConfigureImporterPage.Elem
     @Override
     protected void waitForPage()
     {
-        waitFor(()-> elementCache().upsellBanner().isPresent() ||
+        waitFor(()-> elementCache().EnableModuleBanner().isPresent() ||
                     elementCache().importOptionPickerBanner().isPresent() ||
                     elementCache().configureQueryBasedConnectionPane().isPresent() ||
                     elementCache().freezerProBanner().isPresent(),
@@ -46,9 +46,9 @@ public class ConfigureImporterPage extends LabKeyPage<ConfigureImporterPage.Elem
      * If no importer is enabled in the current folder, an upsell banner should appear.
      * @return true if upsell banner is present
      */
-    public boolean isUpsellBannerShown()
+    public boolean isEnableModuleBannerShown()
     {
-        return elementCache().upsellBanner().isPresent();
+        return elementCache().EnableModuleBanner().isPresent();
     }
 
     public boolean isImportOptionPickerShown()
@@ -88,11 +88,12 @@ public class ConfigureImporterPage extends LabKeyPage<ConfigureImporterPage.Elem
 
     protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
-        // the upsell banner will be present if the current folder does not have Professional enabled in it
-        Optional<WebElement> upsellBanner()
+        // the enable module banner will be present if the current folder does not have Professional enabled in it,
+        // but the Professional module is available within the folder
+        Optional<WebElement> EnableModuleBanner()
         {
-            return Locator.tagWithClass("div", "alert-info")
-                    .withDescendant(Locator.tag("h3").withText("Specimen Import is not available with your current edition of LabKey Server."))
+            return Locator.tagWithClass("div", "alert-warning")
+                    .withText("External Specimen Import is not currently available for this folder. To use External import, enable the Professional Module for this folder.")
                     .findOptionalElement(getDriver());
         }
 

--- a/src/org/labkey/test/pages/study/ConfigureImporterPage.java
+++ b/src/org/labkey/test/pages/study/ConfigureImporterPage.java
@@ -12,7 +12,8 @@ import java.util.Optional;
 
 /**
  * If the current folder has 0 specimen importers (implemented in Professional, and FreezerPro) enabled in it,
- * the user will be shown an upsell banner
+ * but the modules are available on the server, the user will be shown call to action to enable the modules.
+ * If 0 importer modules are available, the user will be shown an upsell banner.
  *
  * If the user has >1, this page will show a configuration selection (pick which one- QueryBased, FreezerPro)
  *
@@ -43,8 +44,8 @@ public class ConfigureImporterPage extends LabKeyPage<ConfigureImporterPage.Elem
     }
 
     /**
-     * If no importer is enabled in the current folder, an upsell banner should appear.
-     * @return true if upsell banner is present
+     * If no importer is enabled in the current folder, a call-to-action enable-module banner should appear.
+     * @return true if banner is present
      */
     public boolean isEnableModuleBannerShown()
     {


### PR DESCRIPTION
#### Rationale
For the situation in which the `professional` module was present but not enabled, we previously displayed a message which could lead to confusion about whether specimen import is possible.  

Previous:
![Screen Shot 2021-04-14 at 1 24 13 PM](https://user-images.githubusercontent.com/18537731/114774184-c0905500-9d24-11eb-9c2f-1e923f3e240c.png)

Current:
For when `professional` is inactive but present, we display:
![Professional off](https://user-images.githubusercontent.com/18537731/114772915-3c899d80-9d23-11eb-931e-7f81a02f4094.png)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2184

#### Changes
* Update 'upsell' element to 'enable module' element
