### PR TITLE
42976: SQL wildcard should not be prefixed by '!' in exported scripts

### DIFF
--- a/src/org/labkey/test/tests/AbstractExportTest.java
+++ b/src/org/labkey/test/tests/AbstractExportTest.java
@@ -17,6 +17,7 @@ package org.labkey.test.tests;
 
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -35,6 +36,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -271,6 +273,23 @@ public abstract class AbstractExportTest extends BaseWebDriverTest
         {
             assertScriptContentLineCount(javaScriptScript, 35);
             assertJavaScriptScriptContents(javaScriptScript, testColumn);
+        });
+
+        // Issue 42976: SQL wildcard should not be prefixed by '!' in exported scripts
+        dataRegion.setFilter(testColumn, "Contains One Of (example usage: a;b;c)", "under_score;two;");
+        exportHelper.exportAndVerifyScript(DataRegionExportHelper.ScriptExportType.JAVASCRIPT, javaScriptScript ->
+        {
+            assertScriptContentLineCount(javaScriptScript, 35);
+            assertThat(javaScriptScript, CoreMatchers.containsString("LABKEY.Filter.create('" + testColumn + "', 'under_score;two;', LABKEY.Filter.Types.CONTAINS_ONE_OF)"));
+        });
+
+        // multi-value separator ';' escaping uses json encoded filter value
+        dataRegion.setFilter(testColumn, "Contains One Of (example usage: a;b;c)", "{json:[\"a;b;c\",\"Z\"]}");
+        exportHelper.exportAndVerifyScript(DataRegionExportHelper.ScriptExportType.JAVASCRIPT, javaScriptScript ->
+        {
+            assertScriptContentLineCount(javaScriptScript, 35);
+            // NOTE: The json string contains quote characters which are backslash escaped and then we need to backslash escape both in the java string
+            assertThat(javaScriptScript, CoreMatchers.containsString("LABKEY.Filter.create('" + testColumn + "', '{json:[\\\"a;b;c\\\",\\\"Z\\\"]}', LABKEY.Filter.Types.CONTAINS_ONE_OF)"));
         });
     }
 


### PR DESCRIPTION
#### Rationale
The SQL wildcard '_' is escaped with a '!' when used as the parameter value in the LIKE filters (CONTAINS, CONTAINS_ONE_OF).  When generating an export language snippet for the grid, we used the escaped parameter value rather than the actual filter parameter value.  In addition, the export script generated filter didn't handle values for clauses that contain multiple parameters that include the separator character.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2242

#### Changes
- remove obsolete code in export script model for multi-valued filter types
- use the unescaped parameter value when rendering the export script
- for filters that support multiple values (IN, CONTAINS_ONE_OF, BETWEEN), encode values using the json filter syntax if they contain the separator character
