### PR TITLE
'react-bootstrap' test component improvements

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1732,11 +1732,8 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     public void createUserWithPermissions(String userName, String projectName, String permissions)
     {
         _userHelper.createUser(userName, true);
-        if(projectName==null)
-            goToProjectHome();
-        else
-            goToProjectHome(projectName);
-        _permissionsHelper.setUserPermissions(userName, permissions);
+        new ApiPermissionsHelper(this)
+                .addMemberToRole(userName, permissions, PermissionsHelper.MemberType.user, projectName);
     }
 
     public ApiPermissionsHelper createSiteDeveloper(String userEmail)

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1731,6 +1731,10 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
      */
     public void createUserWithPermissions(String userName, String projectName, String permissions)
     {
+        if (projectName == null)
+        {
+            projectName = getProjectName();
+        }
         _userHelper.createUser(userName, true);
         new ApiPermissionsHelper(this)
                 .addMemberToRole(userName, permissions, PermissionsHelper.MemberType.user, projectName);

--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -1192,6 +1192,11 @@ public abstract class Locator extends By
             return this.withPredicate("normalize-space()="+xq(text));
         }
 
+        public XPathLocator withRawText(String text)
+        {
+            return this.withPredicate("text()="+xq(text));
+        }
+
         public XPathLocator withText()
         {
             return this.withPredicate("string-length() > 0");

--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -1192,11 +1192,6 @@ public abstract class Locator extends By
             return this.withPredicate("normalize-space()="+xq(text));
         }
 
-        public XPathLocator withRawText(String text)
-        {
-            return this.withPredicate("text()="+xq(text));
-        }
-
         public XPathLocator withText()
         {
             return this.withPredicate("string-length() > 0");

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -11,6 +11,7 @@ import org.labkey.test.WebDriverWrapperImpl;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.selenium.EphemeralWebElement;
 import org.labkey.test.selenium.RefindingWebElement;
+import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
@@ -93,12 +94,12 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
     {
         // if either are present, we're loading options
         return Locators.loadingSpinner.existsIn(getComponentElement()) ||
-                getComponentElement().getText().toLowerCase().equals(LOADING_TEXT);
+                getComponentElement().getText().equalsIgnoreCase(LOADING_TEXT);
     }
 
     protected T waitForLoaded()
     {
-        _wrapper.waitFor(()-> !isLoading(),
+        waitFor(()-> !isLoading(),
                 "Took too long for to become loaded", WAIT_FOR_JAVASCRIPT);
         return (T) this;
     }
@@ -108,7 +109,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         waitForLoaded();
 
         String val = getComponentElement().getText();
-        if (val.toLowerCase().equals(LOADING_TEXT))
+        if (val.equalsIgnoreCase(LOADING_TEXT))
             return null;
         else
             return val;
@@ -140,7 +141,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
     /* waits until the currently selected 'value' (which can include the placeholder) equals or contains the specified string */
     public T expectValue(String value)
     {
-        _wrapper.waitFor(()-> getValue().contains(value),
+        waitFor(()-> getValue().contains(value),
                 "took too long for the ReactSelect value to contain the expected value:["+value+"]", WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
         return (T) this;
     }
@@ -149,9 +150,9 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
     {
         // wait for the down-caret to be clickable/interactive
         long start = System.currentTimeMillis();
-        _wrapper.waitFor(this::isInteractive, "The select-box did not become interactive in time", 2_000);
+        waitFor(this::isInteractive, "The select-box did not become interactive in time", 2_000);
         long elapsed = System.currentTimeMillis() - start;
-        getWrapper().log("waited ["+ elapsed + "] msec for select to become interactive");
+        TestLogger.debug("waited [" + elapsed + "] msec for select to become interactive");
 
         return (T) this;
     }
@@ -186,7 +187,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
             _wrapper.fireEvent(elementCache().arrow, WebDriverWrapper.SeleniumEvent.click);
         }
 
-        WebDriverWrapper.waitFor(this::isExpanded, 4_000);
+        waitFor(this::isExpanded, 4_000);
         _wrapper.fireEvent(_componentElement, WebDriverWrapper.SeleniumEvent.blur);
         return (T) this;
     }
@@ -216,7 +217,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         {
             WebElement clear = elementCache().clear;
             clear.click();
-            _wrapper.waitFor(()->{
+            waitFor(()->{
                 try
                 {
                     return ! (clear.isEnabled() && clear.isDisplayed()); // wait for it to no longer be enabled or displayed

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -483,6 +483,20 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
             return this;
         }
 
+        /**
+         * Find Select within a &lt;FormGroup&gt; based on the FormGroup's label.
+         * Assumes that the FormGroup has a FormLabel.
+         * @param labelText Text of the FormGroup's FormLabel
+         * @return component finder that will find the specified Select
+         */
+        public BaseReactSelectFinder<Select> withinFormGroup(String labelText)
+        {
+            _locator = Locator.tagWithClass("div", "form-group")
+                    .withChild(Locator.tag("label").withPredicate("text() = " + Locator.xq(labelText)))
+                    .descendant(Locators.selectContainer());
+            return this;
+        }
+
         public BaseReactSelectFinder<Select> withLabelContaining(String label)
         {
             _locator = ReactSelect.Locators.containerWithDescendant(Locator.tag("input")

--- a/src/org/labkey/test/components/react/FilteringReactSelect.java
+++ b/src/org/labkey/test/components/react/FilteringReactSelect.java
@@ -178,17 +178,6 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
         return elementCache().getOptions();
     }
 
-    @Override
-    protected ElementCache elementCache()
-    {
-        return new ElementCache();
-    }
-
-    protected class ElementCache extends BaseReactSelect<?>.ElementCache
-    {
-
-    }
-
     public static class SearchingReactSelectFinder extends BaseReactSelect.BaseReactSelectFinder<FilteringReactSelect>
     {
         private SearchingReactSelectFinder(WebDriver driver)

--- a/src/org/labkey/test/components/react/ReactSelect.java
+++ b/src/org/labkey/test/components/react/ReactSelect.java
@@ -6,6 +6,7 @@ package org.labkey.test.components.react;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.test.Locator;
+import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
@@ -19,7 +20,6 @@ import java.util.function.Function;
 
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.WebDriverWrapper.sleep;
-import static org.labkey.test.util.TestLogger.log;
 
 public class ReactSelect extends BaseReactSelect<ReactSelect>
 {
@@ -84,22 +84,22 @@ public class ReactSelect extends BaseReactSelect<ReactSelect>
             }
             catch (StaleElementReferenceException sere)
             {
-                log("optionEl went stale, probably while attempting to scroll it into view");
+                TestLogger.debug("optionEl went stale, probably while attempting to scroll it into view");
                 sleep(500);
             }
         }
-        log("Found optionEl after " + tryCount + " tries");
+        TestLogger.debug("Found optionEl after " + tryCount + " tries");
 
         for (int i = 0; i < 5 && !optionEl.isDisplayed(); i++)
         {
             sleep(500);
             _wrapper.scrollIntoView(optionEl);
-            log("scroll optionEl into view, attempt " + i);
+            TestLogger.debug("scroll optionEl into view, attempt " + i);
         }
 
         assertTrue("Expected '" + option + "' to be displayed.", optionEl.isDisplayed());
         sleep(500); // either react or the test is moving to fast/slow for one another
-        log("optionEl is displayed, clicking");
+        TestLogger.debug("optionEl is displayed, clicking");
         optionEl.click();
 
         new FluentWait<>(_wrapper.getDriver()).withTimeout(Duration.ofSeconds(1)).until(ExpectedConditions.stalenessOf(optionEl));

--- a/src/org/labkey/test/components/react/Tabs.java
+++ b/src/org/labkey/test/components/react/Tabs.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Wraps 'Tab' and 'Tabs' components from 'react-bootstrap'
+ * Controls 'Tabs' and 'Tab' components from 'react-bootstrap'
  *
  * Corresponding application code looks something like:
  * <pre>{@code

--- a/src/org/labkey/test/components/react/Tabs.java
+++ b/src/org/labkey/test/components/react/Tabs.java
@@ -1,0 +1,114 @@
+package org.labkey.test.components.react;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Wraps 'Tab' and 'Tabs' components from 'react-bootstrap'
+ */
+public class Tabs extends WebDriverComponent<Tabs.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected Tabs(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    public WebElement findPanelForTab(String tabText)
+    {
+        return elementCache().findTabPanel(tabText);
+    }
+
+    public WebElement selectTab(String tabText)
+    {
+        WebElement panel = findPanelForTab(tabText);
+        if (!panel.isDisplayed())
+        {
+            elementCache().findTab(tabText).click();
+            getWrapper().shortWait().until(ExpectedConditions.visibilityOf(panel));
+        }
+        return panel;
+    }
+
+    public boolean isTabSelected(String tabText)
+    {
+        return Boolean.valueOf(elementCache().findTab(tabText).getAttribute("aria-selected"));
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        final WebElement tabList = Locator.xpath("./ul").withClass("nav-tabs").findWhenNeeded(this);
+        final Map<String, WebElement> tabs = new HashMap<>();
+        WebElement findTab(String tabText)
+        {
+            if (!tabs.containsKey(tabText))
+            {
+                WebElement tabEl = Locator.tag("a").withAttribute("role", "tab").withText(tabText).findElement(tabList);
+                tabs.put(tabText, tabEl);
+            }
+            return tabs.get(tabText);
+        }
+
+        final WebElement tabContent = Locator.xpath("./div").withClass("tab-content").findWhenNeeded(this);
+        final Map<String, WebElement> tabPanels = new HashMap<>();
+        WebElement findTabPanel(String tabText)
+        {
+            if (!tabPanels.containsKey(tabText))
+            {
+                String panelId = findTab(tabText).getAttribute("aria-controls");
+                tabPanels.put(tabText, Locator.id(panelId).findElement(tabContent));
+            }
+            return tabPanels.get(tabText);
+        }
+    }
+
+    public static class TabsFinder extends WebDriverComponentFinder<Tabs, TabsFinder>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("ul", "tablist").parent();
+
+        public TabsFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        @Override
+        protected Tabs construct(WebElement el, WebDriver driver)
+        {
+            return new Tabs(el, driver);
+        }
+
+        @Override
+        protected Locator locator()
+        {
+            return _baseLocator;
+        }
+    }
+}

--- a/src/org/labkey/test/components/react/Tabs.java
+++ b/src/org/labkey/test/components/react/Tabs.java
@@ -1,17 +1,34 @@
 package org.labkey.test.components.react;
 
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
  * Wraps 'Tab' and 'Tabs' components from 'react-bootstrap'
+ *
+ * Corresponding application code looks something like:
+ * <pre>{@code
+ * <Tabs id="panel-tabs" >
+ *     <Tab title="First Tab">
+ *         <PanelComponent1/>
+ *     </Tab>
+ *
+ *     <Tab title="Second Tab">
+ *         <PanelComponent2/>
+ *     </Tab>
+ * </Tabs>
+ * }</pre>
  */
 public class Tabs extends WebDriverComponent<Tabs.ElementCache>
 {
@@ -66,25 +83,63 @@ public class Tabs extends WebDriverComponent<Tabs.ElementCache>
     protected class ElementCache extends Component<?>.ElementCache
     {
         final WebElement tabList = Locator.xpath("./ul").withClass("nav-tabs").findWhenNeeded(this);
-        final Map<String, WebElement> tabs = new HashMap<>();
-        WebElement findTab(String tabText)
-        {
-            if (!tabs.containsKey(tabText))
-            {
-                WebElement tabEl = Locator.tag("a").withAttribute("role", "tab").withText(tabText).findElement(tabList);
-                tabs.put(tabText, tabEl);
-            }
-            return tabs.get(tabText);
-        }
-
+        final Map<String, WebElement> tabMap = new HashMap<>();
+        final List<WebElement> tabs = new ArrayList<>();
+        private final Locator.XPathLocator tabLoc = Locator.tag("a").withAttribute("role", "tab");
         final WebElement tabContent = Locator.xpath("./div").withClass("tab-content").findWhenNeeded(this);
         final Map<String, WebElement> tabPanels = new HashMap<>();
+
+        public ElementCache()
+        {
+            if (!WebDriverWrapper.waitFor(() -> findAllTabs().size() > 0, 10_000))
+            {
+                tabLoc.findElement(this); // Should trigger a 'NoSuchElementException'
+            }
+        }
+
+        List<WebElement> findAllTabs()
+        {
+            if (tabs.isEmpty())
+            {
+                tabs.addAll(tabLoc.findElements(tabList));
+            }
+            return tabs;
+        }
+
+        WebElement findTab(String tabText)
+        {
+            if (!tabMap.containsKey(tabText))
+            {
+                WebElement tabEl;
+                try
+                {
+                    tabEl = tabLoc.withText(tabText).findElement(tabList);
+                }
+                catch (NoSuchElementException ex)
+                {
+                    throw new NoSuchElementException(String.format("'%s' not among available tabs: %s",
+                            tabText, getWrapper().getTexts(findAllTabs())), ex);
+                }
+                tabMap.put(tabText, tabEl);
+            }
+            return tabMap.get(tabText);
+        }
+
         WebElement findTabPanel(String tabText)
         {
             if (!tabPanels.containsKey(tabText))
             {
                 String panelId = findTab(tabText).getAttribute("aria-controls");
-                tabPanels.put(tabText, Locator.id(panelId).findElement(tabContent));
+                WebElement panelEl;
+                try
+                {
+                    panelEl = Locator.id(panelId).findElement(tabContent);
+                }
+                catch (NoSuchElementException ex)
+                {
+                    throw new NoSuchElementException("Panel not found for tab : " + tabText, ex);
+                }
+                tabPanels.put(tabText, panelEl);
             }
             return tabPanels.get(tabText);
         }

--- a/src/org/labkey/test/components/ui/NotificationBanner.java
+++ b/src/org/labkey/test/components/ui/NotificationBanner.java
@@ -3,7 +3,6 @@ package org.labkey.test.components.ui;
 import org.labkey.test.BootstrapLocators.BannerType;
 import org.labkey.test.Locator;
 import org.labkey.test.components.WebDriverComponent;
-import org.labkey.test.pages.LabKeyPage;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -11,15 +10,15 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import java.util.Arrays;
 import java.util.List;
 
-public class NotificationBanner<P extends LabKeyPage<?>> extends WebDriverComponent<WebDriverComponent<?>.ElementCache>
+public class NotificationBanner extends WebDriverComponent<WebDriverComponent<?>.ElementCache>
 {
     private final WebElement _el;
-    private final P _page;
+    private final WebDriver _driver;
 
-    protected NotificationBanner(WebElement element, P page)
+    protected NotificationBanner(WebElement element, WebDriver driver)
     {
         _el = element;
-        _page = page;
+        _driver = driver;
     }
 
     @Override
@@ -31,7 +30,7 @@ public class NotificationBanner<P extends LabKeyPage<?>> extends WebDriverCompon
     @Override
     public WebDriver getDriver()
     {
-        return _page.getDriver();
+        return _driver;
     }
 
     public String getMessage()
@@ -39,11 +38,10 @@ public class NotificationBanner<P extends LabKeyPage<?>> extends WebDriverCompon
         return getComponentElement().getText();
     }
 
-    public P dismiss()
+    public void dismiss()
     {
         Locator.byClass("fa-times-circle").findElement(getDriver()).click();
-        _page.shortWait().until(ExpectedConditions.invisibilityOf(getComponentElement()));
-        return _page;
+        getWrapper().shortWait().until(ExpectedConditions.invisibilityOf(getComponentElement()));
     }
 
     public BannerType getType()
@@ -59,43 +57,41 @@ public class NotificationBanner<P extends LabKeyPage<?>> extends WebDriverCompon
         return null;
     }
 
-    public static class NotificationBannerFinder<P extends LabKeyPage<?>> extends WebDriverComponentFinder<NotificationBanner<P>, NotificationBannerFinder<P>>
+    public static class NotificationBannerFinder extends WebDriverComponentFinder<NotificationBanner, NotificationBannerFinder>
     {
-        private final P _page;
         private final Locator.XPathLocator _notificationLocator = Locator.tagWithClass("div", "notification-container");
         private Locator _locator = _notificationLocator;
 
-        public NotificationBannerFinder(P page)
+        public NotificationBannerFinder(WebDriver driver)
         {
-            super(page.getDriver());
-            _page = page;
+            super(driver);
         }
 
         @Override
-        protected NotificationBanner<P> construct(WebElement el, WebDriver driver)
+        protected NotificationBanner construct(WebElement el, WebDriver driver)
         {
-            return new NotificationBanner<>(el, _page);
+            return new NotificationBanner(el, driver);
         }
 
-        public NotificationBannerFinder<P> success()
+        public NotificationBannerFinder success()
         {
             _locator = _notificationLocator.withClass(BannerType.SUCCESS.getCss());
             return this;
         }
 
-        public NotificationBannerFinder<P> info()
+        public NotificationBannerFinder info()
         {
             _locator = _notificationLocator.withClass(BannerType.INFO.getCss());
             return this;
         }
 
-        public NotificationBannerFinder<P> warning()
+        public NotificationBannerFinder warning()
         {
             _locator = _notificationLocator.withClass(BannerType.WARNING.getCss());
             return this;
         }
 
-        public NotificationBannerFinder<P> error()
+        public NotificationBannerFinder error()
         {
             _locator = _notificationLocator.withClass(BannerType.ERROR.getCss());
             return this;

--- a/src/org/labkey/test/components/ui/navigation/ProductMenu.java
+++ b/src/org/labkey/test/components/ui/navigation/ProductMenu.java
@@ -7,6 +7,7 @@ package org.labkey.test.components.ui.navigation;
 import org.labkey.test.Locator;
 import org.labkey.test.components.html.BaseBootstrapMenu;
 import org.labkey.test.components.react.MultiMenu;
+import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -39,7 +40,7 @@ public class ProductMenu extends BaseBootstrapMenu
         boolean menuContentDisplayed = elementCache().menuContent.isDisplayed();
         int headerSectionCount =  MENU_SECTION_HEADER_LOC.findElements(this).size();
         int expectedHeaderSecionCount = getExpectedSectionCount();
-        getWrapper().log(String.format("product menu expansion state: aria-expanded is %b, menuContentDisplayed is %b, %d of %d expected header sections are present",
+        TestLogger.debug(String.format("product menu expansion state: aria-expanded is %b, menuContentDisplayed is %b, %d of %d expected header sections are present",
                 ariaExpanded, menuContentDisplayed, headerSectionCount, expectedHeaderSecionCount));
 
         return  ariaExpanded && menuContentDisplayed && headerSectionCount >= expectedHeaderSecionCount;

--- a/src/org/labkey/test/selenium/BaseLazyWebElement.java
+++ b/src/org/labkey/test/selenium/BaseLazyWebElement.java
@@ -1,0 +1,44 @@
+package org.labkey.test.selenium;
+
+import org.openqa.selenium.WebElement;
+
+public abstract class BaseLazyWebElement extends WebElementWrapper
+{
+    private WebElement _wrappedElement;
+
+    @Override
+    public WebElement getWrappedElement()
+    {
+        if (null == _wrappedElement)
+        {
+            _wrappedElement = findWrappedElement();
+        }
+
+        return _wrappedElement;
+    }
+
+    protected void setWrappedElement(WebElement el)
+    {
+        _wrappedElement = el;
+    }
+
+    protected abstract WebElement findWrappedElement();
+
+    protected String getUnfoundToString()
+    {
+        return super.toString();
+    }
+
+    @Override
+    public String toString()
+    {
+        if (_wrappedElement != null)
+        {
+            return _wrappedElement.toString();
+        }
+        else
+        {
+            return getUnfoundToString();
+        }
+    }
+}

--- a/src/org/labkey/test/selenium/CachingWebElement.java
+++ b/src/org/labkey/test/selenium/CachingWebElement.java
@@ -1,0 +1,21 @@
+package org.labkey.test.selenium;
+
+import org.openqa.selenium.WebElement;
+
+import java.util.function.Supplier;
+
+public class CachingWebElement extends BaseLazyWebElement
+{
+    private final Supplier<WebElement> _elementFinder;
+
+    public CachingWebElement(Supplier<WebElement> elementFinder)
+    {
+        _elementFinder = elementFinder;
+    }
+
+    @Override
+    protected WebElement findWrappedElement()
+    {
+        return _elementFinder.get();
+    }
+}

--- a/src/org/labkey/test/selenium/LazyWebElement.java
+++ b/src/org/labkey/test/selenium/LazyWebElement.java
@@ -28,11 +28,10 @@ import java.time.Duration;
 /**
  * WebElement wrapper that waits for an attempt to interact with the WebElement before actually finding it
  */
-public class LazyWebElement<T extends LazyWebElement<T>> extends WebElementWrapper
+public class LazyWebElement<T extends LazyWebElement<T>> extends BaseLazyWebElement
 {
     private final Locator _locator;
     private final SearchContext _searchContext;
-    private WebElement _wrappedElement;
     private Long _waitMs;
 
     public LazyWebElement(@NotNull Locator locator, @NotNull SearchContext searchContext)
@@ -60,11 +59,7 @@ public class LazyWebElement<T extends LazyWebElement<T>> extends WebElementWrapp
         return (T)this;
     }
 
-    protected void setWrappedElement(WebElement el)
-    {
-        _wrappedElement = el;
-    }
-
+    @Override
     protected WebElement findWrappedElement()
     {
         if (_waitMs != null && _waitMs > 0)
@@ -75,15 +70,6 @@ public class LazyWebElement<T extends LazyWebElement<T>> extends WebElementWrapp
         }
         else
             return getLocator().findElement(getSearchContext());
-    }
-
-    @Override
-    public WebElement getWrappedElement()
-    {
-        if (null == _wrappedElement)
-            _wrappedElement = findWrappedElement();
-
-        return _wrappedElement;
     }
 
     protected Locator getLocator()
@@ -97,12 +83,9 @@ public class LazyWebElement<T extends LazyWebElement<T>> extends WebElementWrapp
     }
 
     @Override
-    public String toString()
+    protected String getUnfoundToString()
     {
-        if (_wrappedElement == null)
-            return getSearchContext().toString() + " -> " + getClass().getSimpleName() + "{" + getLocator().toString() + "}";
-        else
-            return _wrappedElement.toString();
+        return getSearchContext().toString() + " -> " + getClass().getSimpleName() + "{" + getLocator().toString() + "}";
     }
 }
 


### PR DESCRIPTION
#### Rationale
The new workflow Job designer uses 'react-bootstrap' tabs. This new component standardizes switching between tabs and finding tab panels. This PR also resolves numerous IntelliJ warnings and removes some log spam from react test components.

#### Related Pull Requests
* LabKey/sampleManagement#596
* LabKey/biologics#910

#### Changes
* Test component for 'react-bootstrap' tabs
* `LazyWebElement` variant that takes a `Supplier<WebElement>`
* Make `createUserWithPermissions` work fully via API
* New locator for `BaseReactSelectFinder`
* Remove some log spam from `ReactSelect`
* Simplify `NotificationBanner` by removing unnecessary type parameter
