### PR TITLE
Update DetailDataPanel and DetailTable to work with aliquots.

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailDataPanel.java
+++ b/src/org/labkey/test/components/ui/grids/DetailDataPanel.java
@@ -85,7 +85,8 @@ public class DetailDataPanel extends WebDriverComponent<DetailDataPanel.ElementC
     }
 
     /**
-     * If this sample is an aliquot there will be two tables in the panel, the first table will contain the aliquot information.
+     * If this sample is an aliquot there will be multiple tables in the panel, the first table will contain the aliquot
+     * information (under the 'Aliquot Data' header). This will return that table.
      *
      * @return A {@link DetailTable}.
      */
@@ -98,6 +99,24 @@ public class DetailDataPanel extends WebDriverComponent<DetailDataPanel.ElementC
 
         // As of release 21.05 if this sample is an aliquot, then the table with the aliquot information is the first table in the panel.
         return tables.get(0);
+    }
+
+    /**
+     * If this sample is an aliquot there will be multiple tables in the panel, the second table is under the 'Original
+     * Sample Data' header, but is a separate table from the other original data displayed and may only be one or two
+     * lines. The fields 'Original sample' and 'Sample description' will show up here.
+     *
+     * @return A {@link DetailTable}.
+     */
+    public DetailTable getAliquotDetailMetaTable()
+    {
+        List<DetailTable> tables = elementCache().detailTables();
+
+        if(tables.size() == 1)
+            throw new RuntimeException("There does not appear to be an 'Aliquot (details meta)' table in this panel.");
+
+        // As of release 21.05 if this sample is an aliquot, then the table with the aliquot information is the first table in the panel.
+        return tables.get(1);
     }
 
     @Override

--- a/src/org/labkey/test/components/ui/grids/DetailDataPanel.java
+++ b/src/org/labkey/test/components/ui/grids/DetailDataPanel.java
@@ -6,6 +6,7 @@ import org.labkey.test.components.WebDriverComponent;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -52,6 +53,12 @@ public class DetailDataPanel extends WebDriverComponent<DetailDataPanel.ElementC
         return elementCache().editButton().isPresent();
     }
 
+    /**
+     * If this sample is an aliquot clicking the edit button will only allow the user to edit the description property.
+     * No other fields are editable.
+     *
+     * @return A {@link DetailTableEdit}
+     */
     public DetailTableEdit clickEdit()
     {
         String title = getTitle();
@@ -64,9 +71,33 @@ public class DetailDataPanel extends WebDriverComponent<DetailDataPanel.ElementC
                 .withTitle("Editing " + title).waitFor();
     }
 
+    /**
+     * Get the table that has the details fields (i.e. column data) for this sample.
+     *
+     * @return A {@link DetailTable}.
+     */
     public DetailTable getTable()
     {
-        return  elementCache().detailTable;
+        List<DetailTable> tables = elementCache().detailTables();
+
+        // As of release 21.05 the table with the column values for the sample is the last table in the panel.
+        return  tables.get(tables.size() - 1);
+    }
+
+    /**
+     * If this sample is an aliquot there will be two tables in the panel, the first table will contain the aliquot information.
+     *
+     * @return A {@link DetailTable}.
+     */
+    public DetailTable getAliquotTable()
+    {
+        List<DetailTable> tables = elementCache().detailTables();
+
+        if(tables.size() == 1)
+            throw new RuntimeException("There does not appear to be an 'Aliquot' table in this panel.");
+
+        // As of release 21.05 if this sample is an aliquot, then the table with the aliquot information is the first table in the panel.
+        return tables.get(0);
     }
 
     @Override
@@ -78,12 +109,18 @@ public class DetailDataPanel extends WebDriverComponent<DetailDataPanel.ElementC
     protected class ElementCache extends Component<?>.ElementCache
     {
         final WebElement heading = Locator.tagWithClass("div", "detail__edit--heading").findWhenNeeded(this);
+
         public Optional<WebElement> editButton()
         {
             return Locator.tagWithClass("div", "detail__edit-button")
                     .findOptionalElement(heading);
         }
-        final DetailTable detailTable = new DetailTable.DetailTableFinder(getDriver()).findWhenNeeded(this);
+
+        final List<DetailTable> detailTables()
+        {
+            return new DetailTable.DetailTableFinder(getDriver()).findAll(this);
+        }
+
     }
 
     public static class DetailDataPanelFinder extends WebDriverComponentFinder<DetailDataPanel, DetailDataPanelFinder>

--- a/src/org/labkey/test/components/ui/grids/DetailDataPanel.java
+++ b/src/org/labkey/test/components/ui/grids/DetailDataPanel.java
@@ -54,7 +54,7 @@ public class DetailDataPanel extends WebDriverComponent<DetailDataPanel.ElementC
     }
 
     /**
-     * If this sample is an aliquot clicking the edit button will only allow the user to edit the description property.
+     * If this is an aliquot sample clicking the edit button will only allow the user to edit the description property.
      * No other fields are editable.
      *
      * @return A {@link DetailTableEdit}
@@ -72,7 +72,8 @@ public class DetailDataPanel extends WebDriverComponent<DetailDataPanel.ElementC
     }
 
     /**
-     * Get the table that has the details fields (i.e. column data) for this sample.
+     * Get the table that has the details fields (i.e. column data) for this item. If this is an aliquot sample this
+     * table will have the fields from the parent sample.
      *
      * @return A {@link DetailTable}.
      */
@@ -85,7 +86,7 @@ public class DetailDataPanel extends WebDriverComponent<DetailDataPanel.ElementC
     }
 
     /**
-     * If this sample is an aliquot there will be multiple tables in the panel, the first table will contain the aliquot
+     * If this is an aliquot sample there will be multiple tables in the panel, the first table will contain the aliquot
      * information (under the 'Aliquot Data' header). This will return that table.
      *
      * @return A {@link DetailTable}.
@@ -102,7 +103,7 @@ public class DetailDataPanel extends WebDriverComponent<DetailDataPanel.ElementC
     }
 
     /**
-     * If this sample is an aliquot there will be multiple tables in the panel, the second table is under the 'Original
+     * If this an aliquot sample there will be multiple tables in the panel, the second table is under the 'Original
      * Sample Data' header, but is a separate table from the other original data displayed and may only be one or two
      * lines. The fields 'Original sample' and 'Sample description' will show up here.
      *
@@ -135,6 +136,7 @@ public class DetailDataPanel extends WebDriverComponent<DetailDataPanel.ElementC
                     .findOptionalElement(heading);
         }
 
+        // If this panel is for an aliquot sample there will be more than one table present.
         final List<DetailTable> detailTables()
         {
             return new DetailTable.DetailTableFinder(getDriver()).findAll(this);

--- a/src/org/labkey/test/components/ui/grids/DetailDataPanel.java
+++ b/src/org/labkey/test/components/ui/grids/DetailDataPanel.java
@@ -3,6 +3,7 @@ package org.labkey.test.components.ui.grids;
 import org.labkey.test.Locator;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -96,7 +97,7 @@ public class DetailDataPanel extends WebDriverComponent<DetailDataPanel.ElementC
         List<DetailTable> tables = elementCache().detailTables();
 
         if(tables.size() == 1)
-            throw new RuntimeException("There does not appear to be an 'Aliquot' table in this panel.");
+            throw new NoSuchElementException("There does not appear to be an 'Aliquot' table in this panel.");
 
         // As of release 21.05 if this sample is an aliquot, then the table with the aliquot information is the first table in the panel.
         return tables.get(0);
@@ -114,7 +115,7 @@ public class DetailDataPanel extends WebDriverComponent<DetailDataPanel.ElementC
         List<DetailTable> tables = elementCache().detailTables();
 
         if(tables.size() == 1)
-            throw new RuntimeException("There does not appear to be an 'Aliquot (details meta)' table in this panel.");
+            throw new NoSuchElementException("There does not appear to be an 'Aliquot (details meta)' table in this panel.");
 
         // As of release 21.05 if this sample is an aliquot, then the table with the aliquot information is the first table in the panel.
         return tables.get(1);

--- a/src/org/labkey/test/components/ui/grids/DetailTable.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTable.java
@@ -63,6 +63,13 @@ public class DetailTable extends WebDriverComponent<DetailTable.ElementCache>
     // TODO Not sure if the get & click methods are correct (or appropriate?), for a @glass component.
     //  It may be appropriate to have these interfaces but maybe the way the cell is identified should be different.
 
+    /**
+     * Rather than add yet another method to get a field value, do a 'best guess' to find the appropriate field. This
+     * will return the first field that meets the criteria.
+     *
+     * @param identifier Some text string that can identify the field.
+     * @return A web element that either had an attribute value equal to the identifier, or had a text in a sibling field (label) with the identifier.
+     */
     private WebElement getField(String identifier)
     {
         if(elementCache().dataCaptionField(identifier).isDisplayed())
@@ -108,6 +115,8 @@ public class DetailTable extends WebDriverComponent<DetailTable.ElementCache>
      **/
     public void clickField(String fieldCaption)
     {
+        // Should not click the container, it could be a td which would miss the clickable element.
+        // Maybe this shouldn't assume an anchor but should be a generic(*)?
         Locator.tag("a").findElement(getField(fieldCaption)).click();
     }
 
@@ -157,6 +166,7 @@ public class DetailTable extends WebDriverComponent<DetailTable.ElementCache>
             return Locator.tagWithAttribute("td", "data-caption", caption).findWhenNeeded(this);
         }
 
+        // Some tables will show a value in a td with no attributes, use the td that has the text (label) to find the value.
         public final WebElement siblingField(String caption)
         {
             return Locator.tagContainingText("td", caption).followingSibling("td").findWhenNeeded(this);


### PR DESCRIPTION
#### Rationale
The DetailDataPanel and DetailTable are used in the overview page of samples. If the sample is an aliquot the DetailDataPanel will have more than one DetailTable on it.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/901
* https://github.com/LabKey/sampleManagement/pull/586

#### Changes
* Fixed a bug in the DetailTable where getting a field value was not scoped to look only at the table (it was looking at the larger container).
* Changed DetailDataPanel to look for multiple panels.
* Added methods to get the DetailTables that show up for aliquots.

### Details
If a sample is not an aliquot, which will be most samples, the **DetailDataPanel** looks like this:
<img width="968" alt="Screen Shot 2021-06-02 at 6 19 39 PM" src="https://user-images.githubusercontent.com/12738200/120573533-97aa4900-c3d2-11eb-9c86-c3e4e497caed.png">

The method `DetailDataPanel.getTable` returns the DetailTable that is shown.

If the sample is an aliquot the DetailDataPanel will look like this:
<img width="968" alt="Screen Shot 2021-06-02 at 6 19 14 PM" src="https://user-images.githubusercontent.com/12738200/120574072-76962800-c3d3-11eb-95cd-d8fa7fc2f101.png">

There are three tables shown. The top panel is aliquot data. The middle table, which is two lines, is meta data for the aliquot. The bottom table is sample data which is as before.

This update adds methods to get the tables that are shown for aliquots.

The **DetailTable** also had to be updated to account for the scenario where a field is a very simple `td` and does not have attributes to identify it.

The aliquot tables basically have this html:
`<table class="table table-responsive table-condensed detail-component--table__fixed sample-aliquots-details-meta-table"><body><tr><td>Sample description</td><td><span class="detail-display">Description for sample STA01_1</span></td></tr></tbody></table>`

This change has been run against LKB, ELN, LKB-Recipe, LKSM & LKFM.

This differs from what was previously expected for a detail which assumes the td containing the value would have attributes `data-caption` or `data-fieldkey` like this:
`<td data-caption="Str" data-fieldkey="str"><span class="detail-display">This is sample 1.</span></td>`

The update to the DetailTable makes the getValue method more flexible so it can get the value for a field that does not have these attributes.

