### PR TITLE
Deprecate inconsistent `clickButton` method

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3110,9 +3110,15 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
     /**
      * Wait for a button to appear, click it, then waits for the text to appear.
+     * @deprecated This method provides minimal convenience and behaves inconsistently with other 'clickButton' methods
      */
+    @Deprecated(since = "21.8")
     public void clickButton(String text, String waitForText)
     {
+        if (isTextPresent(waitForText))
+        {
+            throw new IllegalStateException("'" + waitForText + "' is already present on the page. Pick a better indicator that the page state has changed.");
+        }
         clickButton(text, 0);
         waitForText(waitForText);
     }


### PR DESCRIPTION
#### Rationale
Not waiting for page loads tends to cause intermittent test failures. `clickButton(String, String)` method provides minimal convenience and behaves inconsistently with other 'clickButton' methods (doesn't wait for the page to load).

#### Related Changes
* https://github.com/LabKey/freezerpro/pull/31

#### Changes
* Deprecate `clickButton(String, String)` and throw an error when it is misused
