### PR TITLE
Add an overloaded clickSave method that has a wait parameter.

### DIFF
--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -78,14 +78,20 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
         return getAllTypeCombo().stream().allMatch(rs -> rs.isInteractive() && !rs.isLoading());
     }
 
+    private void clickButtonWaitForPanel(WebElement button)
+    {
+        clickButtonWaitForPanel(button, 1_000);
+    }
+
     /**
      * Clicking either the 'Save' or 'Cancel' button will remove this edit panel. This helper function will click the
      * button sent to it and then wait until it has some indication the edit panel is gone and the default panel is
      * shown.
      *
-     * @param button
+     * @param button Button to click.
+     * @param wait How long to wait for the panel.
      */
-    private void clickButtonWaitForPanel(WebElement button)
+    private void clickButtonWaitForPanel(WebElement button, int wait)
     {
         int count = Locator.tagWithClass("div", "panel-default").findElements(getDriver()).size();
 
@@ -93,8 +99,7 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
 
         WebDriverWrapper.waitFor(()->
                         Locator.tagWithClass("div", "panel-default").findElements(getDriver()).size() > count,
-                "Panel did not exit edit mode", 1_000
-        );
+                "Panel did not exit edit mode", wait);
     }
 
     /** Click the 'Cancel' button. This will make the edit panel go away. */
@@ -109,6 +114,17 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
     {
         clickButtonWaitForPanel(elementCache()
                 .button("Save", "Editing " + _parentType.getType() + " Details"));
+    }
+
+    /** Click the 'Save' button.
+     *
+     * @param waitTime Amount of time to wait for the panel.
+     */
+    public void clickSave(int waitTime)
+    {
+        clickButtonWaitForPanel(elementCache()
+                .button("Save", "Editing " + _parentType.getType() + " Details"),
+                waitTime);
     }
 
     /**


### PR DESCRIPTION
#### Rationale
The clickSave method when editing then parent entity panel had a hard coded wait time of 1 second. That is not always a valid wait time and the test should be able to indicate how long it expects the panel to load.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/643

#### Changes
* Add overload public void clickSave(int waitTime)
* Add overload private void clickButtonWaitForPanel(WebElement button, int wait)
