### PR TITLE
Update casing for SampleID in error message

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -1239,7 +1239,7 @@ public class SampleTypeTest extends BaseWebDriverTest
         log("Verify error message for a few other special field names");
         domainFormPanel.manuallyDefineFields("sampleid");
         checker().verifyEquals("Sample Type SampleId field name error",
-                Arrays.asList("The SampleId field name is reserved for imported or generated sample ids."),
+                Arrays.asList("The SampleID field name is reserved for imported or generated sample ids."),
                 createPage.clickSaveExpectingErrors());
         domainFormPanel.removeAllFields(false);
     }


### PR DESCRIPTION
#### Rationale
We changed the casing in the error messages to match what is used in the rest of the application.  This test got missed when doing that update

