### PR TITLE
Add logging to 'goToModule' and use 'TruncateTableCommand'

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -46,10 +46,9 @@ import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.PostCommand;
 import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.labkey.remoteapi.query.ContainerFilter;
-import org.labkey.remoteapi.query.DeleteRowsCommand;
 import org.labkey.remoteapi.query.Filter;
-import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
+import org.labkey.remoteapi.query.TruncateTableCommand;
 import org.labkey.serverapi.reader.TabLoader;
 import org.labkey.serverapi.writer.PrintWriters;
 import org.labkey.test.components.CustomizeView;
@@ -2132,18 +2131,8 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     public void deleteAllRows(String projectName, String schema, String table) throws IOException, CommandException
     {
         Connection cn = WebTestHelper.getRemoteApiConnection();
-        SelectRowsCommand cmd = new SelectRowsCommand(schema, table);
-        SelectRowsResponse resp = cmd.execute(cn, projectName);
-        if (resp.getRowCount().intValue() > 0)
-        {
-            log("Deleting rows from " + schema + "." + table);
-            DeleteRowsCommand delete = new DeleteRowsCommand(schema, table);
-            for (Map<String, Object> row : resp.getRows())
-            {
-                delete.addRow(row);
-            }
-            delete.execute(cn, projectName);
-        }
+        TruncateTableCommand cmd = new TruncateTableCommand(schema, table);
+        cmd.execute(cn, projectName);
     }
 
     // This class makes it easier to start a specimen import early in a test and wait for completion later.

--- a/src/org/labkey/test/components/html/SiteNavBar.java
+++ b/src/org/labkey/test/components/html/SiteNavBar.java
@@ -29,6 +29,7 @@ import org.labkey.test.pages.files.FileContentPage;
 import org.labkey.test.pages.search.SearchResultsPage;
 import org.labkey.test.pages.user.ShowUsersPage;
 import org.labkey.test.util.AbstractUserHelper;
+import org.labkey.test.util.LogMethod;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -228,6 +229,7 @@ public class SiteNavBar extends WebDriverComponent<SiteNavBar.Elements>
             super(driver, componentElement);
         }
 
+        @LogMethod (quiet = true)
         public void goToModule(String moduleName)
         {
             WebElement moreModulesElement = openMenuTo("Go To Module", "More Modules");


### PR DESCRIPTION
#### Rationale
`goToModule` only logs the opening of the menu. Always "<<openMenuTo(['Go To Module', 'More Modules'])", which isn't especially useful. Also, `BWDT.deleteAllRows` is unnecessarily complicated; we have a specific command to accomplish what it is doing.

#### Changes
* Log calls to `goToModule`
* Use `TruncateTableCommand` to delete rows.
