### PR TITLE
IssueDomainTest.mandatoryFieldTest update to check more fields (rather than just notifylist)

### DIFF
--- a/src/org/labkey/test/tests/issues/IssueDomainSharingTest.java
+++ b/src/org/labkey/test/tests/issues/IssueDomainSharingTest.java
@@ -229,11 +229,6 @@ public class IssueDomainSharingTest extends BaseWebDriverTest
     {
     }
 
-    //@Test @Ignore //TODO
-    public void testProtectedFields()
-    {
-    }
-
     @Override
     protected WebDriverWrapper.BrowserType bestBrowser()
     {

--- a/src/org/labkey/test/tests/issues/IssueDomainTest.java
+++ b/src/org/labkey/test/tests/issues/IssueDomainTest.java
@@ -31,7 +31,6 @@ public class IssueDomainTest extends BaseWebDriverTest
     private IssuesHelper _issuesHelper = new IssuesHelper(this);
     private final String DOMAIN_NAME = "issues";//schemaName
     private final String ISSUES_NAME = "testdomainissue";
-    private final String MISSING_MANDATORY_FIELD_ERROR_MSG = "Mandatory field 'notifylist' not found, it may have been removed or renamed. Unable to update domain.";
 
     @Override
     protected BrowserType bestBrowser()
@@ -85,31 +84,36 @@ public class IssueDomainTest extends BaseWebDriverTest
     @Test
     public void mandatoryFieldTest() throws Exception
     {
-        log("Remove mandatory field 'notifylist'");
-        GetDomainCommand getCmd = new GetDomainCommand(DOMAIN_NAME, ISSUES_NAME);
-        DomainResponse getDomainResponse = getCmd.execute(this.createDefaultConnection(), getContainerPath());
-        List<PropertyDescriptor> getDomainCols = getDomainResponse.getDomain().getFields();
-        ListIterator<PropertyDescriptor> getDomainColsIterator = getDomainCols.listIterator();
-
-        while(getDomainColsIterator.hasNext())
+        log("Attempt to remove mandatory fields (title, notifylist, assignedto, resolution)");
+        List<String> mandatoryFields = Arrays.asList("title", "notifylist", "assignedto", "resolution");
+        for (String mandatoryField : mandatoryFields)
         {
-            String colName = getDomainColsIterator.next().getName();
-            if ("notifylist".equalsIgnoreCase(colName))
+            GetDomainCommand getCmd = new GetDomainCommand(DOMAIN_NAME, ISSUES_NAME);
+            DomainResponse getDomainResponse = getCmd.execute(this.createDefaultConnection(), getContainerPath());
+            List<PropertyDescriptor> getDomainCols = getDomainResponse.getDomain().getFields();
+            ListIterator<PropertyDescriptor> getDomainColsIterator = getDomainCols.listIterator();
+
+            while (getDomainColsIterator.hasNext())
             {
-                getDomainColsIterator.remove();
-                break;
+                String colName = getDomainColsIterator.next().getName();
+                if (mandatoryField.equalsIgnoreCase(colName))
+                {
+                    getDomainColsIterator.remove();
+                    break;
+                }
             }
+
+            log("Attempt saving updated domain without mandatory field");
+            SaveDomainCommand saveCmd = new SaveDomainCommand(DOMAIN_NAME, ISSUES_NAME);
+            Domain existingDomain = getDomainResponse.getDomain();
+            Domain updatedDomain = saveCmd.getDomainDesign();
+
+            updatedDomain.setDomainId(existingDomain.getDomainId());
+            updatedDomain.setDomainURI(existingDomain.getDomainURI());
+            updatedDomain.setFields(getDomainCols);
+            String expectedStr = "Mandatory field '" + mandatoryField + "' not found, it may have been removed or renamed. Unable to update domain.";
+            testForExpectedErrorMessage(saveCmd, expectedStr, "SaveDomain");
         }
-
-        log("Attempt saving updated domain without mandatory field 'notifylist'");
-        SaveDomainCommand saveCmd = new SaveDomainCommand(DOMAIN_NAME, ISSUES_NAME);
-        Domain existingDomain = getDomainResponse.getDomain();
-        Domain updatedDomain = saveCmd.getDomainDesign();
-
-        updatedDomain.setDomainId(existingDomain.getDomainId());
-        updatedDomain.setDomainURI(existingDomain.getDomainURI());
-        updatedDomain.setFields(getDomainCols);
-        testForExpectedErrorMessage(saveCmd, MISSING_MANDATORY_FIELD_ERROR_MSG, "SaveDomain");
     }
 
     private void testForExpectedErrorMessage(SaveDomainCommand cmd, String expectedErrorMsg, String domainApiType) throws IOException

--- a/src/org/labkey/test/tests/issues/IssuesAdminTest.java
+++ b/src/org/labkey/test/tests/issues/IssuesAdminTest.java
@@ -164,6 +164,11 @@ public class IssuesAdminTest extends BaseWebDriverTest
     {
     }
 
+    // @Test @Ignore //TODO
+    public void testCommentSortDirection() throws Exception
+    {
+    }
+
     @Override
     protected BrowserType bestBrowser()
     {


### PR DESCRIPTION
#### Rationale
I noticed that the IssueDomainTest.mandatoryFieldTest test case was only checking the 'notifylist' field in the domain. This PR updates that test case to check the other mandatory fields to make sure they can't be removed from the domain either.

Also, Wendy asked what was left for the "UX Issues List Designer" changes from back in May 2020. I added a few TODO test cases (to match some that were already there) as a guide for the scrumwise backlog story.

#### Changes
* Update IssueDomainTest.mandatoryFieldTest to check the following: title, notifylist, assignedto, resolution
* Add TODOs for test cases that would be good to add for issue list def testing
