### PR TITLE
Test coverage for issue42857

### DIFF
--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -112,13 +112,6 @@ public class FieldDefinition extends PropertyDescriptor
     }
 
     @Override
-    public FieldDefinition setRangeURI(String rangeURI)
-    {
-        super.setRangeURI(rangeURI);
-        return this;
-    }
-
-    @Override
     public FieldDefinition setMvEnabled(Boolean mvEnabled)
     {
         super.setMvEnabled(mvEnabled);

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -112,6 +112,13 @@ public class FieldDefinition extends PropertyDescriptor
     }
 
     @Override
+    public FieldDefinition setRangeURI(String rangeURI)
+    {
+        super.setRangeURI(rangeURI);
+        return this;
+    }
+
+    @Override
     public FieldDefinition setMvEnabled(Boolean mvEnabled)
     {
         super.setMvEnabled(mvEnabled);

--- a/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
+++ b/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
@@ -140,7 +140,8 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
     public void testLookupNameExpression() throws Exception
     {
         String lookupList = "Colors";
-        FieldDefinition.LookupInfo colorsLookup = new FieldDefinition.LookupInfo(getProjectName(), "lists", lookupList);
+        FieldDefinition.LookupInfo colorsLookup = new FieldDefinition.LookupInfo(getProjectName(), "lists", lookupList)
+                .setTableType(FieldDefinition.ColumnType.Integer);
         String nameExpSamples = "NameExpressionSamples";
 
         // begin by creating a lookupList of colors, the sampleType will reference it
@@ -162,7 +163,7 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
 
         // now create a sampleType with a Color column that looks up to Colors
         var sampleTypeDef = new SampleTypeDefinition(nameExpSamples)
-                .setFields(List.of(new FieldDefinition("ColorLookup", colorsLookup).setRangeURI(FieldDefinition.ColumnType.Integer.getRangeURI()),
+                .setFields(List.of(new FieldDefinition("ColorLookup", colorsLookup),
                         new FieldDefinition("Noun", FieldDefinition.ColumnType.String)))
                 .setNameExpression("TEST-${ColorLookup/ColorCode}");   // hopefully this will resolve the 'ColorCode' column from the list
         SampleTypeAPIHelper.createEmptySampleType(getProjectName(), sampleTypeDef);

--- a/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
+++ b/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
@@ -36,9 +36,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @Category({DailyC.class})
@@ -176,7 +177,10 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
                 .setText(pasteData)
                 .submit();
 
-        // todo: validate once this is working
+        var sampleTypeGrid = new DataRegionTable.DataRegionFinder(getDriver())
+                .withName("Material").waitFor();
+        assertThat("Expect lookup to force name-generation that resolves colorCodes from the colorLookup",
+                sampleTypeGrid.getColumnDataAsText("Name"), hasItems("TEST-yl", "TEST-bl", "TEST-gr", "TEST-rd"));
     }
 
     @Test

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -18,6 +18,7 @@ package org.labkey.test.util;
 import org.apache.commons.lang3.time.DateUtils;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
+import org.labkey.api.collections.CaseInsensitiveLinkedHashMap;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
@@ -60,7 +61,7 @@ public class TestDataGenerator
     private static final String ALPHANUMERIC_STRING = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvxyz";
 
     private final Map<Integer, PropertyDescriptor> _indices = new HashMap<>();  // used to keep columns and row keys aligned
-    private final Map<String, PropertyDescriptor> _columns = new CaseInsensitiveHashMap<>();
+    private final Map<String, PropertyDescriptor> _columns = new CaseInsensitiveLinkedHashMap<>();
     private final Map<String, Supplier<Object>> _dataSuppliers = new CaseInsensitiveHashMap<>();
     private List<Map<String, Object>> _rows = new ArrayList<>();
 


### PR DESCRIPTION
#### Rationale
One of our clients wants to bulk-import samples using a nameExpression that can resolve existing values via a lookup to another domain.  This test attempts to do that, and in the attempt appears to have found an [adjacent issue ](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43394)

The test creates an integer-keyed list called Colors, with string columns ColorName and Code
values for ColorName and Code look like 'red' and 'rd', respectively.

It then creates a sampleType with a column named 'Color' that looks up the 'Colors' list (in the same project), and gives the sampleType a nameExpression with value 'TEST-${Color/Code}.
Via the bulk insert UI, it attempts to paste in a new Sample with value in the 'Color' column matching a value in the list's 'Code' column.

#### Related Pull Requests
n/a

#### Changes
just the new test case
