### PR TITLE
Remove domain editor cancel workaround

### DIFF
--- a/src/org/labkey/test/tests/FieldEditorRowSelectionActionTest.java
+++ b/src/org/labkey/test/tests/FieldEditorRowSelectionActionTest.java
@@ -161,7 +161,7 @@ public class FieldEditorRowSelectionActionTest extends BaseWebDriverTest
         downloadedFile = domainFormPanel.clickExportFields();
         checker().verifyEquals("Exported fields are not same UI fields", getFieldsFromExportFile(downloadedFile), domainFormPanel.fieldNames());
 
-        domainDesignerPage.clickCancelWithUnsavedChanges().discardChanges();
+        domainDesignerPage.clickCancel();
     }
 
 


### PR DESCRIPTION
#### Rationale
Field selection state for export was included in the domain editor dirty state check. That behavior seems to have been fixed.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2428

#### Changes
* Update `FieldEditorRowSelectionActionTest.testUserProperties` to not expect a confirmation dialog.
