### PR TITLE
RlabkeyTest - add test cases for labkey.domain.createAndLoad and labkey.query.import

### DIFF
--- a/data/api/rlabkey-api-experiment.xml
+++ b/data/api/rlabkey-api-experiment.xml
@@ -156,7 +156,7 @@
             <![CDATA[
                 Rows via createAndLoad = 3
                 Rows via insert = 2
-                Violation of UNIQUE KEY constraint 'UQ_Material_LSID'. Cannot insert duplicate key in object 'exp.Material'.
+                duplicate key
                 Rows via merge = 10
                 Has audit transaction id = TRUE
              ]]>

--- a/data/api/rlabkey-api-experiment.xml
+++ b/data/api/rlabkey-api-experiment.xml
@@ -81,15 +81,15 @@
             <![CDATA[
                 library(Rlabkey)
                 df <- data.frame(name=c("test1","test2","test3"), customInt=c(1:3), customString=c("aaa", "bbb", "ccc"))
-                labkey.domain.createAndLoad(baseUrl=labkey.url.base, folderPath="%projectName%", domainKind="SampleSet", df=df, name="test sample type with load data")
+                info <- labkey.domain.createAndLoad(baseUrl=labkey.url.base, folderPath="%projectName%", domainKind="SampleSet", df=df, name="test sample type with load data")
+                print(paste("Create successful = ", info$success, sep=""))
+                print(paste("Rows via createAndLoad = ", info$rowCount, sep=""))
             ]]>
         </url>
         <response>
             <![CDATA[
-                $success
-                [1] TRUE
-                $rowCount
-                [1] 3
+                Create successful = TRUE
+                Rows via createAndLoad = 3
              ]]>
         </response>
     </test>
@@ -98,15 +98,67 @@
             <![CDATA[
                 library(Rlabkey)
                 df <- data.frame(name=c("test1","test2","test3"), customInt=c(1:3), customString=c("aaa", "bbb", "ccc"))
-                labkey.domain.createAndLoad(baseUrl=labkey.url.base, folderPath="%projectName%", domainKind="DataClass", df=df, name="test data class with load data")
+                info <- labkey.domain.createAndLoad(baseUrl=labkey.url.base, folderPath="%projectName%", domainKind="DataClass", df=df, name="test data class with load data")
+                print(paste("Create successful = ", info$success, sep=""))
+                print(paste("Rows via createAndLoad = ", info$rowCount, sep=""))
             ]]>
         </url>
         <response>
             <![CDATA[
-                $success
-                [1] TRUE
-                $rowCount
-                [1] 3
+                Create successful = TRUE
+                Rows via createAndLoad = 3
+             ]]>
+        </response>
+    </test>
+    <test name="insert and merge into sample type" type="post">
+        <url>
+            <![CDATA[
+                library(Rlabkey)
+                name <- "test insert and merge into sample type"
+                df <- data.frame(name=c("test1","test2","test3"), customInt=c(1:3), customString=c("aaa", "bbb", "ccc"))
+                info <- labkey.domain.createAndLoad(baseUrl=labkey.url.base, folderPath="%projectName%", domainKind="SampleSet", df=df, name=name)
+                print(paste("Rows via createAndLoad = ", info$rowCount, sep=""))
+
+                # insert via labkey.query.import
+                df <- data.frame(name=c("test4","test5"), customInt=c(4:5), customString=c("aaa", "bbb"))
+                info <- labkey.query.import(
+                    baseUrl=labkey.url.base, folderPath="%projectName%",
+                    schemaName="samples", queryName=name, toImport=df
+                )
+                print(paste("Rows via insert = ", info$rowCount, sep=""))
+
+                # now try labkey.query.import which should fail with duplicate key message
+                df <- data.frame(
+                    name=c("test1","test2","test3","test4","test5","test6","test7","test8","test9","test10"),
+                    customInt=c(101:110)
+                )
+                info <- labkey.query.import(
+                    baseUrl=labkey.url.base, folderPath="%projectName%",
+                    schemaName="samples", queryName=name, toImport=df
+                )
+                print(paste("Error = ", info$exception, sep=""))
+
+                # now merge via labkey.query.import, 5 update and 5 inserts
+                df <- data.frame(
+                    name=c("test1","test2","test3","test4","test5","test6","test7","test8","test9","test10"),
+                    customInt=c(101:110)
+                )
+                info <- labkey.query.import(
+                    baseUrl=labkey.url.base, folderPath="%projectName%",
+                    schemaName="samples", queryName=name, toImport=df,
+                    options=list(insertOption = "MERGE", auditBehavior = "DETAILED")
+                )
+                print(paste("Rows via merge = ", info$rowCount, sep=""))
+                print(paste("Has audit transaction id = ", !is.na(info$transactionAuditId), sep=""))
+            ]]>
+        </url>
+        <response>
+            <![CDATA[
+                Rows via createAndLoad = 3
+                Rows via insert = 2
+                Violation of UNIQUE KEY constraint 'UQ_Material_LSID'. Cannot insert duplicate key in object 'exp.Material'.
+                Rows via merge = 10
+                Has audit transaction id = TRUE
              ]]>
         </response>
     </test>

--- a/data/api/rlabkey-api-experiment.xml
+++ b/data/api/rlabkey-api-experiment.xml
@@ -86,26 +86,10 @@
         </url>
         <response>
             <![CDATA[
-                $rowsAffected
+                $success
+                [1] TRUE
+                $rowCount
                 [1] 3
-
-                $queryName
-                [1] "test sample type with load data"
-
-                $schemaName
-                [1] "samples"
-
-                $rows[[1]]$name
-                [1] "test1"
-
-                $rows[[3]]$customInt
-                [1] 3
-
-                $rows[[3]]$customString
-                [1] "ccc"
-
-                $command
-                [1] "insert"
              ]]>
         </response>
     </test>
@@ -119,26 +103,10 @@
         </url>
         <response>
             <![CDATA[
-                $rowsAffected
+                $success
+                [1] TRUE
+                $rowCount
                 [1] 3
-
-                $queryName
-                [1] "test data class with load data"
-
-                $schemaName
-                [1] "exp.data"
-
-                $rows[[1]]$name
-                [1] "test1"
-
-                $rows[[3]]$customInt
-                [1] 3
-
-                $rows[[3]]$customString
-                [1] "ccc"
-
-                $command
-                [1] "insert"
              ]]>
         </response>
     </test>

--- a/data/api/rlabkey-api-experiment.xml
+++ b/data/api/rlabkey-api-experiment.xml
@@ -76,4 +76,70 @@
             ]]>
         </response>
     </test>
+    <test name="create sample type and load data" type="post">
+        <url>
+            <![CDATA[
+                library(Rlabkey)
+                df <- data.frame(name=c("test1","test2","test3"), customInt=c(1:3), customString=c("aaa", "bbb", "ccc"))
+                labkey.domain.createAndLoad(baseUrl=labkey.url.base, folderPath="%projectName%", domainKind="SampleSet", df=df, name="test sample type with load data")
+            ]]>
+        </url>
+        <response>
+            <![CDATA[
+                $rowsAffected
+                [1] 3
+
+                $queryName
+                [1] "test sample type with load data"
+
+                $schemaName
+                [1] "samples"
+
+                $rows[[1]]$name
+                [1] "test1"
+
+                $rows[[3]]$customInt
+                [1] 3
+
+                $rows[[3]]$customString
+                [1] "ccc"
+
+                $command
+                [1] "insert"
+             ]]>
+        </response>
+    </test>
+    <test name="create data class and load data" type="post">
+        <url>
+            <![CDATA[
+                library(Rlabkey)
+                df <- data.frame(name=c("test1","test2","test3"), customInt=c(1:3), customString=c("aaa", "bbb", "ccc"))
+                labkey.domain.createAndLoad(baseUrl=labkey.url.base, folderPath="%projectName%", domainKind="DataClass", df=df, name="test data class with load data")
+            ]]>
+        </url>
+        <response>
+            <![CDATA[
+                $rowsAffected
+                [1] 3
+
+                $queryName
+                [1] "test data class with load data"
+
+                $schemaName
+                [1] "exp.data"
+
+                $rows[[1]]$name
+                [1] "test1"
+
+                $rows[[3]]$customInt
+                [1] 3
+
+                $rows[[3]]$customString
+                [1] "ccc"
+
+                $command
+                [1] "insert"
+             ]]>
+        </response>
+    </test>
 </ApiTests>

--- a/data/api/rlabkey-api-list.xml
+++ b/data/api/rlabkey-api-list.xml
@@ -129,4 +129,37 @@
             ]]>
         </response>
     </test>
+    <test name="create list and load data" type="post">
+        <url>
+            <![CDATA[
+                library(Rlabkey)
+                df <- data.frame(intKey=c(1:3), customInt=c(1:3), customString=c("aaa", "bbb", "ccc"))
+                labkey.domain.createAndLoad(baseUrl=labkey.url.base, folderPath="%projectName%", domainKind="IntList", df=df, name="test list with load data", options=list(keyName = "intKey"))
+            ]]>
+        </url>
+        <response>
+            <![CDATA[
+                $rowsAffected
+                [1] 3
+
+                $queryName
+                [1] "test list with load data"
+
+                $schemaName
+                [1] "lists"
+
+                $rows[[1]]$intKey
+                [1] 1
+
+                $rows[[3]]$customInt
+                [1] 3
+
+                $rows[[3]]$customString
+                [1] "ccc"
+
+                $command
+                [1] "insert"
+             ]]>
+        </response>
+    </test>
 </ApiTests>

--- a/data/api/rlabkey-api-list.xml
+++ b/data/api/rlabkey-api-list.xml
@@ -139,26 +139,10 @@
         </url>
         <response>
             <![CDATA[
-                $rowsAffected
+                $success
+                [1] TRUE
+                $rowCount
                 [1] 3
-
-                $queryName
-                [1] "test list with load data"
-
-                $schemaName
-                [1] "lists"
-
-                $rows[[1]]$intKey
-                [1] 1
-
-                $rows[[3]]$customInt
-                [1] 3
-
-                $rows[[3]]$customString
-                [1] "ccc"
-
-                $command
-                [1] "insert"
              ]]>
         </response>
     </test>

--- a/data/api/rlabkey-api-list.xml
+++ b/data/api/rlabkey-api-list.xml
@@ -134,15 +134,15 @@
             <![CDATA[
                 library(Rlabkey)
                 df <- data.frame(intKey=c(1:3), customInt=c(1:3), customString=c("aaa", "bbb", "ccc"))
-                labkey.domain.createAndLoad(baseUrl=labkey.url.base, folderPath="%projectName%", domainKind="IntList", df=df, name="test list with load data", options=list(keyName = "intKey"))
+                info <- labkey.domain.createAndLoad(baseUrl=labkey.url.base, folderPath="%projectName%", domainKind="IntList", df=df, name="test list with load data", options=list(keyName = "intKey"))
+                print(paste("Create successful = ", info$success, sep=""))
+                print(paste("Rows via createAndLoad = ", info$rowCount, sep=""))
             ]]>
         </url>
         <response>
             <![CDATA[
-                $success
-                [1] TRUE
-                $rowCount
-                [1] 3
+                Create successful = TRUE
+                Rows via createAndLoad = 3
              ]]>
         </response>
     </test>

--- a/data/api/rlabkey-api-study.xml
+++ b/data/api/rlabkey-api-study.xml
@@ -61,29 +61,10 @@
         </url>
         <response>
             <![CDATA[
-                $rowsAffected
+                $success
+                [1] TRUE
+                $rowCount
                 [1] 3
-
-                $queryName
-                [1] "test dataset with load data"
-
-                $schemaName
-                [1] "study"
-
-                $rows[[1]]$ParticipantId
-                [1] "1"
-
-                $rows[[2]]$SequenceNum
-                [1] 2
-
-                $rows[[3]]$customInt
-                [1] 3
-
-                $rows[[3]]$customString
-                [1] "ccc"
-
-                $command
-                [1] "insert"
             ]]>
         </response>
     </test>

--- a/data/api/rlabkey-api-study.xml
+++ b/data/api/rlabkey-api-study.xml
@@ -56,15 +56,15 @@
             <![CDATA[
                 library(Rlabkey)
                 df <- data.frame(ParticipantID=c(1,1,1), Visit=c(1,2,3), customInt=c(1:3), customString=c("aaa", "bbb", "ccc"))
-                labkey.domain.createAndLoad(baseUrl=labkey.url.base, folderPath="%projectName%", domainKind="StudyDatasetVisit", df=df, name="test dataset with load data")
+                info <- labkey.domain.createAndLoad(baseUrl=labkey.url.base, folderPath="%projectName%", domainKind="StudyDatasetVisit", df=df, name="test dataset with load data")
+                print(paste("Create successful = ", info$success, sep=""))
+                print(paste("Rows via createAndLoad = ", info$rowCount, sep=""))
             ]]>
         </url>
         <response>
             <![CDATA[
-                $success
-                [1] TRUE
-                $rowCount
-                [1] 3
+                Create successful = TRUE
+                Rows via createAndLoad = 3
             ]]>
         </response>
     </test>

--- a/data/api/rlabkey-api-study.xml
+++ b/data/api/rlabkey-api-study.xml
@@ -51,4 +51,40 @@
             ]]>
         </response>
     </test>
+    <test name="create dataset and load data" type="post">
+        <url>
+            <![CDATA[
+                library(Rlabkey)
+                df <- data.frame(ParticipantID=c(1,1,1), Visit=c(1,2,3), customInt=c(1:3), customString=c("aaa", "bbb", "ccc"))
+                labkey.domain.createAndLoad(baseUrl=labkey.url.base, folderPath="%projectName%", domainKind="StudyDatasetVisit", df=df, name="test dataset with load data")
+            ]]>
+        </url>
+        <response>
+            <![CDATA[
+                $rowsAffected
+                [1] 3
+
+                $queryName
+                [1] "test dataset with load data"
+
+                $schemaName
+                [1] "study"
+
+                $rows[[1]]$ParticipantId
+                [1] "1"
+
+                $rows[[2]]$SequenceNum
+                [1] 2
+
+                $rows[[3]]$customInt
+                [1] 3
+
+                $rows[[3]]$customString
+                [1] "ccc"
+
+                $command
+                [1] "insert"
+            ]]>
+        </response>
+    </test>
 </ApiTests>

--- a/data/api/rlabkey-api-webdav.xml
+++ b/data/api/rlabkey-api-webdav.xml
@@ -187,7 +187,7 @@
             <![CDATA[
                 library(Rlabkey)
                 c("remote file.exists pre", file.exists("%remoteDir%/writeChecks/putMe.txt"))
-                c("webdav.put", labkey.webdav.put(localFile="%remoteDir%/readChecks/getMe.txt", baseUrl=labkey.url.base, folderPath="%projectName%", remoteFilePath="remote/writeChecks/putMe.txt"))
+                c("webdav.put", labkey.webdav.put(localFile="%remoteDir%/readChecks/getMe.txt", baseUrl=labkey.url.base, folderPath="%projectName%", remoteFilePath="remote/writeChecks/putMe.txt", description="with test description"))
                 c("remote file.exists post", file.exists("%remoteDir%/writeChecks/putMe.txt"))
                 c("remote file.info.size", file.info("%remoteDir%/writeChecks/putMe.txt")$size)
             ]]>


### PR DESCRIPTION
#### Rationale
See related PRs for rationale. This PR adds test cases for the updates to the Rlabkey package for labkey.domain.createAndLoad and the new labkey.query.import command.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-r/pull/68
* https://github.com/LabKey/platform/pull/2265
* https://github.com/LabKey/testAutomation/pull/724

#### Changes
* RlabkeyTest update to study, list, and experiment API test cases for labkey.domain.createAndLoad
* RlabkeyTest update to experiment API to add test case for labkey.query.import
