### PR TITLE
Use JavaScript to check if page is in admin mode

### DIFF
--- a/src/org/labkey/test/components/html/SiteNavBar.java
+++ b/src/org/labkey/test/components/html/SiteNavBar.java
@@ -145,7 +145,7 @@ public class SiteNavBar extends WebDriverComponent<SiteNavBar.Elements>
 
     public boolean isInPageAdminMode()
     {
-        return Locators.exitAdminBtn.findElementOrNull(getDriver()) != null;
+        return getWrapper().executeScript("return LABKEY.pageAdminMode;", Boolean.class);
     }
 
     public SearchResultsPage search(String searchTerm)


### PR DESCRIPTION
#### Rationale
Checking for the "Exit Admin Mode" button has been unreliable. `isInPageAdminMode` would return false when the page is already in admin mode
```
org.openqa.selenium.NoSuchElementException: Expected condition failed: waiting for xpath=//li/a[normalize-space()='Page Admin Mode'][not(ancestor-or-self::*[contains(@style,'display: none') or contains(@style,'visibility: hidden') or contains(@class, 'x-hide-display') or contains(@class, 'x4-hide-offsets') or contains(@class, 'x-hide-offsets')] or (@type = 'hidden'))]
[...]
  at org.labkey.test.Locator.waitForElement(Locator.java:471)
  at org.labkey.test.Locator.waitForElement(Locator.java:447)
  at org.labkey.test.components.html.BootstrapMenu.openMenuTo(BootstrapMenu.java:87)
  at org.labkey.test.components.html.BootstrapMenu.clickSubMenu(BootstrapMenu.java:100)
  at org.labkey.test.components.html.BootstrapMenu.clickSubMenu(BootstrapMenu.java:109)
  at org.labkey.test.components.html.SiteNavBar.enterPageAdminMode(SiteNavBar.java:121)
  at org.labkey.test.components.html.SiteNavBar.doInAdminMode(SiteNavBar.java:108)
  at org.labkey.test.util.PortalHelper.doInAdminMode(PortalHelper.java:271)
  at org.labkey.test.util.PortalHelper.addWebPart(PortalHelper.java:292)
  at org.labkey.test.util.PortalHelper.addWebPart(PortalHelper.java:307)
```

#### Changes
* Use JavaScript `LABKEY.pageAdminMode` to check page admin state
