### PR TITLE
Add Enum Option to OmniBox Filtering

### DIFF
--- a/src/org/labkey/test/components/ui/OmniBox.java
+++ b/src/org/labkey/test/components/ui/OmniBox.java
@@ -164,14 +164,26 @@ public class OmniBox extends WebDriverComponent<OmniBox.ElementCache>
         elementCache().input.sendKeys(Keys.BACK_SPACE);
     }
 
+    /**
+     * Set a column filter in the OmniBox.
+     *
+     * @param columnName Name of the column to filter on.
+     * @param operator The filter {@link FilterOperator} to use.
+     * @param value The value to compare to.
+     * @return A reference to this OmniBox.
+     */
     public OmniBox setFilter(String columnName, FilterOperator operator, @Nullable String value)
     {
         return setFilter(columnName, operator.getValue(), value);
     }
 
+    /**
+     * @deprecated Use the overloaded method that takes an enum.
+     * @see OmniBox#setFilter(String, FilterOperator, String)
+     */
+    @Deprecated(forRemoval=true)
     public OmniBox setFilter(String columnName, String operator, @Nullable String value)
     {
-        String val  = value != null ? enquoteIfMultiWord(value) : "";
         StringBuilder expectedFilterText = new StringBuilder();     // this builds the text to search for as a filter-item in the box
         expectedFilterText.append(columnName);
         expectedFilterText.append(" " + operator);

--- a/src/org/labkey/test/components/ui/OmniBox.java
+++ b/src/org/labkey/test/components/ui/OmniBox.java
@@ -164,6 +164,11 @@ public class OmniBox extends WebDriverComponent<OmniBox.ElementCache>
         elementCache().input.sendKeys(Keys.BACK_SPACE);
     }
 
+    public OmniBox setFilter(String columnName, FilterOperator operator, @Nullable String value)
+    {
+        return setFilter(columnName, operator.getValue(), value);
+    }
+
     public OmniBox setFilter(String columnName, String operator, @Nullable String value)
     {
         String val  = value != null ? enquoteIfMultiWord(value) : "";
@@ -267,6 +272,38 @@ public class OmniBox extends WebDriverComponent<OmniBox.ElementCache>
         protected Locator locator()
         {
             return _locator;
+        }
+    }
+
+    /**
+     * Enum for the various filter operations that the OmniBox allows.
+     */
+    public enum FilterOperator
+    {
+        EQUAL("="),
+        NOT_EQUAL("<>"),
+        GREATER_THAN(">"),
+        LESS_THAN("<"),
+        GREATER_THAN_OR_EQUALS(">="),
+        LESS_THAN_OR_EQUALS("=<"),
+        HAS_ANY_VALUE("has any value"),
+        IS_BLANK("is blank"),
+        IS_NOT_BLANK("is not blank"),
+        CONTAINS("contains"),
+        DOES_NOT_CONTAINS("does not contain"),
+        STARTS_WITH("starts with"),
+        DOES_NOT_START_WITH("does not start with");
+
+        private final String operator;
+
+        FilterOperator(String value)
+        {
+            this.operator = value;
+        }
+
+        public String getValue()
+        {
+            return operator;
         }
     }
 

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -197,6 +197,11 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         return this;
     }
 
+    public QueryGrid filterOn(String columnName, OmniBox.FilterOperator operator, String value)
+    {
+        return filterOn(columnName, operator.getValue(), value);
+    }
+
     /**
      * adds a filter expression to the table via the omnibox, and waits for the grid to update
      * @param columnName

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -197,18 +197,29 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         return this;
     }
 
+    /**
+     * Adds a filter expression to the table via the omnibox, and waits for the grid to update.
+     *
+     * @param columnName Name of the column to filter on.
+     * @param operator Enum value of the operator {@link OmniBox.FilterOperator}.
+     * @param value The value to compare to.
+     * @return The QueryGrid after the filter has been applied.
+     */
     public QueryGrid filterOn(String columnName, OmniBox.FilterOperator operator, String value)
     {
         return filterOn(columnName, operator.getValue(), value);
     }
 
     /**
-     * adds a filter expression to the table via the omnibox, and waits for the grid to update
+     * @deprecated Use the filterOn method that takes an enum.
+     * @see QueryGrid#filterOn(String, OmniBox.FilterOperator, String) 
+     *
      * @param columnName
      * @param operator
      * @param value
      * @return
      */
+    @Deprecated(forRemoval=true)
     public QueryGrid filterOn(String columnName, String operator, String value)
     {
         doAndWaitForUpdate(()-> getOmniBox().setFilter(columnName, operator, value));


### PR DESCRIPTION
#### Rationale
Simple overload methods to take an enum as the operator when filtering a grid using the OmniBox. Might help avoid user error/fat finger typos etc...

#### Related Pull Requests
* None.

#### Changes
* Overloaded the OmniBox.setFilter method to take an enum.
* Overladed the QueryGrid.filterOn method to take an enum.
* Added enum of the various filters.
<img width="420" alt="Screen Shot 2021-05-20 at 4 28 08 PM" src="https://user-images.githubusercontent.com/12738200/119061378-1772f500-b989-11eb-8db0-89e0be5add73.png">
