### PR TITLE
Clear selection only for deleted items

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -1058,19 +1058,27 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         drtSamples.clickHeaderButton("Delete");
         Window.Window(getDriver()).withTitle("No samples can be deleted").waitFor()
                 .clickButton("Dismiss", true);
+        drtSamples.uncheckAllOnPage();
+        assertEquals("No selection should remain", 0, drtSamples.getCheckedCount());
+        assertEquals("No selection should remain", 0, drtSamples.getSelectedCount());
 
         log("Try to delete parent and child");
         drtSamples.checkCheckbox(drtSamples.getIndexWhereDataAppears(parentSampleNames.get(1), "Name"));
         drtSamples.checkCheckbox(drtSamples.getIndexWhereDataAppears(twoParentChildName, "Name"));
-        sampleHelper.deleteSamples(drtSamples, "Permanently delete 1 sample");
+        assertEquals("Parent and child should be checked", 2, drtSamples.getCheckedCount());
+        assertEquals("Parent and child should be checked", 2, drtSamples.getSelectedCount());
 
+        sampleHelper.deleteSamples(drtSamples, "Permanently delete 1 sample");
         assertEquals("Deleted sample " + twoParentChildName + " still appears in grid", -1, drtSamples.getIndexWhereDataAppears(twoParentChildName, "Name"));
         assertTrue("Parent sample " + parentSampleNames.get(1) + " does not appears in grid", drtSamples.getIndexWhereDataAppears(parentSampleNames.get(1), "Name") > -1);
+        assertEquals("Only parent sample should be checked", 1, drtSamples.getCheckedCount());
+        assertEquals("Only parent sample should be checked", 1, drtSamples.getSelectedCount());
 
         log("Now that the child is gone, try to delete the parent");
         sampleHelper.deleteSamples(drtSamples, "Permanently delete 1 sample");
 
         assertEquals("Deleted sample " + parentSampleNames.get(1) + " still appears in grid", -1, drtSamples.getIndexWhereDataAppears(parentSampleNames.get(1), "Name"));
+        assertEquals("No selection should remain", 0, drtSamples.getCheckedCount());
 
         log("Now try to delete what's left, in several hitches");
         drtSamples.checkAllOnPage();

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -1385,9 +1385,20 @@ public class DataRegionTable extends DataRegion
         });
     }
 
+    /** Get the number of items checked within the current page of the grid. */
     public int getCheckedCount()
     {
         return api().executeScript("getChecked().length;", Long.class).intValue();
+    }
+
+    /**
+     * Get the selected item count persisted in the session state.  Includes rows not visible
+     * on the current page of the grid.  Useful for validating the selection is cleared after
+     * deleting a row from the grid.
+     */
+    public int getSelectedCount()
+    {
+        return api().executeScript("selectedCount;", Long.class).intValue();
     }
 
     @Deprecated


### PR DESCRIPTION
#### Rationale
The change in LabKey/platform#2423 clears all selected items after deleting samples even if the samples can't be deleted.  The `SampleTypeLineageTest.testDeleteSamplesSomeWithDerivedSamples` was relying on this behavior, even if strange.  To not break the test, the selection is only cleared for samples that can be deleted.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2423
* https://github.com/LabKey/platform/pull/2433