### PR TITLE
Fix tests using 'assertUserNotInGroup' on non-existent users

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -107,7 +107,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
 {
     private static final int MAX_SERVER_STARTUP_WAIT_SECONDS = TestProperties.getServerStartupTimeout();
     private static final String CLIENT_SIDE_ERROR = "Client exception detected";
-    public AbstractUserHelper _userHelper = new APIUserHelper(this);
+    public final APIUserHelper _userHelper = new APIUserHelper(this);
 
     public boolean isGuestModeTest()
     {

--- a/src/org/labkey/test/tests/FolderExportTest.java
+++ b/src/org/labkey/test/tests/FolderExportTest.java
@@ -34,6 +34,7 @@ import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.DailyB;
 import org.labkey.test.components.ext4.ComboBox;
+import org.labkey.test.util.APIUserHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PasswordUtil;
@@ -53,6 +54,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -60,7 +62,9 @@ import static org.junit.Assert.fail;
 @BaseWebDriverTest.ClassTimeout(minutes = 17)
 public class FolderExportTest extends BaseWebDriverTest
 {
-    private ApiPermissionsHelper _permissionsHelper = new ApiPermissionsHelper(this);
+    private final ApiPermissionsHelper _permissionsHelper = new ApiPermissionsHelper(this);
+    protected final APIUserHelper _userHelper = new APIUserHelper(this);
+
     String[] webParts = {"Study Overview", "Data Pipeline", "Datasets", "Specimens", "Views", "Test wiki", "Study Data Tools", "Lists", "~!@#$%^&*()_+query web part", "Report web part", "Workbooks"};
     File dataDir = TestFileUtils.getSampleData("FolderExport");
     private static final String folderFromZip = "1 Folder From Zip"; // add numbers to folder names to keep ordering for created folders
@@ -288,9 +292,9 @@ public class FolderExportTest extends BaseWebDriverTest
         else
         {
             log("Verifying absence of users in groups");
-            _permissionsHelper.assertUserNotInGroup(testUser3, parentGroup, projectName, PrincipalType.USER);
-            _permissionsHelper.assertUserNotInGroup(testUser1, submitterGroup, projectName, PrincipalType.USER);
-            _permissionsHelper.assertUserNotInGroup(testUser2, superTesterGroup, projectName, PrincipalType.USER);
+            assertNull("User should not have been created by folder import: " + testUser1, _userHelper.getUserId(testUser1));
+            assertNull("User should not have been created by folder import: " + testUser2, _userHelper.getUserId(testUser2));
+            assertNull("User should not have been created by folder import: " + testUser3, _userHelper.getUserId(testUser3));
         }
         log("Verifying existence of groups in groups");
         _permissionsHelper.assertUserInGroup(submitterGroup, groupGroup, projectName, PrincipalType.GROUP);

--- a/src/org/labkey/test/tests/UserTest.java
+++ b/src/org/labkey/test/tests/UserTest.java
@@ -77,11 +77,7 @@ public class UserTest extends BaseWebDriverTest
     private static final String SELF_SERVICE_EMAIL_USER = "oldaddress@user.test";
     private static final String SELF_SERVICE_EMAIL_USER_CHANGED = "newaddress@user.test";
 
-    public UserTest()
-    {
-        super();
-        _userHelper = new UIUserHelper(this);
-    }
+    protected final UIUserHelper _userHelper = new UIUserHelper(this);
 
     @Nullable
     @Override

--- a/src/org/labkey/test/tests/remoteapi/BulkUpdateGroupApiTest.java
+++ b/src/org/labkey/test/tests/remoteapi/BulkUpdateGroupApiTest.java
@@ -47,8 +47,8 @@ import static org.junit.Assert.fail;
 @BaseWebDriverTest.ClassTimeout(minutes = 4)
 public class BulkUpdateGroupApiTest extends BaseWebDriverTest
 {
-    ApiPermissionsHelper _permissionsHelper = new ApiPermissionsHelper(this);
-    APIUserHelper _userHelper = new APIUserHelper(this);
+    final ApiPermissionsHelper _permissionsHelper = new ApiPermissionsHelper(this);
+    final APIUserHelper _userHelper = new APIUserHelper(this);
 
     private static final String EMAIL_SUFFIX = "@bulkupdategroup.test";
     private static final String USER1 = genTestEmail("preexistinguser1");
@@ -434,7 +434,7 @@ public class BulkUpdateGroupApiTest extends BaseWebDriverTest
         BulkUpdateGroupCommand command = new BulkUpdateGroupCommand(groupName);
         command.setCreateGroup(false);
         command.addMemberUser(user1Id);
-        command.addMemberUser(newUser);
+        command.addMemberUser(newUser); // Shouldn't get created
         Connection connection = createDefaultConnection();
 
         try
@@ -449,7 +449,7 @@ public class BulkUpdateGroupApiTest extends BaseWebDriverTest
         }
 
         _permissionsHelper.assertUserNotInGroup(USER1, groupName, getProjectName(), PrincipalType.USER);
-        _permissionsHelper.assertUserNotInGroup(newUser, groupName, getProjectName(), PrincipalType.USER);
+        assertNull("User was created by failed 'BulkUpdateGroupCommand'", _userHelper.getUserId(newUser));
     }
 
     @Test

--- a/src/org/labkey/test/util/APIUserHelper.java
+++ b/src/org/labkey/test/util/APIUserHelper.java
@@ -16,6 +16,7 @@
 package org.labkey.test.util;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.json.simple.JSONObject;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
@@ -143,7 +144,7 @@ public class APIUserHelper extends AbstractUserHelper
 
     public Map<String, Integer> getUserIds(List<String> userEmails)
     {
-        return getUserIds(userEmails, false);
+        return getUserIds(userEmails, true);
     }
 
     public Map<String, Integer> getUserIds(List<String> userEmails, boolean includeDeactivated)
@@ -158,6 +159,7 @@ public class APIUserHelper extends AbstractUserHelper
         return userIds;
     }
 
+    @Nullable
     public Integer getUserId(String userEmail)
     {
         return getUserIds(Arrays.asList(userEmail)).get(userEmail);

--- a/src/org/labkey/test/util/ApiPermissionsHelper.java
+++ b/src/org/labkey/test/util/ApiPermissionsHelper.java
@@ -119,7 +119,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
             }
             catch (CommandException ex)
             {
-                throw new RuntimeException(ex);
+                return false;
             }
         }
         else if (principalType == PrincipalType.GROUP)


### PR DESCRIPTION
#### Rationale
`ApiPermissionsHelper.isUserInGroup` was changed to not swallow exceptions for non-existent users. This caused some tests to fail when calling `assertUserNotInGroup` for users that don't exist. This change updates those tests to assert that those users don't exist. It also reverts the change to `ApiPermissionsHelper.isUserInGroup` so that it is consistent with `UIPermissionsHelper.isUserInGroup`.

#### Related Pull Requests
* #774 

#### Changes
* Make `isUserInGroup` function consistently between UI and API helpers
* Fix tests using 'assertUserNotInGroup' improperly
* Resolve some IntelliJ warnings
* Use API helpers
