### PR TITLE
Item 8856: Add tests for merging of list data

### DIFF
--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -705,7 +705,7 @@ public class ListTest extends BaseWebDriverTest
 
         log("Try to upload the same data without choosing to merge.  Errors are expected.");
         String[] expectedErrors = new String[]{
-                "duplicate key value violates unique constraint"
+                "duplicate key value"
         };
         setListImportAsTestDataField(toTSV(BatchListColumns, BatchListMergeData), expectedErrors);
         _listHelper.beginAtList(PROJECT_VERIFY, mergeListName);

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -698,27 +698,30 @@ public class ListTest extends BaseWebDriverTest
         _listHelper.beginAtList(PROJECT_VERIFY, mergeListName);
 
         _listHelper.clickImportData();
-        checker().verifyTrue("For list with an integer, non-auto-increment key, merge option should be available", _listHelper.isMergeOptionPresent());
+        checker().verifyTrue("For list with an integer, non-auto-increment key, merge option should be available for copy/paste", _listHelper.isMergeOptionPresent());
         _listHelper.chooseFileUpload();
-        checker().verifyTrue("For list with an integer, non-auto-increment key, merge option should be available", _listHelper.isMergeOptionPresent());
+        checker().verifyTrue("For list with an integer, non-auto-increment key, merge option should be available for file upload", _listHelper.isMergeOptionPresent());
         _listHelper.chooseCopyPasteText();
 
         log("Try to upload the same data without choosing to merge.  Errors are expected.");
         String[] expectedErrors = new String[]{
                 "duplicate key value violates unique constraint"
         };
-        setListImportAsTestDataField(toTSV(BatchListColumns, BatchListData), expectedErrors);
+        setListImportAsTestDataField(toTSV(BatchListColumns, BatchListMergeData), expectedErrors);
+        _listHelper.beginAtList(PROJECT_VERIFY, mergeListName);
+        _listHelper.verifyListData(BatchListColumns, BatchListData, checker());
 
         log("Upload the same data using the merge operation. No errors should result.");
+        _listHelper.clickImportData();
         _listHelper.chooseMerge(false);
         setListImportAsTestDataField(toTSV(BatchListColumns, BatchListData));
-        verifyListData(BatchListColumns, BatchListData);
+        _listHelper.verifyListData(BatchListColumns, BatchListData, checker());
 
         log("Now upload some new data and modify existing data");
         _listHelper.clickImportData();
         _listHelper.chooseMerge(false);
         setListImportAsTestDataField(toTSV(BatchListMergeColumns, BatchListMergeData));
-        verifyListData(BatchListColumns, BatchListAfterMergeData);
+        _listHelper.verifyListData(BatchListColumns, BatchListAfterMergeData, checker());
     }
 
     @Test
@@ -730,20 +733,6 @@ public class ListTest extends BaseWebDriverTest
 
         _listHelper.clickImportData();
         checker().verifyFalse("For list with an integer, auto-increment key, merge option should not be available", _listHelper.isMergeOptionPresent());
-    }
-
-    private void verifyListData(List<ListColumn> columns, String[][] data)
-    {
-        final DataRegionTable dataRegion = DataRegion(getDriver()).withName("query").find();
-        for (int r = 0; r < data.length; r++)
-        {
-            Map<String, String> row = dataRegion.getRowDataAsMap(r);
-            for (int c = 0; c < columns.size(); c++)
-            {
-                ListColumn column = columns.get(c);
-                checker().verifyEquals(String.format("Value for column %s in row %d not as expected", column.getName(), r), data[r][c], row.get(column.getName()));
-            }
-        }
     }
 
     @Test
@@ -1388,7 +1377,7 @@ public class ListTest extends BaseWebDriverTest
                     {"1", "Joe", "Test", "Vanilla", "true"},
                     {"2", "Jane", "Test", " ", "true"},
                     {"3", "Jeffrey", "BugCatcher", "Strawberry", "true"},
-                    {"8", "Jamie", "", "Salted Caramel", ""},
+                    {"8", "Jamie", " ", "Salted Caramel", " "},
             };
 
     String toTSV(List<ListHelper.ListColumn> cols, String[][] data)

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -681,7 +681,7 @@ public class ListTest extends BaseWebDriverTest
         };
 
         createList(multiErrorListName, BatchListColumns, BatchListData);
-        beginAt("/query/" + EscapeUtil.encode(PROJECT_VERIFY) + "/executeQuery.view?schemaName=lists&query.queryName=" + multiErrorListName);
+        _listHelper.beginAtList(PROJECT_VERIFY, multiErrorListName);
         _listHelper.clickImportData();
 
         // insert the new list data and verify the expected errors appear
@@ -691,10 +691,66 @@ public class ListTest extends BaseWebDriverTest
     }
 
     @Test
+    public void testListMerge()
+    {
+        String mergeListName = "listForMerging";
+        createList(mergeListName, BatchListColumns, BatchListData);
+        _listHelper.beginAtList(PROJECT_VERIFY, mergeListName);
+
+        _listHelper.clickImportData();
+        checker().verifyTrue("For list with an integer, non-auto-increment key, merge option should be available", _listHelper.isMergeOptionPresent());
+        _listHelper.chooseFileUpload();
+        checker().verifyTrue("For list with an integer, non-auto-increment key, merge option should be available", _listHelper.isMergeOptionPresent());
+        _listHelper.chooseCopyPasteText();
+
+        log("Try to upload the same data without choosing to merge.  Errors are expected.");
+        String[] expectedErrors = new String[]{
+                "duplicate key value violates unique constraint"
+        };
+        setListImportAsTestDataField(toTSV(BatchListColumns, BatchListData), expectedErrors);
+
+        log("Upload the same data using the merge operation. No errors should result.");
+        _listHelper.chooseMerge(false);
+        setListImportAsTestDataField(toTSV(BatchListColumns, BatchListData));
+        verifyListData(BatchListColumns, BatchListData);
+
+        log("Now upload some new data and modify existing data");
+        _listHelper.clickImportData();
+        _listHelper.chooseMerge(false);
+        setListImportAsTestDataField(toTSV(BatchListMergeColumns, BatchListMergeData));
+        verifyListData(BatchListColumns, BatchListAfterMergeData);
+    }
+
+    @Test
+    public void testAutoIncrementKeyListNoMerge()
+    {
+        String mergeListName = "autoIncrementIdList";
+
+        _listHelper.createList(PROJECT_VERIFY, mergeListName, ListColumnType.AutoInteger, "Key", col("Name", ListColumnType.String));
+
+        _listHelper.clickImportData();
+        checker().verifyFalse("For list with an integer, auto-increment key, merge option should not be available", _listHelper.isMergeOptionPresent());
+    }
+
+    private void verifyListData(List<ListColumn> columns, String[][] data)
+    {
+        final DataRegionTable dataRegion = DataRegion(getDriver()).withName("query").find();
+        for (int r = 0; r < data.length; r++)
+        {
+            Map<String, String> row = dataRegion.getRowDataAsMap(r);
+            for (int c = 0; c < columns.size(); c++)
+            {
+                ListColumn column = columns.get(c);
+                checker().verifyEquals(String.format("Value for column %s in row %d not as expected", column.getName(), r), data[r][c], row.get(column.getName()));
+            }
+        }
+    }
+
+    @Test
     public void testAddListColumnOverRemoteAPI() throws Exception
     {
         List<FieldDefinition> cols = Arrays.asList(
-               new FieldDefinition("name", FieldDefinition.ColumnType.String),
+                new FieldDefinition("name", FieldDefinition.ColumnType.String),
                 new FieldDefinition("title", FieldDefinition.ColumnType.String),
                 new FieldDefinition("dewey", FieldDefinition.ColumnType.Decimal)
         );
@@ -1292,7 +1348,7 @@ public class ListTest extends BaseWebDriverTest
     );
     String[][] Cdata = new String[][]
     {
-        {"1", "one C"},
+            {"1", "one C"},
     };
 
     List<ListHelper.ListColumn> BatchListColumns = Arrays.asList(
@@ -1301,6 +1357,12 @@ public class ListTest extends BaseWebDriverTest
             col("LastName", ListColumnType.String),
             col("IceCreamFlavor", ListColumnType.String),
             col("ShouldInsertCorrectly", ListColumnType.Boolean)
+    );
+
+    List<ListHelper.ListColumn> BatchListMergeColumns = Arrays.asList(
+            BatchListColumns.get(0),
+            BatchListColumns.get(1),
+            BatchListColumns.get(3)
     );
     String[][] BatchListData = new String[][]
             {
@@ -1314,6 +1376,19 @@ public class ListTest extends BaseWebDriverTest
                     {"five", "Crunch", "Test", "Rum Raisin", "false"},
                     {"6", "Will", "ShouldPass", "Rocky Road", "true"},
                     {"7", "Liam", "ShouldPass", "Chocolate", "true"},
+            };
+    String[][] BatchListMergeData = new String[][]
+            {
+                    {"2", "Jane", ""},
+                    {"3", "Jeffrey", "Strawberry"},
+                    {"8", "Jamie", "Salted Caramel"},
+            };
+    String[][] BatchListAfterMergeData = new String[][]
+            {
+                    {"1", "Joe", "Test", "Vanilla", "true"},
+                    {"2", "Jane", "Test", " ", "true"},
+                    {"3", "Jeffrey", "BugCatcher", "Strawberry", "true"},
+                    {"8", "Jamie", "", "Salted Caramel", ""},
             };
 
     String toTSV(List<ListHelper.ListColumn> cols, String[][] data)

--- a/src/org/labkey/test/util/ListHelper.java
+++ b/src/org/labkey/test/util/ListHelper.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.Locator.tag;
 
 public class ListHelper extends LabKeySiteWrapper
 {
@@ -121,12 +122,23 @@ public class ListHelper extends LabKeySiteWrapper
     public void importDataFromFile(@LoggedParam File inputFile, int wait)
     {
         clickImportData();
-        click(Locator.tagWithClass("h3", "panel-title").containing("Upload file"));
+        chooseFileUpload();
         setFormElement(Locator.name("file"), inputFile);
         clickButton("Submit", wait);
     }
 
-    public void checkIndexFileAttachements(boolean index)
+    public void chooseFileUpload()
+    {
+        click(Locator.tagWithClass("h3", "panel-title").containing("Upload file"));
+    }
+
+    public void chooseCopyPasteText()
+    {
+        click(Locator.tagWithClass("h3", "panel-title").containing("Copy/paste text"));
+    }
+
+
+    public void checkIndexFileAttachments(boolean index)
     {
         Locator indexFileAttachmentsCheckbox = Locator.checkboxByLabel("Index file attachments", false);
         if (index)
@@ -369,6 +381,16 @@ public class ListHelper extends LabKeySiteWrapper
         submitImportTsv_success();
     }
 
+    public boolean isMergeOptionPresent()
+    {
+        return isElementPresent(Locator.tagContainingText("label", "Update data"));
+    }
+
+    public void chooseMerge(boolean isFileUpload)
+    {
+        click(tag("input").withAttribute("type", "button").index(isFileUpload ? 0 : 2));
+    }
+
     public EditListDefinitionPage goToEditDesign(String listName)
     {
         goToList(listName);
@@ -381,6 +403,11 @@ public class ListHelper extends LabKeySiteWrapper
         // if we are on the Manage List page, click the list name first
         if (isElementPresent(Locators.bodyTitle("Available Lists")))
             clickAndWait(Locator.linkWithText(listName));
+    }
+
+    public void beginAtList(String projectName, String listName)
+    {
+        beginAt("/query/" + EscapeUtil.encode(projectName) + "/executeQuery.view?schemaName=lists&query.queryName=" + listName);
     }
 
     /**

--- a/src/org/labkey/test/util/ListHelper.java
+++ b/src/org/labkey/test/util/ListHelper.java
@@ -37,6 +37,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.Locator.tag;
+import static org.labkey.test.util.DataRegionTable.DataRegion;
 
 public class ListHelper extends LabKeySiteWrapper
 {
@@ -408,6 +409,20 @@ public class ListHelper extends LabKeySiteWrapper
     public void beginAtList(String projectName, String listName)
     {
         beginAt("/query/" + EscapeUtil.encode(projectName) + "/executeQuery.view?schemaName=lists&query.queryName=" + listName);
+    }
+
+    public void verifyListData(List<ListColumn> columns, String[][] data, DeferredErrorCollector checker)
+    {
+        final DataRegionTable dataRegion = DataRegion(getDriver()).withName("query").find();
+        for (int r = 0; r < data.length; r++)
+        {
+            Map<String, String> row = dataRegion.getRowDataAsMap(r);
+            for (int c = 0; c < columns.size(); c++)
+            {
+                ListColumn column = columns.get(c);
+                checker.verifyEquals(String.format("Value for column %s in row %d not as expected", column.getName(), r), data[r][c], row.get(column.getName()));
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
#### Rationale
We allow merging of data for sample types and datasets within the LKS. This change enables that functionality for lists as well.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2290

#### Changes
* Add tests for merging of list data
* Update list helper with some more helpful methods
