### PR TITLE
Make column name matching case-insensitive

### DIFF
--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -76,6 +76,7 @@ public class DataRegionTable extends DataRegion
     private PagingWidget _pagingWidget;
     private final List<String> _columnLabels = new ArrayList<>();
     private final List<String> _columnNames = new ArrayList<>();
+    private final Map<String, Integer> _columnIndexMap = new CaseInsensitiveHashMap<>();
     private final Map<String, Integer> _mapRows = new HashMap<>();
     private final Map<Integer, Map<Integer, String>> _dataCache = new TreeMap<>();
 
@@ -119,6 +120,7 @@ public class DataRegionTable extends DataRegion
         _exportHelper = null;
         _columnLabels.clear();
         _columnNames.clear();
+        _columnIndexMap.clear();
         _mapRows.clear();
         _dataCache.clear();
     }
@@ -443,20 +445,40 @@ public class DataRegionTable extends DataRegion
      */
     public int getColumnIndex(String name)
     {
-        int i = getColumnNames().indexOf(name);
+        if (_columnIndexMap.isEmpty())
+        {
+            final var columnNames = getColumnNames();
+            for (int j = 0; j < columnNames.size(); j++)
+            {
+                _columnIndexMap.put(columnNames.get(j), j);
+            }
+        }
+        int i = _columnIndexMap.getOrDefault(name, -1);
 
+        // Try removing spaces from column name
         if (i < 0)
-            i = getColumnNames().indexOf(name.replaceAll(" ", ""));
+        {
+            i = _columnIndexMap.getOrDefault(name.replace(" ", ""), -1);
+            if (i >= 0)
+            {
+                TestLogger.warn(String.format("Unnecessary space in requested column name. " +
+                        "Requested: \"%s\" Found: \"%s\"", name, getColumnNames().get(i)));
+            }
+        }
 
+        // Try matching column label
         if (i < 0)
         {
             List<String> columnLabelsWithoutSpaces = new ArrayList<>(getColumnLabels().size());
-            getColumnLabels().stream().forEachOrdered(s -> columnLabelsWithoutSpaces.add(s.replaceAll(" ", "")));
-            i = columnLabelsWithoutSpaces.indexOf(name.replaceAll(" ", ""));
+            getColumnLabels().stream().forEach(s -> columnLabelsWithoutSpaces.add(s.replace(" ", "")));
+            i = columnLabelsWithoutSpaces.indexOf(name.replace(" ", ""));
+            if (i >= 0)
+            {
+                TestLogger.warn(String.format("Please reference columns by name instead of label. " +
+                        "Requested column with label: \"%s\" Found column with name: \"%s\"", name, getColumnNames().get(i)));
+            }
         }
 
-        if (i < 0)
-            TestLogger.log("Column '" + name + "' not found");
         return i;
     }
 


### PR DESCRIPTION
#### Rationale
Actual column name casing varies by database type (Postgres|SQL Server) for some columns. Column names aren't case-sensitive though, so the test component doesn't need to differentiate column names by casing.

#### Changes
* Make `DataRegionTable.getColumnIndex` case-insensitive
