### PR TITLE
Update ReactSelect

### DIFF
--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -367,7 +367,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         elementCache().input.sendKeys(value);
         elementCache().input.sendKeys(Keys.ENTER);
 
-        waitFor(() -> Locators.multiValueLabels.withText(value).existsIn(getComponentElement()), "Failed to create value \"" + value + "\".", 1_000);
+        waitFor(() -> getValueLabelLocator().withText(value).existsIn(getComponentElement()), "Failed to create value \"" + value + "\".", 1_000);
 
         return (T) this;
     }
@@ -454,17 +454,6 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         private static Locator.XPathLocator containerWithDescendant(Locator.XPathLocator descendant)
         {
             return selectContainer().withDescendant(descendant);
-        }
-
-        public static Locator.XPathLocator containerStartsWith(List<String> inputNames)
-        {
-            StringBuilder childXpath = new StringBuilder( "//input[starts-with(@id, '"+ inputNames.get(0) + "')");
-            for (int i = 1; i < inputNames.size(); i++)
-            {
-                childXpath.append(" or starts-with(@id, '"+inputNames.get(i)+"')");
-            }
-            childXpath.append("]");
-            return selectContainer().withDescendant(Locator.xpath(childXpath.toString()));
         }
 
         public static Locator.XPathLocator containerById(String inputId)
@@ -564,12 +553,6 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
             _locator = Locator.tagWithClass("div", "form-group")
                     .withChild(Locator.tag("label").withPredicate("text() = " + Locator.xq(labelText)))
                     .descendant(Locators.selectContainer());
-            return this;
-        }
-
-        public BaseReactSelectFinder<Select> withIdStartingWith(String name)
-        {
-            _locator = ReactSelect.Locators.containerStartsWith(Arrays.asList(name));
             return this;
         }
 

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -12,6 +12,7 @@ import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.selenium.EphemeralWebElement;
 import org.labkey.test.selenium.RefindingWebElement;
 import org.labkey.test.util.TestLogger;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
@@ -320,6 +321,23 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         {
             log("Attempted to scroll reactSelect " + getName() + " into view, but the component element was stale");
         }
+
+        return (T) this;
+    }
+
+    /**
+     * Use this method if the underlying ReactSelect allows for creation of values from user input.
+     * This will input the given value directly into the ReactSelect and invoke the ReactSelect to create the value.
+     */
+    public T createValue(String value)
+    {
+        waitForLoaded();
+        waitForInteractive();
+
+        elementCache().input.sendKeys(value);
+        elementCache().input.sendKeys(Keys.ENTER);
+
+        waitFor(() -> Locators.multiValueLabels.withText(value).existsIn(getComponentElement()), "Failed to create value \"" + value + "\".", 1_000);
 
         return (T) this;
     }

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -76,11 +76,6 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         return hasClass("select-input__value-container--is-multi");
     }
 
-    public boolean isSearchable()
-    {
-        return hasClass("is-searchable");
-    }
-
     public boolean isClearable()
     {
         return hasClass("select-input__clear-indicator");
@@ -243,6 +238,17 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         return !this.getSelections().isEmpty();
     }
 
+    protected Locator.XPathLocator getValueLabelLocator()
+    {
+        return isMulti() ? Locators.multiValueLabels : Locators.singleValueLabel;
+    }
+
+    /**
+     * Returns a list of currently selected values (by label) in the select. If this is a single-select, then this
+     * will at most contain a single value. If this is a multi-select, then this will contain all selected values.
+     *
+     * @return List<String> of the currently selected values.
+     */
     public List<String> getSelections()
     {
         waitForLoaded();
@@ -250,12 +256,12 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         if (!hasValue())
             return Collections.emptyList();
 
-        Locator.XPathLocator locator = isMulti() ? Locators.multiValueLabels : Locators.singleValueLabel;
+        var labelLocator = getValueLabelLocator();
 
         // Wait for at least one of the elements to be visible.
-        waitFor(()-> locator.findElement(getComponentElement()).isDisplayed(), 1_000);
+        waitFor(()-> labelLocator.findElement(getComponentElement()).isDisplayed(), 1_000);
 
-        List<WebElement> selectedItems = locator.findElements(getComponentElement());
+        List<WebElement> selectedItems = labelLocator.findElements(getComponentElement());
         List<String> rawItems = _wrapper.getTexts(selectedItems);
 
         // trim whitespace characters
@@ -347,8 +353,8 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         public static Locator clear = Locator.tagWithClass("div","select-input__clear-indicator");
         public static Locator arrow = Locator.tagWithClass("div","select-input__dropdown-indicator");
         public static Locator selectMenu = Locator.tagWithClass("div", "select-input__menu-list");
-        public static Locator.XPathLocator multiValueLabels = Locator.tagWithClass("span", "select-input__multi-value__label");
-        public static Locator.XPathLocator singleValueLabel = Locator.tagWithClass("span", "select-input__single-value");
+        public static Locator.XPathLocator multiValueLabels = Locator.tagWithClass("div", "select-input__multi-value__label");
+        public static Locator.XPathLocator singleValueLabel = Locator.tagWithClass("div", "select-input__single-value");
         public static Locator loadingSpinner = Locator.tagWithClass("span", "select-input__loading-indicator");
         final public static Locator listItems = Locator.tagWithClass("div", "select-input__option");
 
@@ -470,7 +476,13 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
 
         public BaseReactSelectFinder<Select> followingLabelWithSpan(String labelText)
         {
-            _locator = Locator.tag("label").withChild(Locator.tagWithText("span", labelText)).followingSibling("div").child(Locator.tagWithClass("div", BaseReactSelect.SELECTOR_CLASS));
+            _locator = Locators.containerWithDescendant(Locator.tag("label").withChild(Locator.tagWithText("span", labelText)));
+            return this;
+        }
+
+        public BaseReactSelectFinder<Select> followingLabelWithClass(String cls)
+        {
+            _locator = Locators.containerWithDescendant(Locator.tagWithClass("label", cls));
             return this;
         }
 

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -456,7 +456,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         protected BaseReactSelectFinder(WebDriver driver)
         {
             super(driver);
-            _locator = Locators.selectContainer();    // use this to find the only reactSelect in a scope
+            _locator = Locators.selectContainer(); // use this to find the only reactSelect in a scope
         }
 
         public BaseReactSelectFinder<Select> withContainerClass(String containerClass)

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -5,6 +5,7 @@
 package org.labkey.test.components.react;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebDriverWrapperImpl;
@@ -112,15 +113,35 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         return (T) this;
     }
 
-    public String getValue()
+    public @Nullable String getPlaceholderText()
     {
         waitForLoaded();
 
-        String val = getComponentElement().getText();
-        if (LOADING_TEXT.equalsIgnoreCase(val))
-            return null;
-        else
-            return val;
+        if (isPlaceholderVisible())
+            return Locators.placeholder.findElement(getComponentElement()).getText().trim();
+
+        return null;
+    }
+
+    public boolean isPlaceholderVisible()
+    {
+        var placeholder = Locators.placeholder.findElementOrNull(getComponentElement());
+        return placeholder != null && placeholder.isDisplayed();
+    }
+
+    /**
+     *
+     * @return
+     */
+    public @Nullable String getValue()
+    {
+        waitForLoaded();
+
+        var selections = getSelections();
+
+        if (selections.size() == 1)
+            return selections.get(0);
+        return null;
     }
 
     public boolean hasOption(String value)
@@ -142,10 +163,14 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         return foundElement != null;
     }
 
-    /* waits until the currently selected 'value' (which can include the placeholder) equals or contains the specified string */
+    /* waits until the currently selected 'value' equals or contains the specified string */
     public T expectValue(String value)
     {
-        waitFor(() -> getValue().contains(value),
+        waitFor(() ->
+                {
+                    var _value = getValue();
+                    return _value != null && _value.contains(value);
+                },
                 "took too long for the ReactSelect value to contain the expected value:[" + value + "]", WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
         return (T) this;
     }
@@ -235,7 +260,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         return (T) this;
     }
 
-    public T removeMultipleSelection(String value)
+    public T removeSelection(String value)
     {
         waitForLoaded();
 
@@ -384,6 +409,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         final public static Locator.XPathLocator option = Locator.tagWithClass("div", "select-input__option");
         public static Locator options = Locator.tagWithClass("div", "select-input__option");
         public static Locator placeholder = Locator.tagWithClass("div", "select-input__placeholder");
+        // TODO: Update this locator
         public static Locator createOptionPlaceholder = Locator.tagWithClass("div", "Select-create-option-placeholder");
         public static Locator clear = Locator.tagWithClass("div","select-input__clear-indicator");
         public static Locator arrow = Locator.tagWithClass("div","select-input__dropdown-indicator");

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -451,20 +451,9 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
             return selectContainer().withAttribute("id", id);
         }
 
-        public static Locator.XPathLocator containerWithDescendant(Locator.XPathLocator descendant)
+        private static Locator.XPathLocator containerWithDescendant(Locator.XPathLocator descendant)
         {
             return selectContainer().withDescendant(descendant);
-        }
-
-        public static Locator.XPathLocator container(List<String> inputNames)
-        {
-            StringBuilder childXpath = new StringBuilder( "//input[@id="+ Locator.xq(inputNames.get(0)) + "");
-            for (int i = 1; i < inputNames.size(); i++)
-            {
-                childXpath.append(" or @id=" + Locator.xq(inputNames.get(i)) + "");
-            }
-            childXpath.append("]");
-            return selectContainer().withDescendant(Locator.xpath(childXpath.toString()));
         }
 
         public static Locator.XPathLocator containerStartsWith(List<String> inputNames)
@@ -508,14 +497,6 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
             return this;
         }
 
-        public BaseReactSelectFinder<Select> withIds(List<String> inputNames)
-        {
-            // TODO: Fix usages of this method
-            _locator = Locators.container(inputNames);
-            return this;
-        }
-
-        /* the ID is for the Select > Select-Control > span > div > input of the ReactSelect */
         public BaseReactSelectFinder<Select> withId(String id)
         {
             _locator = Locators.containerWithDescendant(Locator.tagWithId("div", id));
@@ -586,19 +567,6 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
             return this;
         }
 
-        public BaseReactSelectFinder<Select> withLabelContaining(String label)
-        {
-            _locator = ReactSelect.Locators.containerWithDescendant(Locator.tag("input")
-                    .withLabelContaining(label));
-            return this;
-        }
-
-        public BaseReactSelectFinder<Select> withIdsStartingWith(List<String> names)
-        {
-            _locator = ReactSelect.Locators.containerStartsWith(names);
-            return this;
-        }
-
         public BaseReactSelectFinder<Select> withIdStartingWith(String name)
         {
             _locator = ReactSelect.Locators.containerStartsWith(Arrays.asList(name));
@@ -608,16 +576,6 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         public BaseReactSelectFinder<Select> enabled()
         {
             _mustBeEnabled = true;
-            return this;
-        }
-
-        /**
-         * Most React Selects are wrapped by a div that is less prone to going stale. Use this to find the exact Select
-         * div when there is no wrapper div.
-         */
-        public BaseReactSelectFinder<Select> notParent()
-        {
-            _findParent = false;
             return this;
         }
 

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -133,11 +133,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         return placeholder != null && placeholder.isDisplayed();
     }
 
-    /**
-     *
-     * @return
-     */
-    public @Nullable String getValue()
+    public String getValue()
     {
         waitForLoaded();
 
@@ -145,7 +141,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
 
         if (selections.size() == 1)
             return selections.get(0);
-        return null;
+        return "";
     }
 
     public boolean hasOption(String value)
@@ -170,11 +166,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
     /* waits until the currently selected 'value' equals or contains the specified string */
     public T expectValue(String value)
     {
-        waitFor(() ->
-                {
-                    var _value = getValue();
-                    return _value != null && _value.contains(value);
-                },
+        waitFor(() -> getValue().contains(value),
                 "took too long for the ReactSelect value to contain the expected value:[" + value + "]", WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
         return (T) this;
     }

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -84,9 +84,14 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         return hasClass("select-input__clear-indicator");
     }
 
+    public boolean isDisabled()
+    {
+        return hasClass("select-input__control--is-disabled");
+    }
+
     public boolean isEnabled()
     {
-        return !hasClass("select-input__control--is-disabled");
+        return !isDisabled();
     }
 
     public boolean hasValue()
@@ -441,9 +446,9 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
             return multiValue.withChild(multiValueLabels.withText(text)).child(Locators.multiValueRemove);
         }
 
-        public static Locator.XPathLocator container(String inputId)
+        public static Locator.XPathLocator container(String id)
         {
-            return selectContainer().withDescendant(Locator.inputById(inputId));
+            return selectContainer().withAttribute("id", id);
         }
 
         public static Locator.XPathLocator containerWithDescendant(Locator.XPathLocator descendant)
@@ -505,14 +510,15 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
 
         public BaseReactSelectFinder<Select> withIds(List<String> inputNames)
         {
+            // TODO: Fix usages of this method
             _locator = Locators.container(inputNames);
             return this;
         }
 
         /* the ID is for the Select > Select-Control > span > div > input of the ReactSelect */
-        public BaseReactSelectFinder<Select> withId(String inputName)
+        public BaseReactSelectFinder<Select> withId(String id)
         {
-            _locator = Locators.container(inputName);
+            _locator = Locators.containerWithDescendant(Locator.tagWithId("div", id));
             return this;
         }
 

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -21,7 +21,6 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -249,18 +248,9 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
     {
         if (hasSelection())
         {
-            WebElement clear = elementCache().clear;
+            var clear = Locators.clear.waitForElement(getComponentElement(), 1_500);
             clear.click();
-            waitFor(() -> {
-                try
-                {
-                    return !(clear.isEnabled() && clear.isDisplayed()); // wait for it to no longer be enabled or displayed
-                }
-                catch (NoSuchElementException | StaleElementReferenceException nse)
-                {
-                    return true;
-                }
-            }, 1000);
+            getWrapper().shortWait().until(ExpectedConditions.stalenessOf(clear));
         }
         return (T) this;
     }
@@ -393,7 +383,6 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
     protected class ElementCache extends WebDriverComponent<?>.ElementCache
     {
         WebElement input = new EphemeralWebElement(Locator.css(".select-input__input > input"), this);
-        WebElement clear = new EphemeralWebElement(Locators.clear, this);
         WebElement arrow = new EphemeralWebElement(Locators.arrow, this);
         WebElement selectMenu = new EphemeralWebElement(Locators.selectMenu, this).withTimeout(WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
 
@@ -414,8 +403,6 @@ public abstract class BaseReactSelect<T extends BaseReactSelect> extends WebDriv
         final public static Locator.XPathLocator option = Locator.tagWithClass("div", "select-input__option");
         public static Locator options = Locator.tagWithClass("div", "select-input__option");
         public static Locator placeholder = Locator.tagWithClass("div", "select-input__placeholder");
-        // TODO: Update this locator
-        public static Locator createOptionPlaceholder = Locator.tagWithClass("div", "Select-create-option-placeholder");
         public static Locator clear = Locator.tagWithClass("div","select-input__clear-indicator");
         public static Locator arrow = Locator.tagWithClass("div","select-input__dropdown-indicator");
         public static Locator selectMenu = Locator.tagWithClass("div", "select-input__menu-list");

--- a/src/org/labkey/test/components/react/FilteringReactSelect.java
+++ b/src/org/labkey/test/components/react/FilteringReactSelect.java
@@ -89,7 +89,7 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
             throw sere;
         }
 
-        if (! _wrapper.waitFor(()-> !isExpanded(), 1500))   // give it a moment to close, blur if it hasn't
+        if (!_wrapper.waitFor(()-> !isExpanded(), 1500))   // give it a moment to close, blur if it hasn't
         {
             _wrapper.fireEvent(elementCache().input, WebDriverWrapper.SeleniumEvent.blur);
         }

--- a/src/org/labkey/test/components/react/FilteringReactSelect.java
+++ b/src/org/labkey/test/components/react/FilteringReactSelect.java
@@ -48,10 +48,7 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
         open();
 
         var elementToClick = ReactSelect.Locators.options.containing(optionText);
-        var elementToWaitFor = isMulti() ? Locators.multiValueLabels.containing(selectedOptionLabel) : Locators.singleValueLabel.containing(selectedOptionLabel);
-
-        if (isMulti() || hasValue())
-            sleep(500);
+        var elementToWaitFor = getValueLabelLocator().containing(selectedOptionLabel);
 
         setFilter(value);
 
@@ -70,9 +67,6 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
                 {
                     close();
                     open();
-
-                    if (hasValue() || isMulti() || isClearable())
-                        sleep(500);
                     setFilter(value);
                 }
                 else
@@ -87,9 +81,6 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
         {
             _wrapper.scrollIntoView(optionToClick);
             _wrapper.shortWait().until(ExpectedConditions.elementToBeClickable(optionToClick));
-
-            if (isMulti() || hasValue() || isClearable())
-                sleep(250);
             optionToClick.click();
         }
         catch (StaleElementReferenceException sere)
@@ -106,9 +97,6 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
         _wrapper.waitFor(()-> elementToWaitFor.findElementOrNull(getComponentElement()) != null,
                 () -> "Expected selection [" + elementToWaitFor.getLoggableDescription() + "] was not found. Selected value(s) are:" + getSelections(),
                 WAIT_FOR_JAVASCRIPT);
-
-        if (isMulti() || hasValue() || isClearable())
-            sleep(500);
 
         close();
         return this;

--- a/src/org/labkey/test/components/react/FilteringReactSelect.java
+++ b/src/org/labkey/test/components/react/FilteringReactSelect.java
@@ -38,15 +38,17 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
      * waits for that value to show in a selectValueLabel (which is usually how a single-select shows)*/
     public FilteringReactSelect typeAheadSelect(String value)
     {
-        return typeAheadSelect(value, ReactSelect.Locators.options.containing(value),
-                ReactSelect.Locators.selectValueLabelContaining(value));
+        return typeAheadSelect(value, value, value);
     }
 
-    public FilteringReactSelect typeAheadSelect(String value, Locator elementToClick, Locator elementToWaitFor)
+    public FilteringReactSelect typeAheadSelect(String value, String optionText, String selectedOptionLabel)
     {
         waitForLoaded();
         scrollIntoView();
         open();
+
+        var elementToClick = ReactSelect.Locators.options.containing(optionText);
+        var elementToWaitFor = isMulti() ? Locators.multiValueLabels.containing(selectedOptionLabel) : Locators.singleValueLabel.containing(selectedOptionLabel);
 
         if (isMulti() || hasValue())
             sleep(500);
@@ -100,11 +102,14 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
         {
             _wrapper.fireEvent(elementCache().input, WebDriverWrapper.SeleniumEvent.blur);
         }
+
         _wrapper.waitFor(()-> elementToWaitFor.findElementOrNull(getComponentElement()) != null,
-                "Expected selection ["+elementToWaitFor.getLoggableDescription()+"] was not found. Selected value(s) are:" + getSelections(),
+                () -> "Expected selection [" + elementToWaitFor.getLoggableDescription() + "] was not found. Selected value(s) are:" + getSelections(),
                 WAIT_FOR_JAVASCRIPT);
+
         if (isMulti() || hasValue() || isClearable())
             sleep(500);
+
         close();
         return this;
     }

--- a/src/org/labkey/test/components/react/FilteringReactSelect.java
+++ b/src/org/labkey/test/components/react/FilteringReactSelect.java
@@ -102,10 +102,9 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
         return this;
     }
 
-
     public FilteringReactSelect filterSelect(String value) // adds text for usage in cases where the item isn't in the dropdown and the text is editable
     {
-        return filterSelect(value, Locator.tagWithClass("span", "Select-value-label").containing(value));
+        return filterSelect(value, BaseReactSelect.Locators.selectValueLabelContaining(value));
     }
 
     /* for use with editable instances of a reactSelect, where the options aren't shown

--- a/src/org/labkey/test/components/react/FilteringReactSelect.java
+++ b/src/org/labkey/test/components/react/FilteringReactSelect.java
@@ -104,7 +104,7 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
 
     public FilteringReactSelect filterSelect(String value) // adds text for usage in cases where the item isn't in the dropdown and the text is editable
     {
-        return filterSelect(value, BaseReactSelect.Locators.selectValueLabelContaining(value));
+        return filterSelect(value, getValueLabelLocator().containing(value));
     }
 
     /* for use with editable instances of a reactSelect, where the options aren't shown
@@ -149,7 +149,7 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
             success = elementToWaitFor.findElement(getComponentElement());
         }
 
-        if ( success == null)
+        if (success == null)
             log("Expected selection was not found. Selected value(s) are:" + getSelections());
 
         close();

--- a/src/org/labkey/test/components/react/FilteringReactSelect.java
+++ b/src/org/labkey/test/components/react/FilteringReactSelect.java
@@ -126,7 +126,6 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
 
             WebElement elemToClick = Locator.waitForAnyElement(
                     new FluentWait<SearchContext>(getComponentElement()).withTimeout(Duration.ofMillis(WAIT_FOR_JAVASCRIPT)),
-                    Locators.createOptionPlaceholder.containing(value),
                     Locators.options.containing(value));
 
             log("clicking item with value [" +value+"]");

--- a/src/org/labkey/test/components/react/ReactSelect.java
+++ b/src/org/labkey/test/components/react/ReactSelect.java
@@ -99,13 +99,6 @@ public class ReactSelect extends BaseReactSelect<ReactSelect>
         new FluentWait<>(_wrapper.getDriver()).withTimeout(Duration.ofSeconds(1)).until(ExpectedConditions.stalenessOf(optionEl));
     }
 
-    public boolean noResultsFound()  // asks whether or not the select has loaded its options
-    {
-        return Locator.tagWithClass("div", "Select-menu")
-                .child(Locator.tagWithClass("div", "Select-noresults"))
-                .findElementOrNull(getComponentElement()) != null;
-    }
-
     @Override
     protected ElementCache newElementCache()
     {

--- a/src/org/labkey/test/components/react/ReactSelect.java
+++ b/src/org/labkey/test/components/react/ReactSelect.java
@@ -30,12 +30,6 @@ public class ReactSelect extends BaseReactSelect<ReactSelect>
         super(element, driver);
     }
 
-    @Override
-    public WebElement getComponentElement()
-    {
-        return _componentElement;
-    }
-
     static public ReactSelectFinder finder(WebDriver driver)
     {
         return new ReactSelectFinder(driver);
@@ -127,7 +121,6 @@ public class ReactSelect extends BaseReactSelect<ReactSelect>
             Locator loc = _optionLocFactory.apply(option);
             return loc.findElement(selectMenu);
         }
-
     }
 
     public static class ReactSelectFinder extends BaseReactSelect.BaseReactSelectFinder<ReactSelect>

--- a/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
@@ -148,7 +148,8 @@ public abstract class SampleTypeDesigner<T extends SampleTypeDesigner<T>> extend
 
         ReactSelect parentAliasSelect(int index)
         {
-            return ReactSelect.finder(getDriver()).locatedBy(Locator.byClass("sampleset-insert--parent-select"))
+            return ReactSelect.finder(getDriver())
+                    .withInputClass("sampleset-insert--parent-select")
                     .index(index).find(propertiesPanel);
         }
 

--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -52,7 +52,7 @@ public class EntityBulkUpdateDialog extends ModalDialog
         FilteringReactSelect reactSelect = elementCache().getSelect(columnTitle);
         WebDriverWrapper.waitFor(reactSelect::isEnabled,
                 "the ["+columnTitle+"] reactSelect did not become enabled in time", WAIT_TIMEOUT);
-        selectValues.forEach(s -> {reactSelect.filterSelect(s);});
+        selectValues.forEach(reactSelect::filterSelect);
         return this;
     }
 
@@ -215,7 +215,7 @@ public class EntityBulkUpdateDialog extends ModalDialog
 
         public FilteringReactSelect getSelect(String fieldKey)
         {
-            return FilteringReactSelect.finder(getDriver()).waitFor(formRow(fieldKey));
+            return FilteringReactSelect.finder(getDriver()).withNamedInput(fieldKey).findWhenNeeded(this);
         }
 
         public Input textInput(String fieldKey)

--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -29,7 +29,6 @@ import static org.labkey.test.WebDriverWrapper.sleep;
  */
 public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.ElementCache>
 {
-
     private final WebDriver _driver;
     private final WebElement _editingDiv;
 
@@ -51,22 +50,15 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
         return _driver;
     }
 
-    public ReactSelect entityTypeSelect()
+    public ReactSelect targetEntityTypeSelect()
     {
-        return ReactSelect.finder(getDriver()).withIdStartingWith("targetEntityType").waitFor();
+        return ReactSelect.finder(getDriver()).withName("targetEntityType").waitFor();
     }
 
-    /**
-     * use parameterless entityTypeSelect(), above
-     * @param labelText
-     * @return
-     */
-    @Deprecated
-    public ReactSelect getEntityTypeSelect(String labelText)
+    private ReactSelect parentEntityTypeSelect(String label)
     {
-        return ReactSelect.finder(getDriver()).followingLabelWithSpan(labelText).findWhenNeeded(getDriver());
+        return ReactSelect.finder(getDriver()).followingLabelWithSpan(label).findWhenNeeded(getDriver());
     }
-
 
     public EntityInsertPanel addParent(String label, String parentType)
     {
@@ -85,7 +77,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
             getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().addParent));
             elementCache().addParent.click();
             getWrapper().waitForElement(Locator.tag("label").withChild(Locator.tagWithText("span", label)));
-            getEntityTypeSelect(label).select(parentType);
+            parentEntityTypeSelect(label).select(parentType);
             return this;
         }
         catch (WebDriverException ex)
@@ -104,9 +96,9 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     public ReactSelect getParentSelect(String label)
     {
-        if (!ReactSelect.finder(getDriver()).followingLabelWithSpan(label).findOptional(this).isPresent())
+        if (ReactSelect.finder(getDriver()).followingLabelWithSpan(label).findOptional(this).isEmpty())
             elementCache().addParent.click();
-        return getEntityTypeSelect(label);
+        return parentEntityTypeSelect(label);
     }
 
     public EntityInsertPanel clearParents()
@@ -336,7 +328,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
             {
                 return  isGridVisible() ||          // when uploading assay data there is no target select
                         isFileUploadVisible() ||
-                        entityTypeSelect().isInteractive();
+                        targetEntityTypeSelect().isInteractive();
             }catch (NoSuchElementException nse)
             {
                 return false;
@@ -410,7 +402,5 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
         {
             return _locator;
         }
-
     }
-
 }

--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -328,7 +328,7 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
      */
     protected ParentEntityEditPanel removeParentId(int index, String id)
     {
-        getIdCombo(index).removeMultipleSelection(id);
+        getIdCombo(index).removeSelection(id);
         return this;
     }
 

--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -295,8 +295,7 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
            {
                // If this is removing the last/only one the count of combos will still be 1, so need a different check.
                ReactSelect rs = getAllTypeCombo().get(0);
-               rs.getSelections();
-               getWrapper().waitFor(() -> rs.getSelections().get(0).toLowerCase().contains("select a "),
+               getWrapper().waitFor(() -> rs.getSelections().isEmpty(),
                        "The type '" + typeName + "' was not successfully removed.",
                        1_000);
            }

--- a/src/org/labkey/test/pages/study/DatasetDesignerPage.java
+++ b/src/org/labkey/test/pages/study/DatasetDesignerPage.java
@@ -91,7 +91,7 @@ public class DatasetDesignerPage extends DomainDesigner<DatasetDesignerPage.Elem
     public DatasetDesignerPage setCategory(String category)
     {
         expandPropertiesPanel();
-        elementCache().categorySelect.filterSelect(category);
+        elementCache().categorySelect.createValue(category);
         return this;
     }
 

--- a/src/org/labkey/test/tests/component/EntityInsertPanelTest.java
+++ b/src/org/labkey/test/tests/component/EntityInsertPanelTest.java
@@ -61,7 +61,7 @@ public class EntityInsertPanelTest extends BaseWebDriverTest
         TestDataGenerator dgen = SampleTypeAPIHelper.createEmptySampleType(getProjectName(), props);
         CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
         EntityInsertPanel testPanel = testPage.getEntityInsertPanel();
-        testPanel.getEntityTypeSelect("Sample Type").select(sampleTypeName);
+        testPanel.targetEntityTypeSelect().select(sampleTypeName);
 
         String pasteText = "ed\tbrother\tthe quiet one\t\t2\tstringfellow\t11/11/2020\ttrue\n" +
                 "jed\tother brother\tthe squinty one\t\t3\tstrongfellow\t11/11/2020\tfalse\n" +
@@ -102,7 +102,7 @@ public class EntityInsertPanelTest extends BaseWebDriverTest
         File testFile = dgen.writeData("fileUploadTest.tsv");
         CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
         EntityInsertPanel testPanel = testPage.getEntityInsertPanel();
-        testPanel.getEntityTypeSelect("Sample Type").select(sampleTypeName);
+        testPanel.targetEntityTypeSelect().select(sampleTypeName);
         var previewGrid = testPanel.uploadFileExpectingPreview(testFile, true);
 
         clickFileImport();  // the file import submit button is different from the grid submit button


### PR DESCRIPTION
#### Rationale
Test component and test updates associated with the update of our `react-select` dependency in `@labkey/components`.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/584
* https://github.com/LabKey/biologics/pull/945
* https://github.com/LabKey/sampleManagement/pull/632
* https://github.com/LabKey/inventory/pull/280
* https://github.com/LabKey/testAutomation/pull/807
* https://github.com/LabKey/platform/pull/2473
* https://github.com/LabKey/commonAssays/pull/351

#### Changes
* BaseReactSelect
	* Update all locators to match the DOM structure of `react-select@4.3.1`.
	* Introduce new locators `withContainerClass` and `withInputClass` to allow for easy association with configuration of the component in React.
	* Add a `createValue()` method which will attempt to create new values in the associated `react-select`. This supports when the scenarios where the component is set to `creatable={true}` (e.g. the "Alias" field in Biologics).
	* Update `getSelections()` to only return selections if they are actually made. The presence of placeholder text is no longer considered a selection/value.
	* Added `getPlaceholderText()` and `isPlaceholderVisible()` utilities to assist with processing the placeholder.
* FilteringReactSelect:
	* Update `FilteringReactSelect.typeAheadSelect` to no longer accept arbitrary elements but rather enforce selection based on the component's expected state.
	* Remove superfluous sleeps/waits statements.
* Update test locators and tests.
