### PR TITLE
DomainDesignerTest - fix for FieldValidator.toJSONObject() to include "expression"

### DIFF
--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -654,6 +654,7 @@ public class FieldDefinition extends PropertyDescriptor
         {
             JSONObject json = new JSONObject();
             json.put("name", _name);
+            json.put("expression", getExpression());
             if (_description != null)
             {
                 json.put("description", _description);


### PR DESCRIPTION
#### Rationale
A few DomainDesignerTest cases started failing after this PR was merged: https://github.com/LabKey/testAutomation/pull/714.
There was a necessary change in that PR so that the FieldDefinition.java test class would properly call the toJSONObject method. This PR fixes up the FieldValidator.toJSONObject part of that class to include the required "expression" property.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/714

#### Changes
* Update for FieldValidator.toJSONObject() to include "expression"
