### PR TITLE
Test coverage for project locking and review workflow

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -39,6 +39,7 @@ import org.labkey.test.components.html.RadioButton;
 import org.labkey.test.components.html.SiteNavBar;
 import org.labkey.test.components.labkey.LabKeyAlert;
 import org.labkey.test.pages.admin.FolderManagementPage;
+import org.labkey.test.pages.admin.PermissionsPage;
 import org.labkey.test.pages.assay.AssayBeginPage;
 import org.labkey.test.pages.core.admin.ProjectSettingsPage;
 import org.labkey.test.pages.list.BeginPage;
@@ -812,9 +813,10 @@ public abstract class WebDriverWrapper implements WrapsDriver
         return new FolderManagementPage(getDriver());
     }
 
-    public void goToFolderPermissions()
+    public PermissionsPage goToFolderPermissions()
     {
         clickAdminMenuItem("Folder", "Permissions");
+        return new PermissionsPage(getDriver());
     }
 
     public ProjectSettingsPage goToProjectSettings()

--- a/src/org/labkey/test/pages/admin/PermissionsPage.java
+++ b/src/org/labkey/test/pages/admin/PermissionsPage.java
@@ -472,6 +472,27 @@ public class PermissionsPage extends LabKeyPage<PermissionsPage.ElementCache>
         return this;
     }
 
+    public PermissionsPage lockProject()
+    {
+        _ext4Helper.clickTabContainingText("Project Locking & Review");
+        clickButton("Lock This Project");
+        return this;
+    }
+
+    public PermissionsPage unlockProject()
+    {
+        _ext4Helper.clickTabContainingText("Project Locking & Review");
+        clickButton("Unlock This Project");
+        return this;
+    }
+
+    public PermissionsPage resetLockExpiration()
+    {
+        _ext4Helper.clickTabContainingText("Project Locking & Review");
+        clickButton("Reset Expiration");
+        return this;
+    }
+
     @Override
     protected ElementCache newElementCache()
     {

--- a/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
+++ b/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
@@ -12,8 +12,10 @@ import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PipelineStatusTable;
 import org.labkey.test.util.TextSearcher;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.Collection;
 import java.util.List;
@@ -34,6 +36,12 @@ public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsP
     {
         driver.beginAt(WebTestHelper.buildURL("pipeline-status", driver.getCurrentContainerPath(), "details", Map.of("rowId", String.valueOf(rowId))));
         return new PipelineStatusDetailsPage(driver);
+    }
+
+    @Override
+    protected void waitForPage()
+    {
+        shortWait().until(ExpectedConditions.visibilityOf(elementCache().statusText));
     }
 
     public PipelineStatusDetailsPage(WebDriver driver)


### PR DESCRIPTION
#### Rationale
These are proposed changes to support testing of project locking and review (most of the functionality and tests are in the compliance module)

#### Related Pull Requests
https://github.com/LabKey/compliance/pull/120

#### Changes
Add methods to PermissionsPage to support project locking and review behaviors
update GoToFolderPermissions to return a PermissionsPage