### PR TITLE
Update expected error message

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -808,7 +808,7 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
             fail("Expect CommandException when inserting bogus lineage");
         }catch (CommandException successMaybe)  // success looks like a CommandException with the expected message
         {
-            assertTrue("expect bad lineage to produce error containing [Sample input 'BOGUS' in SampleType 'badParentLineage' not found];\n" +
+            assertTrue("expect bad lineage to produce error containing [Sample 'BOGUS' not found in Sample Type 'badParentLineage'.];\n" +
                             "instead got: [" + successMaybe.getMessage() + "]",
                     successMaybe.getMessage().contains("Sample 'BOGUS' not found in Sample Type 'badParentLineage'."));
         }

--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -779,9 +779,9 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
             fail("Expect CommandException when inserting bogus lineage");
         }catch (CommandException successMaybe)
         {
-            assertTrue("expect bad lineage to produce error containing [Sample input 'BOGUS' in SampleType 'badLineageTest' not found];\n" +
+            assertTrue("expect bad lineage to produce error containing [Sample 'BOGUS' not found in Sample Type 'badLineageTest'.];\n" +
                             "instead got: [" + successMaybe.getMessage() + "]",
-                    successMaybe.getMessage().contains("Sample 'BOGUS' not found in in Sample Type 'badLineageTest'."));
+                    successMaybe.getMessage().contains("Sample 'BOGUS' not found in Sample Type 'badLineageTest'."));
         }
     }
 

--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -781,7 +781,7 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         {
             assertTrue("expect bad lineage to produce error containing [Sample input 'BOGUS' in SampleType 'badLineageTest' not found];\n" +
                             "instead got: [" + successMaybe.getMessage() + "]",
-                    successMaybe.getMessage().contains("Sample input 'BOGUS' in SampleType 'badLineageTest' not found"));
+                    successMaybe.getMessage().contains("Sample 'BOGUS' not found in in Sample Type 'badLineageTest'."));
         }
     }
 
@@ -810,7 +810,7 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         {
             assertTrue("expect bad lineage to produce error containing [Sample input 'BOGUS' in SampleType 'badParentLineage' not found];\n" +
                             "instead got: [" + successMaybe.getMessage() + "]",
-                    successMaybe.getMessage().contains("Sample input 'BOGUS' in SampleType 'badParentLineage' not found"));
+                    successMaybe.getMessage().contains("Sample 'BOGUS' not found in Sample Type 'badParentLineage'."));
         }
 
         // clean up on success


### PR DESCRIPTION
#### Rationale
The error messaging for samples and data objects not found was updated with [Platform  PR #2481](https://github.com/LabKey/platform/pull/2481), but I missed updating these tests' expectations.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2481

#### Changes
* Expected error message updates.
