### PR TITLE
Adjust test wrapper for checkbox removal

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -683,7 +683,6 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                 clickAndWait(Locator.lkButton("Next"));
                 // admin-newInstallSiteSettings
                 assertElementPresent(Locator.id("rootPath"));
-                uncheckCheckbox(Locator.name("allowReporting"));
                 clickAndWait(Locator.lkButton("Next"));
                 // admin-installComplete
                 clickAndWait(Locator.linkContainingText("Go to the server's Home page"));


### PR DESCRIPTION
#### Rationale
"Allow Reporting" checkbox on the new install page no longer exists