### PR TITLE
Simplify `ReactDatePicker` component

### DIFF
--- a/src/org/labkey/test/components/react/ReactDatePicker.java
+++ b/src/org/labkey/test/components/react/ReactDatePicker.java
@@ -1,29 +1,32 @@
 package org.labkey.test.components.react;
 
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.html.Input;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
 
 public class ReactDatePicker extends WebDriverComponent<ReactDatePicker.ElementCache>
 {
-    private WebDriver _driver;
-    private WebElement _el;
+    private final WebDriver _driver;
+    private final WebElement _el;
 
-    public ReactDatePicker(WebElement element, WebDriver driver)
+    protected ReactDatePicker(WebElement element, WebDriver driver)
     {
         _el = element;
         _driver = driver;
     }
 
+    @Override
     public WebElement getComponentElement()
     {
         return _el;
     }
 
+    @Override
     public WebDriver getDriver()
     {
         return _driver;
@@ -34,68 +37,38 @@ public class ReactDatePicker extends WebDriverComponent<ReactDatePicker.ElementC
         return elementCache().input.get();
     }
 
-    public ReactDatePicker set(String value)
-    {
-        return set(value, true);
-    }
-
-    public ReactDatePicker set(String value, boolean collapseAfter)
+    public void set(String value)
     {
         elementCache().input.set(value);
-        if (collapseAfter)
-            collapse();
-        return this;
+        elementCache().input.getComponentElement().sendKeys(Keys.ENTER); // Dismiss date picker
     }
 
     public void clear()
     {
-        elementCache().closeBtn().click();
-        getWrapper().waitFor(()-> !isExpanded() && elementCache().input.get().isEmpty(), 1000);
+        set("");
+        WebDriverWrapper.waitFor(()-> !isExpanded(), "Date picker didn't close", 1000);
     }
 
     public ReactDatePicker clickTime(String time)
     {
         expand();
         elementCache().timeListItem(time).click();
-        getWrapper().waitFor(()-> !isExpanded(), 1000);
+        WebDriverWrapper.waitFor(()-> !isExpanded(), "Date picker didn't close", 1000);
         return this;
     }
 
     private boolean isExpanded()
     {
-        return elementCache().popupLoc.existsIn(getDriver());
+        return elementCache().popup.isDisplayed();
     }
 
-    private ReactDatePicker expand()
+    private void expand()
     {
         if (!isExpanded())
         {
             getComponentElement().click();
-            getWrapper().waitFor(()-> isExpanded(), 1500);
+            WebDriverWrapper.waitFor(this::isExpanded, "Date picker didn't open", 1500);
         }
-        return this;
-    }
-
-    private ReactDatePicker collapse()
-    {
-        if (isExpanded())
-        {
-            // attempt to click at a spot just above or below the containing element, on
-            // the standard way to close the dialog is to click outside of its containing rectangle,
-            // or select a time from the time list
-            String placement = elementCache().popup().getAttribute("data-placement");
-            int offset = elementCache().inputContainer.getSize().height;
-            int height = placement == "bottom-start" ? offset : -offset;    // attempt to click above or below,
-                                                                            // depending on where the picker is
-            Actions builder = new Actions(getDriver());
-            builder.moveToElement(elementCache().inputContainer, 0, height)
-                    .click()
-                    .build()
-                    .perform();
-
-            getWrapper().waitFor(() -> !isExpanded(), 1500);
-        }
-        return this;
     }
 
     @Override
@@ -104,38 +77,23 @@ public class ReactDatePicker extends WebDriverComponent<ReactDatePicker.ElementC
         return new ElementCache();
     }
 
-    protected class ElementCache extends Component.ElementCache
+    protected class ElementCache extends Component<?>.ElementCache
     {
-        Locator popupLoc = Locator.tagWithClass("div", "react-datepicker-popper");
-        Locator closeBtnLoc = Locator.tagWithClass("button", "react-datepicker__close-icon");
         WebElement inputContainer = Locator.tagWithClass("div", "react-datepicker__input-container")
                 .findElement(this);
         public Input input = new Input(Locator.tag("input").findWhenNeeded(inputContainer), getDriver());
 
-        public WebElement closeBtn()
-        {
-            return closeBtnLoc.findElement(inputContainer);
-        }
+        WebElement popup = Locator.xpath(".").followingSibling("div").withClass("react-datepicker__tab-loop")
+                .refindWhenNeeded(this);
 
-        WebElement popup()
-        {
-            return popupLoc.findElementOrNull(getDriver());  // it falls outside of the component
-        }
-
-        WebElement timeList()
-        {
-            if (popup() != null)
-                return Locator.tagWithClass("div", "react-datepicker__time-box")
+        WebElement timeList = Locator.tagWithClass("div", "react-datepicker__time-box")
                     .child(Locator.tagWithClass("ul", "react-datepicker__time-list"))
-                    .findElement(popup());
-            else return null;
-        }
+                    .refindWhenNeeded(popup);
+
         WebElement timeListItem(String text)
         {
-            if (timeList() != null)
-                return Locator.tagWithClass("li", "react-datepicker__time-list-item")
-                    .withText(text).findElement(timeList());
-            else return null;
+            return Locator.tagWithClass("li", "react-datepicker__time-list-item").withText(text)
+                    .findElement(timeList);
         }
     }
 


### PR DESCRIPTION
#### Rationale
Clicking blindly to close the date picker is fiddly and might click something we don't mean to. Pressing enter closes the date picker in the places I was able to find. I think this will fix some intermittent failures in the SM Workflow tests.

#### Changes
* Press `ENTER` to close date picker
* Refactor element cache to avoid NPEs when attempting to click a non-existent time list
