### PR TITLE
Add test helper method for conversion error messages. Use it.

### DIFF
--- a/data/api/rlabkey-api-query.xml
+++ b/data/api/rlabkey-api-query.xml
@@ -258,7 +258,7 @@
         </url>
         <response>
             <![CDATA[
-                HTTP request was unsuccessful. Status code = 400, Error message = Could not convert value 'string' for field 'IntFld'; expected type Integer
+                HTTP request was unsuccessful. Status code = 400, Error message = Could not convert value 'string' (String) for Integer field 'IntFld'
             ]]>
         </response>
     </test>

--- a/data/api/rlabkey-api-query.xml
+++ b/data/api/rlabkey-api-query.xml
@@ -258,7 +258,7 @@
         </url>
         <response>
             <![CDATA[
-                HTTP request was unsuccessful. Status code = 400, Error message = Could not convert 'string' for field IntFld, should be of type Integer
+                HTTP request was unsuccessful. Status code = 400, Error message = Could not convert value 'string' for field 'IntFld'; expected type Integer
             ]]>
         </response>
     </test>

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -2438,6 +2438,13 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         return exportIconLoc.findElements(getDriver()).size();
     }
 
+    // Note: Keep in sync with OntologyManager.getStandardConversionErrorMessage()
+    public String getConversionErrorMessage(Object value, String fieldName, Class<?> targetClass)
+    {
+        String fromType = (value instanceof String) ? "" : "(" + (value.getClass().getSimpleName() + ") ");
+        return "Could not convert value " + fromType + "'" + value + "' for field '" + fieldName + "'; expected type " + targetClass.getSimpleName();
+    }
+
     public void clickExportScriptIcon(String chartParentCls, int chartIndex)
     {
         Locator.XPathLocator chartLoc = Locator.tagWithClass("div", chartParentCls).index(chartIndex);

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -2438,13 +2438,6 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         return exportIconLoc.findElements(getDriver()).size();
     }
 
-    // Note: Keep in sync with OntologyManager.getStandardConversionErrorMessage()
-    public String getConversionErrorMessage(Object value, String fieldName, Class<?> targetClass)
-    {
-        String fromType = (value instanceof String) ? "" : "(" + (value.getClass().getSimpleName() + ") ");
-        return "Could not convert value " + fromType + "'" + value + "' for field '" + fieldName + "'; expected type " + targetClass.getSimpleName();
-    }
-
     public void clickExportScriptIcon(String chartParentCls, int chartIndex)
     {
         Locator.XPathLocator chartLoc = Locator.tagWithClass("div", chartParentCls).index(chartIndex);

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -1586,7 +1586,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         clickButton("Confirm Delete");
     }
 
-    // Note: Keep in sync with OntologyManager.getStandardConversionErrorMessage()
+    // Note: Keep in sync with ConvertHelper.getStandardConversionErrorMessage()
     // Example: "Could not convert value '2.34' (Double) for Boolean field 'Medical History.Dep Diagnosed in Last 18 Months'"
     public String getConversionErrorMessage(Object value, String fieldName, Class<?> targetClass)
     {

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -1585,4 +1585,11 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
             checkCheckbox(Locator.id("deleteRuns"));
         clickButton("Confirm Delete");
     }
+
+    // Note: Keep in sync with OntologyManager.getStandardConversionErrorMessage()
+    // Example: "Could not convert value '2.34' (Double) for Boolean field 'Medical History.Dep Diagnosed in Last 18 Months'"
+    public String getConversionErrorMessage(Object value, String fieldName, Class<?> targetClass)
+    {
+        return "Could not convert value '" + value + "' (" + value.getClass().getSimpleName() + ") for " + targetClass.getSimpleName() + " field '" + fieldName + "'";
+    }
 }

--- a/src/org/labkey/test/tests/SampleTypeLimitsTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLimitsTest.java
@@ -134,7 +134,7 @@ public class SampleTypeLimitsTest extends BaseWebDriverTest
         clickButton("Submit");
 
         String errMsg = Locators.labkeyError.findElement(getDriver()).getText();
-        assertEquals("Expecpted error is different", "Could not convert value: Sample2", errMsg);
+        assertEquals("Expected error is different", "Could not convert value: Sample2", errMsg);
 
         setFormElement(Locator.name("quf_lookUpField"), "Sample1");
         clickButton("Submit");

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -676,8 +676,8 @@ public class ListTest extends BaseWebDriverTest
         // create the list for this case
         String multiErrorListName = "multiErrorBatchList";
         String[] expectedErrors = new String[]{
-                "Could not convert 'green' for field ShouldInsertCorrectly, should be of type Boolean",
-                "Could not convert 'five' for field Id, should be of type Integer; Missing value for required property: Id"
+            getConversionErrorMessage("green", "ShouldInsertCorrectly", Boolean.class),
+            getConversionErrorMessage("five", "Id", Integer.class) + "; Missing value for required property: Id"
         };
 
         createList(multiErrorListName, BatchListColumns, BatchListData);


### PR DESCRIPTION
#### Rationale
Conversion error message verification is scattered about the tests and the product wording is changing. Add a helper method that generates the expected message.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2232
