### PR TITLE
Update FilterTest

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -1373,6 +1373,21 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
             goToHome();
     }
 
+    /**
+     * Impersonate a user and perform some action.
+     * Stops impersonating and returns to initial page when complete.
+     * @param email User to impersonate
+     * @param action Runnable to invoke while impersonating
+     */
+    public void doAsUser(String email, Runnable action)
+    {
+        pushLocation();
+        impersonate(email);
+        action.run();
+        stopImpersonating(false);
+        popLocation();
+    }
+
     public void goToHome()
     {
         beginAt(WebTestHelper.buildURL("project", "home", "begin"));

--- a/src/org/labkey/test/pages/query/UpdateQueryRowPage.java
+++ b/src/org/labkey/test/pages/query/UpdateQueryRowPage.java
@@ -1,0 +1,138 @@
+package org.labkey.test.pages.query;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.components.html.Checkbox;
+import org.labkey.test.components.html.OptionSelect;
+import org.labkey.test.pages.LabKeyPage;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class UpdateQueryRowPage extends LabKeyPage<UpdateQueryRowPage.ElementCache>
+{
+    public UpdateQueryRowPage(WebDriver driver)
+    {
+        super(driver);
+    }
+
+    public static UpdateQueryRowPage beginAt(WebDriverWrapper webDriverWrapper, String schemaName, String queryName, int rowId)
+    {
+        return beginAt(webDriverWrapper, webDriverWrapper.getCurrentContainerPath(), schemaName, queryName, rowId);
+    }
+
+    public static UpdateQueryRowPage beginAt(WebDriverWrapper webDriverWrapper, String schemaName, String queryName, Pair<String, String> rowKey)
+    {
+        return beginAt(webDriverWrapper, webDriverWrapper.getCurrentContainerPath(), schemaName, queryName, rowKey);
+    }
+
+    public static UpdateQueryRowPage beginAt(WebDriverWrapper webDriverWrapper, String containerPath, String schemaName, String queryName, int rowId)
+    {
+        return beginAt(webDriverWrapper, containerPath, schemaName, queryName, Pair.of("rowId", String.valueOf(rowId)));
+    }
+
+    public static UpdateQueryRowPage beginAt(WebDriverWrapper webDriverWrapper, String containerPath, String schemaName, String queryName, Pair<String, String> rowKey)
+    {
+        webDriverWrapper.beginAt(WebTestHelper.buildURL("query", containerPath, "updateQueryRow",
+                Map.of("schemaName", schemaName, "query.queryName", queryName, rowKey.getKey(), rowKey.getValue())));
+        return new UpdateQueryRowPage(webDriverWrapper.getDriver());
+    }
+
+    public void update(Map<String, ?> fields)
+    {
+        for (Map.Entry<String, ?> entry : fields.entrySet())
+        {
+            Object value = entry.getValue();
+            if (value instanceof String)
+            {
+                setField(entry.getKey(), (String) value);
+            }
+            else if (value instanceof Boolean)
+            {
+                setField(entry.getKey(), (Boolean) value);
+            }
+            else if (value instanceof Integer)
+            {
+                setField(entry.getKey(), (Integer) value);
+            }
+            else if (value instanceof File)
+            {
+                setField(entry.getKey(), (File) value);
+            }
+            else
+            {
+                throw new IllegalArgumentException("Unsupported value type for '" + entry.getKey() + "': " + value.getClass().getName());
+            }
+        }
+        submit();
+    }
+
+    public UpdateQueryRowPage setField(String fieldName, String value)
+    {
+        WebElement field = elementCache().findField(fieldName);
+        if (field.getTagName().equals("select"))
+        {
+            setField(fieldName, OptionSelect.SelectOption.textOption(value));
+        }
+        else
+        {
+            setFormElement(field, value);
+        }
+        return this;
+    }
+
+    public UpdateQueryRowPage setField(String fieldName, Boolean value)
+    {
+        new Checkbox(elementCache().findField(fieldName)).set(value);
+        return this;
+    }
+
+    public UpdateQueryRowPage setField(String fieldName, Integer value)
+    {
+        return setField(fieldName, String.valueOf(value));
+    }
+
+    public UpdateQueryRowPage setField(String fieldName, File file)
+    {
+        setFormElement(elementCache().findField(fieldName), file);
+        return this;
+    }
+
+    public UpdateQueryRowPage setField(String fieldName, OptionSelect.SelectOption option)
+    {
+        new OptionSelect<>(elementCache().findField(fieldName)).selectOption(option);
+        return this;
+    }
+
+    public void submit()
+    {
+        clickAndWait(elementCache().submitButton);
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
+    {
+        private final Map<String, WebElement> fieldMap = new HashMap<>();
+
+        WebElement findField(String name)
+        {
+            if (!fieldMap.containsKey(name))
+            {
+                fieldMap.put(name, Locator.name("quf_" + name).findElement(this));
+            }
+            return fieldMap.get(name);
+        }
+
+        final WebElement submitButton = Locator.lkButton("Submit").findWhenNeeded(this);
+    }
+}

--- a/src/org/labkey/test/params/list/ListDefinition.java
+++ b/src/org/labkey/test/params/list/ListDefinition.java
@@ -10,14 +10,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class ListDefinition extends DomainProps
+public abstract class ListDefinition extends DomainProps
 {
-    private static final String DOMAIN_KIND = "VarList";
-
     private String _name;
     private String _description;
     private List<FieldDefinition> _fields = new ArrayList<>();
     private String _keyName;
+    // API Options
+    private String _titleColumn;
 
     public ListDefinition(String name)
     {
@@ -74,6 +74,17 @@ public class ListDefinition extends DomainProps
         return this;
     }
 
+    public String getTitleColumn()
+    {
+        return _titleColumn;
+    }
+
+    public ListDefinition setTitleColumn(String titleColumn)
+    {
+        _titleColumn = titleColumn;
+        return this;
+    }
+
     /*
     DomainProps
      */
@@ -90,19 +101,16 @@ public class ListDefinition extends DomainProps
 
     @NotNull
     @Override
-    protected String getKind()
-    {
-        return DOMAIN_KIND;
-    }
-
-    @NotNull
-    @Override
     protected Map<String, Object> getOptions()
     {
         Map<String, Object> options = new HashMap<>();
         options.put("name", getName());
         options.put("description", getDescription());
         options.put("keyName", getKeyName());
+        if (getTitleColumn() != null)
+        {
+            options.put("titleColumn", getTitleColumn());
+        }
         return options;
     }
 

--- a/src/org/labkey/test/params/list/VarListDefinition.java
+++ b/src/org/labkey/test/params/list/VarListDefinition.java
@@ -1,0 +1,45 @@
+package org.labkey.test.params.list;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.test.params.FieldDefinition;
+
+import java.util.List;
+
+public class VarListDefinition extends ListDefinition
+{
+    private static final String DOMAIN_KIND = "VarList";
+
+    public VarListDefinition(String name)
+    {
+        super(name);
+    }
+
+    @Override
+    public ListDefinition addField(@NotNull FieldDefinition field)
+    {
+        if (getKeyName() == null)
+        {
+            // Use first field as key
+            setKeyName(field.getName());
+        }
+        return super.addField(field);
+    }
+
+    @Override
+    public ListDefinition setFields(List<FieldDefinition> fields)
+    {
+        if (!fields.isEmpty() && getKeyName() == null)
+        {
+            // Use first field as key
+            setKeyName(fields.get(0).getName());
+        }
+        return super.setFields(fields);
+    }
+
+    @NotNull
+    @Override
+    protected String getKind()
+    {
+        return DOMAIN_KIND;
+    }
+}

--- a/src/org/labkey/test/params/property/DomainProps.java
+++ b/src/org/labkey/test/params/property/DomainProps.java
@@ -1,10 +1,13 @@
 package org.labkey.test.params.property;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.domain.CreateDomainCommand;
 import org.labkey.remoteapi.domain.Domain;
 import org.labkey.test.util.TestDataGenerator;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,5 +34,11 @@ public abstract class DomainProps
     public TestDataGenerator getTestDataGenerator(String containerPath)
     {
         return new TestDataGenerator(getSchemaName(), getQueryName(), containerPath).withColumns(getDomainDesign().getFields());
+    }
+
+    public final TestDataGenerator create(Connection connection, String containerPath) throws IOException, CommandException
+    {
+        getCreateCommand().execute(connection, containerPath);
+        return getTestDataGenerator(containerPath);
     }
 }

--- a/src/org/labkey/test/tests/SampleTypeLimitsTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLimitsTest.java
@@ -17,6 +17,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.DailyC;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.list.ListDefinition;
+import org.labkey.test.params.list.VarListDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ExperimentalFeaturesHelper;
 import org.labkey.test.util.PortalHelper;
@@ -113,7 +114,7 @@ public class SampleTypeLimitsTest extends BaseWebDriverTest
         clickButton("Submit");
 
         log("Creating the list via API");
-        ListDefinition listDef = new ListDefinition(listName);
+        ListDefinition listDef = new VarListDefinition(listName);
         listDef.setKeyName("id");
         listDef.addField(new FieldDefinition("name", FieldDefinition.ColumnType.String));
         listDef.addField(new FieldDefinition("lookUpField",

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -36,6 +36,7 @@ import org.labkey.test.components.study.DatasetFacetPanel;
 import org.labkey.test.components.study.ViewPreferencesPage;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.TimeChartWizard;
+import org.labkey.test.pages.query.UpdateQueryRowPage;
 import org.labkey.test.selenium.RefindingWebElement;
 import org.labkey.test.selenium.WebElementDecorator;
 import org.openqa.selenium.NoSuchElementException;
@@ -731,18 +732,17 @@ public class DataRegionTable extends DataRegion
         setRowData(data, validateText);
     }
 
-    //todo: return edit page
-    public void clickEditRow(int rowIndex)
+    public UpdateQueryRowPage clickEditRow(int rowIndex)
     {
         WebElement updateLink = updateLink(rowIndex);
         getWrapper().fireEvent(updateLink, WebDriverWrapper.SeleniumEvent.mouseover);
         getWrapper().clickAndWait(updateLink);
+        return new UpdateQueryRowPage(getDriver());
     }
 
-    //todo: return edit page
-    public void clickEditRow(String key)
+    public UpdateQueryRowPage clickEditRow(String key)
     {
-        clickEditRow(getRowIndexStrict(key));
+        return clickEditRow(getRowIndexStrict(key));
     }
 
     public void clickRowDetails(int rowIndex)
@@ -759,7 +759,11 @@ public class DataRegionTable extends DataRegion
 
     protected void setRowData(Map<String, ?> data, boolean validateText)
     {
-        new ListHelper(getWrapper()).setRowData(data, validateText);
+        new UpdateQueryRowPage(getDriver()).update(data);
+        if (validateText)
+        {
+            getWrapper().assertTextPresent(String.valueOf(data.values().iterator().next()));  //make sure some text from the map is present
+        }
     }
 
     public String getDetailsHref(int row)

--- a/src/org/labkey/test/util/ListHelper.java
+++ b/src/org/labkey/test/util/ListHelper.java
@@ -401,9 +401,11 @@ public class ListHelper extends LabKeySiteWrapper
 
     public void goToList(String listName)
     {
-        // if we are on the Manage List page, click the list name first
-        if (isElementPresent(Locators.bodyTitle("Available Lists")))
-            clickAndWait(Locator.linkWithText(listName));
+        if (!isElementPresent(Locators.bodyTitle("Available Lists")))
+        {
+            goToManageLists();
+        }
+        clickAndWait(Locator.linkWithText(listName));
     }
 
     public void beginAtList(String projectName, String listName)


### PR DESCRIPTION
#### Rationale
When adding a new regression test case to `FilterTest`, I noticed numerous areas for improvement. Most significantly, it used a single monolithic `@Test` method and spent far too long setting up lists through the UI.

#### Changes
* Issue 40362: Automated Regression Coverage for ~me~ filter value
* Use API to create lists in `FilterTest`
* Split `FilterTest` into multiple @Test methods
* Create `VarListDefinition`
* Create test page for `UpdateQueryRowAction`.
* Update `DataRegionTable` to use new `UpdateQueryRowPage`
* Add `DomainProps.create` to create a domain and return an appropriate `TestDataGenerator`
