### PR TITLE
Automated test fixes for change to value conversion error message text

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -281,8 +281,8 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         clickButton("Submit");
 
         log("Do a simple check that data validation works.");
-        checker().verifyTrue("Expected error message 'must be of type Integer' is not present.",
-                isTextPresent("must be of type Integer"));
+        checker().verifyTrue("Expected error message '(String) for Integer field' is not present.",
+                isTextPresent("(String) for Integer field"));
         checkCheckbox(Locator.name("outputSample1_IntColFolderCheckBox"));
         setFormElement(Locator.name("outputSample1_IntColFolder"), "500");
         clickButton("Submit");
@@ -309,8 +309,8 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         clickButton("Submit");
 
         log("Again check that data validation works as expected.");
-        checker().verifyTrue("Expected error message 'must be of type Date and Time' is not present.",
-                isTextPresent("must be of type Date and Time"));
+        checker().verifyTrue("Expected error message '(String) for Date field' is not present.",
+                isTextPresent("(String) for Date field"));
         setFormElement(Locator.name("outputSample1_DateCol"), "1/1/2007");
         clickButton("Submit");
 

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -285,7 +285,7 @@ public class NabAssayTest extends AbstractAssayTest
                         runFile(TEST_ASSAY_NAB_FILE2).
                         build()).doImport();
 
-        assertElementPresent(Locators.labkeyError.containing("Date must be of type Date and Time. Value \"bad-date\" could not be converted."), 1);
+        assertElementPresent(Locators.labkeyError.containing("Could not convert value 'bad-date' (String) for Date field 'Date'."), 1);
 //        These dates are SQL Server specific
 //        assertElementPresent(Locators.labkeyError.containing("Only dates between January 1, 1753 and December 31, 9999 are accepted."), 1);
         assertElementPresent(Locators.labkeyError.containing("Only dates between "), 1);


### PR DESCRIPTION
#### Rationale
- see https://github.com/LabKey/platform/pull/2429
- DefaultAssayRunCreator.validateProperty() was updated to use ConvertHelper.getStandardConversionErrorMessage()

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2446
* https://github.com/LabKey/testAutomation/pull/795

#### Changes
* Update error text checks to match output from ConvertHelper.getStandardConversionErrorMessage
