### PR TITLE
Wait for 'document.readyState' to be 'complete'

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1874,6 +1874,10 @@ public abstract class WebDriverWrapper implements WrapsDriver
         new WebDriverWait(getDriver(), millis / 1000)
                 .withMessage("waiting for browser to navigate")
                 .until(ExpectedConditions.stalenessOf(toBeStale));
+        // WebDriver usually does this automatically, but not always.
+        new WebDriverWait(getDriver(), millis / 1000)
+                .withMessage("waiting for document to be ready")
+                .until(wd -> executeScript("return document.readyState;").equals("complete"));
         waitForOnReady("jQuery");
         waitForOnReady("Ext");
         waitForOnReady("Ext4");


### PR DESCRIPTION
#### Rationale
Tests have recently been having failures immediately after navigating. They attempt to interact with the page but the screenshots show a blank page and the fullscreen screenshots (when available) show the page is still loading. This indicates that `WebDriverWrapper.waitForPageToLoad` did not actually function as expected.

#### Changes
* Wait for `document.readyState === 'complete'` in `waitForPageToLoad`