### PR TITLE
Enable Specimen Module for Test

### DIFF
--- a/src/org/labkey/test/tests/AbstractAssayTest.java
+++ b/src/org/labkey/test/tests/AbstractAssayTest.java
@@ -191,6 +191,9 @@ public abstract class AbstractAssayTest extends BaseWebDriverTest
         _containerHelper.createProject(getProjectName(), null);
         goToProjectHome(getProjectName());
 
+        // Some test use a stand alone specimen file. Before the file can be imported the Specimen module needs to be enabled.
+        _containerHelper.enableModule("Specimen");
+
         log("Setting up groups, users and initial permissions");
         ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
 


### PR DESCRIPTION
#### Rationale
Some test use a stand alone specimen file, the Specimen module needs to be enabled for the file import. This will address some Team City failures.

#### Related Pull Requests
* None.

#### Changes
* Added an enableModule("Specimen") call in the setup.
