### PR TITLE
Add `waitForReady` to base component

### DIFF
--- a/src/org/labkey/test/components/Component.java
+++ b/src/org/labkey/test/components/Component.java
@@ -53,9 +53,14 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
     protected EC elementCache()
     {
         if (null == _elementCache)
+        {
             _elementCache = newElementCache();
+            waitForReady(_elementCache);
+        }
         return _elementCache;
     }
+
+    protected void waitForReady(EC ec) { }
 
     protected EC newElementCache()
     {

--- a/src/org/labkey/test/components/Component.java
+++ b/src/org/labkey/test/components/Component.java
@@ -17,6 +17,7 @@ package org.labkey.test.components;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.labkey.test.Locator;
+import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.By;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebElement;
@@ -28,6 +29,8 @@ import java.util.function.Function;
 
 public abstract class Component<EC extends Component.ElementCache> implements SearchContext
 {
+    private boolean _cacheCreated = false;
+
     public abstract WebElement getComponentElement();
 
     @Override
@@ -70,10 +73,23 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
     protected void clearElementCache()
     {
         _elementCache = null;
+        _cacheCreated = false;
     }
 
     public abstract class ElementCache implements SearchContext
     {
+        protected ElementCache()
+        {
+            if (_cacheCreated)
+            {
+                TestLogger.warn("Misused element cache in " + Component.this.getClass().getName());
+            }
+            else
+            {
+                _cacheCreated = true;
+            }
+        }
+
         @Override
         public List<WebElement> findElements(By by)
         {

--- a/src/org/labkey/test/components/bootstrap/ModalDialog.java
+++ b/src/org/labkey/test/components/bootstrap/ModalDialog.java
@@ -54,11 +54,11 @@ public class ModalDialog extends WebDriverComponent<ModalDialog.ElementCache>
         return new ModalDialogFinder(driver);
     }
 
-    protected ElementCache waitForReady(ElementCache ec)
+    @Override
+    protected void waitForReady(ElementCache ec)
     {
         ec.body.isDisplayed(); // Make sure timeout doesn't get used up by waiting for the dialog to appear
         WebDriverWrapper.waitFor(() -> ec.body.getText().length() > 0, "Modal dialog not ready", 2000);
-        return ec;
     }
 
     @Override
@@ -132,7 +132,7 @@ public class ModalDialog extends WebDriverComponent<ModalDialog.ElementCache>
     @Override
     protected ElementCache newElementCache()
     {
-        return waitForReady(new ElementCache());
+        return new ElementCache();
     }
 
     protected class ElementCache extends Component<ElementCache>.ElementCache


### PR DESCRIPTION
#### Rationale
We have numerous different methods for waiting for a component to be ready. This adds a standard location for these waits.

#### Changes
* Add no-op `waitForReady` to base Component
* Update `ModalDialog` to use new pattern
