### PR TITLE
Item 7034: Sample type parent/source alias additional test cases

### DIFF
--- a/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
@@ -70,6 +70,12 @@ public abstract class SampleTypeDesigner<T extends SampleTypeDesigner<T>> extend
         throw new NotFoundException("No such parent alias: " + parentAlias);
     }
 
+    public List<String> getParentAliasOptions(int index)
+    {
+        expandPropertiesPanel();
+        return elementCache().parentAliasSelect(index).getOptions();
+    }
+
     public T removeParentAlias(String parentAlias)
     {
         expandPropertiesPanel();

--- a/src/org/labkey/test/tests/SampleTypeParentColumnTest.java
+++ b/src/org/labkey/test/tests/SampleTypeParentColumnTest.java
@@ -639,6 +639,26 @@ public class SampleTypeParentColumnTest extends BaseWebDriverTest
     }
 
     @Test
+    public void testSampleTypeParentAliasOptions()
+    {
+        SampleTypeHelper sampleHelper = new SampleTypeHelper(this);
+
+        goToProjectHome();
+        projectMenu().navigateToFolder(PROJECT_NAME, SUB_FOLDER_NAME);
+        CreateSampleTypePage createPage = sampleHelper.goToCreateNewSampleType();
+        List<String> options = createPage.addParentAlias("test").getParentAliasOptions(0);
+
+        log("Verify that parent alias options include both data classes and sample types.");
+        checker().verifyTrue("Missing expected parent alias option", options.contains("(Current Sample Type)"));
+        checker().verifyTrue("Missing expected parent alias option", options.contains("Data Class: " + PARENT_CONTAINER_DATA_CLASS_NAME + " (" + PROJECT_NAME + ")"));
+        checker().verifyTrue("Missing expected parent alias option", options.contains("Data Class: " + SIBLING_DATA_CLASS_NAME + " (" + SUB_FOLDER_NAME + ")"));
+        checker().verifyTrue("Missing expected parent alias option", options.contains("Sample Type: " + PARENT_CONTAINER_SAMPLE_TYPE_NAME + " (" + PROJECT_NAME + ")"));
+        checker().verifyTrue("Missing expected parent alias option", options.contains("Sample Type: " + SIBLING_SAMPLE_TYPE_NAME + " (" + SUB_FOLDER_NAME + ")"));
+
+        createPage.clickCancel();
+    }
+
+    @Test
     public void testAliasNameConflictsWithFieldName()
     {
         final String ALIAS_NAME_CONFLICT = "ConflictName";
@@ -683,6 +703,8 @@ public class SampleTypeParentColumnTest extends BaseWebDriverTest
 
         clickFolder(SUB_FOLDER_NAME);
         updatePage = sampleHelper.goToEditSampleType(SAMPLE_TYPE_NAME);
+        Assert.assertEquals("Expected parent alias name not found.", GOOD_PARENT_NAME, updatePage.getParentAlias(0));
+        Assert.assertEquals("Expected parent alias value not found.", SampleTypeDesigner.CURRENT_SAMPLE_TYPE, updatePage.getParentAliasSelectText(0));
         updatePage.getFieldsPanel().addField(GOOD_PARENT_NAME);
         errors = updatePage.clickSaveExpectingErrors();
 


### PR DESCRIPTION
#### Rationale
https://docs.google.com/document/d/1C4cCgHyC_EStBaNfY1YhhjFONALTvapB_o-hlykmvD8/edit#heading=h.mvaa0z4200c3
- verify sample type designer parent alias options include data classes and sample types
- verify sample type designer reshow of saved parent alias option

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/822
* https://github.com/LabKey/biologics/pull/955
* https://github.com/LabKey/sampleManagement/pull/642
