### PR TITLE
Link crawler improvements

### DIFF
--- a/modules/crawlerTest/module.properties
+++ b/modules/crawlerTest/module.properties
@@ -1,0 +1,6 @@
+ModuleClass: org.labkey.crawlertest.CrawlerTestModule
+Label: Crawler Test Module
+Description: Module with actions vulnerable to script injection. For validating crawler functionality. Not intended for deployment of any kind.
+URL: http://labkey.org
+License: Apache 2.0
+LicenseURL: http://www.apache.org/licenses/LICENSE-2.0

--- a/modules/crawlerTest/src/org/labkey/crawlertest/CrawlerTestController.java
+++ b/modules/crawlerTest/src/org/labkey/crawlertest/CrawlerTestController.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.labkey.crawlertest;
+
+import org.labkey.api.action.LabKeyError;
+import org.labkey.api.action.SimpleErrorView;
+import org.labkey.api.action.SimpleViewAction;
+import org.labkey.api.action.SpringActionController;
+import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.security.RequiresPermission;
+import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.util.ErrorView;
+import org.labkey.api.view.JspView;
+import org.labkey.api.view.NavTree;
+import org.springframework.validation.BindException;
+import org.springframework.web.servlet.ModelAndView;
+
+public class CrawlerTestController extends SpringActionController
+{
+    private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(CrawlerTestController.class);
+    public static final String NAME = "crawlertest";
+
+    public CrawlerTestController()
+    {
+        setActionResolver(_actionResolver);
+    }
+
+    @RequiresPermission(ReadPermission.class)
+    public class InjectJspAction extends SimpleViewAction<InjectForm>
+    {
+        @Override
+        public ModelAndView getView(InjectForm form, BindException errors)
+        {
+            if (!getViewContext().getContainer().getActiveModules().contains(ModuleLoader.getInstance().getModule(CrawlerTestModule.class)))
+            {
+                // Add extra barrier to having this action available unless explicitly wanted
+                errors.reject(ERROR_MSG, "CrawlerTest module is not enabled. Enable with caution. Doing so will expose a script injection vulnerability.");
+                return new SimpleErrorView(errors);
+            }
+            getPageConfig().setTitle("Injection test page");
+            return new JspView<>("/org/labkey/crawlertest/view/injectJsp.jsp", form.getInject());
+        }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        { }
+    }
+
+    public static class InjectForm
+    {
+        private String _inject;
+
+        public String getInject()
+        {
+            return _inject;
+        }
+
+        public InjectForm setInject(String inject)
+        {
+            _inject = inject;
+            return this;
+        }
+    }
+}

--- a/modules/crawlerTest/src/org/labkey/crawlertest/CrawlerTestModule.java
+++ b/modules/crawlerTest/src/org/labkey/crawlertest/CrawlerTestModule.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.labkey.crawlertest;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.Container;
+import org.labkey.api.module.CodeOnlyModule;
+import org.labkey.api.module.ModuleContext;
+import org.labkey.api.view.WebPartFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class CrawlerTestModule extends CodeOnlyModule
+{
+    public static final String NAME = "CrawlerTest";
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    @NotNull
+    protected Collection<WebPartFactory> createWebPartFactories()
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    protected void init()
+    {
+        addController(CrawlerTestController.NAME, CrawlerTestController.class);
+    }
+
+    @Override
+    public void doStartup(ModuleContext moduleContext)
+    {
+    }
+
+    @Override
+    @NotNull
+    public Collection<String> getSummary(Container c)
+    {
+        return Collections.emptyList();
+    }
+}

--- a/modules/crawlerTest/src/org/labkey/crawlertest/view/injectJsp.jsp
+++ b/modules/crawlerTest/src/org/labkey/crawlertest/view/injectJsp.jsp
@@ -1,0 +1,25 @@
+<%
+/*
+ * Copyright (c) 2020 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+%>
+<%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+
+<%
+    String inject = ((HttpView<String>) HttpView.currentView()).getModelBean();
+%>
+<span>Param:</span>
+<div id="crawlerTestDiv"><%=unsafe(inject)%></div>

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -182,10 +182,10 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
     public static final String TRICKY_CHARACTERS = "><&/%\\' \"1\u00E4\u00F6\u00FC\u00C5";
     public static final String TRICKY_CHARACTERS_NO_QUOTES = "></% 1\u00E4\u00F6\u00FC\u00C5";
-    public static final String TRICKY_CHARACTERS_FOR_PROJECT_NAMES = "\u2603~!@$&()_+{}-=[],.#\u00E4\u00F6\u00FC\u00C5";
+    public static final String TRICKY_CHARACTERS_FOR_PROJECT_NAMES = "\u2603~!@$&()_+{}-=[],.#\u00E4\u00F6\u00FC\u00C5"; // No slash or space
     // TODO using </script> breaks CustomizeViewTest because of the '/'
-    public static final String INJECT_CHARS_1 = "-->\">'>'\"<script>alert('8(');</script>";
-    public static final String INJECT_CHARS_2 = "-->\">'>'\"<img src=\"xss\" onerror=\"alert('8(')\">";
+    public static final String INJECT_CHARS_1 = Crawler.injectScriptBlock;
+    public static final String INJECT_CHARS_2 = Crawler.injectAttributeScript;
 
     /** Have we already done a memory leak and error check in this test harness VM instance? */
     protected static boolean _checkedLeaksAndErrors = false;

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -1295,21 +1295,6 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         return projectMenu().expandProjectFully(getCurrentProject());
     }
 
-    /**
-     * @deprecated Old UX only. Used by {@link #clickFolder(String)} below.
-     */
-    @Deprecated
-    public void expandFolderTree(String folder)
-    {
-        Locator.XPathLocator folderNav = Locator.id("folderBar_menu").append("/div/div/div/ul").withClass("folder-nav-top");
-        Locator.XPathLocator treeAncestor = folderNav.append("//li").withClass("collapse-folder").withDescendant(Locator.linkWithText(folder)).append("/span").withClass("marked");
-        List<WebElement> els = treeAncestor.findElements(getDriver());
-        for (WebElement el : els)
-        {
-            el.click();
-        }
-    }
-
     public void clickFolder(String folder)
     {
         projectMenu().navigateToFolder(getCurrentProject(), folder);

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1043,6 +1043,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
      * @param relativeURL URL to navigate to
      * @param millis Max wait for page to load
      * @param allowDownload 'true' to allow navigation or download. 'false' to expect a navigation
+     * @return array of downloaded files or null if navigation occurred
      */
     public File[] beginAt(String relativeURL, int millis, boolean allowDownload)
     {
@@ -1118,7 +1119,8 @@ public abstract class WebDriverWrapper implements WrapsDriver
             logMessage += TestLogger.formatElapsedTime(elapsedTime);
 
 
-            return downloadedFiles.getValue();
+            File[] ret = downloadedFiles.getValue();
+            return ret != null && ret.length > 0 ? ret : null;
         }
         finally
         {

--- a/src/org/labkey/test/tests/CrawlerTest.java
+++ b/src/org/labkey/test/tests/CrawlerTest.java
@@ -1,0 +1,128 @@
+package org.labkey.test.tests;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
+import org.labkey.test.Locators;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.categories.Daily;
+import org.labkey.test.util.Crawler;
+import org.openqa.selenium.UnhandledAlertException;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Category({Daily.class})
+public class CrawlerTest extends BaseWebDriverTest
+{
+
+    private static final String MODULE_NAME = "CrawlerTest";
+
+    @BeforeClass
+    public static void setupProject()
+    {
+        CrawlerTest init = (CrawlerTest) getCurrentTest();
+
+        init.doSetup();
+    }
+
+    private void doSetup()
+    {
+        _containerHelper.createProject(getProjectName(), null);
+    }
+
+    /**
+     * Ensure that 'testCrawler' is a valid test
+     */
+    @Test
+    public void testCrawlerTest()
+    {
+        String safeParam = "OK!";
+
+        log("Verify vulnerable page must be enabled");
+        beginAt(getInjectUrl(safeParam));
+        assertElementPresent(Locators.labkeyError);
+        assertElementNotPresent(Locator.tag("div").withText(safeParam));
+
+        _containerHelper.enableModule(MODULE_NAME);
+
+        log("Verify vulnerable page displays safe parameter");
+        beginAt(getInjectUrl(safeParam));
+        assertElementPresent(Locator.tag("div").withText(safeParam));
+
+        log("Verify that page is vulnerable");
+        try
+        {
+            beginAt(getInjectUrl(Crawler.injectScriptBlock));
+            Assert.fail("Expected an injection alert.");
+        }
+        catch (UnhandledAlertException alert)
+        {
+            if (!alert.getMessage().contains(Crawler.injectedAlert))
+            {
+                throw alert; // Wrong alert
+            }
+        }
+        try
+        {
+            beginAt(getInjectUrl(Crawler.injectAttributeScript));
+            Assert.fail("Expected an injection alert.");
+        }
+        catch (UnhandledAlertException alert)
+        {
+            if (!alert.getMessage().contains(Crawler.injectedAlert))
+            {
+                throw alert; // Wrong alert
+            }
+        }
+    }
+
+    @Test
+    public void testCrawler()
+    {
+        String safeParam = "OK!";
+
+        log("Test crawler against a vulnerable page");
+        Crawler crawler = new Crawler(this, Duration.ofSeconds(30), true);
+        try
+        {
+            crawler.validatePage(getInjectUrl(safeParam));
+            Assert.fail("Crawler should have triggered a malicious script. Crawled:\n" + String.join("\n", crawler.getUrlsVisited()));
+        }
+        catch (AssertionError expectedError)
+        {
+            if (!expectedError.getMessage().equals("Crawler: Malicious script executed"))
+            {
+                throw expectedError;
+            }
+        }
+    }
+
+    private String getInjectUrl(String injectionParam)
+    {
+        return WebTestHelper.buildRelativeUrl(MODULE_NAME, getProjectName(), "injectJsp", Map.of("inject", injectionParam));
+    }
+
+    @Override
+    protected BrowserType bestBrowser()
+    {
+        return BrowserType.CHROME;
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return "CrawlerTest Project" + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Arrays.asList();
+    }
+}

--- a/src/org/labkey/test/tests/CrawlerTest.java
+++ b/src/org/labkey/test/tests/CrawlerTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 @Category({Daily.class})
+@BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class CrawlerTest extends BaseWebDriverTest
 {
 
@@ -70,7 +71,7 @@ public class CrawlerTest extends BaseWebDriverTest
         log("Verify that page is vulnerable");
         try
         {
-            beginAt(getInjectUrl(Crawler.injectScriptBlock));
+            beginAt(getInjectUrl(Crawler.injectScriptBlock), 10_000, true);
             Assert.fail("Expected an injection alert.");
         }
         catch (UnhandledAlertException alert)
@@ -82,7 +83,7 @@ public class CrawlerTest extends BaseWebDriverTest
         }
         try
         {
-            beginAt(getInjectUrl(Crawler.injectAttributeScript));
+            beginAt(getInjectUrl(Crawler.injectAttributeScript), 10_000, true);
             Assert.fail("Expected an injection alert.");
         }
         catch (UnhandledAlertException alert)

--- a/src/org/labkey/test/tests/CustomizeViewTest.java
+++ b/src/org/labkey/test/tests/CustomizeViewTest.java
@@ -144,7 +144,7 @@ public class CustomizeViewTest extends BaseWebDriverTest
         log("** Test HTML/JavaScript escaping");
         Crawler.tryInject(this, () -> {
             _customizeViewsHelper.openCustomizeViewPanel();
-            _customizeViewsHelper.saveCustomView("BAD" + Crawler.injectString);
+            _customizeViewsHelper.saveCustomView("BAD" + Crawler.injectScriptBlock);
             assertTextBefore("Billson", "Johnson");
         });
     }

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -919,8 +919,7 @@ public class Crawler
                             {
                                 if (!formAddresses.contains(url)) // forms might have strange target action (e.g. '../formulations')
                                 {
-                                    origin = null; // Don't grab screenshot for origin page
-                                    throw new AssertionError("Unable to parse link: " + url, badUrl);
+                                    throw new AssertionError("Unable to parse link: \"" + url + "\". " + originMessage, badUrl);
                                 }
                             }
                         }
@@ -1112,8 +1111,9 @@ public class Crawler
                 fail("Crawler: Server error detected\n" + url);
             }
         }
-        else if (responseCode == 400) // 400 probably means the crawler generated a bad URL
+        else if (responseCode == 400 && !test.onLabKeyPage())
         {
+            // 400 on a non-LabKey page probably means the crawler generated a bad URL
             fail("Crawler: Bad request: " + test.getDriver().getCurrentUrl());
         }
     }


### PR DESCRIPTION
#### Rationale
Recent crawler improvements to allow it to crawl download URLs causes occasional false-positives. After crawling a URL, the crawler checks the destination for errors. The crawler also attempts script injections against the pages it crawls but is less strict about finding errors on such pages. When the crawler checks a download URL immediately after hitting an error page from an injection attempt, it will fail because it still performs the error checks that it does after crawling a non-download URL. For a similar reason, we are not attempting script injection against download URLs.
This change skips response checks after crawling a download URL and continues to attempt script injection against them.
There is also a new test to ensure the injection checker continues to function as well as a new test module to facilitate this test.

#### Related Pull Requests
* #749 

#### Changes
* Fix crawler to not inspect the browser after hitting a download URL
* [Issue 39581: Add test to ensure injection check continues to work](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=39581)
