### PR TITLE
Wait for page load when signing in through `LoggedOutDialog`

### DIFF
--- a/src/org/labkey/test/components/bootstrap/LoggedOutDialog.java
+++ b/src/org/labkey/test/components/bootstrap/LoggedOutDialog.java
@@ -60,7 +60,7 @@ public class LoggedOutDialog extends ModalDialog
         getWrapper().assertElementPresent(Locator.tagWithName("form", "login"));
         getWrapper().setFormElement(Locator.name("email"), PasswordUtil.getUsername());
         getWrapper().setFormElement(Locator.name("password"), PasswordUtil.getPassword());
-        getWrapper().clickButton("Sign In", 0);
+        getWrapper().clickButton("Sign In");
 
         var returnUrl = getWrapper().getCurrentRelativeURL();
         assertThat("Signing back in did not take us back to the expected page.", returnUrl, startsWith(expectedURL));


### PR DESCRIPTION
#### Rationale
If the test doesn't wait for the page to load after clicking "Sign In", it might get the URL from the login page instead of the destination page. I suspect this code was copy-pasted from `simpleSignIn` which is trying to account for behavior that isn't relevant for this component.

#### Related Pull Requests
* #761 

#### Changes
* Wait for page load when signing in through `LoggedOutDialog`
