### PR TITLE
Add 'null' checks to WebElement wrappers

### DIFF
--- a/src/org/labkey/test/selenium/EphemeralWebElement.java
+++ b/src/org/labkey/test/selenium/EphemeralWebElement.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.selenium;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.test.Locator;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebElement;
@@ -24,7 +25,7 @@ import org.openqa.selenium.WebElement;
  */
 public class EphemeralWebElement extends LazyWebElement<EphemeralWebElement>
 {
-    public EphemeralWebElement(Locator locator, SearchContext searchContext)
+    public EphemeralWebElement(@NotNull Locator locator, @NotNull SearchContext searchContext)
     {
         super(locator, searchContext);
     }

--- a/src/org/labkey/test/selenium/ReclickingWebElement.java
+++ b/src/org/labkey/test/selenium/ReclickingWebElement.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 
 public class ReclickingWebElement extends WebElementDecorator
 {
-    public ReclickingWebElement(WebElement decoratedElement)
+    public ReclickingWebElement(@NotNull WebElement decoratedElement)
     {
         super(decoratedElement);
     }

--- a/src/org/labkey/test/selenium/RefindingWebElement.java
+++ b/src/org/labkey/test/selenium/RefindingWebElement.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.selenium;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.test.Locator;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.SearchContext;
@@ -32,12 +33,12 @@ public class RefindingWebElement extends LazyWebElement<RefindingWebElement>
 {
     private final List<Consumer<WebElement>> _listeners = new ArrayList<>();
 
-    public RefindingWebElement(Locator locator, SearchContext searchContext)
+    public RefindingWebElement(@NotNull Locator locator, @NotNull SearchContext searchContext)
     {
         super(locator, searchContext);
     }
 
-    public RefindingWebElement(WebElement element, SearchContext searchContext)
+    public RefindingWebElement(@NotNull WebElement element, @NotNull SearchContext searchContext)
     {
         this(Locator.id(element.getAttribute("id")), searchContext);
         withRefindListener(this::assertUniqueId);
@@ -55,7 +56,7 @@ public class RefindingWebElement extends LazyWebElement<RefindingWebElement>
      * Refinding reliability depends on the specificity of the provided Locator
      * There is no verification that the provided WebElement matches the provided Locator and SearchContext
      */
-    public RefindingWebElement(WebElement element, Locator locator, SearchContext searchContext)
+    public RefindingWebElement(@NotNull WebElement element, @NotNull Locator locator, @NotNull SearchContext searchContext)
     {
         this(locator, searchContext);
         setWrappedElement(element);

--- a/src/org/labkey/test/selenium/WebElementDecorator.java
+++ b/src/org/labkey/test/selenium/WebElementDecorator.java
@@ -15,13 +15,14 @@
  */
 package org.labkey.test.selenium;
 
+import org.jetbrains.annotations.NotNull;
 import org.openqa.selenium.WebElement;
 
 public abstract class WebElementDecorator extends WebElementWrapper
 {
     private final WebElement _decoratedElement;
 
-    protected WebElementDecorator(WebElement decoratedElement)
+    protected WebElementDecorator(@NotNull WebElement decoratedElement)
     {
         _decoratedElement = decoratedElement;
     }

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -37,7 +37,7 @@ import org.labkey.test.components.study.ViewPreferencesPage;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.TimeChartWizard;
 import org.labkey.test.selenium.RefindingWebElement;
-import org.labkey.test.selenium.WebElementWrapper;
+import org.labkey.test.selenium.WebElementDecorator;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebDriver;
@@ -408,14 +408,8 @@ public class DataRegionTable extends DataRegion
         col += hasSelectors() ? 1 : 0;
         final WebElement cell = elementCache().getCell(row, col);
         final WebElement link = Locator.xpath("a").findElement(cell);
-        return new WebElementWrapper()
+        return new WebElementDecorator(link)
         {
-            @Override
-            public WebElement getWrappedElement()
-            {
-                return link;
-            }
-
             @Override
             public void click()
             {


### PR DESCRIPTION
#### Rationale
Occasionally, we get NPEs when attempting to interact with the wrapped elements. It is not clear how the null element is introduced but this change should cause an exception immediately when one is.

#### Changes
* Add `@NotNull` annotations to WebElementWrapper subclass constructors
