### PR TITLE
Fix NPEs when waiting for page load

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1871,13 +1871,21 @@ public abstract class WebDriverWrapper implements WrapsDriver
     private void waitForPageToLoad(WebElement toBeStale, int millis)
     {
         _testTimeout = true;
-        new WebDriverWait(getDriver(), millis / 1000)
-                .withMessage("waiting for browser to navigate")
-                .until(ExpectedConditions.stalenessOf(toBeStale));
+        try
+        {
+            new WebDriverWait(getDriver(), millis / 1000)
+                    .withMessage("waiting for browser to navigate")
+                    .until(ExpectedConditions.stalenessOf(toBeStale));
+        }
+        catch (NullPointerException ignore)
+        {
+            // Staleness check sometimes throws an NPE if the element goes stale too quickly. Carry on.
+        }
+
         // WebDriver usually does this automatically, but not always.
         new WebDriverWait(getDriver(), millis / 1000)
                 .withMessage("waiting for document to be ready")
-                .until(wd -> executeScript("return document.readyState;").equals("complete"));
+                .until(wd -> "complete".equals(executeScript("return document.readyState;")));
         waitForOnReady("jQuery");
         waitForOnReady("Ext");
         waitForOnReady("Ext4");


### PR DESCRIPTION
#### Rationale
Should fix a couple of NPEs that the `CrawlerTest` is seeing.
```
java.lang.NullPointerException
  at org.labkey.test.WebDriverWrapper.lambda$17(WebDriverWrapper.java:1880)
  at org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:249)
  at org.labkey.test.WebDriverWrapper.waitForPageToLoad(WebDriverWrapper.java:1880)
  at org.labkey.test.WebDriverWrapper.doAndMaybeWaitForPageToLoad(WebDriverWrapper.java:1966)
  at org.labkey.test.WebDriverWrapper.beginAt(WebDriverWrapper.java:1082)
  at org.labkey.test.tests.CrawlerTest.testCrawlerTest(CrawlerTest.java:74)
```
-and-
```
java.lang.NullPointerException
  at org.openqa.selenium.remote.RemoteWebElement.isEnabled(RemoteWebElement.java:159)
  at org.labkey.test.selenium.WebElementWrapper.isEnabled(WebElementWrapper.java:78)
  at org.openqa.selenium.support.ui.ExpectedConditions$24.apply(ExpectedConditions.java:700)
  at org.openqa.selenium.support.ui.ExpectedConditions$24.apply(ExpectedConditions.java:695)
  at org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:249)
  at org.labkey.test.WebDriverWrapper.waitForPageToLoad(WebDriverWrapper.java:1876)
  at org.labkey.test.WebDriverWrapper.doAndMaybeWaitForPageToLoad(WebDriverWrapper.java:1966)
  at org.labkey.test.WebDriverWrapper.beginAt(WebDriverWrapper.java:1082)
  at org.labkey.test.tests.CrawlerTest.testCrawlerTest(CrawlerTest.java:86)
```

#### Changes
* Prevent NPEs in `waitForPageToLoad`
