### PR TITLE
Fix Locators for some tab and dataregion bootstrap menus

### DIFF
--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -1517,7 +1517,7 @@ public class DataRegionTable extends DataRegion
         private List<WebElement> summaryStatCells;
         private final WebElement toggleHeaderCell = Locator.tag("th").withClasses("labkey-column-header", "labkey-selectors").findWhenNeeded(columnHeaderRow);
         private final WebElement toggleAllOnPage = Locator.input(".toggle").findWhenNeeded(toggleHeaderCell); // tri-state checkbox
-        private SelectorMenu selectionMenu = new SelectorMenu(new BootstrapMenu.BootstrapMenuFinder(getDriver()).findWhenNeeded(columnHeaderRow));
+        private SelectorMenu selectionMenu = new SelectorMenu(toggleHeaderCell);
 
         protected List<WebElement> getDataRows()
         {
@@ -1629,9 +1629,9 @@ public class DataRegionTable extends DataRegion
 
     public class SelectorMenu extends BootstrapMenu
     {
-        private SelectorMenu(BootstrapMenu menu)
+        private SelectorMenu(WebElement menu)
         {
-            super(DataRegionTable.this.getDriver(), menu.getComponentElement());
+            super(DataRegionTable.this.getDriver(), menu);
         }
 
         private void clickSubMenu(String... subMenuLabels)

--- a/src/org/labkey/test/util/PortalHelper.java
+++ b/src/org/labkey/test/util/PortalHelper.java
@@ -83,9 +83,7 @@ public class PortalHelper extends WebDriverWrapper
     @LogMethod(quiet = true)
     private void clickTabMenuItem(@LoggedParam String tabText, boolean wait, @LoggedParam String... items)
     {
-        BootstrapMenu tabMenu = new BootstrapMenu(getDriver(),
-                BootstrapMenu.Locators.dropdownMenu()
-                        .withChild(Locator.linkWithText(tabText)).findElement(getDriver()));
+        BootstrapMenu tabMenu = PortalTab.find(tabText, getDriver()).getMenu();
         tabMenu.clickSubMenu(wait,  items);
     }
 


### PR DESCRIPTION
#### Rationale
`BootstrapMenu` is a bit more strict about its structure now. These instances were wrapping the wrong element.

#### Related Pull Requests
* #828 

#### Changes
* Update element for `DataRegionTable.SelectorMenu`
* Update element for `PortalHelper.clickTabMenuItem`
