### PR TITLE
Test building modules with published JSP taglibs

### DIFF
--- a/buildTestModules/communityArtifacts/src/org/labkey/communityartifacts/view/hello.jsp
+++ b/buildTestModules/communityArtifacts/src/org/labkey/communityartifacts/view/hello.jsp
@@ -18,8 +18,12 @@
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.security.User" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
     Container c = getContainer();
     User user = getUser();
 %>
+
+<labkey:errors></labkey:errors>
+
 <div name="helloMessage">Hello, and welcome to the CommunityArtifacts module.</div>

--- a/buildTestModules/starterArtifacts/src/org/labkey/starterartifacts/view/hello.jsp
+++ b/buildTestModules/starterArtifacts/src/org/labkey/starterartifacts/view/hello.jsp
@@ -18,8 +18,12 @@
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.security.User" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
     Container c = getContainer();
     User user = getUser();
 %>
+
+<labkey:errors></labkey:errors>
+
 <div name="helloMessage">Hello, and welcome to the StarterArtifacts module.</div>


### PR DESCRIPTION
#### Rationale
Add some regression testing for building standalone modules with LabKey taglibs. Available in 1.27.0 of the gradle plugins

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/123

#### Changes
* Update standalone build test module.
