### PR TITLE
Disable mothership reporting when bootstrapping in production mode

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -48,6 +48,7 @@ import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.components.core.ProjectMenu;
 import org.labkey.test.components.dumbster.EmailRecordTable;
 import org.labkey.test.components.html.SiteNavBar;
+import org.labkey.test.pages.core.admin.CustomizeSitePage;
 import org.labkey.test.pages.core.admin.ShowAdminPage;
 import org.labkey.test.pages.user.UserDetailsPage;
 import org.labkey.test.util.APIUserHelper;
@@ -693,6 +694,16 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                 String displayName = AbstractUserHelper.getDefaultDisplayName(PasswordUtil.getUsername())
                         + (WebTestHelper.RANDOM.nextBoolean() ? BaseWebDriverTest.INJECT_CHARS_1 : BaseWebDriverTest.INJECT_CHARS_2);
                 _userHelper.setDisplayName(PasswordUtil.getUsername(), displayName);
+
+                if (!TestProperties.isDevModeEnabled())
+                {
+                    TestLogger.log("Disable mothership reporting when bootstrapping in production mode");
+                    CustomizeSitePage customizeSitePage = CustomizeSitePage.beginAt(this);
+                    customizeSitePage.setUsageReportingLevel(CustomizeSitePage.ReportingLevel.NONE); // Don't report usage to labkey.org
+                    customizeSitePage.setExceptionReportingLevel(CustomizeSitePage.ReportingLevel.NONE); // Don't report exceptions to labkey.org
+                    // Note: leave the self-report setting unchanged
+                    customizeSitePage.save();
+                }
             }
             else // Just upgrading
             {

--- a/src/org/labkey/test/tests/BasicTest.java
+++ b/src/org/labkey/test/tests/BasicTest.java
@@ -88,12 +88,6 @@ public class BasicTest extends BaseWebDriverTest
             checker().verifyEquals("Wrong server mode",
                     TestProperties.isDevModeEnabled() ? "Development" : "Production", mode); // Verify whether we're running in dev mode
 
-        CustomizeSitePage customizeSitePage = goToAdminConsole().clickSiteSettings();
-        customizeSitePage.setUsageReportingLevel(CustomizeSitePage.ReportingLevel.NONE); // Don't report usage to labkey.org
-        customizeSitePage.setExceptionReportingLevel(CustomizeSitePage.ReportingLevel.NONE); // Don't report exceptions to labkey.org
-        // Note: leave the self-report setting unchanged
-        customizeSitePage.save();
-
         // Verify scheduled system maintenance is disabled (see above). Can disable this only in dev mode.
         if (TestProperties.isDevModeEnabled() && !TestProperties.isPrimaryUserAppAdmin())
         {


### PR DESCRIPTION
#### Rationale
The mothership reporting checkbox has been removed from 'admin-newInstallSiteSettings'. Bootstrapping tests should go to site settings to disable it to avoid sending test noise to labkey.org.

#### Related Pull Requests
* #709 

#### Changes
* Move mothership configuration from `BasicTest.testSystemSettings` to bootstrapping helper
