### PR TITLE
Java API test Commands

### DIFF
--- a/src/org/labkey/remoteapi/core/SaveModulePropertiesCommand.java
+++ b/src/org/labkey/remoteapi/core/SaveModulePropertiesCommand.java
@@ -55,6 +55,7 @@ public class SaveModulePropertiesCommand extends PostCommand<CommandResponse>
             propJson.put("moduleName", prop.getModuleName());
             propJson.put("propName", prop.getPropertyName());
             propJson.put("value", prop.getValue());
+            properties.add(propJson);
         }
         json.put("properties", properties);
         return json;

--- a/src/org/labkey/remoteapi/core/SaveModulePropertiesCommand.java
+++ b/src/org/labkey/remoteapi/core/SaveModulePropertiesCommand.java
@@ -1,0 +1,62 @@
+package org.labkey.remoteapi.core;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.security.GetContainersCommand;
+import org.labkey.remoteapi.security.GetContainersResponse;
+import org.labkey.test.params.ModuleProperty;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SaveModulePropertiesCommand extends PostCommand<CommandResponse>
+{
+    private final List<ModuleProperty> _moduleProperties;
+    private final Map<String, String> _containerIds = new HashMap<>();
+
+    public SaveModulePropertiesCommand(List<? extends ModuleProperty> moduleProperties)
+    {
+        super("core", "saveModuleProperties");
+        _moduleProperties = Collections.unmodifiableList(moduleProperties);
+    }
+
+    @Override
+    public CommandResponse execute(Connection connection, String folderPath) throws IOException, CommandException
+    {
+        for (ModuleProperty prop : _moduleProperties)
+        {
+            String containerPath = prop.getContainerPath();
+            if (!_containerIds.containsKey(containerPath))
+            {
+                GetContainersResponse response = new GetContainersCommand().execute(connection, containerPath);
+                _containerIds.put(containerPath, response.getContainerId());
+            }
+        }
+        return super.execute(connection, folderPath);
+    }
+
+    @Override
+    public JSONObject getJsonObject()
+    {
+        JSONObject json = new JSONObject();
+        JSONArray properties = new JSONArray();
+        for (ModuleProperty prop : _moduleProperties)
+        {
+            JSONObject propJson = new JSONObject();
+            propJson.put("userId", 0);
+            propJson.put("container", _containerIds.get(prop.getContainerPath()));
+            propJson.put("moduleName", prop.getModuleName());
+            propJson.put("propName", prop.getPropertyName());
+            propJson.put("value", prop.getValue());
+        }
+        json.put("properties", properties);
+        return json;
+    }
+}

--- a/src/org/labkey/remoteapi/query/InsertExternalSchemaCommand.java
+++ b/src/org/labkey/remoteapi/query/InsertExternalSchemaCommand.java
@@ -1,0 +1,155 @@
+package org.labkey.remoteapi.query;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.message.BasicNameValuePair;
+import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.PostCommand;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+public class InsertExternalSchemaCommand extends PostCommand<CommandResponse>
+{
+    /*
+    schemaType: external
+userSchemaName: fdahpuserregws
+dataSource: labkeyDataSource
+sourceSchemaName: fdahpuserregws
+includeSystem: on
+@includeSystem:
+@editable:
+indexable: on
+@indexable:
+@fastCacheRefresh:
+metaData:
+tables: List.of("apppropertiesdetails", "authinfo", "loginattempts", "passwordhistory", "userappdetails", "userdetails");
+X-LABKEY-CSRF: 1f4f5eb0adc721ba44c3e44ee58c3e59
+X-LABKEY-CSRF: 1f4f5eb0adc721ba44c3e44ee58c3e59
+     */
+    private final Params _params;
+
+    public InsertExternalSchemaCommand(Params params)
+    {
+        super("query", "insertExternalSchema");
+        _params = params;
+    }
+
+    @Override
+    protected HttpUriRequest createRequest(URI uri)
+    {
+        HttpPost request = (HttpPost) super.createRequest(uri);
+
+        try
+        {
+            request.setEntity(_params.toFormEntity());
+        }
+        catch (UnsupportedEncodingException e)
+        {
+            throw new RuntimeException(e);
+        }
+
+        return request;
+    }
+
+    public static class Params
+    {
+        private String userSchemaName;
+        private String sourceSchemaName;
+        private String tables = "";
+        private String schemaType = "external";
+        private String dataSource = "labkeyDataSource";
+        private boolean includeSystem = true;
+        private boolean editable = false;
+        private boolean indexable = true;
+        private boolean fastCacheRefresh = true; // Enable fast refresh by default for tests
+        private String metaData = "";
+
+        public Params(String userSchemaName, String sourceSchemaName)
+        {
+            setUserSchemaName(userSchemaName);
+            setSourceSchemaName(sourceSchemaName);
+        }
+
+        private UrlEncodedFormEntity toFormEntity() throws UnsupportedEncodingException
+        {
+            List<NameValuePair> form = new ArrayList<>();
+            form.add(new BasicNameValuePair("userSchemaName", userSchemaName));
+            form.add(new BasicNameValuePair("sourceSchemaName", sourceSchemaName));
+            form.add(new BasicNameValuePair("tables", tables));
+            form.add(new BasicNameValuePair("schemaType", schemaType));
+            form.add(new BasicNameValuePair("dataSource", dataSource));
+            if (includeSystem)
+            {
+                form.add(new BasicNameValuePair("includeSystem", "on"));
+            }
+            if (editable)
+            {
+                form.add(new BasicNameValuePair("editable", "on"));
+            }
+            if (indexable)
+            {
+                form.add(new BasicNameValuePair("indexable", "on"));
+            }
+            if (fastCacheRefresh)
+            {
+                form.add(new BasicNameValuePair("fastCacheRefresh", "on"));
+            }
+            form.add(new BasicNameValuePair("metadata", metaData));
+
+            return new UrlEncodedFormEntity(form);
+        }
+
+        public Params setUserSchemaName(String userSchemaName)
+        {
+            this.userSchemaName = userSchemaName;
+            return this;
+        }
+
+        public Params setSourceSchemaName(String sourceSchemaName)
+        {
+            this.sourceSchemaName = sourceSchemaName;
+            return this;
+        }
+
+        public Params setTables(List<String> tables)
+        {
+            this.tables = String.join(",", tables);
+            return this;
+        }
+
+        public Params setSchemaType(String schemaType)
+        {
+            this.schemaType = schemaType;
+            return this;
+        }
+
+        public Params setDataSource(String dataSource)
+        {
+            this.dataSource = dataSource;
+            return this;
+        }
+
+        public Params setIncludeSystem(boolean includeSystem)
+        {
+            this.includeSystem = includeSystem;
+            return this;
+        }
+
+        public Params setIndexable(boolean indexable)
+        {
+            this.indexable = indexable;
+            return this;
+        }
+
+        public Params setMetaData(String metaData)
+        {
+            this.metaData = metaData;
+            return this;
+        }
+    }
+}

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1567,7 +1567,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             else
                 log("setting property: " + desc + " to value: " + value.getValue());
             String val = value.getInputType().valueToString(ref.getValue());
-            if((StringUtils.isEmpty(val) != StringUtils.isEmpty(value.getValue())) || !val.equals(value.getValue()))
+            if((StringUtils.isEmpty(val) != StringUtils.isEmpty(String.valueOf(value.getValue()))) || !val.equals(value.getValue()))
             {
                 changed = true;
                 ref.setValue(value.getValue());

--- a/src/org/labkey/test/ModulePropertyValue.java
+++ b/src/org/labkey/test/ModulePropertyValue.java
@@ -15,15 +15,12 @@
  */
 package org.labkey.test;
 
+import org.labkey.test.params.ModuleProperty;
 import org.labkey.test.util.ext4cmp.Ext4FieldRef;
 
-public class ModulePropertyValue
+public class ModulePropertyValue extends ModuleProperty
 {
-    private String _moduleName;
-    private String _containerPath;
-    private String _propertyName;
-    private String _value;
-    private InputType _inputType;
+    private final InputType _inputType;
 
     public enum InputType
     {
@@ -78,14 +75,9 @@ public class ModulePropertyValue
         }
     }
 
-    public ModulePropertyValue(String moduleName, String containerPath, String propertyName, String value, InputType inputType)
+    public ModulePropertyValue(String moduleName, String containerPath, String propertyName, Object value, InputType inputType)
     {
-        _moduleName = moduleName;
-        _containerPath = containerPath;
-        if (!_containerPath.startsWith("/"))
-            _containerPath = "/" + _containerPath;
-        _propertyName = propertyName;
-        _value = value;
+        super(moduleName, containerPath, propertyName, value);
         _inputType = inputType;
     }
 
@@ -94,24 +86,9 @@ public class ModulePropertyValue
         this(moduleName, containerPath, propertyName, value, InputType.text);
     }
 
-    public String getModuleName()
+    public ModulePropertyValue(String moduleName, String containerPath, String propertyName, boolean value)
     {
-        return _moduleName;
-    }
-
-    public String getContainerPath()
-    {
-        return _containerPath;
-    }
-
-    public String getPropertyName()
-    {
-        return _propertyName;
-    }
-
-    public String getValue()
-    {
-        return _value;
+        this(moduleName, containerPath, propertyName, value, InputType.checkbox);
     }
 
     public InputType getInputType()

--- a/src/org/labkey/test/params/ModuleProperty.java
+++ b/src/org/labkey/test/params/ModuleProperty.java
@@ -1,0 +1,40 @@
+package org.labkey.test.params;
+
+public class ModuleProperty
+{
+    private final String _moduleName;
+    private final String _containerPath;
+    private final String _propertyName;
+    private final Object _value;
+
+    public ModuleProperty(String moduleName, String containerPath, String propertyName, Object value)
+    {
+        _moduleName = moduleName;
+        if (!containerPath.startsWith("/"))
+            _containerPath = "/" + containerPath;
+        else
+            _containerPath = containerPath;
+        _propertyName = propertyName;
+        _value = value;
+    }
+
+    public String getModuleName()
+    {
+        return _moduleName;
+    }
+
+    public String getContainerPath()
+    {
+        return _containerPath;
+    }
+
+    public String getPropertyName()
+    {
+        return _propertyName;
+    }
+
+    public Object getValue()
+    {
+        return _value;
+    }
+}

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -1525,7 +1525,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
         propList.add(new ModulePropertyValue(MODULE_NAME, "/", prop1, prop1Value));
         propList.add(new ModulePropertyValue(MODULE_NAME, "/" + getProjectName() + "/" + FOLDER_NAME, prop2 , "FolderValue"));
         propList.add(new ModulePropertyValue(MODULE_NAME, "/" + getProjectName() + "/" + FOLDER_NAME, propTextArea , "updated1\nupdated2", ModulePropertyValue.InputType.textarea));
-        propList.add(new ModulePropertyValue(MODULE_NAME, "/", "TestCheckbox", "true", ModulePropertyValue.InputType.checkbox));
+        propList.add(new ModulePropertyValue(MODULE_NAME, "/", "TestCheckbox", true));
         propList.add(new ModulePropertyValue(MODULE_NAME, "/", "TestSelect", "value1", ModulePropertyValue.InputType.select));
         propList.add(new ModulePropertyValue(MODULE_NAME, "/", "TestCombo", "comboValue1", ModulePropertyValue.InputType.combo));
 
@@ -1657,9 +1657,10 @@ public class SimpleModuleTest extends BaseWebDriverTest
         beginAt(subfolderPath);
         propList.forEach(property ->
         {
+            Object expectedValue = String.valueOf(property.getValue());
             Object actualValue = executeScript("return LABKEY.getModuleContext('simpletest')." + property.getPropertyName());
-            if (!property.getValue().equals(actualValue))
-                errors.add(property.getPropertyName() + " has incorrect value. Expected " + property.getValue() + " but was " + actualValue);
+            if (!expectedValue.equals(actualValue))
+                errors.add(property.getPropertyName() + " has incorrect value. Expected " + expectedValue + " but was " + actualValue);
         });
         if (!errors.isEmpty())
         {


### PR DESCRIPTION
#### Rationale
Interacting with `core-saveModuleProperties` and `query-insertExternalSchema` through the UI is time consuming and often unnecessary. Setting up folders in the `UserReg-WS` module requires hitting both of these actions so we can save some time for those tests by using the API.

#### Related Pull Requests
* FDA-MyStudies/UserReg-WS#8

#### Changes
* Add `SaveModulePropertiesCommand` and minor refactors to UI module property helpers
* Add `InsertExternalSchemaCommand`
