### PR TITLE
Update types for `DataRegionTable.updateRow`

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1792,7 +1792,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     {
         // if the row does not exist then most likely the cohort passed in is incorrect
         int rowIndex = cohortTable.getRowIndex("Label", cohort);
-        cohortTable.updateRow(rowIndex, Map.of("enrolled", Boolean.toString(enroll)), true);
+        cohortTable.updateRow(rowIndex, Map.of("enrolled", enroll), true);
     }
 
     public void setExportPhi(PhiSelectType exportPhiLevel)

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -707,25 +707,25 @@ public class DataRegionTable extends DataRegion
     }
 
     /* Key is the PK on the table, it is usually the contents of the 'value' attribute of the row selector checkbox  */
-    public void updateRow(String key, Map<String, String> data)
+    public void updateRow(String key, Map<String, ?> data)
     {
         updateRow(key, data, true);
     }
 
     /* Key is the PK on the table, it is usually the contents of the 'value' attribute of the row selector checkbox  */
-    public void updateRow(String key, Map<String, String> data, boolean validateText)
+    public void updateRow(String key, Map<String, ?> data, boolean validateText)
     {
         clickEditRow(key);
 
         setRowData(data, validateText);
     }
 
-    public void updateRow(int rowIndex, Map<String, String> data)
+    public void updateRow(int rowIndex, Map<String, ?> data)
     {
         updateRow(rowIndex, data, true);
     }
 
-    public void updateRow(int rowIndex, Map<String, String> data, boolean validateText)
+    public void updateRow(int rowIndex, Map<String, ?> data, boolean validateText)
     {
         clickEditRow(rowIndex);
 


### PR DESCRIPTION
#### Rationale
`DataRegionTable.updateRow` has been updated to use `UpdateQueryRowPage` instead of `ListHelper`. The new method uses input types to decide behavior instead of taking all `Strings` and making them match the form.

#### Related Pull Requests
* #759 

#### Changes
* Update input data type for `DataRegionTable.updateRow`
