### PR TITLE
Use correct property name for 'principalConceptCode'

### DIFF
--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -304,12 +304,12 @@ public class FieldDefinition extends PropertyDescriptor
 
     public String getPrincipalConceptCode()
     {
-        return (String) getFieldProperty("conceptCode");
+        return (String) getFieldProperty("principalConceptCode");
     }
 
-    public FieldDefinition setPrincipalConceptCode(String conceptCode)
+    public FieldDefinition setPrincipalConceptCode(String principalConceptCode)
     {
-        setFieldProperty("conceptCode", conceptCode);
+        setFieldProperty("principalConceptCode", principalConceptCode);
         return this;
     }
 


### PR DESCRIPTION
#### Rationale
Previous update used the incorrect property name 'conceptCode', instead of 'principalConceptCode'

#### Related Pull Requests
* #727

#### Changes
* Fix property name
