### PR TITLE
Ontology annotation test components and wrappers

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -9,6 +9,7 @@ import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.html.RadioButton;
 import org.labkey.test.components.html.SelectWrapper;
+import org.labkey.test.components.ui.ontology.ConceptPickerDialog;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.LabKeyExpectedConditions;
 import org.openqa.selenium.ElementNotInteractableException;
@@ -23,6 +24,7 @@ import org.openqa.selenium.support.ui.Select;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
@@ -466,6 +468,64 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         return elementCache().getLookupValidatorEnabledCheckbox().get();
     }
 
+    // ontology lookup settings
+
+    public DomainFieldRow setOntology(String ontology, String importField, String labelField)
+    {
+        setType(FieldDefinition.ColumnType.OntologyLookup);
+        setSelectedOntology(ontology)
+                .setConceptImportField(importField)
+                .setConceptImportLabelField(labelField);
+        return this;
+    }
+
+    public DomainFieldRow setOntologyLookup()
+    {
+        setType(FieldDefinition.ColumnType.OntologyLookup);
+        return this;
+    }
+
+    public DomainFieldRow setSelectedOntology(String ontology)
+    {
+        expand();
+        elementCache().getOntologySelect().selectByVisibleText(ontology);
+        return this;
+    }
+
+    public DomainFieldRow setConceptImportField(String importField)
+    {
+        expand();
+        elementCache().getConceptImportFieldSelect().selectByVisibleText(importField);
+        return this;
+    }
+
+    public DomainFieldRow setConceptImportLabelField(String labelField)
+    {
+        expand();
+        elementCache().getConceptLabelFieldSelect().selectByVisibleText(labelField);
+        return this;
+    }
+
+    public ConceptPickerDialog clickSelectConcept()
+    {
+        expand();
+        elementCache().selectConceptButton().click();
+        return new ConceptPickerDialog(new ModalDialog.ModalDialogFinder(getDriver()).withTitle("Select Concept"));
+    }
+
+    public Optional<WebElement> optionalOntologyConceptLink()
+    {
+        return elementCache().selectedConceptLink();
+    }
+
+    public DomainFieldRow clickRemoveOntologyConcept()
+    {
+        WebDriverWrapper.waitFor(()-> elementCache().selectedConceptLink().isPresent(),
+                "the expected ontology link is not present", 2000);
+        elementCache().removeSelectedConceptLink().get().click();
+        return this;
+    }
+
     // advanced settings
 
     public DomainFieldRow showFieldOnDefaultView(boolean checked)
@@ -793,6 +853,54 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
             Select select = SelectWrapper.Select(Locator.name("domainpropertiesrow-sampleTypeSelect")).find(this);
             return waitForSelectToLoad(select);
         }
+
+        // ontology lookup settings
+        public Select getOntologySelect()
+        {
+            Select select = SelectWrapper.Select(Locator.tagWithAttributeContaining("select", "id", "domainpropertiesrow-sourceOntology")).waitFor(this);
+            return waitForSelectToLoad(select);
+        }
+
+        public Select getConceptImportFieldSelect()
+        {
+            Select select = SelectWrapper.Select(
+                    Locator.tagWithAttributeContaining("select", "id", "domainpropertiesrow-conceptImportColumn"))
+                    .waitFor(this);
+            return waitForSelectToLoad(select);
+        }
+
+        public Select getConceptLabelFieldSelect()
+        {
+            Select select = SelectWrapper.Select(
+                    Locator.tagWithAttributeContaining("select", "id", "domainpropertiesrow-conceptLabelColumn"))
+                    .waitFor(this);
+            return waitForSelectToLoad(select);
+        }
+
+        public WebElement selectConceptButton()
+        {
+            return Locator.tagWithAttribute("button", "name", "domainpropertiesrow-principalConceptCode")
+                    .withText("Select Concept")
+                    .waitForElement(this, 2000);
+        }
+
+        Optional<WebElement> selectedConceptLink()
+        {
+            return Locator.tagWithClass("table", "domain-annotation-table")
+                    .descendant(Locator.tagWithClass("td", "content")
+                            .child(Locator.tagWithClass("a", "domain-annotation-item")))
+                    .findOptionalElement(this);
+        }
+
+        Optional<WebElement> removeSelectedConceptLink()
+        {
+            return Locator.tagWithClass("table", "domain-annotation-table")
+                    .descendant(Locator.tagWithClass("td", "content")
+                            .child(Locator.tagWithClass("a", "domain-validator-link")
+                            .child(Locator.tagWithClass("i", "fa-remove"))))
+                    .findOptionalElement(this);
+        }
+
 
         private Select waitForSelectToLoad(Select select)
         {

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -475,7 +475,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         setType(FieldDefinition.ColumnType.OntologyLookup);
         setSelectedOntology(ontology)
                 .setConceptImportField(importField)
-                .setConceptImportLabelField(labelField);
+                .setConceptLabelField(labelField);
         return this;
     }
 
@@ -488,8 +488,14 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
     public DomainFieldRow setSelectedOntology(String ontology)
     {
         expand();
-        elementCache().getOntologySelect().selectByVisibleText(ontology);
+        elementCache().getOntologySelect().selectByValue(ontology);
         return this;
+    }
+
+    public String getSelectedOntology()
+    {
+        expand();
+        return elementCache().getOntologySelect().getFirstSelectedOption().getAttribute("value");
     }
 
     public DomainFieldRow setConceptImportField(String importField)
@@ -499,7 +505,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         return this;
     }
 
-    public DomainFieldRow setConceptImportLabelField(String labelField)
+    public DomainFieldRow setConceptLabelField(String labelField)
     {
         expand();
         elementCache().getConceptLabelFieldSelect().selectByVisibleText(labelField);

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -80,6 +80,18 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
         if (fieldDefinition.getLookupValidatorEnabled() != null)
             fieldRow.setLookupValidatorEnabled(fieldDefinition.getLookupValidatorEnabled());
 
+        // ontology-specific
+        if (fieldDefinition.getSourceOntology() != null)
+            fieldRow.setSelectedOntology(fieldDefinition.getSourceOntology());
+        if (fieldDefinition.getConceptImportColumn() != null)
+            fieldRow.setConceptImportField(fieldDefinition.getConceptImportColumn());
+        if (fieldDefinition.getConceptLabelColumn() != null)
+            fieldRow.setConceptLabelField(fieldDefinition.getConceptLabelColumn());
+        if (fieldDefinition.getPrincipalConceptCode() != null)
+            fieldRow.clickSelectConcept()
+                    .searchConcept(fieldDefinition.getPrincipalConceptSearchExpression(), fieldDefinition.getPrincipalConceptCode())
+                    .clickApply();
+
         if (fieldDefinition.getValidators() != null && !fieldDefinition.getValidators().isEmpty())
         {
             List<FieldDefinition.RegExValidator> regexValidators = new ArrayList<>();

--- a/src/org/labkey/test/components/ui/ontology/ConceptInfoTabs.java
+++ b/src/org/labkey/test/components/ui/ontology/ConceptInfoTabs.java
@@ -1,0 +1,175 @@
+package org.labkey.test.components.ui.ontology;
+
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.Input;
+import org.labkey.test.pages.LabKeyPage;
+import org.labkey.test.util.LabKeyExpectedConditions;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+import static org.labkey.test.components.html.Input.Input;
+
+public class ConceptInfoTabs extends WebDriverComponent<ConceptInfoTabs.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected ConceptInfoTabs(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    private boolean isOverviewDisplayed()
+    {
+        return "false".equals(elementCache().overviewPane.getAttribute("aria-hidden")) &&
+                "true".equals(elementCache().pathInformationPane.getAttribute("aria-hidden"));
+    }
+
+    public ConceptInfoTabs showOverview()
+    {
+        if (!isOverviewDisplayed())
+        {
+            elementCache().overviewTab.click();
+            getWrapper().shortWait().until(LabKeyExpectedConditions.animationIsDone(elementCache().overviewPane));
+            WebDriverWrapper.waitFor(() -> isOverviewDisplayed(),
+                    "the overview pane did not become enabled", 2000);
+        }
+        return this;
+    }
+
+    public ConceptInfoTabs showPathInformation()
+    {
+        if (isOverviewDisplayed())
+        {
+            elementCache().pathInformationTab.click();
+            getWrapper().shortWait().until(LabKeyExpectedConditions.animationIsDone(elementCache().overviewPane));
+            WebDriverWrapper.waitFor(() -> !isOverviewDisplayed(),
+                    "the path information pane did not become enabled", 2000);
+        }
+        return this;
+    }
+
+    public String getTitle()
+    {
+        showOverview();
+        return elementCache().title.getText();
+    }
+
+    public String getCode()
+    {
+        showOverview();
+        return elementCache().codeBox.getText();
+    }
+
+    public List<String> getSynonyms()
+    {
+        showOverview();
+        return  getWrapper().getTexts(elementCache().synonyms());
+    }
+
+    public List<String> getSelectedPath()
+    {
+        showPathInformation();
+        return getWrapper().getTexts(elementCache().conceptPathParts());
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        // navigation tabs
+        WebElement tabListContainer = Locator.tagWithClass("ul", "nav-tabs")
+                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+        WebElement overviewTab = Locator.tag("li").withChild(Locator.id("concept-information-tabs-tab-overview"))
+                .findWhenNeeded(tabListContainer);
+        WebElement pathInformationTab = Locator.tag("li").withChild(Locator.id("concept-information-tabs-tab-pathinfo"))
+                .findWhenNeeded(tabListContainer);
+
+        // panes
+        WebElement tabContentContainer = Locator.tagWithClass("div", "tab-content")
+                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+
+        // overview pane
+        WebElement overviewPane = Locator.id("concept-information-tabs-pane-overview")
+                .refindWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+        WebElement title = Locator.tagWithClass("div", "title").findWhenNeeded(overviewPane);
+        WebElement codeBox = Locator.tagWithClass("span", "code").findWhenNeeded(overviewPane);
+        List<WebElement> synonyms()
+        {
+            return Locator.tagWithClass("ul", "synonyms-text").child(Locator.tag("li"))
+                    .findElements(overviewPane);
+        }
+
+        // path info pane
+        WebElement pathInformationPane = Locator.id("concept-information-tabs-pane-pathinfo")
+                .refindWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+        WebElement conceptPathContainer()
+        {
+            return Locator.tagWithClass("div", "concept-path-container")
+                    .findWhenNeeded(pathInformationPane);
+        }
+        List<WebElement> conceptPathParts()
+        {
+            return Locator.tagWithClass("div", "concept-path")
+                    .child(Locator.tagWithClass("span", "concept-path-label")).findElements(conceptPathContainer());
+        }
+
+        WebElement alternatePathContainer()
+        {
+            return Locator.tagWithClass("div", "alternate-paths-container")
+                    .findWhenNeeded(pathInformationPane);
+        }
+        List<WebElement> alternateConceptPathParts()
+        {
+            return Locator.tagWithClass("div", "concept-path")
+                    .child(Locator.tagWithClass("span", "concept-path-label")).findElements(alternatePathContainer());
+        }
+    }
+
+
+    public static class ConceptInfoTabsFinder extends WebDriverComponentFinder<ConceptInfoTabs, ConceptInfoTabsFinder>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.id("concept-information-tabs");
+
+        public ConceptInfoTabsFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        @Override
+        protected ConceptInfoTabs construct(WebElement el, WebDriver driver)
+        {
+            return new ConceptInfoTabs(el, driver);
+        }
+
+        @Override
+        protected Locator locator()
+        {
+            return _baseLocator;
+        }
+    }
+}

--- a/src/org/labkey/test/components/ui/ontology/ConceptPickerDialog.java
+++ b/src/org/labkey/test/components/ui/ontology/ConceptPickerDialog.java
@@ -1,0 +1,70 @@
+package org.labkey.test.components.ui.ontology;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.bootstrap.ModalDialog;
+import org.labkey.test.components.ui.ontology.OntologyTreeSearch;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+
+public class ConceptPickerDialog extends ModalDialog
+{
+    protected ConceptPickerDialog(WebElement element, WebDriver driver)
+    {
+        super(element, driver);
+    }
+
+    public ConceptPickerDialog(ModalDialogFinder finder)
+    {
+        super(finder);
+    }
+
+    // optional ontology select, in case there are multiple ontologies
+    // searchPath
+    // getPathInformation
+
+    public ConceptPickerDialog searchConcept(String conceptSearchExpression, String code)
+    {
+        elementCache().searchBox.selectItemWithCode(conceptSearchExpression, code);
+        return this;
+    }
+
+
+
+    public void clickApply()
+    {
+        dismiss("Apply");
+    }
+
+    @Override
+    protected ModalDialog.ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends ModalDialog.ElementCache
+    {
+        final OntologyTreeSearch searchBox = new OntologyTreeSearch.OntologyTreeSearchFinder(getDriver())
+                .findWhenNeeded(this);
+
+        final OntologyTreePanel treePanel = new OntologyTreePanel.OntologyTreePanelFinder(getDriver())
+                .findWhenNeeded(this);
+        // tree control
+        // tab views
+        // cancel/apply buttons
+
+//        final WebElement fileTreeContainer = Locator.tagWithClass("div", "filetree-container")
+//                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+//        final WebElement infoTabsContainer = Locator.id("concept-information-tabs")
+//                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+    }
+
+
+}

--- a/src/org/labkey/test/components/ui/ontology/ConceptPickerDialog.java
+++ b/src/org/labkey/test/components/ui/ontology/ConceptPickerDialog.java
@@ -6,6 +6,8 @@ import org.labkey.test.components.ui.ontology.OntologyTreeSearch;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
+import java.util.List;
+
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 
 public class ConceptPickerDialog extends ModalDialog
@@ -21,16 +23,45 @@ public class ConceptPickerDialog extends ModalDialog
     }
 
     // optional ontology select, in case there are multiple ontologies
-    // searchPath
-    // getPathInformation
 
+    /**
+     * uses the search bar to select an item in the ontology tree
+     * @param conceptSearchExpression an expression close enough to the target node to hit
+     * @param code  the intended concept code
+     * @return the current dialog
+     */
     public ConceptPickerDialog searchConcept(String conceptSearchExpression, String code)
     {
         elementCache().searchBox.selectItemWithCode(conceptSearchExpression, code);
         return this;
     }
 
+    /**
+     * uses the information tabs to get the name of the selected concept
+     * @return the contents of the 'title' element on the overview tab panel
+     */
+    public String getSelectedConcept()
+    {
+        return elementCache().infoTabs.getTitle();
+    }
 
+    /**
+     * uses the information tabs to obtain the concept code
+     * @return the contents of the 'code' span on the overview tab panel
+     */
+    public String getSelectedConceptCode()
+    {
+        return elementCache().infoTabs.getCode();
+    }
+
+    /**
+     * uses the information tabs to obtain the parts of the current-selected path
+     * @return contents of spans in the pathContainer
+     */
+    public List<String> getSelectedConceptPath()
+    {
+        return elementCache().infoTabs.getSelectedPath();
+    }
 
     public void clickApply()
     {
@@ -56,14 +87,9 @@ public class ConceptPickerDialog extends ModalDialog
 
         final OntologyTreePanel treePanel = new OntologyTreePanel.OntologyTreePanelFinder(getDriver())
                 .findWhenNeeded(this);
-        // tree control
-        // tab views
-        // cancel/apply buttons
 
-//        final WebElement fileTreeContainer = Locator.tagWithClass("div", "filetree-container")
-//                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
-//        final WebElement infoTabsContainer = Locator.id("concept-information-tabs")
-//                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+        final ConceptInfoTabs infoTabs = new ConceptInfoTabs.ConceptInfoTabsFinder(getDriver())
+                .findWhenNeeded(this);
     }
 
 

--- a/src/org/labkey/test/components/ui/ontology/OntologyTreePanel.java
+++ b/src/org/labkey/test/components/ui/ontology/OntologyTreePanel.java
@@ -1,0 +1,88 @@
+package org.labkey.test.components.ui.ontology;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class OntologyTreePanel extends WebDriverComponent<OntologyTreePanel.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected OntologyTreePanel(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    public TreeNode getRootNode()
+    {
+        return elementCache().rootElement;
+    }
+
+    public TreeNode openToPath(List<String> nodes)
+    {
+        var currentNode = getRootNode();
+        assertThat(currentNode.getTitle(), is(nodes.get(0)));
+
+        for (int i=1; i < nodes.size(); i++)
+        {
+            currentNode = currentNode.getChild(nodes.get(i));
+        }
+        return currentNode;
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        WebElement nodeContainer = Locator.tag("ul").findWhenNeeded(this);
+        TreeNode rootElement = new TreeNode.TreeNodeFinder(getDriver()).waitFor(nodeContainer);
+    }
+
+
+    public static class OntologyTreePanelFinder extends WebDriverComponentFinder<OntologyTreePanel, OntologyTreePanelFinder>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "filetree-container");
+
+        public OntologyTreePanelFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        @Override
+        protected OntologyTreePanel construct(WebElement el, WebDriver driver)
+        {
+            return new OntologyTreePanel(el, driver);
+        }
+
+        @Override
+        protected Locator locator()
+        {
+            return _baseLocator;
+        }
+    }
+}

--- a/src/org/labkey/test/components/ui/ontology/OntologyTreePanel.java
+++ b/src/org/labkey/test/components/ui/ontology/OntologyTreePanel.java
@@ -47,6 +47,7 @@ public class OntologyTreePanel extends WebDriverComponent<OntologyTreePanel.Elem
         for (int i=1; i < nodes.size(); i++)
         {
             currentNode = currentNode.getChild(nodes.get(i));
+            currentNode.select();
         }
         return currentNode;
     }
@@ -59,10 +60,9 @@ public class OntologyTreePanel extends WebDriverComponent<OntologyTreePanel.Elem
 
     protected class ElementCache extends Component<?>.ElementCache
     {
-        WebElement nodeContainer = Locator.tag("ul").findWhenNeeded(this);
+        WebElement nodeContainer = Locator.tag("ul").parent().findWhenNeeded(this);
         TreeNode rootElement = new TreeNode.TreeNodeFinder(getDriver()).waitFor(nodeContainer);
     }
-
 
     public static class OntologyTreePanelFinder extends WebDriverComponentFinder<OntologyTreePanel, OntologyTreePanelFinder>
     {

--- a/src/org/labkey/test/components/ui/ontology/OntologyTreeSearch.java
+++ b/src/org/labkey/test/components/ui/ontology/OntologyTreeSearch.java
@@ -1,0 +1,113 @@
+package org.labkey.test.components.ui.ontology;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.Input;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+/**
+ * wraps ontologyTreeSearchContainer.tsx
+ */
+public class OntologyTreeSearch extends WebDriverComponent<OntologyTreeSearch.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected OntologyTreeSearch(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    public OntologyTreeSearch selectItemWithCode(String searchExpression, String code)
+    {
+        setInput(searchExpression);
+        TreeSearchResult searchResult = new TreeSearchResult.TreeSearchResultFinder(getDriver())
+                .withCode(code)
+                .waitFor(elementCache().resultContainer());
+        searchResult.select();
+        return this;
+    }
+
+    public OntologyTreeSearch selectItemWithLabel(String searchExpression, String label)
+    {
+        setInput(searchExpression);
+        TreeSearchResult searchResult = new TreeSearchResult.TreeSearchResultFinder(getDriver())
+                .withLabel(label)
+                .waitFor(elementCache().resultContainer());
+        searchResult.select();
+        return this;
+    }
+
+    private OntologyTreeSearch setInput(String value)
+    {
+        elementCache().searchInput.set(value);
+        return this;
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        final Input searchInput = Input.Input(Locator.input("concept-search"), getDriver())
+                .timeout(2000).findWhenNeeded(this);
+
+        WebElement resultContainer()
+        {
+            return Locator.tag("div").withChild(Locator.tagWithClass("ul", "result-menu"))
+                    .waitForElement(this, 2000);
+        }
+
+        public List<TreeSearchResult> searchHits()
+        {
+            return new TreeSearchResult.TreeSearchResultFinder(getDriver()).findAll(resultContainer());
+        }
+
+        final Locator noSearchResults = Locator.tag("div").withChild(Locator.tagWithText("div", "No search results found."));
+    }
+
+    public static class OntologyTreeSearchFinder extends WebDriverComponentFinder<OntologyTreeSearch, OntologyTreeSearchFinder>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "concept-search-container");
+        private String _title = null;
+
+        public OntologyTreeSearchFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+
+        @Override
+        protected OntologyTreeSearch construct(WebElement el, WebDriver driver)
+        {
+            return new OntologyTreeSearch(el, driver);
+        }
+
+        @Override
+        protected Locator locator()
+        {
+            return _baseLocator;
+        }
+    }
+}

--- a/src/org/labkey/test/components/ui/ontology/TreeNode.java
+++ b/src/org/labkey/test/components/ui/ontology/TreeNode.java
@@ -1,0 +1,166 @@
+package org.labkey.test.components.ui.ontology;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+public class TreeNode extends WebDriverComponent<TreeNode.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected TreeNode(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+
+    public String getTitle()
+    {
+        return elementCache().resourceRow.getAttribute("title");
+    }
+
+    public TreeNode expand()
+    {
+        if (!isExpanded())
+        {
+            elementCache().caret.click();
+            getWrapper().waitFor(()-> isExpanded(), "The treenode did not expand in time",1000);
+        }
+        return this;
+    }
+
+    public TreeNode collapse()
+    {
+        if (isExpanded())
+        {
+            elementCache().caret.click();
+            getWrapper().waitFor(()-> !isExpanded(), "the treenode did not collapse in time", 1000);
+        }
+        return this;
+    }
+
+    /**
+     * a Tree node that is selected shows up in blue bold text.  The root always remains selected, while only
+     * the lowest-traversed node (which can be a branch or a leaf node) will be selected.  The selected node's
+     * information will appear in the detail tabs when they are shown
+     * @return
+     */
+    public TreeNode select()
+    {
+        if (!isSelected())
+            elementCache().checkboxContainer.click();
+        getWrapper().waitFor(()-> isSelected(), "the node did not become selected in time", 1000);
+        return this;
+    }
+
+    private boolean isExpanded()
+    {
+        return elementCache().caretContainer.getAttribute("style").contains("90deg");
+    }
+
+    private boolean isSelected()
+    {
+        return elementCache().checkboxContainer.getAttribute("class").contains("active");
+    }
+
+    private boolean isLeaf()
+    {
+        return elementCache().checkboxContainer.getAttribute("class").contains("filetree-leaf-node");
+    }
+
+    public List<TreeNode> getChildren()
+    {
+        expand();
+        return elementCache().children();
+    }
+
+    public TreeNode getChild(String title)
+    {
+        expand();
+        return new TreeNode.TreeNodeFinder(getDriver()).withTitle(title).waitFor(elementCache().childrenContainer);
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        final WebElement caretContainer = Locator.tagWithAttributeContaining("div", "style", "transform: rotateZ")
+                .withDescendant(Locator.tag("polygon")).findWhenNeeded(this);
+        final WebElement caret = Locator.tag("polygon").findElement(caretContainer);
+        final WebElement checkboxContainer = Locator.tagWithClass("span", "filetree-checkbox-container")
+                .refindWhenNeeded(this).withTimeout(1500);
+        final WebElement resourceRow = Locator.tagWithClass("div", "filetree-resource-row")
+                .refindWhenNeeded(checkboxContainer).withTimeout(1500);
+
+        // note: when expanded/collapsed, the UL is destroyed/recreated
+        // because we want to search just for children (not descendants) use the div as searchcontext, so
+        // children of the UL can be found/further descendants can be filtered out
+        final WebElement childrenContainer = Locator.tag("div").withChild(Locator.tag("ul")).findWhenNeeded(this);
+
+        List<TreeNode> children()
+        {
+            return new TreeNode.TreeNodeFinder(getDriver()).findAll(childrenContainer);
+        }
+    }
+
+
+    public static class TreeNodeFinder extends WebDriverComponentFinder<TreeNode, TreeNodeFinder>
+    {
+        // this locator finds only children of the UL, which hopefully filters
+        private final Locator.XPathLocator _baseLocator = Locator.tag("ul").child(Locator.tag("li")
+                .withChild(Locator.tagWithClass("span", "filetree-checkbox-container")));
+        private String _title = null;
+
+        public TreeNodeFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        public TreeNodeFinder withTitle(String title)
+        {
+            _title = title;
+            return this;
+        }
+
+        @Override
+        protected TreeNode construct(WebElement el, WebDriver driver)
+        {
+            return new TreeNode(el, driver);
+        }
+
+        @Override
+        protected Locator locator()
+        {
+            if (_title != null)
+                return _baseLocator.withChild(Locator.tag("div")
+                                .withChild(Locator.tag("div")
+                                .withChild(Locator.tagWithClass("div", "filetree-resource-row")
+                                        .withAttribute("title", _title))));
+            else
+                return _baseLocator;
+        }
+    }
+}

--- a/src/org/labkey/test/components/ui/ontology/TreeNode.java
+++ b/src/org/labkey/test/components/ui/ontology/TreeNode.java
@@ -8,6 +8,9 @@ import org.openqa.selenium.WebElement;
 
 import java.util.List;
 
+/**
+ * wraps nodes in the ontologyTreePanel
+ */
 public class TreeNode extends WebDriverComponent<TreeNode.ElementCache>
 {
     private final WebElement _el;
@@ -108,8 +111,8 @@ public class TreeNode extends WebDriverComponent<TreeNode.ElementCache>
     protected class ElementCache extends Component<?>.ElementCache
     {
         final WebElement caretContainer = Locator.tagWithAttributeContaining("div", "style", "transform: rotateZ")
-                .withDescendant(Locator.tag("polygon")).findWhenNeeded(this);
-        final WebElement caret = Locator.tag("polygon").findElement(caretContainer);
+                .findWhenNeeded(this);
+        final WebElement caret = Locator.tag("polygon").findWhenNeeded(caretContainer);
         final WebElement checkboxContainer = Locator.tagWithClass("span", "filetree-checkbox-container")
                 .refindWhenNeeded(this).withTimeout(1500);
         final WebElement resourceRow = Locator.tagWithClass("div", "filetree-resource-row")
@@ -131,7 +134,8 @@ public class TreeNode extends WebDriverComponent<TreeNode.ElementCache>
     {
         // this locator finds only children of the UL, which hopefully filters
         private final Locator.XPathLocator _baseLocator = Locator.tag("ul").child(Locator.tag("li")
-                .withChild(Locator.tagWithClass("span", "filetree-checkbox-container")));
+                .withChild(Locator.tag("div")
+                        .withChild(Locator.tagWithClass("span", "filetree-checkbox-container"))));
         private String _title = null;
 
         public TreeNodeFinder(WebDriver driver)
@@ -155,10 +159,8 @@ public class TreeNode extends WebDriverComponent<TreeNode.ElementCache>
         protected Locator locator()
         {
             if (_title != null)
-                return _baseLocator.withChild(Locator.tag("div")
-                                .withChild(Locator.tag("div")
-                                .withChild(Locator.tagWithClass("div", "filetree-resource-row")
-                                        .withAttribute("title", _title))));
+                return _baseLocator.withDescendant(Locator.tagWithClass("div", "filetree-resource-row")
+                                        .withAttribute("title", _title));
             else
                 return _baseLocator;
         }

--- a/src/org/labkey/test/components/ui/ontology/TreeSearchResult.java
+++ b/src/org/labkey/test/components/ui/ontology/TreeSearchResult.java
@@ -1,0 +1,103 @@
+package org.labkey.test.components.ui.ontology;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+public class TreeSearchResult extends WebDriverComponent<TreeSearchResult.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected TreeSearchResult(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    public String getLabel()
+    {
+        return elementCache().label.getText();
+    }
+
+    public String getCode()
+    {
+        return elementCache().code.getText();
+    }
+
+    public void select()
+    {
+        WebElement component = getComponentElement();
+        getWrapper().scrollIntoView(component);
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(component));
+        component.click();
+        getWrapper().shortWait().until(ExpectedConditions.stalenessOf(component));
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        final WebElement label = Locator.tagWithClass("div", "bold").findWhenNeeded(this);
+        final WebElement code = Locator.tagWithClass("div", "col-xs-2").findWhenNeeded(this);
+    }
+
+
+    public static class TreeSearchResultFinder extends WebDriverComponentFinder<TreeSearchResult, TreeSearchResultFinder>
+    {
+        private Locator.XPathLocator _locator= Locator.tagWithClass("li", "selectable-item")
+                .withChild(Locator.tagWithClass("div", "row"));
+
+        public TreeSearchResultFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        public TreeSearchResultFinder withLabel(String label)
+        {
+            _locator = Locator.tagWithClass("li", "selectable-item")
+                    .withChild(Locator.tagWithClass("div", "row")
+                            .withChild(Locator.tagWithClass("div", "bold").withText(label)));
+            return this;
+        }
+
+        public TreeSearchResultFinder withCode(String code)
+        {
+            _locator = Locator.tagWithClass("li", "selectable-item")
+                    .withChild(Locator.tagWithClass("div", "row")
+                    .withChild(Locator.tagWithClass("div", "col-xs-2").withText(code)));
+            return this;
+        }
+
+        @Override
+        protected TreeSearchResult construct(WebElement el, WebDriver driver)
+        {
+            return new TreeSearchResult(el, driver);
+        }
+
+        @Override
+        protected Locator locator()
+        {
+            return _locator;
+        }
+    }
+}

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -393,7 +393,7 @@ public class FieldDefinition extends PropertyDescriptor
         Attachment("Attachment", "attachment"),
         User("User", "int", null, new LookupInfo(null, "core", "users")),
         Lookup("Lookup", null),
-        OntologyLookup("Ontology Lookup", null),
+        OntologyLookup("Ontology Lookup", "string", "http://www.labkey.org/types#conceptCode", null),
         Sample("Sample", "int", "http://www.labkey.org/exp/xml#sample", new LookupInfo(null, "exp", "Materials"));
 
         private final String _label; // the display value in the UI for this kind of field

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -64,14 +64,14 @@ public class FieldDefinition extends PropertyDescriptor
     }
 
     @Override
-    public JSONObject toJSONObject()
+    public JSONObject toJSONObject(boolean forProtocol)
     {
         if (getType() != null && getType().getRangeURI() == null)
         {
             throw new IllegalArgumentException("`FieldDefinition` cannot be used to create column over API: " + getType().name());
         }
 
-        JSONObject json = super.toJSONObject();
+        JSONObject json = super.toJSONObject(forProtocol);
         if (getScale() != null)
             json.put("scale", getScale());
         if (isPrimaryKey() != null)

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -40,6 +40,11 @@ public class FieldDefinition extends PropertyDescriptor
     private String _url;
     private List<FieldValidator<?>> _validators;
     private String _importAliases;
+    private String _sourceOntology;
+    private String _conceptLabelColumn;
+    private String _conceptImportColumn;
+    private String _principalConceptCode;
+    private String _principalConceptSearchExpression;
 
     public FieldDefinition(String name, ColumnType type)
     {
@@ -91,6 +96,14 @@ public class FieldDefinition extends PropertyDescriptor
             getValidators().stream().map(FieldValidator::toJSONObject).forEachOrdered(propertyValidators::add);
             json.put("propertyValidators", propertyValidators);
         }
+        if (getSourceOntology() != null)
+            json.put("sourceOntology", getSourceOntology());
+        if (getConceptLabelColumn() != null)
+            json.put("conceptLabelColumn", getConceptLabelColumn());
+        if (getConceptImportColumn() != null)
+            json.put("conceptImportColumn", getConceptImportColumn());
+        if (getPrincipalConceptCode() != null)
+            json.put("principalConceptCode", getPrincipalConceptCode());
 
         return json;
     }
@@ -279,6 +292,61 @@ public class FieldDefinition extends PropertyDescriptor
     {
         _scale = scale;
         return this;
+    }
+
+    public FieldDefinition setSourceOntology(String sourceOntology)
+    {
+        _sourceOntology = sourceOntology;
+        return this;
+    }
+
+    public String getSourceOntology()
+    {
+        return _sourceOntology;
+    }
+
+    public FieldDefinition setConceptLabelColumn(String conceptLabelColumn)
+    {
+        _conceptLabelColumn = conceptLabelColumn;
+        return this;
+    }
+
+    public String getConceptLabelColumn()
+    {
+        return _conceptLabelColumn;
+    }
+
+    public FieldDefinition setConceptImportColumn(String conceptImportColumn)
+    {
+        _conceptImportColumn = conceptImportColumn;
+        return this;
+    }
+
+    public String getConceptImportColumn()
+    {
+        return _conceptImportColumn;
+    }
+
+    public FieldDefinition setPrincipalConceptCode(String conceptCode)
+    {
+        _principalConceptCode = conceptCode;
+        return this;
+    }
+
+    public String getPrincipalConceptCode()
+    {
+        return _principalConceptCode;
+    }
+
+    public FieldDefinition setPrincipalConceptSearchExpression(String searchExpression)
+    {
+        _principalConceptSearchExpression = searchExpression;
+        return this;
+    }
+
+    public String getPrincipalConceptSearchExpression()
+    {
+        return _principalConceptSearchExpression;
     }
 
     public enum RangeType

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -325,6 +325,7 @@ public class FieldDefinition extends PropertyDescriptor
         Attachment("Attachment", "attachment"),
         User("User", "int", null, new LookupInfo(null, "core", "users")),
         Lookup("Lookup", null),
+        OntologyLookup("Ontology Lookup", null),
         Sample("Sample", "int", "http://www.labkey.org/exp/xml#sample", new LookupInfo(null, "exp", "Materials"));
 
         private final String _label; // the display value in the UI for this kind of field

--- a/src/org/labkey/test/util/search/SearchAdminAPIHelper.java
+++ b/src/org/labkey/test/util/search/SearchAdminAPIHelper.java
@@ -62,7 +62,7 @@ public abstract class SearchAdminAPIHelper
         // Invoke a special server action that waits until all previous indexer tasks are complete, even wait for background indexing tasks to complete (e.g. deleteContainer)
         var cmd = new PostCommand("search", "waitForIndexer");
         cmd.setTimeout(timeout);
-        cmd.setParameters(Map.of("priority","background"));
+        cmd.setParameters(new HashMap<>(Map.of("priority", "background")));
 
         executeWaitForIndexer(cmd);
     }

--- a/src/org/labkey/test/util/search/SearchAdminAPIHelper.java
+++ b/src/org/labkey/test/util/search/SearchAdminAPIHelper.java
@@ -49,14 +49,8 @@ public abstract class SearchAdminAPIHelper
         // Invoke a special server action that waits until all previous indexer tasks are complete
         var cmd = new PostCommand("search", "waitForIndexer");
         cmd.setTimeout(timeout);
-        try
-        {
-            var response = cmd.execute(WebTestHelper.getRemoteApiConnection(), null);
-            assertEquals("WaitForIndexer action timed out", HttpStatus.SC_OK, response.getStatusCode());
-        } catch (Exception cmdException)
-        {
-            throw new RuntimeException("an error occurred while waiting for search indexing to finish", cmdException);
-        }
+
+       executeWaitForIndexer(cmd);
     }
 
     public static void waitForIndexerBackground()
@@ -72,6 +66,11 @@ public abstract class SearchAdminAPIHelper
         cmd.setTimeout(timeout);
         cmd.setParameters(new HashMap<>(Map.of("priority", "background")));
 
+        executeWaitForIndexer(cmd);
+    }
+
+    private static void executeWaitForIndexer(PostCommand cmd)
+    {
         try
         {
             var response = cmd.execute(WebTestHelper.getRemoteApiConnection(), null);

--- a/src/org/labkey/test/util/search/SearchAdminAPIHelper.java
+++ b/src/org/labkey/test/util/search/SearchAdminAPIHelper.java
@@ -26,6 +26,7 @@ import org.labkey.test.util.SimpleHttpResponse;
 import org.openqa.selenium.WebDriver;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -48,7 +49,14 @@ public abstract class SearchAdminAPIHelper
         // Invoke a special server action that waits until all previous indexer tasks are complete
         var cmd = new PostCommand("search", "waitForIndexer");
         cmd.setTimeout(timeout);
-        executeWaitForIndexer(cmd);
+        try
+        {
+            var response = cmd.execute(WebTestHelper.getRemoteApiConnection(), null);
+            assertEquals("WaitForIndexer action timed out", HttpStatus.SC_OK, response.getStatusCode());
+        } catch (Exception cmdException)
+        {
+            throw new RuntimeException("an error occurred while waiting for search indexing to finish", cmdException);
+        }
     }
 
     public static void waitForIndexerBackground()
@@ -64,11 +72,6 @@ public abstract class SearchAdminAPIHelper
         cmd.setTimeout(timeout);
         cmd.setParameters(new HashMap<>(Map.of("priority", "background")));
 
-        executeWaitForIndexer(cmd);
-    }
-
-    private static void executeWaitForIndexer(PostCommand cmd)
-    {
         try
         {
             var response = cmd.execute(WebTestHelper.getRemoteApiConnection(), null);


### PR DESCRIPTION
#### Rationale
Contains new component wrappers for ontology-specific UI, also updates to DomainDesigner components (and FieldDefinition) to support ontology 

#### Related Pull Requests
https://github.com/LabKey/ontology/pull/39 <-- contains the test class, + page for concept browser

#### Changes
modal dialog for ontologyPicker (which currently assumes there's only one ontology, doesn't pick the intended one yet)
wrappers for subcomponents on the browse-concept page and the ontology picker dialog:
**OntologyTreeSearch** - wraps the search bar in the picker dialog, uses **TreeSearchResult** to wrap search results
![image](https://user-images.githubusercontent.com/16809856/117207529-e4393f00-ada8-11eb-95cf-e64a525a9c59.png)
- notable support: find item by label, or by code

**OntologyTreePanel** - wraps the treeview, uses **TreeNode** to wrap nodes in it
![image](https://user-images.githubusercontent.com/16809856/117207893-5873e280-ada9-11eb-81db-58e1dea32bf2.png)
-currently supports: can select a node given a List<String> path to it
-TreeNode can find its own children, or pick one with a given title

**ConceptInfoTabs** - wraps the tabs on the right in the picker dialog (or on the browse concept page)
![image](https://user-images.githubusercontent.com/16809856/117208297-d1733a00-ada9-11eb-9380-4097a3a2bbc4.png)
Can obtain selected concept title, selected concept code, synonyms, and path
Does not (yet) navigate to alternate path

Added fields to FieldDefinition.java, to support ontology concepts
Added support in DomainFieldRow, to interact with ontology field properties UI when defining a domain
