### PR TITLE
Wait for data region to update after deleting samples

### DIFF
--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -309,7 +309,7 @@ public class DataRegionTable extends DataRegion
         return -1;
     }
 
-    protected int getRowIndexStrict(String columnLabel, String value)
+    public int getRowIndexStrict(String columnLabel, String value)
     {
         int rowIndex = getRowIndex(columnLabel, value);
         if (rowIndex < 0)
@@ -317,7 +317,7 @@ public class DataRegionTable extends DataRegion
         return rowIndex;
     }
 
-    protected int getRowIndexStrict(int columnIndex, String value)
+    public int getRowIndexStrict(int columnIndex, String value)
     {
         int rowIndex = getRowIndex(columnIndex, value);
         if (rowIndex < 0)
@@ -372,11 +372,13 @@ public class DataRegionTable extends DataRegion
 
     /**
      * returns index of the row of the first appearance of the specified data, in the specified column
+     *
+     * @deprecated Use {@link #getRowIndex(String, String)} or {@link #getRowIndexStrict(String, String)}
      */
+    @Deprecated
     public int getIndexWhereDataAppears(String data, String column)
     {
-        List<String> allData = getColumnDataAsText(column);
-        return allData.indexOf(data);
+        return getRowIndex(column, data);
     }
 
     public static Locator.XPathLocator detailsLinkLocator()
@@ -715,9 +717,9 @@ public class DataRegionTable extends DataRegion
     /* Key is the PK on the table, it is usually the contents of the 'value' attribute of the row selector checkbox  */
     public void updateRow(String key, Map<String, ?> data, boolean validateText)
     {
-        clickEditRow(key);
+        UpdateQueryRowPage updatePage = clickEditRow(key);
 
-        setRowData(data, validateText);
+        setRowData(updatePage, data, validateText);
     }
 
     public void updateRow(int rowIndex, Map<String, ?> data)
@@ -727,9 +729,9 @@ public class DataRegionTable extends DataRegion
 
     public void updateRow(int rowIndex, Map<String, ?> data, boolean validateText)
     {
-        clickEditRow(rowIndex);
+        UpdateQueryRowPage updatePage = clickEditRow(rowIndex);
 
-        setRowData(data, validateText);
+        setRowData(updatePage, data, validateText);
     }
 
     public UpdateQueryRowPage clickEditRow(int rowIndex)
@@ -757,9 +759,9 @@ public class DataRegionTable extends DataRegion
         clickRowDetails(getRowIndexStrict(key));
     }
 
-    protected void setRowData(Map<String, ?> data, boolean validateText)
+    protected void setRowData(UpdateQueryRowPage updatePage, Map<String, ?> data, boolean validateText)
     {
-        new UpdateQueryRowPage(getDriver()).update(data);
+        updatePage.update(data);
         if (validateText)
         {
             getWrapper().assertTextPresent(String.valueOf(data.values().iterator().next()));  //make sure some text from the map is present


### PR DESCRIPTION
#### Rationale
`SampleTypeTest.testUpdateAndDeleteWithCommentsAndFlags` recently failed because it tried to interact with a data region while it was updating. This was caused when the test deleted some samples without waiting for the data region to update. I resolved a lot of IntelliJ warnings as well.

```
org.openqa.selenium.StaleElementReferenceException: The element reference of <form id="lk-region-47636-form" class="form-horizontal"> is stale; either the element is no longer attached to the DOM, it is not in the current frame context, or the document has been refreshed
[...]
  at org.labkey.test.selenium.WebElementWrapper.isEnabled(WebElementWrapper.java:78)
  at org.labkey.test.selenium.WebElementWrapper.isEnabled(WebElementWrapper.java:78)
  at org.labkey.test.util.DataRegion.elementCache(DataRegion.java:96)
  at org.labkey.test.util.DataRegionTable.elementCache(DataRegionTable.java:104)
  at org.labkey.test.util.DataRegionTable$DataRegionFinder.construct(DataRegionTable.java:237)
  at org.labkey.test.util.DataRegionTable$DataRegionFinder.construct(DataRegionTable.java:1)
  at org.labkey.test.components.WebDriverComponent$WebDriverComponentFinder.construct(WebDriverComponent.java:100)
  at org.labkey.test.components.Component$ComponentFinder.find(Component.java:194)
  at org.labkey.test.components.WebDriverComponent$WebDriverComponentFinder.find(WebDriverComponent.java:70)
  at org.labkey.test.util.SampleTypeHelper.getSamplesDataRegionTable(SampleTypeHelper.java:163)
  at org.labkey.test.util.SampleTypeHelper.startTsvImport(SampleTypeHelper.java:239)
  at org.labkey.test.util.SampleTypeHelper.startTsvImport(SampleTypeHelper.java:252)
  at org.labkey.test.util.SampleTypeHelper.mergeImport(SampleTypeHelper.java:227)
  at org.labkey.test.tests.SampleTypeTest.updateSampleType(SampleTypeTest.java:757)
  at org.labkey.test.tests.SampleTypeTest.testUpdateAndDeleteWithCommentsAndFlags(SampleTypeTest.java:651)
```

#### Changes
* Wait for data region to update after deleting samples
* Fix some warnings in `SampleTypeTest`
* Deprecate redundant method in `DataRegionTable`
