### PR TITLE
Fix NPE in 'waitForPageToLoad'

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1877,7 +1877,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
         // WebDriver usually does this automatically, but not always.
         new WebDriverWait(getDriver(), millis / 1000)
                 .withMessage("waiting for document to be ready")
-                .until(wd -> executeScript("return document.readyState;").equals("complete"));
+                .until(wd -> "complete".equals(executeScript("return document.readyState;")));
         waitForOnReady("jQuery");
         waitForOnReady("Ext");
         waitForOnReady("Ext4");

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1877,7 +1877,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
         // WebDriver usually does this automatically, but not always.
         new WebDriverWait(getDriver(), millis / 1000)
                 .withMessage("waiting for document to be ready")
-                .until(wd -> "complete".equals(executeScript("return document.readyState;")));
+                .until(wd -> Objects.equals(executeScript("return document.readyState;"), "complete"));
         waitForOnReady("jQuery");
         waitForOnReady("Ext");
         waitForOnReady("Ext4");


### PR DESCRIPTION
#### Rationale
`document.readyState` sometimes returns `null`

#### Related Pull Requests
* #821 

#### Changes
* Use `Objects.equals` to avoid NPE
