### PR TITLE
Update locators for product navigation links

### DIFF
--- a/src/org/labkey/test/components/domain/BaseDomainDesigner.java
+++ b/src/org/labkey/test/components/domain/BaseDomainDesigner.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
  */
 public abstract class BaseDomainDesigner<EC extends BaseDomainDesigner.ElementCache> extends WebDriverComponent<EC>
 {
+    public static final String RESERVED_FIELDS_WARNING_PREFIX = "Fields with reserved names or prefixes found in your file are not shown below. ";
     private final WebElement el;
     private final WebDriver driver;
 

--- a/src/org/labkey/test/components/ui/navigation/apps/LKSNavContainer.java
+++ b/src/org/labkey/test/components/ui/navigation/apps/LKSNavContainer.java
@@ -42,7 +42,7 @@ public class LKSNavContainer extends BaseNavContainer
 
     private List<WebElement> tabLinks()
     {
-        return Locator.tagWithClass("div", "clickable-item").findElements(elementCache().tabContainer);
+        return Locator.tagWithClass("a", "clickable-item").findElements(elementCache().tabContainer);
     }
 
     public List<String> tabTexts()

--- a/src/org/labkey/test/components/ui/navigation/apps/LKSNavContainer.java
+++ b/src/org/labkey/test/components/ui/navigation/apps/LKSNavContainer.java
@@ -42,7 +42,7 @@ public class LKSNavContainer extends BaseNavContainer
 
     private List<WebElement> tabLinks()
     {
-        return Locator.tagWithClass("a", "clickable-item").findElements(elementCache().tabContainer);
+        return elementCache().tabLink.findElements(elementCache().tabContainer);
     }
 
     public List<String> tabTexts()
@@ -52,7 +52,7 @@ public class LKSNavContainer extends BaseNavContainer
 
     public void clickTab(String tabText)
     {
-        WebElement link = Locator.tagWithClass("div", "clickable-item").withText(tabText)
+        WebElement link = elementCache().tabLink.withText(tabText)
                 .waitForElement(elementCache().tabContainer, 2000);
         getWrapper().clickAndWait(link);
     }
@@ -71,6 +71,7 @@ public class LKSNavContainer extends BaseNavContainer
 
     protected class ElementCache extends BaseNavContainer.ElementCache
     {
+        final Locator tabLink = Locator.tagWithClass("a", "clickable-item");
         final WebElement backLink = Locator.tagWithClass("span", "header-title")
                 .withChild(Locator.tagWithClass("i", "back-icon"))
                 .findWhenNeeded(this).withTimeout(2000);

--- a/src/org/labkey/test/components/ui/navigation/apps/LKSNavContainer.java
+++ b/src/org/labkey/test/components/ui/navigation/apps/LKSNavContainer.java
@@ -60,7 +60,7 @@ public class LKSNavContainer extends BaseNavContainer
     @Override
     protected ElementCache elementCache()
     {
-        return new ElementCache();
+        return (ElementCache) super.elementCache();
     }
 
     @Override
@@ -74,7 +74,7 @@ public class LKSNavContainer extends BaseNavContainer
         final WebElement backLink = Locator.tagWithClass("span", "header-title")
                 .withChild(Locator.tagWithClass("i", "back-icon"))
                 .findWhenNeeded(this).withTimeout(2000);
-        final WebElement homeLink = Locator.tagWithClass("div", "container-item").withText("LabKey Home")
+        final WebElement homeLink = Locator.tagWithClass("a", "container-item").withText("LabKey Home")
                 .findWhenNeeded(navList).withTimeout(2000);
         final WebElement tabContainer = Locator.tagWithClass("div", "container-tabs")
                 .findWhenNeeded(navList).withTimeout(2000);
@@ -85,7 +85,7 @@ public class LKSNavContainer extends BaseNavContainer
 
         WebElement projectLink(String project)
         {
-            return Locator.tagWithClass("div", "container-item").withText(project)
+            return Locator.tagWithClass("a", "container-item").withText(project)
                     .waitForElement(navList, 2000);
         }
     }

--- a/src/org/labkey/test/components/ui/navigation/apps/LeafNavContainer.java
+++ b/src/org/labkey/test/components/ui/navigation/apps/LeafNavContainer.java
@@ -56,7 +56,7 @@ public class LeafNavContainer extends BaseNavContainer
 
     protected class ElementCache extends BaseNavContainer.ElementCache
     {
-        final Locator clickableItem = Locator.tagWithClass("div", "clickable-item");
+        final Locator clickableItem = Locator.tagWithClass("a", "clickable-item");
         final WebElement backLink = Locator.tagWithClass("span", "header-title")
                 .child(Locator.tagWithClass("i", "back-icon")).findWhenNeeded(header).withTimeout(2000);
     }

--- a/src/org/labkey/test/components/ui/navigation/apps/ProductsNavContainer.java
+++ b/src/org/labkey/test/components/ui/navigation/apps/ProductsNavContainer.java
@@ -69,7 +69,7 @@ public class ProductsNavContainer extends BaseNavContainer
     @Override
     protected ElementCache elementCache()
     {
-        return new ElementCache();
+        return (ElementCache) super.elementCache();
     }
 
     @Override

--- a/src/org/labkey/test/tests/DataClassTest.java
+++ b/src/org/labkey/test/tests/DataClassTest.java
@@ -22,6 +22,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.DailyC;
+import org.labkey.test.components.domain.BaseDomainDesigner;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.experiment.CreateDataClassPage;
 import org.labkey.test.params.FieldDefinition;
@@ -134,7 +135,7 @@ public class DataClassTest extends BaseWebDriverTest
     @Test
     public void testIgnoreReservedFieldNames()
     {
-        final String expectedInfoMsg = "Reserved fields found in your file are not shown below. " +
+        final String expectedInfoMsg = BaseDomainDesigner.RESERVED_FIELDS_WARNING_PREFIX +
                 "These fields are already used by LabKey to support this data class: " +
                 "Name, Created, createdBy, Modified, modifiedBy, container, created, createdby, modified, modifiedBy, Container.";
 

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -35,6 +35,7 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.DailyC;
 import org.labkey.test.components.CustomizeView;
+import org.labkey.test.components.domain.BaseDomainDesigner;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.pages.ReactAssayDesignerPage;
@@ -1211,7 +1212,7 @@ public class SampleTypeTest extends BaseWebDriverTest
     @Test
     public void testIgnoreReservedFieldNames() throws Exception
     {
-        final String expectedInfoMsg = "Reserved fields found in your file are not shown below. " +
+        final String expectedInfoMsg = BaseDomainDesigner.RESERVED_FIELDS_WARNING_PREFIX +
                 "These fields are already used by LabKey to support this sample type: " +
                 "Name, Created, createdBy, Modified, modifiedBy, container, created, createdby, modified, modifiedBy, Container, SampleId, SampleID.";
 

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -36,6 +36,7 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.DailyA;
 import org.labkey.test.categories.Data;
 import org.labkey.test.categories.Hosting;
+import org.labkey.test.components.domain.BaseDomainDesigner;
 import org.labkey.test.components.domain.ConditionalFormatDialog;
 import org.labkey.test.components.domain.DomainFieldRow;
 import org.labkey.test.components.domain.DomainFormPanel;
@@ -1006,7 +1007,7 @@ public class ListTest extends BaseWebDriverTest
     @Test
     public void testIgnoreReservedFieldNames()
     {
-        final String expectedInfoMsg = "Reserved fields found in your file are not shown below. " +
+        final String expectedInfoMsg = BaseDomainDesigner.RESERVED_FIELDS_WARNING_PREFIX +
                 "These fields are already used by LabKey: " +
                 "Created, createdBy, Modified, modifiedBy, container, created, createdby, modified, modifiedBy, Container.";
 


### PR DESCRIPTION
#### Rationale
Product navigation links have changed (back) from `div` to `a` elements, so we need the locators to be updated accordingly

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/585

#### Changes
* Update locators
* Update some elementCache usages.
