### PR TITLE
Make test helpers more reliable when using S3

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -412,7 +412,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             @Override
             protected void succeeded(Description description)
             {
-                getCurrentTest().checker().recordResults();
+                getCurrentTest().checker().reportResults();
                 if (!_anyTestFailed)
                     getCurrentTest().doPostamble();
                 else
@@ -717,7 +717,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             {
                 closeExtraWindows();
                 checker().wrapAssertion(() -> checkErrors());
-                checker().recordResults();
+                checker().reportResults();
             }
         };
 

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3519,34 +3519,6 @@ public abstract class WebDriverWrapper implements WrapsDriver
         setInput(dropZone, files);
     }
 
-    /**
-     * @deprecated Use {@link org.labkey.test.util.FileBrowserHelper#dragAndDropFileInDropZone(File)} or
-     * {@link org.labkey.test.util.FileBrowserHelper#dragDropUpload(File)}
-     */
-    @Deprecated
-    public void dragAndDropFileInDropZone(File fileName)
-    {
-        //Offsets for the drop zone
-        int offsetX = 0;
-        int offsetY = 0;
-
-        //Min version of the JS script - creates the dataTransfer object
-        String JS_DROP_FILES = "var c=arguments,b=c[0],k=c[1];c=c[2];for(var d=b.ownerDocument||document,l=0;;){var e=b.getBoundingClientRect(),g=e.left+(k||e.width/2),h=e.top+(c||e.height/2),f=d.elementFromPoint(g,h);if(f&&b.contains(f))break;if(1<++l)throw b=Error('Element not interactable'),b.code=15,b;}var a=d.createElement('INPUT');a.setAttribute('type','file');a.setAttribute('multiple','');a.setAttribute('style','position:fixed;z-index:2147483647;left:0;top:0;');a.onchange=function(b){a.parentElement.removeChild(a);b.stopPropagation();var c={constructor:DataTransfer,effectAllowed:'all',dropEffect:'none',types:['Files'],files:a.files,setData:function(){},getData:function(){},clearData:function(){},setDragImage:function(){}};window.DataTransferItemList&&(c.items=Object.setPrototypeOf(Array.prototype.map.call(a.files,function(a){return{constructor:DataTransferItem,kind:'file',type:a.type,getAsFile:function(){return a},getAsString:function(b){var c=new FileReader;c.onload=function(a){b(a.target.result)};c.readAsText(a)}}}),{constructor:DataTransferItemList,add:function(){},clear:function(){},remove:function(){}}));['dragenter','dragover','drop'].forEach(function(a){var b=d.createEvent('DragEvent');b.initMouseEvent(a,!0,!0,d.defaultView,0,0,0,g,h,!1,!1,!1,!1,0,null);Object.setPrototypeOf(b,null);b.dataTransfer=c;Object.setPrototypeOf(b,DragEvent.prototype);f.dispatchEvent(b)})};d.documentElement.appendChild(a);a.getBoundingClientRect();return a;";
-
-         //Execute the script to make the drop zone visible.
-        executeScript("LABKEY.internal.FileDrop.showDropzones()");
-
-        //Locator to the drop zone
-        WebElement element = Locator.tagWithClassContaining("div","dropzone").findElement(getDriver());
-        WebElement input = (WebElement)executeScript(JS_DROP_FILES,element,offsetX,offsetY);
-        log("Web element returned " + input);
-
-        //setting the input
-        input.sendKeys(fileName.getAbsolutePath());
-
-        executeScript("LABKEY.internal.FileDrop.hideDropzones()");
-    }
-
     public void setFormElement(Locator loc, File file)
     {
         WebElement el = loc.waitForElement(new WebDriverWait(getDriver(), 5));

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3519,6 +3519,34 @@ public abstract class WebDriverWrapper implements WrapsDriver
         setInput(dropZone, files);
     }
 
+    /**
+     * @deprecated Use {@link org.labkey.test.util.FileBrowserHelper#dragAndDropFileInDropZone(File)} or
+     * {@link org.labkey.test.util.FileBrowserHelper#dragDropUpload(File)}
+     */
+    @Deprecated
+    public void dragAndDropFileInDropZone(File fileName)
+    {
+        //Offsets for the drop zone
+        int offsetX = 0;
+        int offsetY = 0;
+
+        //Min version of the JS script - creates the dataTransfer object
+        String JS_DROP_FILES = "var c=arguments,b=c[0],k=c[1];c=c[2];for(var d=b.ownerDocument||document,l=0;;){var e=b.getBoundingClientRect(),g=e.left+(k||e.width/2),h=e.top+(c||e.height/2),f=d.elementFromPoint(g,h);if(f&&b.contains(f))break;if(1<++l)throw b=Error('Element not interactable'),b.code=15,b;}var a=d.createElement('INPUT');a.setAttribute('type','file');a.setAttribute('multiple','');a.setAttribute('style','position:fixed;z-index:2147483647;left:0;top:0;');a.onchange=function(b){a.parentElement.removeChild(a);b.stopPropagation();var c={constructor:DataTransfer,effectAllowed:'all',dropEffect:'none',types:['Files'],files:a.files,setData:function(){},getData:function(){},clearData:function(){},setDragImage:function(){}};window.DataTransferItemList&&(c.items=Object.setPrototypeOf(Array.prototype.map.call(a.files,function(a){return{constructor:DataTransferItem,kind:'file',type:a.type,getAsFile:function(){return a},getAsString:function(b){var c=new FileReader;c.onload=function(a){b(a.target.result)};c.readAsText(a)}}}),{constructor:DataTransferItemList,add:function(){},clear:function(){},remove:function(){}}));['dragenter','dragover','drop'].forEach(function(a){var b=d.createEvent('DragEvent');b.initMouseEvent(a,!0,!0,d.defaultView,0,0,0,g,h,!1,!1,!1,!1,0,null);Object.setPrototypeOf(b,null);b.dataTransfer=c;Object.setPrototypeOf(b,DragEvent.prototype);f.dispatchEvent(b)})};d.documentElement.appendChild(a);a.getBoundingClientRect();return a;";
+
+         //Execute the script to make the drop zone visible.
+        executeScript("LABKEY.internal.FileDrop.showDropzones()");
+
+        //Locator to the drop zone
+        WebElement element = Locator.tagWithClassContaining("div","dropzone").findElement(getDriver());
+        WebElement input = (WebElement)executeScript(JS_DROP_FILES,element,offsetX,offsetY);
+        log("Web element returned " + input);
+
+        //setting the input
+        input.sendKeys(fileName.getAbsolutePath());
+
+        executeScript("LABKEY.internal.FileDrop.hideDropzones()");
+    }
+
     public void setFormElement(Locator loc, File file)
     {
         WebElement el = loc.waitForElement(new WebDriverWait(getDriver(), 5));

--- a/src/org/labkey/test/pages/StartImportPage.java
+++ b/src/org/labkey/test/pages/StartImportPage.java
@@ -17,6 +17,7 @@ package org.labkey.test.pages;
 
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.components.ext4.Checkbox;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.util.FileBrowserHelper;
 import org.labkey.test.util.LogMethod;
@@ -102,10 +103,7 @@ public class StartImportPage extends LabKeyPage
 
     private void setInitialCheckBox(Locator checkBox, boolean check)
     {
-        if (check)
-            checkCheckbox(checkBox);
-        else
-            uncheckCheckbox(checkBox);
+        Checkbox.Checkbox(checkBox).timeout(10_000).waitFor(getDriver()).set(check);
     }
 
     public void clickStartImport()

--- a/src/org/labkey/test/pages/StartImportPage.java
+++ b/src/org/labkey/test/pages/StartImportPage.java
@@ -152,6 +152,12 @@ public class StartImportPage extends LabKeyPage<StartImportPage.ElementCache>
                 .forEach(cb -> cb.set(checked));
     }
 
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
     protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
         protected final Checkbox validateQueriesCheckbox = initialCheckbox("validateQueries");

--- a/src/org/labkey/test/pages/StartImportPage.java
+++ b/src/org/labkey/test/pages/StartImportPage.java
@@ -17,21 +17,22 @@ package org.labkey.test.pages;
 
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
-import org.labkey.test.components.ext4.Checkbox;
 import org.labkey.test.components.ext4.Window;
+import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.util.FileBrowserHelper;
+import org.labkey.test.util.LabKeyExpectedConditions;
 import org.labkey.test.util.LogMethod;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-public class StartImportPage extends LabKeyPage
+public class StartImportPage extends LabKeyPage<StartImportPage.ElementCache>
 {
     public StartImportPage(WebDriver test)
     {
@@ -40,25 +41,24 @@ public class StartImportPage extends LabKeyPage
 
     public static StartImportPage startImportFromFile(BaseWebDriverTest test, File zipFile, boolean validateQueries, boolean showAdvancedImportOptions)
     {
-        StartImportPage sip = new StartImportPage(test.getDriver());
-
         test.goToFolderManagement();
         test.clickAndWait(Locator.linkWithText("Import"));
         test.waitForElement(Locator.name("folderZip"));
         test.setFormElement(Locator.name("folderZip"), zipFile);
 
+        StartImportPage sip = new StartImportPage(test.getDriver());
         sip.setValidateQueriesCheckBox(validateQueries);
         sip.setAdvancedImportOptionsCheckBox(showAdvancedImportOptions);
 
         test.clickButtonContainingText("Import Folder");
         test.waitForText("Select specific objects to import");
 
+        sip.clearCache();
         return sip;
     }
 
     public static StartImportPage startImportFromPipeline(BaseWebDriverTest test, File zipFile, boolean validateQueries, boolean selectSpecificImportOptions)
     {
-        StartImportPage sip = new StartImportPage(test.getDriver());
         FileBrowserHelper fileBrowserHelper = new FileBrowserHelper(test);
 
         test.goToFolderManagement();
@@ -70,6 +70,7 @@ public class StartImportPage extends LabKeyPage
         fileBrowserHelper.importFile(zipFile.getName(), "Import Folder");
         test.waitForText("Import Folder from Pipeline");
 
+        StartImportPage sip = new StartImportPage(test.getDriver());
         sip.setValidateQueriesCheckBox(validateQueries);
         sip.setSelectSpecificImportOptions(selectSpecificImportOptions);
 
@@ -78,32 +79,34 @@ public class StartImportPage extends LabKeyPage
 
     public void setValidateQueriesCheckBox(boolean check)
     {
-        setInitialCheckBox(Locator.css("input[name='validateQueries']"), check);
-    }
-
-    public void setAdvancedImportOptionsCheckBox(boolean check)
-    {
-        setInitialCheckBox(Locator.css("input[name='advancedImportOptions']"), check);
-    }
-
-    public void setSelectSpecificImportOptions(boolean check)
-    {
-        setInitialCheckBox(Locator.css("input[name='specificImportOptions']"), check);
-    }
-
-    public void setApplyToMultipleFoldersCheckBox(boolean check)
-    {
-        setInitialCheckBox(Locator.css("input[name='applyToMultipleFolders']"), check);
+        elementCache().validateQueriesCheckbox.set(check);
     }
 
     public void setFailForUndefinedVisitsCheckBox(boolean check)
     {
-        setInitialCheckBox(Locator.css("input[name='failForUndefinedVisits']"), check);
+        elementCache().failForUndefinedVisitsCheckbox.set(check);
     }
 
-    private void setInitialCheckBox(Locator checkBox, boolean check)
+    public void setAdvancedImportOptionsCheckBox(boolean check)
     {
-        Checkbox.Checkbox(checkBox).timeout(10_000).waitFor(getDriver()).set(check);
+        elementCache().advancedImportOptionsCheckbox.set(check);
+    }
+
+    public void setSelectSpecificImportOptions(boolean check)
+    {
+        elementCache().specificImportOptionsCheckbox.set(check);
+        shortWait().until(LabKeyExpectedConditions.visibilityOf(elementCache().advancedOptionsPanel, check));
+    }
+
+    public void setApplyToMultipleFoldersCheckBox(boolean check)
+    {
+        elementCache().applyToMultipleFoldersCheckbox.set(check);
+        shortWait().until(LabKeyExpectedConditions.visibilityOf(elementCache().applyMultiplePanel, check));
+    }
+
+    public boolean isMultipleFolderImportAvailable()
+    {
+        return elementCache().applyToMultipleFoldersCheckbox.isDisplayed();
     }
 
     public void clickStartImport()
@@ -133,42 +136,48 @@ public class StartImportPage extends LabKeyPage
     }
 
     @LogMethod()
-    public void setAdvancedOptionCheckBoxes(Map<AdvancedOptionsCheckBoxes, Boolean> checkBoxes)
+    public void setAdvancedOptionCheckBoxes(Map<AdvancedOptionsCheckBoxes, Boolean> options)
     {
-        for(Map.Entry<AdvancedOptionsCheckBoxes, Boolean> checkBox : checkBoxes.entrySet())
+        for(Map.Entry<AdvancedOptionsCheckBoxes, Boolean> entry : options.entrySet())
         {
-            log("Setting value for checkbox: " + checkBox.getKey().toString());
-            if(checkBox.getValue())
-                checkCheckbox(getCheckBoxLocatorCss(checkBox.getKey()));
-            else
-                uncheckCheckbox(getCheckBoxLocatorCss(checkBox.getKey()));
+            log("Setting value for checkbox: " + entry.toString());
+            elementCache().dataTypesCheckbox(entry.getKey()).set(entry.getValue());
         }
     }
 
     public void setAllAdvancedOptionCheckBoxes(boolean checked)
     {
-        List<WebElement> chkBoxes = Locator.css("div.advanced-options-panel div.x4-column-layout-ct div.x4-panel-body input").findElements(getDriver());
-        chkBoxes
-                .stream()
-                .forEach(chkBox -> {
-                    if (!chkBox.getAttribute("value").toLowerCase().equals("study"))
-                    {
-                        if (checked)
-                            checkCheckbox(chkBox);
-                        else
-                            uncheckCheckbox(chkBox);
-                    }
-                });
+        Checkbox.Checkbox(Locator.checkbox())
+                .findAll(elementCache().advancedOptionsPanel)
+                .forEach(cb -> cb.set(checked));
     }
 
-    public Locator getCheckBoxLocatorCss(AdvancedOptionsCheckBoxes chkBox)
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
-        return Locator.css("input[value='" + chkBox.getValue() + "']");
-    }
+        protected final Checkbox validateQueriesCheckbox = initialCheckbox("validateQueries");
+        protected final Checkbox advancedImportOptionsCheckbox = initialCheckbox("advancedImportOptions");
+        protected final Checkbox specificImportOptionsCheckbox = initialCheckbox("specificImportOptions");
+        protected final Checkbox applyToMultipleFoldersCheckbox = initialCheckbox("applyToMultipleFolders");
+        protected final Checkbox failForUndefinedVisitsCheckbox = initialCheckbox("failForUndefinedVisits");
 
-    public Locator getCheckBoxLocatorXpath(AdvancedOptionsCheckBoxes chkBox)
-    {
-        return Locator.xpath("input[value='" + chkBox.getValue() + "']");
+        protected final WebElement advancedOptionsPanel = Locator.byClass("advanced-options-panel").findWhenNeeded(this);
+        protected final WebElement applyMultiplePanel = Locator.byClass("apply-multiple-panel").findWhenNeeded(this);
+
+        public ElementCache()
+        {
+            shortWait().until(ExpectedConditions.visibilityOf(validateQueriesCheckbox.getComponentElement()));
+        }
+
+        public Checkbox initialCheckbox(String name)
+        {
+            return Checkbox.Checkbox(Locator.input(name)).findWhenNeeded(this);
+        }
+
+        public Checkbox dataTypesCheckbox(AdvancedOptionsCheckBoxes value)
+        {
+            return Checkbox.Checkbox(Locator.tagWithAttribute("input", "value", value.getValue()))
+                    .findWhenNeeded(advancedOptionsPanel);
+        }
     }
 
     public enum AdvancedOptionsCheckBoxes
@@ -213,6 +222,12 @@ public class StartImportPage extends LabKeyPage
         }
 
         public String getValue()
+        {
+            return value;
+        }
+
+        @Override
+        public String toString()
         {
             return value;
         }

--- a/src/org/labkey/test/pages/StartImportPage.java
+++ b/src/org/labkey/test/pages/StartImportPage.java
@@ -39,7 +39,7 @@ public class StartImportPage extends LabKeyPage<StartImportPage.ElementCache>
         super(test);
     }
 
-    public static StartImportPage startImportFromFile(BaseWebDriverTest test, File zipFile, boolean validateQueries, boolean showAdvancedImportOptions)
+    public static StartImportPage startImportFromFile(BaseWebDriverTest test, File zipFile, boolean validateQueries)
     {
         test.goToFolderManagement();
         test.clickAndWait(Locator.linkWithText("Import"));
@@ -48,7 +48,7 @@ public class StartImportPage extends LabKeyPage<StartImportPage.ElementCache>
 
         StartImportPage sip = new StartImportPage(test.getDriver());
         sip.setValidateQueriesCheckBox(validateQueries);
-        sip.setAdvancedImportOptionsCheckBox(showAdvancedImportOptions);
+        sip.setAdvancedImportOptionsCheckBox(true);
 
         test.clickButtonContainingText("Import Folder");
         test.waitForText("Select specific objects to import");

--- a/src/org/labkey/test/tests/AdvancedImportOptionsTest.java
+++ b/src/org/labkey/test/tests/AdvancedImportOptionsTest.java
@@ -57,7 +57,7 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
     private static final String IMPORT_PROJECT_FILE02 = "Advanced Import By File With Filters";
     private static final String IMPORT_PROJECT_FILE03 = "Advanced Import By Pipeline With Filters";
 
-    private static final String IMPORT_PROJECT_MULTI = "Advanced Import to Multiple Folders";
+    protected static final String IMPORT_PROJECT_MULTI = "Advanced Import to Multiple Folders";
     private static final String IMPORT_FOLDER_MULTI01 = "Advance Import Folder 01";
     private static final String IMPORT_FOLDER_MULTI02 = "Advance Import Folder 02";
     private static final String IMPORT_FOLDER_MULTI03 = "Advance Import Folder 03";
@@ -109,7 +109,7 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
         _containerHelper.createProject(IMPORT_PROJECT_FILE01, "Study");
 
         log("Get to the import page and validate that is looks as expected.");
-        StartImportPage importPage = StartImportPage.startImportFromFile(this, zipFile, true, true);
+        StartImportPage importPage = StartImportPage.startImportFromFile(this, zipFile, true);
         importPage.setSelectSpecificImportOptions(true);
         assertTrue("The 'Select specific objects to import' is not visible, and it should be in this case.", importPage.isSelectSpecificImportOptionsVisible());
 
@@ -162,10 +162,10 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
         File zipFile = IMPORT_STUDY_FILE;
 
         log("Create a new project to import the existing data.");
-        _containerHelper.createProject(IMPORT_PROJECT_FILE02, "Study");
+        _containerHelper.createProject(IMPORT_PROJECT_FILE02);
 
         log("Get to the import page and validate that is looks as expected.");
-        StartImportPage importPage = StartImportPage.startImportFromFile(this, zipFile, true, true);
+        StartImportPage importPage = StartImportPage.startImportFromFile(this, zipFile, true);
         importPage.setSelectSpecificImportOptions(true);
         assertTrue("The 'Select specific objects to import' is not visible, and it should be in this case.", importPage.isSelectSpecificImportOptionsVisible());
 
@@ -228,7 +228,7 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
         File zipFile = IMPORT_STUDY_FILE;
 
         log("Create a new project to import the existing data.");
-        _containerHelper.createProject(IMPORT_PROJECT_FILE03, "Study");
+        _containerHelper.createProject(IMPORT_PROJECT_FILE03);
 
         log("Get to the import page and validate that is looks as expected.");
         StartImportPage importPage = StartImportPage.startImportFromPipeline(this, zipFile, true, true);
@@ -297,7 +297,7 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
         _userHelper.createUser(LIMITED_USER);
 
         log("Create a new project to import the existing data into multiple folders.");
-        _containerHelper.createProject(IMPORT_PROJECT_MULTI, "Study");
+        _containerHelper.createProject(IMPORT_PROJECT_MULTI);
         _containerHelper.enableModule(IMPORT_PROJECT_MULTI, "Specimen");
 
         log("Create subfolders and setup permissions.");
@@ -319,7 +319,7 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
         impersonate(LIMITED_USER);
         clickFolder(IMPORT_FOLDER_MULTI01);
         log("Get to the import page and validate that is looks as expected.");
-        StartImportPage importPage = StartImportPage.startImportFromFile(this, zipFile, false, true);
+        StartImportPage importPage = StartImportPage.startImportFromFile(this, zipFile, false);
         importPage.setSelectSpecificImportOptions(true);
         importPage.setApplyToMultipleFoldersCheckBox(true);
 

--- a/src/org/labkey/test/tests/AdvancedImportOptionsTest.java
+++ b/src/org/labkey/test/tests/AdvancedImportOptionsTest.java
@@ -57,6 +57,7 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
     private static final String IMPORT_PROJECT_FILE02 = "Advanced Import By File With Filters";
     private static final String IMPORT_PROJECT_FILE03 = "Advanced Import By Pipeline With Filters";
 
+    private static final String IMPORT_PROJECT_MULTI = "Advanced Import to Multiple Folders";
     private static final String IMPORT_FOLDER_MULTI01 = "Advance Import Folder 01";
     private static final String IMPORT_FOLDER_MULTI02 = "Advance Import Folder 02";
     private static final String IMPORT_FOLDER_MULTI03 = "Advance Import Folder 03";
@@ -92,6 +93,7 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
         _containerHelper.deleteProject(IMPORT_PROJECT_FILE01, false);
         _containerHelper.deleteProject(IMPORT_PROJECT_FILE02, false);
         _containerHelper.deleteProject(IMPORT_PROJECT_FILE03, false);
+        _containerHelper.deleteProject(IMPORT_PROJECT_MULTI, false);
 
         _userHelper.deleteUser(LIMITED_USER);
     }
@@ -104,7 +106,6 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
         File zipFile = IMPORT_STUDY_FILE;
 
         log("Create a new project to import the existing data.");
-        _containerHelper.deleteProject(IMPORT_PROJECT_FILE01, false);
         _containerHelper.createProject(IMPORT_PROJECT_FILE01, "Study");
 
         log("Get to the import page and validate that is looks as expected.");
@@ -219,8 +220,6 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
         assertTextPresent("WikiPage01", "This folder does not currently contain any wiki pages to display.");
         assertElementNotPresent(Locator.xpath("//div[@class='labkey-wiki']//p[text() = 'This is a very basic wiki page.']"));
 
-        log("Cleanup and remove the project.");
-        _containerHelper.deleteProject(IMPORT_PROJECT_FILE02);
     }
 
     @Test
@@ -286,8 +285,6 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
         assertTextPresent("WikiPage01", "This folder does not currently contain any wiki pages to display.");
         assertElementNotPresent(Locator.xpath("//div[@class='labkey-wiki']//p[text() = 'This is a very basic wiki page.']"));
 
-        log("Cleanup and remove the project.");
-        _containerHelper.deleteProject(IMPORT_PROJECT_FILE03);
     }
 
     @Test
@@ -300,14 +297,13 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
         _userHelper.createUser(LIMITED_USER);
 
         log("Create a new project to import the existing data into multiple folders.");
-        _containerHelper.deleteProject(IMPORT_PROJECT_FILE01, false);
-        _containerHelper.createProject(IMPORT_PROJECT_FILE01, "Study");
-        _containerHelper.enableModule(IMPORT_PROJECT_FILE01, "Specimen");
+        _containerHelper.createProject(IMPORT_PROJECT_MULTI, "Study");
+        _containerHelper.enableModule(IMPORT_PROJECT_MULTI, "Specimen");
 
         log("Create subfolders and setup permissions.");
-        _containerHelper.createSubfolder(IMPORT_PROJECT_FILE01, IMPORT_FOLDER_MULTI01);
-        _containerHelper.createSubfolder(IMPORT_PROJECT_FILE01, IMPORT_FOLDER_MULTI02);
-        _containerHelper.createSubfolder(IMPORT_PROJECT_FILE01, IMPORT_FOLDER_MULTI03);
+        _containerHelper.createSubfolder(IMPORT_PROJECT_MULTI, IMPORT_FOLDER_MULTI01);
+        _containerHelper.createSubfolder(IMPORT_PROJECT_MULTI, IMPORT_FOLDER_MULTI02);
+        _containerHelper.createSubfolder(IMPORT_PROJECT_MULTI, IMPORT_FOLDER_MULTI03);
 
         ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
 
@@ -331,7 +327,7 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
 
         log("Verify user can import only into folders they have admin access to");
         waitForElement(Locator.tagWithClass("span", "x4-tree-node-text").withText(IMPORT_FOLDER_MULTI01).notHidden(), 5000);
-        assertElementNotPresent(Locator.tagWithClass("span", "x4-tree-node-text").withText(IMPORT_PROJECT_FILE01));
+        assertElementNotPresent(Locator.tagWithClass("span", "x4-tree-node-text").withText(IMPORT_PROJECT_MULTI));
         assertElementNotPresent(Locator.tagWithClass("span", "x4-tree-node-text").withText(IMPORT_FOLDER_MULTI02));
 
         Locator.tagWithClass("span", "x4-tree-node-text").withText(IMPORT_FOLDER_MULTI01).waitForElement(new WebDriverWait(getDriver(), 5)).click();

--- a/src/org/labkey/test/tests/AdvancedImportOptionsTest.java
+++ b/src/org/labkey/test/tests/AdvancedImportOptionsTest.java
@@ -52,7 +52,7 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
 {
     private static final String LIMITED_USER = "limited@advancedimport.test";
 
-    private static final File IMPORT_STUDY_FILE = TestFileUtils.getSampleData("AdvancedImportOptions/AdvancedImportStudyProject01.folder.zip");
+    protected static final File IMPORT_STUDY_FILE = TestFileUtils.getSampleData("AdvancedImportOptions/AdvancedImportStudyProject01.folder.zip");
     private static final String IMPORT_PROJECT_FILE01 = "Advanced Import By File";
     private static final String IMPORT_PROJECT_FILE02 = "Advanced Import By File With Filters";
     private static final String IMPORT_PROJECT_FILE03 = "Advanced Import By Pipeline With Filters";
@@ -76,7 +76,7 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
     @Override
     protected String getProjectName()
     {
-        return "AdvancedImportOptions";
+        return null;
     }
 
     @Override
@@ -344,10 +344,11 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
         log("Import into multiple folders from the same template");
         importPage = StartImportPage.startImportFromPipeline(this, zipFile, true, true);
         importPage.setSelectSpecificImportOptions(true);
-        importPage.setAdvancedOptionCheckBoxes(StartImportPage.AdvancedOptionsCheckBoxes.DatasetData, false);
-        importPage.setAdvancedOptionCheckBoxes(StartImportPage.AdvancedOptionsCheckBoxes.DatasetDefinitions, false);
-        importPage.setAdvancedOptionCheckBoxes(StartImportPage.AdvancedOptionsCheckBoxes.Specimens, false);
-        importPage.setAdvancedOptionCheckBoxes(StartImportPage.AdvancedOptionsCheckBoxes.SpecimenSettings, false);
+        importPage.setAdvancedOptionCheckBoxes(Map.of(
+                StartImportPage.AdvancedOptionsCheckBoxes.DatasetData, false,
+                StartImportPage.AdvancedOptionsCheckBoxes.DatasetDefinitions, false,
+                StartImportPage.AdvancedOptionsCheckBoxes.Specimens, false,
+                StartImportPage.AdvancedOptionsCheckBoxes.SpecimenSettings, false));
         importPage.setApplyToMultipleFoldersCheckBox(true);
 
         assertTrue("The 'Select specific objects to import' is not visible, and it should be in this case.", importPage.isSelectSpecificImportOptionsVisible());

--- a/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
@@ -58,8 +58,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.labkey.test.components.ext4.Window.Window;
 import static org.labkey.test.util.FileBrowserHelper.BrowserAction;
 
@@ -261,6 +261,7 @@ public class FileContentUploadTest extends BaseWebDriverTest
     @Test
     public void testFolderNameCharacters()
     {
+        goToProjectHome();
         goToModule("FileContent");
         List<String> stringsToCheck = folderSubstringsToVerify();
         Set<String> expectedFolders = new HashSet<>();

--- a/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
@@ -218,7 +218,6 @@ public class FileContentUploadTest extends BaseWebDriverTest
     {
         log("Check Absolute File Path in File Browser");
 
-        final String ABSOLUTE_FILE_PATH_BUTTON_ID = "10";
         final String s = File.separator;
 
         new ApiPermissionsHelper(this)
@@ -231,7 +230,7 @@ public class FileContentUploadTest extends BaseWebDriverTest
 
         _fileBrowserHelper.goToAdminMenu();
         _fileBrowserHelper.goToConfigureButtonsTab();
-        _fileBrowserHelper.unhideGridColumn(ABSOLUTE_FILE_PATH_BUTTON_ID);
+        _fileBrowserHelper.unhideGridColumn(FileBrowserHelper.ABSOLUTE_FILE_PATH_COLUMN_ID);
         click(Ext4Helper.Locators.ext4Button("submit"));
         WebElement columnHeader = waitForElement(Locator.byClass("x4-column-header").withText("Absolute File Path").notHidden());
 

--- a/src/org/labkey/test/util/DeferredErrorCollector.java
+++ b/src/org/labkey/test/util/DeferredErrorCollector.java
@@ -2,6 +2,7 @@ package org.labkey.test.util;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Matcher;
+import org.hamcrest.MatcherAssert;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.labkey.test.BaseWebDriverTest;
@@ -24,6 +25,14 @@ public class DeferredErrorCollector
     private final List<Class<? extends Throwable>> errorTypes = new ArrayList<>();
 
     private FatalErrorCollector _fatalErrorCollector;
+
+    /**
+     * For wrapper classes. Avoids resetting error types in wrapped collector.
+     */
+    protected DeferredErrorCollector()
+    {
+        artifactCollector = null;
+    }
 
     /**
      * @param artifactCollector An {@link ArtifactCollector} to be used for screenshots
@@ -73,7 +82,7 @@ public class DeferredErrorCollector
     {
         if (_fatalErrorCollector == null)
         {
-            _fatalErrorCollector = new FatalErrorCollector();
+            _fatalErrorCollector = new FatalErrorCollector(this);
         }
         return _fatalErrorCollector;
     }
@@ -86,7 +95,17 @@ public class DeferredErrorCollector
      */
     public DeferredErrorCollector withScreenshot(@NotNull String screenshotName)
     {
-        return new DeferredErrorCollectorWithScreenshot(screenshotName);
+        return new DeferredErrorCollectorWithScreenshot(this, screenshotName);
+    }
+
+    /**
+     * Create temporary error collector that takes a screenshot for any recorded errors.
+     *
+     * @return Wrapped error collector. Intended to be used only once.
+     */
+    public final DeferredErrorCollector withScreenshot()
+    {
+        return withScreenshot("recordedError");
     }
 
     /**
@@ -134,7 +153,7 @@ public class DeferredErrorCollector
      * @param screenshotName A string to identify screenshots; Will be included in screenshot filenames.
      * @see #takeScreenShot(String)
      */
-    public void screenShotIfNewError(String screenshotName)
+    public void screenShotIfNewError(@NotNull String screenshotName)
     {
         if (errorsSinceMark() > 0)
             takeScreenShot(screenshotName);
@@ -150,25 +169,25 @@ public class DeferredErrorCollector
      * @return <code>true</code> if <code>wrappedAssertion</code> does not throw, <code>false</code> if an error was recorded,
      * otherwise rethrow exception thrown by <code>wrappedAssertion</code>
      */
-    public boolean wrapAssertion(Runnable wrappedAssertion)
+    public final boolean wrapAssertion(Runnable wrappedAssertion)
     {
         try
         {
             wrappedAssertion.run();
             return true;
         }
-        catch (Exception | AssertionError err)
+        catch (Throwable err)
         {
-            if (isErrorRecordable(err))
+            if (isErrorDeferrable(err))
             {
-                recordError(err.getMessage());
+                recordError(err);
                 return false;
             }
             throw err; // Not a recordable error
         }
     }
 
-    protected boolean isErrorRecordable(Throwable err)
+    protected boolean isErrorDeferrable(Throwable err)
     {
         for (Class<? extends Throwable> errorType : errorTypes)
         {
@@ -267,12 +286,12 @@ public class DeferredErrorCollector
      * @param actual the computed value being compared
      * @param matcher an expression, built of {@link Matcher}s, specifying allowed
      * values
-     * @see Assert#assertThat(String, Object, Matcher)
+     * @see MatcherAssert#assertThat(String, Object, Matcher)
      * @return <code>true</code> if the object satisfies the specified condition
      */
     public final <T> boolean verifyThat(String reason, T actual, Matcher<? super T> matcher)
     {
-        return wrapAssertion(() -> Assert.assertThat(reason, actual, matcher));
+        return wrapAssertion(() -> MatcherAssert.assertThat(reason, actual, matcher));
     }
 
     /**
@@ -288,37 +307,39 @@ public class DeferredErrorCollector
     }
 
     /**
-     * Log an error message, take a screen shot and record the call stack.
+     * Record an arbitrary Throwable.
      *
-     * @param errorMessage Message to log.
+     * @param error Throwable to record.
      */
-    protected void recordError(String errorMessage)
+    public final void recordError(Throwable error)
     {
-        StringBuilder messageForLog = new StringBuilder();
+        recordError(error.getMessage(), error);
+    }
+
+    /**
+     * Record an error, take a screen shot if requested, and records the call stack.
+     * Allows subclasses to customize the error message.
+     *
+     * @param errorMessage Message for error
+     * @param error Throwable to record
+     */
+    protected void recordError(String errorMessage, Throwable error)
+    {
         StringBuilder messageForFailure = new StringBuilder();
 
-        StackTraceElement[] cause = Thread.currentThread().getStackTrace();
-
-        messageForLog.append("\n*******************************\n");
-        messageForLog.append("\n");
-        messageForLog.append(errorMessage);
-        messageForLog.append("\n");
+        StackTraceElement[] cause = error.getStackTrace();
 
         // Don't repeat everything in the list of all error messages, only some parts of this detailed error.
         messageForFailure.append(errorMessage);
 
-        StringBuilder deepCallStack = new StringBuilder(); // Keep deep stack for possible DEBUG logging in the future
         StringBuilder shallowCallStack = new StringBuilder();
         int shallowStackDepth = 0;
 
-        deepCallStack.append("\n");
         shallowCallStack.append("\n");
 
+        // Filter out library methods from stack trace
         for(StackTraceElement ste : cause)
         {
-            deepCallStack.append(ste);
-            deepCallStack.append("\n");
-
             if(ste.getClassName().toLowerCase().contains("org.labkey.test") && 
                     !ste.getClassName().startsWith(this.getClass().getName()) &&
                     shallowStackDepth < 6)
@@ -331,23 +352,31 @@ public class DeferredErrorCollector
         }
         
         // Record the call stack.
-        messageForLog.append(shallowCallStack);
         messageForFailure.append(shallowCallStack);
-        
-        messageForLog.append("\n*******************************\n");
-        
+
         allErrorMessages.add(messageForFailure.toString());
 
-        TestLogger.log(messageForLog.toString());
+        TestLogger.error("\n*******************************\n" + errorMessage + "\n*******************************\n", error);
+    }
+
+    /**
+     * Use {@link #reportResults()}
+     */
+    @Deprecated (since = "21.9")
+    public void recordResults()
+    {
+        reportResults();
     }
 
     /**
      * Throws an {@link AssertionError} if any errors have been recorded. Should be called when done performing checks.
      */
-    public void recordResults()
+    public void reportResults()
     {
         if(hasErrorBeenRecorded())
+        {
             Assert.fail(getFailureMessage());
+        }
     }
 
     /**
@@ -391,7 +420,7 @@ public class DeferredErrorCollector
      * @param screenshotName A string to identify screenshots; Will be included in screenshot filenames.
      * @return The name of the file used. Basically the screenshotName parameter with a counter added to the end.
      */
-    public String takeScreenShot(String screenshotName)
+    public String takeScreenShot(@NotNull String screenshotName)
     {
         String snapShotNumberedName = screenshotName + "_" + screenShotCount++;
 
@@ -399,128 +428,135 @@ public class DeferredErrorCollector
 
         return snapShotNumberedName;
     }
+}
 
-    private abstract class DeferredErrorCollectorWrapper extends DeferredErrorCollector
+/**
+ * Wraps an existing error collector. Any errors will be recorded within the wrapped collector.
+ */
+abstract class DeferredErrorCollectorWrapper extends DeferredErrorCollector
+{
+    private final DeferredErrorCollector wrappedCollector;
+
+    protected DeferredErrorCollectorWrapper(DeferredErrorCollector collector)
     {
-        protected DeferredErrorCollectorWrapper()
-        {
-            super((ArtifactCollector) null);
-        }
-
-        protected DeferredErrorCollector getWrappedErrorColloctor()
-        {
-            return DeferredErrorCollector.this;
-        }
-
-        @Override
-        public final DeferredErrorCollector fatal()
-        {
-            return getWrappedErrorColloctor().fatal();
-        }
-
-        @Override
-        public DeferredErrorCollector withScreenshot(@NotNull String screenshotName)
-        {
-            return new DeferredErrorCollectorWithScreenshot(screenshotName);
-        }
-
-        @Override
-        public boolean hasErrorBeenRecorded()
-        {
-            return getWrappedErrorColloctor().hasErrorBeenRecorded();
-        }
-
-        @Override
-        public int getErrorCount()
-        {
-            return getWrappedErrorColloctor().getErrorCount();
-        }
-
-        @Override
-        public String takeScreenShot(String screenshotName)
-        {
-            return getWrappedErrorColloctor().takeScreenShot(screenshotName);
-        }
-
-        @Override
-        public void resetErrorTypes()
-        {
-            getWrappedErrorColloctor().resetErrorTypes();
-        }
-
-        @Override
-        public void addRecordableErrorType(Class<? extends Exception> errorType)
-        {
-            getWrappedErrorColloctor().addRecordableErrorType(errorType);
-        }
-
-        @Override
-        public void setErrorMark()
-        {
-            getWrappedErrorColloctor().setErrorMark();
-        }
-
-        @Override
-        public int errorsSinceMark()
-        {
-            return getWrappedErrorColloctor().errorsSinceMark();
-        }
-
-        @Override
-        public void screenShotIfNewError(String screenshotName)
-        {
-            getWrappedErrorColloctor().screenShotIfNewError(screenshotName);
-        }
-
-        @Override
-        protected boolean isErrorRecordable(Throwable err)
-        {
-            return getWrappedErrorColloctor().isErrorRecordable(err);
-        }
-
-        @Override
-        protected void recordError(String errorMessage)
-        {
-            getWrappedErrorColloctor().recordError(errorMessage);
-        }
-
-        @Override
-        public void recordResults()
-        {
-            getWrappedErrorColloctor().recordResults();
-        }
+        super();
+        wrappedCollector = collector;
     }
 
-    private class FatalErrorCollector extends DeferredErrorCollectorWrapper
+    @Override
+    public final DeferredErrorCollector fatal()
     {
-        protected FatalErrorCollector()
-        {
-            super();
-        }
-
-        @Override
-        public boolean wrapAssertion(Runnable wrappedAssertion)
-        {
-            wrappedAssertion.run();
-            return true;
-        }
+        return wrappedCollector.fatal();
     }
 
-    private class DeferredErrorCollectorWithScreenshot extends DeferredErrorCollectorWrapper
+    @Override
+    public DeferredErrorCollector withScreenshot(@NotNull String screenshotName)
     {
-        private final String _screenshotName;
+        return wrappedCollector.withScreenshot(screenshotName);
+    }
 
-        protected DeferredErrorCollectorWithScreenshot(String screenshotName)
-        {
-            _screenshotName = screenshotName;
-        }
+    @Override
+    public boolean hasErrorBeenRecorded()
+    {
+        return wrappedCollector.hasErrorBeenRecorded();
+    }
 
-        @Override
-        protected void recordError(String errorMessage)
-        {
-            String shotName = super.takeScreenShot(_screenshotName);
-            errorMessage = errorMessage + "\nScreen shot name: " + shotName + "\n";
-            super.recordError(errorMessage);
-        }
+    @Override
+    public int getErrorCount()
+    {
+        return wrappedCollector.getErrorCount();
+    }
+
+    @Override
+    public String takeScreenShot(@NotNull String screenshotName)
+    {
+        return wrappedCollector.takeScreenShot(screenshotName);
+    }
+
+    @Override
+    public void resetErrorTypes()
+    {
+        wrappedCollector.resetErrorTypes();
+    }
+
+    @Override
+    public void addRecordableErrorType(Class<? extends Exception> errorType)
+    {
+        wrappedCollector.addRecordableErrorType(errorType);
+    }
+
+    @Override
+    public void setErrorMark()
+    {
+        wrappedCollector.setErrorMark();
+    }
+
+    @Override
+    public int errorsSinceMark()
+    {
+        return wrappedCollector.errorsSinceMark();
+    }
+
+    @Override
+    public void screenShotIfNewError(@NotNull String screenshotName)
+    {
+        wrappedCollector.screenShotIfNewError(screenshotName);
+    }
+
+    @Override
+    protected boolean isErrorDeferrable(Throwable err)
+    {
+        return wrappedCollector.isErrorDeferrable(err);
+    }
+
+    @Override
+    protected void recordError(String errorMessage, Throwable cause)
+    {
+        wrappedCollector.recordError(errorMessage, cause);
+    }
+
+    @Override
+    public void reportResults()
+    {
+        wrappedCollector.reportResults();
+    }
+}
+
+/**
+ * Will never defer any errors.
+ */
+class FatalErrorCollector extends DeferredErrorCollectorWrapper
+{
+    protected FatalErrorCollector(DeferredErrorCollector collector)
+    {
+        super(collector);
+    }
+
+    @Override
+    protected boolean isErrorDeferrable(Throwable err)
+    {
+        return false;
+    }
+}
+
+/**
+ * Wraps an error collector and takes a screenshot if any errors are recorded.
+ */
+class DeferredErrorCollectorWithScreenshot extends DeferredErrorCollectorWrapper
+{
+    private final String _screenshotName;
+
+    protected DeferredErrorCollectorWithScreenshot(DeferredErrorCollector collector, String screenshotName)
+    {
+        super(collector);
+        _screenshotName = screenshotName;
+    }
+
+    @Override
+    protected void recordError(String errorMessage, Throwable error)
+    {
+        String shotName = super.takeScreenShot(_screenshotName);
+        errorMessage = errorMessage + "\nScreen shot name: " + shotName + "\n";
+        super.recordError(errorMessage, error);
     }
 }

--- a/src/org/labkey/test/util/DeferredErrorCollector.java
+++ b/src/org/labkey/test/util/DeferredErrorCollector.java
@@ -172,7 +172,7 @@ public class DeferredErrorCollector
     {
         for (Class<? extends Throwable> errorType : errorTypes)
         {
-            if (errorType.isInstance(err))
+            if (errorType.isAssignableFrom(err.getClass()))
             {
                 return true;
             }

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -200,6 +200,7 @@ public class FileBrowserHelper extends WebDriverWrapper
 
     private String doAndWaitForFileListRefresh(Runnable func, WebDriverWait wait)
     {
+        waitForFileGridReady();
         Mutable<String> signal = new MutableObject<>();
         doAndWaitForElementToRefresh(() -> signal.setValue(doAndWaitForPageSignal(func, FILE_LIST_SIGNAL_NAME, wait)), this::waitForGrid, wait);
         return signal.getValue();
@@ -539,12 +540,10 @@ public class FileBrowserHelper extends WebDriverWrapper
     }
 
     /**
-     *
      * @param file
      */
-    @Override
     @LogMethod
-    public void dragAndDropFileInDropZone(@LoggedParam File file)
+    protected void dragAndDropFileInDropZone(@LoggedParam File file)
     {
         waitForFileGridReady();
 
@@ -576,7 +575,6 @@ public class FileBrowserHelper extends WebDriverWrapper
     {
         doAndWaitForFileListRefresh(() -> dragAndDropFileInDropZone(file));
         waitForElement(fileGridCell.withText(expectedFileName));
-        waitForGrid();
     }
 
     public void importFile(String filePath, String importAction)
@@ -719,6 +717,7 @@ public class FileBrowserHelper extends WebDriverWrapper
      */
     public int waitForFileGridReady()
     {
+        waitForElement(org.labkey.test.Locators.pageSignal(IMPORT_SIGNAL_NAME));
         String signalValue = waitForElement(org.labkey.test.Locators.pageSignal(FILE_LIST_SIGNAL_NAME)).getAttribute("value");
         waitForGrid();
         return Integer.parseInt(signalValue);

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -540,10 +540,12 @@ public class FileBrowserHelper extends WebDriverWrapper
     }
 
     /**
+     *
      * @param file
      */
+    @Override
     @LogMethod
-    protected void dragAndDropFileInDropZone(@LoggedParam File file)
+    public void dragAndDropFileInDropZone(@LoggedParam File file)
     {
         waitForFileGridReady();
 

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -53,7 +53,9 @@ public class FileBrowserHelper extends WebDriverWrapper
 {
     private static final String IMPORT_SIGNAL_NAME = "import-actions-updated";
     private static final String FILE_LIST_SIGNAL_NAME = "file-list-updated";
-    public static final Locator fileGridCell = Locator.tagWithClass("div", "labkey-filecontent-grid").append(Locator.tagWithClass("div", "x4-grid-cell-inner"));
+
+    public static final String ABSOLUTE_FILE_PATH_COLUMN_ID = "10";
+    private static final Locator fileGridCell = Locator.tagWithClass("div", "labkey-filecontent-grid").append(Locator.tagWithClass("div", "x4-grid-cell-inner"));
 
     private final WrapsDriver _driver;
 

--- a/src/org/labkey/test/util/LabKeyExpectedConditions.java
+++ b/src/org/labkey/test/util/LabKeyExpectedConditions.java
@@ -237,4 +237,17 @@ public class LabKeyExpectedConditions
         };
     }
 
+    /**
+     * Wraps {@link ExpectedConditions#visibilityOf(WebElement)} and {@link ExpectedConditions#invisibilityOf(WebElement)}
+     *
+     * @param element WebElement that should become visible or invisible.
+     * @param visible 'true' if the element is expected to become visible, 'false' if it not
+     */
+    public static ExpectedCondition<?> visibilityOf(WebElement element, boolean visible)
+    {
+        return visible
+                ? ExpectedConditions.visibilityOf(element)
+                : ExpectedConditions.invisibilityOf(element);
+    }
+
 }


### PR DESCRIPTION
#### Rationale
Some test helpers assume particular pages will run quickly. The aren't as reliable when particular API calls have to talk to S3 before a page is ready.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2541

#### Changes
* Wait for checkboxes to appear on `StartImportPage`
* Wait for file browser to be fully loaded
