### PR TITLE
Update SiteWrapper to be aware of LKSM App page.

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -48,6 +48,7 @@ import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.components.core.ProjectMenu;
 import org.labkey.test.components.dumbster.EmailRecordTable;
 import org.labkey.test.components.html.SiteNavBar;
+import org.labkey.test.components.ui.navigation.UserMenu;
 import org.labkey.test.pages.core.admin.CustomizeSitePage;
 import org.labkey.test.pages.core.admin.ShowAdminPage;
 import org.labkey.test.pages.user.UserDetailsPage;
@@ -133,7 +134,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
             executeScript("window.onbeforeunload = null;"); // Just get logged in, ignore 'unload' alerts
             beginAt(WebTestHelper.buildURL("login", "login"));
             waitForAnyElement("Should be on login or Home portal", Locator.id("email"), SiteNavBar.Locators.userMenu,
-                    Locator.tagWithId("a", "user-menu-dropdown"));
+                    UserMenu.AppUserMenu());
         }
 
         if (PasswordUtil.getUsername().equals(getCurrentUser()))
@@ -156,7 +157,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                 if (isElementPresent(SiteNavBar.Locators.userMenu))
                     return true;
 
-                if(isElementPresent(Locator.tagWithId("a", "user-menu-dropdown")))
+                if(isElementPresent(UserMenu.AppUserMenu()))
                 {
                     goToHome();
                     return true;

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -134,7 +134,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
             executeScript("window.onbeforeunload = null;"); // Just get logged in, ignore 'unload' alerts
             beginAt(WebTestHelper.buildURL("login", "login"));
             waitForAnyElement("Should be on login or Home portal", Locator.id("email"), SiteNavBar.Locators.userMenu,
-                    UserMenu.AppUserMenu());
+                    UserMenu.appUserMenu());
         }
 
         if (PasswordUtil.getUsername().equals(getCurrentUser()))
@@ -154,7 +154,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
             // verify we're signed in now
             if (!waitFor(() ->
             {
-                if(isElementPresent(UserMenu.AppUserMenu()))
+                if(isElementPresent(UserMenu.appUserMenu()))
                 {
                     goToHome();
                 }

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -154,14 +154,13 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
             // verify we're signed in now
             if (!waitFor(() ->
             {
-                if (isElementPresent(SiteNavBar.Locators.userMenu))
-                    return true;
-
                 if(isElementPresent(UserMenu.AppUserMenu()))
                 {
                     goToHome();
-                    return true;
                 }
+
+                if (isElementPresent(SiteNavBar.Locators.userMenu))
+                    return true;
 
                 bypassSecondaryAuthentication();
                 return false;

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -132,7 +132,8 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         {
             executeScript("window.onbeforeunload = null;"); // Just get logged in, ignore 'unload' alerts
             beginAt(WebTestHelper.buildURL("login", "login"));
-            waitForAnyElement("Should be on login or Home portal", Locator.id("email"), SiteNavBar.Locators.userMenu);
+            waitForAnyElement("Should be on login or Home portal", Locator.id("email"), SiteNavBar.Locators.userMenu,
+                    Locator.tagWithId("a", "user-menu-dropdown"));
         }
 
         if (PasswordUtil.getUsername().equals(getCurrentUser()))
@@ -154,6 +155,13 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
             {
                 if (isElementPresent(SiteNavBar.Locators.userMenu))
                     return true;
+
+                if(isElementPresent(Locator.tagWithId("a", "user-menu-dropdown")))
+                {
+                    goToHome();
+                    return true;
+                }
+
                 bypassSecondaryAuthentication();
                 return false;
             }, defaultWaitForPage))

--- a/src/org/labkey/test/components/ui/navigation/UserMenu.java
+++ b/src/org/labkey/test/components/ui/navigation/UserMenu.java
@@ -43,7 +43,7 @@ public abstract class UserMenu extends BootstrapMenu
     @Override
     protected Locator getToggleLocator()
     {
-        return Locator.id(MENU_ID);
+        return appUserMenu();
     }
 
     /**
@@ -51,8 +51,8 @@ public abstract class UserMenu extends BootstrapMenu
      *
      * @return A locator to the drop down user menu button.
      */
-    public static Locator AppUserMenu()
+    public static Locator appUserMenu()
     {
-        return Locator.tagWithId("a", "user-menu-dropdown");
+        return Locator.tagWithId("a", MENU_ID);
     }
 }

--- a/src/org/labkey/test/components/ui/navigation/UserMenu.java
+++ b/src/org/labkey/test/components/ui/navigation/UserMenu.java
@@ -45,4 +45,14 @@ public abstract class UserMenu extends BootstrapMenu
     {
         return Locator.id(MENU_ID);
     }
+
+    /**
+     * The button for the drop down user menu. The user menu on the SampleManager app is an example of this button.
+     *
+     * @return A locator to the drop down user menu button.
+     */
+    public static Locator AppUserMenu()
+    {
+        return Locator.tagWithId("a", "user-menu-dropdown");
+    }
 }


### PR DESCRIPTION
#### Rationale
In order to run the LKSM automation against a trial instance the siteWrapper needs to be able to identify when a login has succeeded. The LKSM App page does not have the traditional LKS elements so added a check to for the user menu that is specific to the App UI. Hopefully it is general enough that if other apps are created that share the same header menu they will just work when running against a trial instance.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/564

#### Changes
* Update LabKeySiteWrapper.simpleSignIn to look for user menu in LKSM App.
