### PR TITLE
Fix for Test Automation Issue 41038

### DIFF
--- a/src/org/labkey/test/pages/experiment/CreateSampleTypePage.java
+++ b/src/org/labkey/test/pages/experiment/CreateSampleTypePage.java
@@ -1,8 +1,10 @@
 package org.labkey.test.pages.experiment;
 
+import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.ui.domainproperties.samples.SampleTypeDesigner;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 
 public class CreateSampleTypePage extends SampleTypeDesigner<CreateSampleTypePage>
@@ -10,6 +12,26 @@ public class CreateSampleTypePage extends SampleTypeDesigner<CreateSampleTypePag
     public CreateSampleTypePage(WebDriver driver)
     {
         super(driver);
+
+        // Addressing Issue 41038: Add a waitForPageLoad in org.labkey.test.pages.experiment.UpdateSampleTypePage
+        WebDriverWrapper.waitFor(()-> {
+                    try
+                    {
+                        // There should be at least two panels for a sample type a 'general properties' panel and a 'fields' panel.
+                        // Wait until the headers for these two panels are there before returning.
+                        return Locator
+                                .tagWithClassContaining("div", "domain-panel-header")
+                                .findElements(this).size() >= 2;
+                    }
+                    catch(NoSuchElementException nse)
+                    {
+                        return false;
+                    }
+                },
+                "Did not find the 'General Properties' and 'Fields' panels for the SampleType page.",
+                1_000);
+
+
     }
 
     public static CreateSampleTypePage beginAt(WebDriverWrapper driver)

--- a/src/org/labkey/test/pages/experiment/UpdateSampleTypePage.java
+++ b/src/org/labkey/test/pages/experiment/UpdateSampleTypePage.java
@@ -10,11 +10,8 @@ public class UpdateSampleTypePage extends CreateSampleTypePage
     public UpdateSampleTypePage(WebDriver driver)
     {
         super(driver);
+        // The parent page CreateSampleTypePage has a wait in the constructor.
     }
-
-    // TODO: Add a waitForLoad, or some other appropriate check, that the page is loaded. If not here then in one of
-    //  the parent classes.
-    // Issue 41038: Add a waitForPageLoad in org.labkey.test.pages.experiment.UpdateSampleTypePage
 
     public static UpdateSampleTypePage beginAt(WebDriverWrapper driver, Integer sampleTypeId)
     {


### PR DESCRIPTION
#### Rationale
Fix for Test Automation Issue 41038 (Add a waitForPageLoad in org.labkey.test.pages.experiment.UpdateSampleTypePage). There are random failures in LKS because the page is not completely loaded before the test uses it. Added a simple check in the constructor that should help with this.

#### Related Pull Requests
* None.

#### Changes
* Add a check in the constructor for the page being loaded to some degree.
