### PR TITLE
Use consistent toggle locator for BootstrapMenu

### DIFF
--- a/src/org/labkey/test/components/WebPart.java
+++ b/src/org/labkey/test/components/WebPart.java
@@ -21,7 +21,6 @@ import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebDriverWrapperImpl;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.components.html.SiteNavBar;
-import org.labkey.test.selenium.LazyWebElement;
 import org.labkey.test.selenium.RefindingWebElement;
 import org.labkey.test.util.LogMethod;
 import org.openqa.selenium.WebDriver;
@@ -120,7 +119,7 @@ public abstract class WebPart<EC extends WebPart.ElementCache> extends WebPartPa
 
     public BootstrapMenu getWebParMenu()
     {
-        return new BootstrapMenu(getDriver(), elementCache().UX_MENU);
+        return getTitleMenu();
     }
 
     public void clickMenuItem(String... items)
@@ -130,22 +129,22 @@ public abstract class WebPart<EC extends WebPart.ElementCache> extends WebPartPa
 
     public void clickMenuItem(boolean wait, String... items)
     {
-        new BootstrapMenu(getDriver(), elementCache().UX_MENU).clickSubMenu(wait, items);
+        getTitleMenu().clickSubMenu(wait, items);
     }
 
     public BootstrapMenu getTitleMenu()
     {
-        return  new BootstrapMenu(getDriver(), elementCache().UX_MENU);
+        return elementCache().webPartMenu;
     }
 
     public void openTitleMenu()
     {
-        new BootstrapMenu(getDriver(), elementCache().UX_MENU).expand();
+        getTitleMenu().expand();
     }
 
     public void closeTitleMenu()
     {
-        new BootstrapMenu(getDriver(), elementCache().UX_MENU).collapse();
+        getTitleMenu().collapse();
     }
 
     @Override
@@ -153,7 +152,6 @@ public abstract class WebPart<EC extends WebPart.ElementCache> extends WebPartPa
 
     public class ElementCache extends WebPartPanel.ElementCache
     {
-        public WebElement UX_MENU = new LazyWebElement(
-                Locator.xpath("//span[contains(@class,'dropdown') and ./a[@data-toggle='dropdown']]"), this);
+        protected final BootstrapMenu webPartMenu = BootstrapMenu.finder(getDriver()).findWhenNeeded(this);
     }
 }

--- a/src/org/labkey/test/components/html/BootstrapMenu.java
+++ b/src/org/labkey/test/components/html/BootstrapMenu.java
@@ -17,6 +17,7 @@ package org.labkey.test.components.html;
 
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.components.react.BaseBootstrapMenu;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.openqa.selenium.WebDriver;
@@ -29,7 +30,7 @@ public class BootstrapMenu extends BaseBootstrapMenu
     /* componentElement should contain the toggle anchor *and* the UL containing list items */
     public BootstrapMenu(WebDriver driver, WebElement componentElement)
     {
-        super(driver, componentElement);
+        super(componentElement, driver);
     }
 
     static public BootstrapMenuFinder finder(WebDriver driver)

--- a/src/org/labkey/test/components/html/BootstrapMenu.java
+++ b/src/org/labkey/test/components/html/BootstrapMenu.java
@@ -26,8 +26,6 @@ import java.util.List;
 
 public class BootstrapMenu extends BaseBootstrapMenu
 {
-    private Locator _toggleLocator;
-
     /* componentElement should contain the toggle anchor *and* the UL containing list items */
     public BootstrapMenu(WebDriver driver, WebElement componentElement)
     {
@@ -112,16 +110,7 @@ public class BootstrapMenu extends BaseBootstrapMenu
     @Override
     protected Locator getToggleLocator()
     {
-        if (_toggleLocator != null)
-            return _toggleLocator;
-        else
-            return Locators.toggleAnchor();
-    }
-
-    public BootstrapMenu setToggleLocator(Locator toggleLocator)
-    {
-        _toggleLocator = toggleLocator;
-        return this;
+        return Locators.dropdownToggle();
     }
 
     @Override
@@ -165,9 +154,9 @@ public class BootstrapMenu extends BaseBootstrapMenu
 
     static public class Locators
     {
-        public static Locator.XPathLocator toggleAnchor()
+        public static Locator.XPathLocator dropdownToggle()
         {
-            return Locator.tagWithAttribute("*", "data-toggle", "dropdown");
+            return Locator.byClass("dropdown-toggle");
         }
 
         public static Locator.XPathLocator menuItem(String text)
@@ -180,32 +169,43 @@ public class BootstrapMenu extends BaseBootstrapMenu
             return Locator.tagWithClass("li", "disabled").childTag("a").withText(text).notHidden();
         }
 
-        public static Locator.XPathLocator bootstrapMenuContainer()
+        public static Locator.XPathLocator dropdownMenu()
         {
-            return Locator.tag("*")
-                    .withPredicate(toggleAnchor()
-                    .followingSibling("ul"));
+            return dropdownMenu(dropdownToggle());
+        }
+
+        private static Locator.XPathLocator dropdownMenu(Locator.XPathLocator toggleLoc)
+        {
+            return Locator.byClass("dropdown")
+                    .withChild(toggleLoc)
+                    .withChild(Locator.tag("ul"));
         }
     }
 
     public static class BootstrapMenuFinder extends WebDriverComponentFinder<BootstrapMenu, BootstrapMenu.BootstrapMenuFinder>
     {
-        private Locator _locator = Locators.bootstrapMenuContainer().withChild(Locators.toggleAnchor());
+        private Locator _locator = Locators.dropdownMenu();
 
         public BootstrapMenuFinder(WebDriver driver)
         {
             super(driver);
         }
 
+        public BootstrapMenuFinder withToggleId(String id)
+        {
+            _locator = Locators.dropdownMenu(Locators.dropdownToggle().withAttribute("id", id));
+            return this;
+        }
+
         public BootstrapMenuFinder withButtonText(String text)
         {
-            _locator = Locators.bootstrapMenuContainer().withChild(Locators.toggleAnchor().withText(text));
+            _locator = Locators.dropdownMenu(Locators.dropdownToggle().withText(text));
             return this;
         }
 
         public BootstrapMenuFinder withButtonTextContaining(String text)
         {
-            _locator = Locators.bootstrapMenuContainer().withChild(Locators.toggleAnchor().containing(text));
+            _locator = Locators.dropdownMenu(Locators.dropdownToggle().containing(text));
             return this;
         }
 

--- a/src/org/labkey/test/components/react/BaseBootstrapMenu.java
+++ b/src/org/labkey/test/components/react/BaseBootstrapMenu.java
@@ -1,4 +1,4 @@
-package org.labkey.test.components.html;
+package org.labkey.test.components.react;
 
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
@@ -8,14 +8,17 @@ import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
+/**
+ * Wraps basic open/close functionality of 'Dropdown' and 'DropdownButton' components from '@types/react-bootstrap'
+ */
 public abstract class BaseBootstrapMenu extends WebDriverComponent<BaseBootstrapMenu.ElementCache>
 {
-    protected final WebDriver _driver;
-    protected final WebElement _componentElement;
+    private final WebElement _componentElement;
+    private final WebDriver _driver;
     private int _expandRetryCount = 1;
 
     /* componentElement should contain the toggle anchor *and* the UL containing list items */
-    public BaseBootstrapMenu(WebDriver driver, WebElement componentElement)
+    public BaseBootstrapMenu(WebElement componentElement, WebDriver driver)
     {
         _componentElement = componentElement;
         _driver = driver;
@@ -82,7 +85,7 @@ public abstract class BaseBootstrapMenu extends WebDriverComponent<BaseBootstrap
         return new ElementCache();
     }
 
-    protected class ElementCache extends Component.ElementCache
+    protected class ElementCache extends Component<?>.ElementCache
     {
         public final WebElement toggleAnchor = getToggleLocator().findWhenNeeded(getComponentElement());
 

--- a/src/org/labkey/test/components/react/DropdownButtonGroup.java
+++ b/src/org/labkey/test/components/react/DropdownButtonGroup.java
@@ -3,7 +3,6 @@ package org.labkey.test.components.react;
 
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
-import org.labkey.test.WebDriverWrapperImpl;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
@@ -14,22 +13,20 @@ import java.util.List;
 
 import static org.labkey.test.WebDriverWrapper.sleep;
 
-
+/**
+ * This component is redundant (I think)
+ * @deprecated Use {@link org.labkey.test.components.html.BootstrapMenu} or {@link MultiMenu}
+ */
+@Deprecated
 public class DropdownButtonGroup extends WebDriverComponent<DropdownButtonGroup.ElementCache>
 {
     final WebElement _el;
     final WebDriver _driver;
 
-    /* componentElement should contain the toggle anchor *and* the UL containing list items */
-    public DropdownButtonGroup(WebDriver driver, WebElement componentElement)
+    public DropdownButtonGroup(WebElement el, WebDriver driver)
     {
-        this(componentElement, new WebDriverWrapperImpl(driver));
-    }
-
-    public DropdownButtonGroup(WebElement element, WebDriverWrapper wrapper)
-    {
-        _el = element;
-        _driver = wrapper.getDriver();
+        _el = el;
+        _driver = driver;
     }
 
     @Override
@@ -295,7 +292,7 @@ public class DropdownButtonGroup extends WebDriverComponent<DropdownButtonGroup.
         @Override
         protected DropdownButtonGroup construct(WebElement el, WebDriver driver)
         {
-            return new DropdownButtonGroup(driver, el);
+            return new DropdownButtonGroup(el, driver);
         }
 
         @Override

--- a/src/org/labkey/test/components/react/MultiMenu.java
+++ b/src/org/labkey/test/components/react/MultiMenu.java
@@ -180,12 +180,6 @@ public class MultiMenu extends BootstrapMenu
         return getComponentElement().getText();
     }
 
-    @Override
-    protected Locator getToggleLocator()
-    {
-        return Locators.dropdownToggle();
-    }
-
     public static abstract class Locators
     {
         static public Locator.XPathLocator menuContainer()
@@ -195,12 +189,7 @@ public class MultiMenu extends BootstrapMenu
 
         static public Locator.XPathLocator menuContainer(String text)
         {
-            return menuContainer().withChild(dropdownToggle().withText(text));
-        }
-
-        private static Locator.XPathLocator dropdownToggle()
-        {
-            return Locator.byClass("dropdown-toggle");
+            return menuContainer().withChild(BootstrapMenu.Locators.dropdownToggle().withText(text));
         }
     }
 
@@ -232,7 +221,7 @@ public class MultiMenu extends BootstrapMenu
          */
         public MultiMenuFinder exportButton()
         {
-            _locator = Locators.menuContainer().withChild(Locators.dropdownToggle().withChild(Locator.byClass("fa-download")));
+            _locator = Locators.menuContainer().withChild(BootstrapMenu.Locators.dropdownToggle().withChild(Locator.byClass("fa-download")));
             return this;
         }
 

--- a/src/org/labkey/test/components/ui/files/AttachmentCard.java
+++ b/src/org/labkey/test/components/ui/files/AttachmentCard.java
@@ -88,8 +88,7 @@ public class AttachmentCard extends WebDriverComponent<AttachmentCard.ElementCac
         final WebElement fileSize = Locator.byClass("attachment-card__size").findWhenNeeded(this);
         BootstrapMenu menu = BootstrapMenu.finder(getDriver())
                 .locatedBy(Locator.tagWithClass("div", "attachment-card__menu"))
-                .findWhenNeeded(this)
-                .setToggleLocator(Locator.byClass("dropdown-toggle"));
+                .findWhenNeeded(this);
     }
 
 

--- a/src/org/labkey/test/components/ui/navigation/ProductMenu.java
+++ b/src/org/labkey/test/components/ui/navigation/ProductMenu.java
@@ -5,7 +5,7 @@
 package org.labkey.test.components.ui.navigation;
 
 import org.labkey.test.Locator;
-import org.labkey.test.components.html.BaseBootstrapMenu;
+import org.labkey.test.components.react.BaseBootstrapMenu;
 import org.labkey.test.components.react.MultiMenu;
 import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.NoSuchElementException;
@@ -25,7 +25,7 @@ public class ProductMenu extends BaseBootstrapMenu
 
     protected ProductMenu(WebElement element, WebDriver driver)
     {
-        super(driver, element);
+        super(element, driver);
     }
 
     public static SimpleWebDriverComponentFinder<ProductMenu> finder(WebDriver driver)

--- a/src/org/labkey/test/components/ui/navigation/UserMenu.java
+++ b/src/org/labkey/test/components/ui/navigation/UserMenu.java
@@ -1,8 +1,8 @@
 package org.labkey.test.components.ui.navigation;
 
 import org.labkey.test.Locator;
-import org.labkey.test.components.react.MultiMenu;
 import org.labkey.test.components.html.BootstrapMenu;
+import org.labkey.test.components.react.MultiMenu;
 import org.labkey.test.pages.LabKeyPage;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -38,12 +38,6 @@ public abstract class UserMenu extends BootstrapMenu
     {
         clickSubMenu(true, "Sign Out");
         return new LabKeyPage<>(getDriver());
-    }
-
-    @Override
-    protected Locator getToggleLocator()
-    {
-        return appUserMenu();
     }
 
     /**

--- a/src/org/labkey/test/components/ui/navigation/apps/AppsMenu.java
+++ b/src/org/labkey/test/components/ui/navigation/apps/AppsMenu.java
@@ -2,8 +2,8 @@ package org.labkey.test.components.ui.navigation.apps;
 
 import org.labkey.test.Locator;
 import org.labkey.test.components.WebDriverComponent;
-import org.labkey.test.components.html.BaseBootstrapMenu;
 import org.labkey.test.components.html.BootstrapMenu;
+import org.labkey.test.components.react.BaseBootstrapMenu;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -16,7 +16,7 @@ public class AppsMenu extends BaseBootstrapMenu
 
     protected AppsMenu(WebElement element, WebDriver driver)
     {
-        super(driver, element);
+        super(element, driver);
     }
 
     /**
@@ -61,10 +61,8 @@ public class AppsMenu extends BaseBootstrapMenu
     public static class AppsMenuFinder extends WebDriverComponent.WebDriverComponentFinder<AppsMenu, AppsMenuFinder>
     {
         private Locator _locator = Locator.XPathLocator.union(
-                Locator.tagWithClass("div", "navbar-item-product-navigation")   //lksm/bio
-                .child(Locator.tagWithClass("div", "dropdown"))
-                .withChild(Locator.id("product-navigation-button")),
-                Locator.id("headerProductDropdown"));                                       //lks
+                Locator.id("product-navigation-button").parent(),   //lksm/bio
+                Locator.id("headerProductDropdown"));               //lks
 
         public AppsMenuFinder(WebDriver driver)
         {

--- a/src/org/labkey/test/components/ui/navigation/apps/AppsMenu.java
+++ b/src/org/labkey/test/components/ui/navigation/apps/AppsMenu.java
@@ -3,7 +3,7 @@ package org.labkey.test.components.ui.navigation.apps;
 import org.labkey.test.Locator;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.html.BaseBootstrapMenu;
-import org.openqa.selenium.NoSuchElementException;
+import org.labkey.test.components.html.BootstrapMenu;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -54,10 +54,7 @@ public class AppsMenu extends BaseBootstrapMenu
     @Override
     protected Locator getToggleLocator()
     {
-        // the toggle appears differently in-app (LKSM, Biologics) than it does in LKS.
-        return Locator.XPathLocator.union(
-                Locator.tagWithAttribute("button", "id", "product-navigation-button"),  // lksm/bio
-                Locator.tagWithAttribute("a", "data-toggle", "dropdown"));              // lks
+        return BootstrapMenu.Locators.dropdownToggle();
     }
 
 

--- a/src/org/labkey/test/util/PortalHelper.java
+++ b/src/org/labkey/test/util/PortalHelper.java
@@ -84,7 +84,7 @@ public class PortalHelper extends WebDriverWrapper
     private void clickTabMenuItem(@LoggedParam String tabText, boolean wait, @LoggedParam String... items)
     {
         BootstrapMenu tabMenu = new BootstrapMenu(getDriver(),
-                BootstrapMenu.Locators.bootstrapMenuContainer()
+                BootstrapMenu.Locators.dropdownMenu()
                         .withChild(Locator.linkWithText(tabText)).findElement(getDriver()));
         tabMenu.clickSubMenu(wait,  items);
     }


### PR DESCRIPTION
#### Rationale
'dropdown-toggle' is the standard css class for the 'react-bootstrap' <Dropdown> component menu toggle. `data-toggle="dropdown"` is common but not universal.
One of the early influences on the `BootstrapMenu` test component was data region header menu buttons. They don't have the 'dropdown-toggle' class but they aren't actually 'react-bootstrap' components. A related platform change adds the class to data region buttons.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2532

#### Changes
* Update toggle locator to make setting custom locator unnecessary.
