### PR TITLE
Update hard-coded controller name to fix TrialShare test

### DIFF
--- a/src/org/labkey/test/pages/study/specimen/ShowCreateSpecimenRequestPage.java
+++ b/src/org/labkey/test/pages/study/specimen/ShowCreateSpecimenRequestPage.java
@@ -21,7 +21,7 @@ public class ShowCreateSpecimenRequestPage extends LabKeyPage<ShowCreateSpecimen
 
     public static ShowCreateSpecimenRequestPage beginAt(WebDriverWrapper webDriverWrapper, String containerPath)
     {
-        webDriverWrapper.beginAt(WebTestHelper.buildURL("specimen", containerPath, "showCreateSpecimenRequest"));
+        webDriverWrapper.beginAt(WebTestHelper.buildURL("specimen2", containerPath, "showCreateSpecimenRequest"));
         return new ShowCreateSpecimenRequestPage(webDriverWrapper.getDriver());
     }
 


### PR DESCRIPTION
#### Rationale
Controller name changed, but ShowCreateSpecimenRequestPage didn't get the memo

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2318