### PR TITLE
Fix stale element exception on pipeline status details

### DIFF
--- a/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
+++ b/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
@@ -12,7 +12,6 @@ import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PipelineStatusTable;
 import org.labkey.test.util.TextSearcher;
 import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -431,7 +430,7 @@ public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsP
         protected final WebElement modified = Locator.id("modified").findWhenNeeded(this);
         protected final WebElement email = Locator.id("email").findWhenNeeded(this);
         protected final WebElement statusSpinner = Locator.id("status-spinner").findWhenNeeded(this);
-        protected final WebElement statusText = Locator.id("status-text").findWhenNeeded(this);
+        protected final WebElement statusText = Locator.id("status-text").refindWhenNeeded(this);
         protected final WebElement info = Locator.id("info").findWhenNeeded(this);
         protected final WebElement description = Locator.id("description").findWhenNeeded(this);
         protected final WebElement filePath = Locator.id("file-path").findWhenNeeded(this);

--- a/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
+++ b/src/org/labkey/test/pages/pipeline/PipelineStatusDetailsPage.java
@@ -411,7 +411,7 @@ public class PipelineStatusDetailsPage extends LabKeyPage<PipelineStatusDetailsP
     @LogMethod
     public PipelineStatusDetailsPage clickCancel()
     {
-        elementCache().cancelButton.click();
+        clickAndWait(elementCache().cancelButton);
         waitForLogText("Attempting to cancel");
         waitForCancelled();
         return this;


### PR DESCRIPTION
#### Rationale
`PipelineCancelTest` has been failing periodically when waiting for a pipeline job's status via `PipelineStatusDetailsPage.waitForStatus`.
```
org.openqa.selenium.StaleElementReferenceException: The element reference of <span id="status-text"> is stale; either the element is no longer attached to the DOM, it is not in the current frame context, or the document has been refreshed
  [...]
  at org.labkey.test.selenium.WebElementWrapper.getText(WebElementWrapper.java:84)
  at org.labkey.test.selenium.WebElementWrapper.getText(WebElementWrapper.java:84)
  at org.labkey.test.pages.pipeline.PipelineStatusDetailsPage.getStatus(PipelineStatusDetailsPage.java:79)
  at org.labkey.test.pages.pipeline.PipelineStatusDetailsPage.lambda$0(PipelineStatusDetailsPage.java:146)
  at org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2133)
  at org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2164)
  at org.labkey.test.pages.pipeline.PipelineStatusDetailsPage.waitForFinish(PipelineStatusDetailsPage.java:146)
  at org.labkey.test.pages.pipeline.PipelineStatusDetailsPage.waitForStatus(PipelineStatusDetailsPage.java:128)
  at org.labkey.test.pages.pipeline.PipelineStatusDetailsPage.waitForStatus(PipelineStatusDetailsPage.java:122)
  at org.labkey.test.pages.pipeline.PipelineStatusDetailsPage.waitForCancelled(PipelineStatusDetailsPage.java:153)
  at org.labkey.test.pages.pipeline.PipelineStatusDetailsPage.clickCancel(PipelineStatusDetailsPage.java:417)
  at org.labkey.test.tests.PipelineCancelTest.testSteps(PipelineCancelTest.java:48)
```

#### Changes
* Make `clickCancel` wait for the page load that occurs.
* `status-text` element flashes as it updates. Refind `WebElement` when it does.
