### PR TITLE
Change label on assay data page from "Assay Id" to "Assay ID"

### DIFF
--- a/src/org/labkey/test/pages/assay/AssayRunsPage.java
+++ b/src/org/labkey/test/pages/assay/AssayRunsPage.java
@@ -56,8 +56,8 @@ public class AssayRunsPage extends LabKeyPage<AssayRunsPage.ElementCache>
 
     public AssayDataPage clickAssayIdLink(String assayId)
     {
-        int rowIndex = getTable().getRowIndex("Assay Id", assayId);
-        WebElement cell =  getTable().findCell(rowIndex, "Assay Id");
+        int rowIndex = getTable().getRowIndex("Assay ID", assayId);
+        WebElement cell =  getTable().findCell(rowIndex, "Assay ID");
         WebElement link = Locator.linkWithText(assayId).waitForElement(cell, WAIT_FOR_JAVASCRIPT);
         clickAndWait(link);
         return new AssayDataPage(getDriver());

--- a/src/org/labkey/test/tests/ModuleAssayTest.java
+++ b/src/org/labkey/test/tests/ModuleAssayTest.java
@@ -239,11 +239,11 @@ public class ModuleAssayTest extends AbstractAssayTest
         runsDt.goToView("AssayDesignRuns");
         runsDt.goToView("AssayDesignChildSchemaRuns");
         assertTextPresent("Created By", "Modified");
-        assertTextNotPresent("Assay Id", "MetaOverride Double Run", "Run Count", "run01.tsv", "run02.tsv");
+        assertTextNotPresent("Assay ID", "MetaOverride Double Run", "Run Count", "run01.tsv", "run02.tsv");
 
         // Verify file-based view associated with assay type shows up, with expected columns
         runsDt.goToView("AssayTypeRuns");
-        assertTextPresent("Assay Id", "Created By", "MetaOverride Double Run", "run01.tsv", "run02.tsv");
+        assertTextPresent("Assay ID", "Created By", "MetaOverride Double Run", "run01.tsv", "run02.tsv");
         assertTextNotPresent("Modified", "Run Count");
 
         runsDt.goToView("Default");
@@ -270,7 +270,7 @@ public class ModuleAssayTest extends AbstractAssayTest
 
         // Verify file-based view associated with assay type shows up, with expected columns
         dataTable.goToView(  "AssayTypeData");
-        assertTextPresent("Sample Id", "Monkey 1", "Monkey 2", "Time Point", "Double Data", "Assay Id", "run01.tsv");
+        assertTextPresent("Sample Id", "Monkey 1", "Monkey 2", "Time Point", "Double Data", "Assay ID", "run01.tsv");
         assertTextNotPresent("MetaOverride Double Run", "Run Count", "Target Study");
 
         dataTable.goToView(  "Default");

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -357,7 +357,7 @@ public class NabAssayTest extends AbstractAssayTest
         // Edit the first run
         doAndWaitForPageToLoad(() ->
         {
-            table.updateLink(table.getRowIndex("Assay Id", "ptid + visit + specimenid")).click();
+            table.updateLink(table.getRowIndex("Assay ID", "ptid + visit + specimenid")).click();
         });
 
         // Make sure that the properties that affect calculations aren't shown


### PR DESCRIPTION
#### Rationale
Changing label from Assay Id to Assay ID for consistency in our applications.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2556


