### PR TITLE
Fill test-generated text files with random alphanumeric characters, but not random bytes

### DIFF
--- a/src/org/labkey/test/tests/RlabkeyTest.java
+++ b/src/org/labkey/test/tests/RlabkeyTest.java
@@ -246,15 +246,15 @@ public class RlabkeyTest extends BaseWebDriverTest
         scriptReplacements.put("downloadDir", downloadDir.getAbsolutePath().replaceAll("\\\\", "/"));
 
         // Setup files in simulated target server
-        webDav.putRandomBytes("remote/readChecks/getMe.txt");
-        webDav.putRandomBytes("remote/readChecks/getMe/a.txt");
-        webDav.putRandomBytes("remote/readChecks/getMe/subdir/b.txt");
+        webDav.putRandomAlphanumeric("remote/readChecks/getMe.txt");
+        webDav.putRandomAlphanumeric("remote/readChecks/getMe/a.txt");
+        webDav.putRandomAlphanumeric("remote/readChecks/getMe/subdir/b.txt");
         webDav.mkDir("remote/readChecks/getMe/empty_subdir");
         webDav.mkDir("remote/readChecks/empty_dir");
         webDav.mkDir("remote/writeChecks");
         webDav.mkDir("remote/writeChecks/deleteMe_empty");
-        webDav.putRandomBytes("remote/writeChecks/deleteMe/file.txt");
-        webDav.putRandomBytes("remote/writeChecks/deleteMe.txt");
+        webDav.putRandomAlphanumeric("remote/writeChecks/deleteMe/file.txt");
+        webDav.putRandomAlphanumeric("remote/writeChecks/deleteMe.txt");
         File remoteDir = new File(downloadDir.getParentFile(), "remote");
         scriptReplacements.put("remoteDir", remoteDir.getAbsolutePath().replaceAll("\\\\", "/"));
 

--- a/src/org/labkey/test/util/core/webdav/WebDavUploadHelper.java
+++ b/src/org/labkey/test/util/core/webdav/WebDavUploadHelper.java
@@ -170,13 +170,13 @@ public class WebDavUploadHelper
         _sardine.put(putUrl, fileContents.getBytes(StandardCharsets.UTF_8));
     }
 
-    public void putRandomBytes(String relativePath) throws IOException
+    public void putRandomAlphanumeric(String relativePath) throws IOException
     {
-        putRandomBytes(relativePath, 5);
+        putRandomAlphanumeric(relativePath, 5);
     }
 
-    public void putRandomBytes(String relativePath, int size) throws IOException
+    public void putRandomAlphanumeric(String relativePath, int size) throws IOException
     {
-        WebDavUtils.putRandomBytes(_sardine, _urlFactory.getPath(relativePath), size);
+        WebDavUtils.putRandomAlphanumeric(_sardine, _urlFactory.getPath(relativePath), size);
     }
 }

--- a/src/org/labkey/test/util/core/webdav/WebDavUtils.java
+++ b/src/org/labkey/test/util/core/webdav/WebDavUtils.java
@@ -17,6 +17,7 @@ package org.labkey.test.util.core.webdav;
 
 import com.github.sardine.Sardine;
 import com.github.sardine.SardineFactory;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.labkey.test.TestProperties;
 import org.labkey.test.WebTestHelper;
@@ -26,6 +27,7 @@ import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.TestLogger;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
 
 public class WebDavUtils
@@ -98,5 +100,12 @@ public class WebDavUtils
         byte[] fileBytes = new byte[fileSize];
         random.nextBytes(fileBytes);
         sardine.put(fullDavUrl, fileBytes);
+    }
+
+    @LogMethod
+    public static void putRandomAlphanumeric(Sardine sardine, @LoggedParam String fullDavUrl, int fileSize) throws IOException
+    {
+        String random = RandomStringUtils.randomAlphanumeric(fileSize);
+        sardine.put(fullDavUrl, random.getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
#### Rationale
RlabkeyTest is now failing because it generates .txt files containing random bytes. When these files are indexed for full-text search, Tika rejects them because it can't determine the character encoding. Solution is to fill them with random alphanumerics, not random bytes.
