### PR TITLE
Test Code Cleanup in OmniBox and EditableGrid

### DIFF
--- a/src/org/labkey/test/components/ui/OmniBox.java
+++ b/src/org/labkey/test/components/ui/OmniBox.java
@@ -222,13 +222,9 @@ public class OmniBox extends WebDriverComponent<OmniBox.ElementCache>
 
     private OmniBox setText(String inputValue)
     {
-        int numStartValues = getValues().size();
         new WebDriverWait(getWrapper().getDriver(), 1).until(ExpectedConditions.elementToBeClickable(elementCache().input));
         elementCache().input.sendKeys(inputValue);
         elementCache().input.sendKeys(Keys.ENTER);
-        WebDriverWrapper.waitFor(()-> {
-            return getValues().size() == numStartValues +1;
-        }, 1500);
 
         return this;
     }

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -739,32 +739,26 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         public Optional<WebElement> selectColumn = Locator.xpath("//th/input[@type='checkbox']").findOptionalElement(getComponentElement());
         public WebElement inputCell()
         {
-            getWrapper().waitForElementToBeVisible(Locators.inputCell);
             return Locators.inputCell.findElement(getComponentElement());
         }
 
         public WebElement lookupInputCell()
         {
-            getWrapper().waitForElementToBeVisible(Locators.lookupInputCell);
             return Locators.lookupInputCell.findElement(getComponentElement());
         }
 
         public WebElement lookupMenu()
         {
-            getWrapper().waitForElementToBeVisible(Locators.lookupMenu);
             return Locators.lookupMenu.findElement(getComponentElement());
         }
 
         public WebElement listGroupItem(String text)
         {
-            getWrapper().waitForElementToBeVisible(Locators.lookupMenu);
-            getWrapper().waitForElementToBeVisible(Locators.listGroupItem(text));
             return Locators.listGroupItem(text).findElement(getComponentElement());
         }
 
         public WebElement itemElement(String text)
         {
-            getWrapper().waitForElementToBeVisible(Locators.itemElement(text));
             return Locators.itemElement(text).findElement(getComponentElement());
         }
 


### PR DESCRIPTION
#### Rationale
Looking at test code in the profile shows that the editable grid and omnibox are a little slow. For example calls to isVisible can be expensive. This change removes some code that looks redundant.

This changes has passed all the LKB, ELN, LabBook, LKSM and LKI tests.

#### Related Pull Requests
* None

#### Changes
* Remove redundant calls to isVisible for elements in elementCache in the editableGrid.
* Remove a waitfor in the omnibox.
