### PR TITLE
ontology picker test components update

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -506,6 +506,10 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         return this;
     }
 
+    /**
+     * Allows test code to get which ontologies are available for selection
+     * @return a list of the full text shown in the options
+     */
     public List<String> getConceptImportSelectOptions()
     {
         expand();

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -9,6 +9,7 @@ import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.html.RadioButton;
 import org.labkey.test.components.html.SelectWrapper;
+import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.components.ui.ontology.ConceptPickerDialog;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.LabKeyExpectedConditions;
@@ -503,6 +504,12 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         expand();
         elementCache().getConceptImportFieldSelect().selectByVisibleText(importField);
         return this;
+    }
+
+    public List<String> getConceptImportSelectOptions()
+    {
+        expand();
+        return getWrapper().getTexts(elementCache().getOntologySelect().getOptions());
     }
 
     public DomainFieldRow setConceptLabelField(String labelField)

--- a/src/org/labkey/test/components/ui/ontology/ConceptInfoTabs.java
+++ b/src/org/labkey/test/components/ui/ontology/ConceptInfoTabs.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 import static org.labkey.test.components.html.Input.Input;
@@ -71,6 +72,8 @@ public class ConceptInfoTabs extends WebDriverComponent<ConceptInfoTabs.ElementC
     public String getTitle()
     {
         showOverview();
+        if (elementCache().noneSelectedElement().isPresent())
+            return elementCache().noneSelectedElement().get().getText();
         return elementCache().title.getText();
     }
 
@@ -122,6 +125,10 @@ public class ConceptInfoTabs extends WebDriverComponent<ConceptInfoTabs.ElementC
         {
             return Locator.tagWithClass("ul", "synonyms-text").child(Locator.tag("li"))
                     .findElements(overviewPane);
+        }
+        Optional<WebElement> noneSelectedElement()
+        {
+            return Locator.tagWithClass("div", "none-selected").findOptionalElement(overviewPane);
         }
 
         // path info pane

--- a/src/org/labkey/test/components/ui/ontology/ConceptInfoTabs.java
+++ b/src/org/labkey/test/components/ui/ontology/ConceptInfoTabs.java
@@ -69,6 +69,11 @@ public class ConceptInfoTabs extends WebDriverComponent<ConceptInfoTabs.ElementC
         return this;
     }
 
+    /**
+     * If no concept is selected, the 'none selected' element will be present.
+     * If a concept is selected, returns the text in the title element
+     * @return The text of the title element, or that of the 'none selected' element if none is selected
+     */
     public String getTitle()
     {
         showOverview();
@@ -126,6 +131,8 @@ public class ConceptInfoTabs extends WebDriverComponent<ConceptInfoTabs.ElementC
             return Locator.tagWithClass("ul", "synonyms-text").child(Locator.tag("li"))
                     .findElements(overviewPane);
         }
+
+        // if no concept is selected, this element will be shown instead of the 'title' element
         Optional<WebElement> noneSelectedElement()
         {
             return Locator.tagWithClass("div", "none-selected").findOptionalElement(overviewPane);

--- a/src/org/labkey/test/components/ui/ontology/ConceptPickerDialog.java
+++ b/src/org/labkey/test/components/ui/ontology/ConceptPickerDialog.java
@@ -1,10 +1,7 @@
 package org.labkey.test.components.ui.ontology;
 
-import org.labkey.test.Locator;
 import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.components.react.ReactSelect;
-import org.labkey.test.components.ui.ontology.OntologyTreeSearch;
-import org.labkey.test.pages.ontology.BrowseConceptsPage;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -25,8 +22,6 @@ public class ConceptPickerDialog extends ModalDialog
     {
         super(finder);
     }
-
-    // optional ontology select, in case there are multiple ontologies
 
     /**
      * uses the search bar to select an item in the ontology tree
@@ -67,6 +62,11 @@ public class ConceptPickerDialog extends ModalDialog
         return elementCache().infoTabs.getSelectedPath();
     }
 
+    /**
+     * uses the treePanel control to expand the nodes in order
+     * @param pathToNode
+     * @return the current dialog
+     */
     public ConceptPickerDialog selectNodeFromPath(List<String> pathToNode)
     {
         elementCache().treePanel.openToPath(pathToNode);
@@ -77,7 +77,10 @@ public class ConceptPickerDialog extends ModalDialog
      * This select is only shown if there are multiple ontologies available to choose from.
      * When it is shown, no ontology-specific controls (like the tree view, the search bar, or the
      * info tabs will be shown.
-     * @return
+     * Note that when shown to select concept for an ontology lookup field, the ontology is selected
+     * at the field-row level and this select will not be shown in this dialog.  For any other field
+     * this select should be shown.
+     * @return  Whether or not the ontology select is present
      */
     public boolean hasOntologySelect()
     {
@@ -85,9 +88,10 @@ public class ConceptPickerDialog extends ModalDialog
     }
 
     /**
-     * When the select-ontology select appears, this sets it.  Once set,
-     * @param ontology
-     * @return
+     * When the select-ontology select appears, this sets it.  Once set, the select should disappear
+     * and the rest of the controls should appear in the dialog
+     * @param ontology The option to select from the ontology select
+     * @return the current dialog
      */
     public ConceptPickerDialog selectOntology(String ontology)
     {
@@ -100,6 +104,10 @@ public class ConceptPickerDialog extends ModalDialog
         return this;
     }
 
+    /**
+     * gets the options in the ontology select
+     * @return A list of string values from the options present in the select
+     */
     public List<String> getAvailableOntologies()
     {
         getWrapper().waitFor(() -> elementCache().selectOntologySelect().isPresent(),

--- a/src/org/labkey/test/components/ui/ontology/ConceptPickerDialog.java
+++ b/src/org/labkey/test/components/ui/ontology/ConceptPickerDialog.java
@@ -2,11 +2,15 @@ package org.labkey.test.components.ui.ontology;
 
 import org.labkey.test.Locator;
 import org.labkey.test.components.bootstrap.ModalDialog;
+import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.components.ui.ontology.OntologyTreeSearch;
+import org.labkey.test.pages.ontology.BrowseConceptsPage;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 
@@ -69,9 +73,49 @@ public class ConceptPickerDialog extends ModalDialog
         return this;
     }
 
+    /**
+     * This select is only shown if there are multiple ontologies available to choose from.
+     * When it is shown, no ontology-specific controls (like the tree view, the search bar, or the
+     * info tabs will be shown.
+     * @return
+     */
+    public boolean hasOntologySelect()
+    {
+        return elementCache().selectOntologySelect().isPresent();
+    }
+
+    /**
+     * When the select-ontology select appears, this sets it.  Once set,
+     * @param ontology
+     * @return
+     */
+    public ConceptPickerDialog selectOntology(String ontology)
+    {
+        getWrapper().waitFor(() -> elementCache().selectOntologySelect().isPresent(),
+                "the ontology select did not become present", WAIT_FOR_JAVASCRIPT);
+        var select = elementCache().selectOntologySelect().get();
+        var selectElement = select.getComponentElement();
+        select.select(ontology);
+        getWrapper().shortWait().until(ExpectedConditions.stalenessOf(selectElement));
+        return this;
+    }
+
+    public List<String> getAvailableOntologies()
+    {
+        getWrapper().waitFor(() -> elementCache().selectOntologySelect().isPresent(),
+                "the ontology select did not become present", WAIT_FOR_JAVASCRIPT);
+        var select = elementCache().selectOntologySelect().get();
+        return select.getOptions();
+    }
+
     public void clickApply()
     {
         dismiss("Apply");
+    }
+
+    public void clickCancel()
+    {
+        dismiss("Cancel");
     }
 
     @Override
@@ -96,6 +140,12 @@ public class ConceptPickerDialog extends ModalDialog
 
         final ConceptInfoTabs infoTabs = new ConceptInfoTabs.ConceptInfoTabsFinder(getDriver())
                 .findWhenNeeded(this);
+
+        Optional<ReactSelect> selectOntologySelect()
+        {
+            return ReactSelect.finder(getDriver())
+                    .withId("ontology-select").findOptional();
+        }
     }
 
 

--- a/src/org/labkey/test/components/ui/ontology/ConceptPickerDialog.java
+++ b/src/org/labkey/test/components/ui/ontology/ConceptPickerDialog.java
@@ -63,6 +63,12 @@ public class ConceptPickerDialog extends ModalDialog
         return elementCache().infoTabs.getSelectedPath();
     }
 
+    public ConceptPickerDialog selectNodeFromPath(List<String> pathToNode)
+    {
+        elementCache().treePanel.openToPath(pathToNode);
+        return this;
+    }
+
     public void clickApply()
     {
         dismiss("Apply");

--- a/src/org/labkey/test/components/ui/ontology/OntologyTreeSearch.java
+++ b/src/org/labkey/test/components/ui/ontology/OntologyTreeSearch.java
@@ -1,13 +1,16 @@
 package org.labkey.test.components.ui.ontology;
 
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.html.Input;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * wraps ontologyTreeSearchContainer.tsx
@@ -55,10 +58,74 @@ public class OntologyTreeSearch extends WebDriverComponent<OntologyTreeSearch.El
         return this;
     }
 
-    private OntologyTreeSearch setInput(String value)
+    public boolean showsNoSearchResultsFound()
     {
+        return Locator.tagWithClass("div", "col").withText("No search results found.")
+                .existsIn(elementCache().resultContainer());
+    }
+
+    public boolean isResultContainerExpanded()
+    {
+        try
+        {
+            return elementCache().resultContainer().isDisplayed();
+        } catch (NoSuchElementException nse)
+        {
+            return false;
+        }
+    }
+
+    public OntologyTreeSearch setInput(String value)
+    {
+        clearInput();
         elementCache().searchInput.set(value);
         return this;
+    }
+
+    /**
+     * sets the input text to empty and waits for the search results container to collapse
+     * and for the placeholder to become visible
+     * @return
+     */
+    public OntologyTreeSearch clearInput()
+    {
+        var input = elementCache().searchInput;
+        String placeholder = input.getComponentElement().getAttribute("placeholder");
+        input.set("");
+        // wait for the results container to collapse, and for the placeholder for the input to be shown
+        getWrapper().waitFor(()-> !isResultContainerExpanded() &&
+                Locator.css("input:placeholder-shown").withAttribute("placeholder", placeholder)
+                        .existsIn(this),  2000);
+        return this;
+    }
+
+    public List<TreeSearchResult> waitForResults()
+    {
+        getWrapper().waitFor(()-> isResultContainerExpanded() && getSearchResults().size() > 0 || showsNoSearchResultsFound()
+                , WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
+        return getSearchResults();
+    }
+
+    private List<TreeSearchResult> getSearchResults()
+    {
+        return new TreeSearchResult.TreeSearchResultFinder(getDriver()).findAll(elementCache().resultContainer());
+    }
+
+    /**
+     * when more search hits exist than are shown (max of 20 can be shown), an added search result footer element
+     * will appear with text advising the user to refine their search
+     * @return
+     */
+    Optional<WebElement> searchResultFooterElement()
+    {
+        return Locator.tagWithClass("div", "result-footer").findOptionalElement(elementCache().resultContainer());
+    }
+
+    public String getSearchResultFooterText()
+    {
+        getWrapper().waitFor(()-> searchResultFooterElement().isPresent(),
+                "the search footer did not appear", WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
+        return searchResultFooterElement().get().getText();
     }
 
     @Override

--- a/src/org/labkey/test/components/ui/ontology/OntologyTreeSearch.java
+++ b/src/org/labkey/test/components/ui/ontology/OntologyTreeSearch.java
@@ -84,7 +84,9 @@ public class OntologyTreeSearch extends WebDriverComponent<OntologyTreeSearch.El
 
     /**
      * sets the input text to empty and waits for the search results container to collapse
-     * and for the placeholder to become visible
+     * and for the placeholder to become visible.
+     * Clearing the search results in this manner (and ensuring that they are not present) is helpful to ensure
+     * that subsequent calls to waitForResults won't find the last set as they go stale
      * @return
      */
     public OntologyTreeSearch clearInput()


### PR DESCRIPTION
#### Rationale
Updates to components and page classes to support more granular search testing and selection when multiple ontologies are present

#### Related Pull Requests
https://github.com/LabKey/ontology/pull/42

#### Changes

- Add ontology select to Concept Picker dialog to enable testing to cover scenarios in which there are multiple ontologies to choose from
- surface search component to allow test to do more granular search behavior, add better synchronization to search behavior
- enable test code to get available options from domainFieldRow's ontology select
