### PR TITLE
TabbedGridPanel

### DIFF
--- a/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
+++ b/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
@@ -1,0 +1,131 @@
+package org.labkey.test.components.ui.grids;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.Input;
+import org.labkey.test.pages.LabKeyPage;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import java.util.List;
+
+import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+import static org.labkey.test.components.html.Input.Input;
+
+/**
+ * TabbedGridPanel wraps components/src/public/QueryModel/TabbedGridPanel.tsx
+ * The model of a tabbed grid panel is different from previous models; rather than being a component of the
+ * QueryGrid, the TabbedGridPanel contains multiple grids that are shown/hidden via bootstrap style
+ */
+public class TabbedGridPanel extends WebDriverComponent<TabbedGridPanel.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected TabbedGridPanel(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+
+    public List<String> getTabs()
+    {
+        return getWrapper().getTexts(elementCache().navTabs());
+    }
+
+    private boolean isSelected(String tabText)
+    {
+        String tabClass = elementCache().navTab(tabText).getAttribute("class");
+        return tabClass != null &&"active".equals(tabClass);
+    }
+
+    public QueryGrid selectGrid(String tabText)
+    {
+        if (!isSelected(tabText))
+        {
+            var tab = elementCache().navTab(tabText);
+            getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(tab));
+            tab.click();
+            getWrapper().waitFor(()-> isSelected(tabText), "tab did not become selected in time", 2000);
+        }
+        return getSelectedGrid();
+    }
+
+    public QueryGrid getSelectedGrid()
+    {
+        return new QueryGrid.QueryGridFinder(getDriver()).waitFor(this);
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        final WebElement body = Locator.tagWithClass("div", "tabbed-grid-panel__body")
+                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+        final Locator navTab = Locator.tagWithClass("ul", "nav-tabs")
+                .child(Locator.tag("li").withChild(Locator.tag("a")));
+        List<WebElement> navTabs()
+        {
+            return navTab.findElements(body);
+        }
+        WebElement navTab(String text)
+        {
+            return Locator.tagWithClass("ul", "nav-tabs")
+                    .child(Locator.tag("li").withChild(Locator.tag("a").withText(text))).findElement(body);
+        }
+
+    }
+
+
+    public static class TabbedGridPanelFinder extends WebDriverComponentFinder<TabbedGridPanel, TabbedGridPanelFinder>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "tabbed-grid-panel");
+        private String _title = null;
+
+        public TabbedGridPanelFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        public TabbedGridPanelFinder withTitle(String title)
+        {
+            _title = title;
+            return this;
+        }
+
+        @Override
+        protected TabbedGridPanel construct(WebElement el, WebDriver driver)
+        {
+            return new TabbedGridPanel(el, driver);
+        }
+
+        @Override
+        protected Locator locator()
+        {
+            if (_title != null)
+                return _baseLocator.withChild(Locator.tagWithClass("div", "tabbed-grid-panel__title").withText(_title));
+            else
+                return _baseLocator;
+        }
+    }
+}

--- a/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
+++ b/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
@@ -3,8 +3,6 @@ package org.labkey.test.components.ui.grids;
 import org.labkey.test.Locator;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
-import org.labkey.test.components.html.Input;
-import org.labkey.test.pages.LabKeyPage;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -12,7 +10,6 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import java.util.List;
 
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
-import static org.labkey.test.components.html.Input.Input;
 
 /**
  * TabbedGridPanel wraps components/src/public/QueryModel/TabbedGridPanel.tsx
@@ -42,7 +39,6 @@ public class TabbedGridPanel extends WebDriverComponent<TabbedGridPanel.ElementC
         return _driver;
     }
 
-
     public List<String> getTabs()
     {
         return getWrapper().getTexts(elementCache().navTabs());
@@ -51,7 +47,7 @@ public class TabbedGridPanel extends WebDriverComponent<TabbedGridPanel.ElementC
     private boolean isSelected(String tabText)
     {
         String tabClass = elementCache().navTab(tabText).getAttribute("class");
-        return tabClass != null &&"active".equals(tabClass);
+        return "active".equals(tabClass);
     }
 
     public QueryGrid selectGrid(String tabText)
@@ -63,6 +59,7 @@ public class TabbedGridPanel extends WebDriverComponent<TabbedGridPanel.ElementC
             tab.click();
             getWrapper().waitFor(()-> isSelected(tabText), "tab did not become selected in time", 2000);
         }
+
         return getSelectedGrid();
     }
 
@@ -77,25 +74,24 @@ public class TabbedGridPanel extends WebDriverComponent<TabbedGridPanel.ElementC
         return new ElementCache();
     }
 
-
     protected class ElementCache extends Component<?>.ElementCache
     {
         final WebElement body = Locator.tagWithClass("div", "tabbed-grid-panel__body")
                 .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
         final Locator navTab = Locator.tagWithClass("ul", "nav-tabs")
                 .child(Locator.tag("li").withChild(Locator.tag("a")));
+
         List<WebElement> navTabs()
         {
             return navTab.findElements(body);
         }
+
         WebElement navTab(String text)
         {
             return Locator.tagWithClass("ul", "nav-tabs")
                     .child(Locator.tag("li").withChild(Locator.tag("a").withText(text))).findElement(body);
         }
-
     }
-
 
     public static class TabbedGridPanelFinder extends WebDriverComponentFinder<TabbedGridPanel, TabbedGridPanelFinder>
     {
@@ -124,8 +120,7 @@ public class TabbedGridPanel extends WebDriverComponent<TabbedGridPanel.ElementC
         {
             if (_title != null)
                 return _baseLocator.withChild(Locator.tagWithClass("div", "tabbed-grid-panel__title").withText(_title));
-            else
-                return _baseLocator;
+            return _baseLocator;
         }
     }
 }

--- a/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
+++ b/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
@@ -13,8 +13,9 @@ import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 
 /**
  * TabbedGridPanel wraps components/src/public/QueryModel/TabbedGridPanel.tsx
- * The model of a tabbed grid panel is different from previous models; rather than being a component of the
- * QueryGrid, the TabbedGridPanel contains multiple grids that are shown/hidden via bootstrap style
+ * The model of a tabbed grid panel is different from previous models; rather than conceiving the tabs to
+ * be a subcomponent of a constant QueryGrid, the TabbedGridPanel uses reactBootstrap to swap one or many
+ * grids into or out of existence, while showing only the selected one.
  */
 public class TabbedGridPanel extends WebDriverComponent<TabbedGridPanel.ElementCache>
 {


### PR DESCRIPTION
#### Rationale
Adds a component wrapper for `TabbedGridPanel` component that is a part of our `@labkey/components` package. Done in collaboration with @labkey-chrisj.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/528
* https://github.com/LabKey/biologics/pull/885
* https://github.com/LabKey/sampleManagement/pull/572
* https://github.com/LabKey/testAutomation/pull/726

#### Changes
* Adds a `TabbedGridPanel` component wrapper for interacting with the related `@labkey/component` React component on app pages.
