### PR TITLE
Test coverage for column filtering via filter dialog search

### DIFF
--- a/src/org/labkey/test/components/ui/ontology/OntologyTreePanel.java
+++ b/src/org/labkey/test/components/ui/ontology/OntologyTreePanel.java
@@ -39,6 +39,16 @@ public class OntologyTreePanel extends WebDriverComponent<OntologyTreePanel.Elem
         return elementCache().rootElement;
     }
 
+    public TreeNode getVisibleActiveNode()
+    {
+        return new TreeNode.TreeNodeFinder(getDriver()).activeOnly().waitFor(this);
+    }
+
+    public List<TreeNode> getFilteringNodes()
+    {
+        return new TreeNode.TreeNodeFinder(getDriver()).withSelectedFilter().findAll(this);
+    }
+
     public TreeNode openToPath(List<String> nodes)
     {
         var currentNode = getRootNode();


### PR DESCRIPTION
#### Rationale
This includes updates to test components to support column filtering via the dataregion filter dialog

#### Related Pull Requests
 https://github.com/LabKey/ontology/pull/44

#### Changes
To support concept selection via the tree control, this change updates TreeNode.java to be aware of the optional filter icon it can have in filtering usage, to get and set its toggle state
This change also adds the ability for the tree control to identify the active/selected node in the filter tree