### PR TITLE
Add test for finding samples by ids.

### DIFF
--- a/src/org/labkey/test/components/ui/navigation/FindByIdsDialog.java
+++ b/src/org/labkey/test/components/ui/navigation/FindByIdsDialog.java
@@ -1,0 +1,82 @@
+package org.labkey.test.components.ui.navigation;
+
+import org.apache.commons.lang3.StringUtils;
+import org.labkey.test.Locator;
+import org.labkey.test.components.bootstrap.ModalDialog;
+import org.labkey.test.components.html.RadioButton;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+public class FindByIdsDialog  extends ModalDialog
+{
+    public static final String TITLE = "Find Samples";
+
+    public FindByIdsDialog(WebDriver driver)
+    {
+        super(new ModalDialog.ModalDialogFinder(driver).withTitle(TITLE));
+    }
+
+    public boolean isBarcodeChecked()
+    {
+        return elementCache().barcodeRadio.isChecked();
+    }
+
+    public boolean isSampleIdChecked()
+    {
+        return elementCache().sampleIDsRadio.isChecked();
+    }
+
+    public FindByIdsDialog chooseBarcodes()
+    {
+        elementCache().barcodeRadio.check();
+        return this;
+    }
+
+    public FindByIdsDialog chooseSampleIDs()
+    {
+        elementCache().sampleIDsRadio.check();
+        return this;
+    }
+
+    public FindByIdsDialog addIds(List<String> ids)
+    {
+        elementCache().idTextArea.sendKeys(StringUtils.join(ids, "\n"));
+        return this;
+    }
+
+    public void clickCancel()
+    {
+        elementCache().cancelButton.click();
+    }
+
+    public void clickFindSamples()
+    {
+        elementCache().findSamplesButton.click();
+    }
+
+    @Override
+    protected FindByIdsDialog.ElementCache newElementCache()
+    {
+        return new FindByIdsDialog.ElementCache();
+    }
+
+    @Override
+    protected FindByIdsDialog.ElementCache elementCache()
+    {
+        return (FindByIdsDialog.ElementCache) super.elementCache();
+    }
+
+    protected class ElementCache extends ModalDialog.ElementCache
+    {
+        RadioButton barcodeRadio = RadioButton.RadioButton(Locator.radioButtonByName("uniqueIds")).findWhenNeeded(getComponentElement());
+        RadioButton sampleIDsRadio = RadioButton.RadioButton(Locator.radioButtonByName("sampleIds")).findWhenNeeded(getComponentElement());
+        WebElement idTextArea = Locator.tag("textarea").findWhenNeeded(getComponentElement());
+
+        WebElement cancelButton = Locator.tagWithText("button", "Cancel")
+                .findWhenNeeded(getComponentElement());
+        WebElement findSamplesButton = Locator.tagWithText("button", "Find Samples")
+                .findWhenNeeded(getComponentElement());
+    }
+}

--- a/src/org/labkey/test/components/ui/navigation/FindByIdsDialog.java
+++ b/src/org/labkey/test/components/ui/navigation/FindByIdsDialog.java
@@ -70,13 +70,13 @@ public class FindByIdsDialog  extends ModalDialog
 
     protected class ElementCache extends ModalDialog.ElementCache
     {
-        RadioButton barcodeRadio = RadioButton.RadioButton(Locator.radioButtonByName("uniqueIds")).findWhenNeeded(getComponentElement());
-        RadioButton sampleIDsRadio = RadioButton.RadioButton(Locator.radioButtonByName("sampleIds")).findWhenNeeded(getComponentElement());
-        WebElement idTextArea = Locator.tag("textarea").findWhenNeeded(getComponentElement());
+        final RadioButton barcodeRadio = RadioButton.RadioButton(Locator.radioButtonByName("uniqueIds")).findWhenNeeded(getComponentElement());
+        final RadioButton sampleIDsRadio = RadioButton.RadioButton(Locator.radioButtonByName("sampleIds")).findWhenNeeded(getComponentElement());
+        final WebElement idTextArea = Locator.tag("textarea").findWhenNeeded(getComponentElement());
 
-        WebElement cancelButton = Locator.tagWithText("button", "Cancel")
+        final WebElement cancelButton = Locator.tagWithText("button", "Cancel")
                 .findWhenNeeded(getComponentElement());
-        WebElement findSamplesButton = Locator.tagWithText("button", "Find Samples")
+        final WebElement findSamplesButton = Locator.tagWithText("button", "Find Samples")
                 .findWhenNeeded(getComponentElement());
     }
 }

--- a/src/org/labkey/test/components/ui/navigation/NavBar.java
+++ b/src/org/labkey/test/components/ui/navigation/NavBar.java
@@ -14,6 +14,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+import static org.labkey.test.WebDriverWrapper.waitFor;
 
 public abstract class NavBar extends WebDriverComponent<NavBar.ElementCache>
 {
@@ -51,6 +52,7 @@ public abstract class NavBar extends WebDriverComponent<NavBar.ElementCache>
     public FindByIdsDialog findByIds()
     {
         elementCache().findAndSearchMenuButton.click();
+        waitFor(()->elementCache().findSamplesOption.isDisplayed(), "Find samples menu did not show up.", 500);
         elementCache().findSamplesOption.click();
         return new FindByIdsDialog(getDriver());
     }

--- a/src/org/labkey/test/components/ui/navigation/NavBar.java
+++ b/src/org/labkey/test/components/ui/navigation/NavBar.java
@@ -48,6 +48,13 @@ public abstract class NavBar extends WebDriverComponent<NavBar.ElementCache>
         return null;
     }
 
+    public FindByIdsDialog findByIds()
+    {
+        elementCache().findAndSearchMenuButton.click();
+        elementCache().findSamplesOption.click();
+        return new FindByIdsDialog(getDriver());
+    }
+
     public String getDisplayedProjectName()
     {
         return elementCache().projectNameDisplay.getText();
@@ -85,5 +92,8 @@ public abstract class NavBar extends WebDriverComponent<NavBar.ElementCache>
         public WebElement userIcon = Locator.tagWithAttribute("img", "alt", "User Avatar").findWhenNeeded(this);
         public WebElement projectNameDisplay = Locator.tagWithClass("span", "project-name").findWhenNeeded(this);
         public Input searchBox = Input.Input(Locator.tagWithClass("input", "navbar__search-input"), getDriver()).findWhenNeeded(this);
+        public WebElement searchForm = Locator.tagWithClass("form", "navbar__search-form").findWhenNeeded(this);
+        public WebElement findAndSearchMenuButton = Locator.tagWithId("button", "find-and-search-menu").findWhenNeeded(searchForm);
+        public WebElement findSamplesOption = Locator.linkContainingText("Find Samples").findWhenNeeded(searchForm);
     }
 }


### PR DESCRIPTION
#### Rationale
We added functionality for finding samples by Ids in all of our premium applications.  Now we are adding tests for that functionality and we'll locate the dialog that is common across application in testAutomation.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2543
* https://github.com/LabKey/labkey-ui-components/pull/606
* https://github.com/LabKey/biologics/pull/965
* https://github.com/LabKey/inventory/pull/291
* https://github.com/LabKey/sampleManagement/pull/659

#### Changes
* add `FindByIdsDialog`
* Update `NavBar` to be able to activate the `FindByIdsDialog`.
