### PR TITLE
Add synchronization method to address race condition in ExpTest

### DIFF
--- a/src/org/labkey/test/components/QueryMetadataEditorPage.java
+++ b/src/org/labkey/test/components/QueryMetadataEditorPage.java
@@ -1,6 +1,7 @@
 package org.labkey.test.components;
 
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.domain.DomainDesigner;
 import org.labkey.test.components.query.AliasFieldDialog;
 import org.openqa.selenium.WebDriver;
@@ -45,6 +46,15 @@ public class QueryMetadataEditorPage extends DomainDesigner<QueryMetadataEditorP
     public QueryMetadataEditorPage clickSave()
     {
         elementCache().saveButton.click();
+        return this;
+    }
+
+    public QueryMetadataEditorPage clickSaveAndWaitForSuccess()
+    {
+        clickSave();
+        WebDriverWrapper.waitFor(()->  Locator.tagWithClass("div", "alert-success")
+                        .containingIgnoreCase("Save Successful").existsIn(this),
+                "Expected success message did not appear in time", WAIT_FOR_JAVASCRIPT);
         return this;
     }
 

--- a/src/org/labkey/test/tests/ExpTest.java
+++ b/src/org/labkey/test/tests/ExpTest.java
@@ -173,7 +173,7 @@ public class ExpTest extends BaseWebDriverTest
         domainRow.setType(FieldDefinition.ColumnType.Lookup).setFromSchema("exp").setFromTargetTable("dataCustomQuery" + " (Integer)");
 
         // Save it
-        designerPage.clickSave();
+        designerPage.clickSaveAndWaitForSuccess();
         designerPage.viewData();
 
         // Customize the view to add the newly joined column


### PR DESCRIPTION
#### Rationale
ExpTest has recently failed due to what appears to be a race condition in the QueryMetaDataEditorPage- the test clicks the 'save' button on the page and immediately thereafter clicks 'view data', causing the page to show a blocking modal dialog (are you sure you want to navigate away?), which in turn caused the navigation expected in viewData() to not happen.

#### Related Pull Requests
n/a

#### Changes
Adds a '`clickSaveAndWaitForSuccess`()' method to the `QueryMetadataEditorPage`
failing test [here](https://teamcity.labkey.org/viewLog.html?buildId=1537314&buildTypeId=bt21&fromExperimentalUI=true#testNameId-1429695608300521834)
