### PR TITLE
Fix queryGrid to look for a button with "Clear" not just "Clear all".

### DIFF
--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -253,7 +253,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
     {
         if (isGridPanel())
         {
-            if (elementCache().clearAllBtnLoc.existsIn(this))
+            if (elementCache().clearBtnLoc.existsIn(this))
                 doAndWaitForUpdate(() ->
                         elementCache().clearAllSelectionStatusBtn().click());
             else
@@ -310,8 +310,8 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         Locator selectionStatusContainerLoc = Locator.tagWithClass("div", "selection-status");
         Locator selectAllBtnLoc = Locator.tagWithClass("span", "selection-status__select-all")
                 .child(Locator.buttonContainingText("Select all"));
-        Locator clearAllBtnLoc = Locator.tagWithClass("span", "selection-status__clear-all")
-                .child(Locator.button("Clear all"));
+        Locator clearBtnLoc = Locator.tagWithClass("span", "selection-status__clear-all")
+                .child(Locator.tagContainingText("button", "Clear"));
 
         WebElement selectionStatusContainer()
         {
@@ -319,7 +319,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         }
         WebElement clearAllSelectionStatusBtn()
         {
-            return clearAllBtnLoc.findElement(selectionStatusContainer());
+            return clearBtnLoc.findElement(selectionStatusContainer());
         }
         WebElement selectAllN_Btn()
         {


### PR DESCRIPTION
#### Rationale
The QueryGrid was not clearing the selected items if there were selections on different pages of the grid. This was because the locator for the button assumed the text would always be "Clear All" it is not, sometimes it is just "Clear". This fixes the locator.
Fix was validated with runs in LKB, LKSM, ELN and Inventory.

#### Related Pull Requests
* None

#### Changes
* Change locator to look for a button containing the text "Clear".
* Changed name of element cache object to clearBtnLoc.
