### PR TITLE
Add rowCount to ETLScheduler

### DIFF
--- a/modules/ETLtest/resources/ETLs/appendTransformedColumn.xml
+++ b/modules/ETLtest/resources/ETLs/appendTransformedColumn.xml
@@ -18,4 +18,7 @@
     </transform>
 </transforms>
 <incrementalFilter className="SelectAllFilterStrategy" />
+<schedule>
+    <poll interval="15s" />
+</schedule>
 </etl>

--- a/src/org/labkey/test/pages/dataintegration/ETLScheduler.java
+++ b/src/org/labkey/test/pages/dataintegration/ETLScheduler.java
@@ -60,6 +60,11 @@ public class ETLScheduler extends LabKeyPage<ETLScheduler.Elements>
         return new LabKeyPage(_test);
     }
 
+    public int rowCount()
+    {
+        return Locator.xpath("//tr[@transformId]").findElements(getDriver()).size();
+    }
+
     @Override
     protected Elements elementCache()
     {


### PR DESCRIPTION
#### Rationale
Add rowCount to ETLScheduler for checking number of ETLs available on dataintegration home page

#### Related Pull Requests
* https://github.com/LabKey/dataintegration/pull/112

#### Changes
* Add rowCount to ETLScheduler
* Add schedule to appendTransformColumn ETL for use in scheduling tests