### PR TITLE
new lineageGrid test component

### DIFF
--- a/src/org/labkey/test/components/ui/grids/LineageGrid.java
+++ b/src/org/labkey/test/components/ui/grids/LineageGrid.java
@@ -18,6 +18,9 @@ import java.util.stream.Collectors;
 
 import static org.labkey.test.components.html.Input.Input;
 
+/**
+ * Wraps the component described in ui-components internal\components\lineage\grid\LineageGridDisplay.tsx
+ */
 public class LineageGrid extends WebDriverComponent<LineageGrid.ElementCache>
 {
     private final WebElement _el;

--- a/src/org/labkey/test/components/ui/grids/LineageGrid.java
+++ b/src/org/labkey/test/components/ui/grids/LineageGrid.java
@@ -1,0 +1,207 @@
+package org.labkey.test.components.ui.grids;
+
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.UpdatingComponent;
+import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.Input;
+import org.labkey.test.components.ui.Pager;
+import org.labkey.test.pages.LabKeyPage;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.labkey.test.components.html.Input.Input;
+
+public class LineageGrid extends WebDriverComponent<LineageGrid.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected LineageGrid(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    public int getRecordCount()
+    {
+        Locator pagingCountLoc = Locator.XPathLocator.union(
+                Locator.tagWithClass("span","paging-counts-with-buttons"),
+                Locator.tagWithClass("span","paging-counts-without-buttons"));
+        return Integer.parseInt(pagingCountLoc.findElement(this).getAttribute("data-total"));
+    }
+
+    public boolean isShowingChildrenBtnEnabled()
+    {
+        return !elementCache().showChildrenBtn().getAttribute("class").contains("disabled");
+    }
+
+    public LineageGrid showChildren()
+    {
+        if (isShowingChildrenBtnEnabled())
+            elementCache().showChildrenBtn().click();
+        WebDriverWrapper.waitFor(()-> !isShowingChildrenBtnEnabled(),
+                "the 'show children' button did not become disabled", 1000);
+        return this;
+    }
+
+    public boolean isShowingParentsBtnEnabled()
+    {
+        return !elementCache().showParentsBtn().getAttribute("class").contains("disabled");
+    }
+
+    public LineageGrid showParents()
+    {
+        if (isShowingParentsBtnEnabled())
+            elementCache().showParentsBtn().click();
+        WebDriverWrapper.waitFor(()-> !isShowingParentsBtnEnabled(),
+                "the 'show parents' button did not become disabled", 1000);
+        return this;
+    }
+
+    public String getSeedMessage()
+    {
+        return elementCache().lineageSeedInfoEl().getText();
+    }
+
+    public String getSeedName()
+    {
+        return elementCache().seedNameEl().getText();
+    }
+
+    public Pager pager()
+    {
+        return new Pager.PagerFinder(getDriver(), elementCache().table).waitFor(this);
+    }
+
+    public List<LineageGridRow> getRows()
+    {
+        return new GridRow.GridRowFinder(elementCache().table)
+                .findAll().stream().map(a-> new LineageGridRow(elementCache().table, a.getComponentElement(), getDriver()))
+                .collect(Collectors.toList());
+    }
+
+    public Map<String, String> getRowMap(String lineageName)
+    {
+        return elementCache().table.getRow("ID", lineageName).getRowMap();
+    }
+
+    public List<Map<String, String>> getRowMaps()
+    {
+        return elementCache().table.getRowMaps();
+    }
+
+    public List<String> getLineageNamesOnPage()
+    {
+        return elementCache().table.getColumnDataAsText("ID");
+    }
+
+    public List<LineageGridRow> getLineageRows(String lineageName)
+    {
+        return getRows().stream().filter(a-> a.getLineageName().equals(lineageName))
+                .collect(Collectors.toList());
+    }
+
+    public List<LineageGridRow> getDuplicates()
+    {
+        return getRows().stream().filter(a-> a.isDuplicate()).collect(Collectors.toList());
+    }
+
+    public List<LineageGridRow> getDuplicatesByName(String lineageName)
+    {
+        return getRows().stream().filter(a-> a.isDuplicate() && a.getLineageName().equals(lineageName))
+                .collect(Collectors.toList());
+    }
+
+    public List<LineageGridRow> getFirstParents(String lineageName)
+    {
+        return getRows().stream().filter(a-> a.isFirstParent() && a.getLineageName().equals(lineageName))
+                .collect(Collectors.toList());
+    }
+
+    public List<LineageGridRow> getSecondParent(String lineageName)
+    {
+        return getRows().stream().filter(a-> a.isSecondParent() && a.getLineageName().equals(lineageName))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        WebElement showParentsBtn()
+        {
+            return Locator.tagWithClass("a", "btn-success").withText("Show Parents")
+                    .waitForElement( this, 2000);
+        }
+
+        WebElement showChildrenBtn()
+        {
+            return Locator.tagWithClass("a", "btn-success").withText("Show Children")
+                    .waitForElement(this, 2000);
+        }
+
+        // seed label
+        WebElement lineageSeedInfoEl()
+        {
+            return Locator.tagWithClass("div", "lineage-seed-info").findElement(this);
+        }
+
+        WebElement seedNameEl()
+        {
+            return Locator.tagWithClass("span", "lineage-seed-name").findElement(this);
+        }
+
+
+        ResponsiveGrid table = new ResponsiveGrid.ResponsiveGridFinder(getDriver()).find(this);
+
+        WebElement generationLimitMsgEl = Locator.tagWithClass("div", "lineage-grid-generation-limit-msg")
+                .findWhenNeeded(this);
+    }
+
+
+    public static class LineageGridFinder extends WebDriverComponentFinder<LineageGrid, LineageGridFinder>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "lineage-grid-display");
+
+        public LineageGridFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        @Override
+        protected LineageGrid construct(WebElement el, WebDriver driver)
+        {
+            return new LineageGrid(el, driver);
+        }
+
+        @Override
+        protected Locator locator()
+        {
+            return _baseLocator;
+        }
+    }
+}

--- a/src/org/labkey/test/components/ui/grids/LineageGridRow.java
+++ b/src/org/labkey/test/components/ui/grids/LineageGridRow.java
@@ -1,0 +1,101 @@
+package org.labkey.test.components.ui.grids;
+
+
+import org.labkey.test.Locator;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+
+
+
+public class LineageGridRow extends GridRow
+{
+    private Locator seedLocator = Locator.tagWithClass("span", "show-on-hover").withText("Seed");
+    private Locator dupeLocator = Locator.tagWithClass("span", "label-warning").withText("Duplicate");
+    private Locator firstParentLoc = Locator.tagWithClass("span", "label-info").withText("1st parent");
+    private Locator secondParentLoc = Locator.tagWithClass("span", "label-primary").withText("2nd parent");
+
+    protected LineageGridRow(ResponsiveGrid grid, WebElement el, WebDriver driver)
+    {
+        super(grid, el, driver);
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    public String getLineageName()
+    {
+        return Locator.tag("a").findElement(elementCache().lineageNameElement).getText();
+    }
+
+    public String getLineageNameTitle()
+    {
+        return elementCache().lineageNameElement.getAttribute("title");
+    }
+
+    public boolean isSeed()
+    {
+        return seedLocator.existsIn(elementCache().lineageNameElement);
+    }
+
+    public boolean isDuplicate()
+    {
+        return dupeLocator.existsIn(elementCache().lineageNameElement);
+    }
+
+    public boolean isFirstParent()
+    {
+        return firstParentLoc.existsIn(elementCache().lineageNameElement);
+    }
+
+    public boolean isSecondParent()
+    {
+        return secondParentLoc.existsIn(elementCache().lineageNameElement);
+    }
+
+    public void changeSeed(SeedDirection direction)
+    {
+        WebElement cell = getCell("Change Seed");
+
+        _grid.doAndWaitForUpdate(()->
+                elementCache().lineageBtnSeed(getLineageName(), direction).findElement(cell).click());
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+    protected class ElementCache extends GridRow.ElementCache
+    {
+        public WebElement lineageNameElement = Locator.tagWithClass("div", "lineage-name").findWhenNeeded(this);
+
+        Locator lineageBtnSeed(String lineageName, SeedDirection direction)
+        {
+            String title = direction.equals(SeedDirection.PARENT) ? "Parent for " + lineageName : "Children for " + lineageName;
+            return Locator.tagWithClass("a", "lineage-btn-seed").withAttribute("title", title);
+        }
+    }
+
+    public enum SeedDirection
+    {
+        PARENT,
+        CHILD
+    }
+}

--- a/src/org/labkey/test/components/ui/grids/LineageGridRow.java
+++ b/src/org/labkey/test/components/ui/grids/LineageGridRow.java
@@ -14,6 +14,7 @@ public class LineageGridRow extends GridRow
     private Locator dupeLocator = Locator.tagWithClass("span", "label-warning").withText("Duplicate");
     private Locator firstParentLoc = Locator.tagWithClass("span", "label-info").withText("1st parent");
     private Locator secondParentLoc = Locator.tagWithClass("span", "label-primary").withText("2nd parent");
+    private String _lineageName;
 
     protected LineageGridRow(ResponsiveGrid grid, WebElement el, WebDriver driver)
     {
@@ -34,7 +35,9 @@ public class LineageGridRow extends GridRow
 
     public String getLineageName()
     {
-        return Locator.tag("a").findElement(elementCache().lineageNameElement).getText();
+        if (null == _lineageName)
+            _lineageName = Locator.tag("a").findElement(elementCache().lineageNameElement).getText();
+        return _lineageName;
     }
 
     public String getLineageNameTitle()


### PR DESCRIPTION
#### Rationale
This introduces 2 new test component wrappers: 1 for the LineageGrid, another to encapsulate the rows in the lineageGrid

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/999 <-- contains the updated tests, pages that are currently the only usages of these new components

#### Changes
Eliminates the deprecated responsiveGrid in Biologics, replaces all usages with the new components

New classes: LineageGrid, which contains the panel (including the show parents, show children buttons), the seed-status message up top, the ResponsiveGrid wrapping the table: 
![image](https://user-images.githubusercontent.com/16809856/134036885-b54da0f4-1342-4529-8996-1d88c5718e09.png)
Uses the current ResponsiveGrid class as a subcomponent to surface rowMap data, and to find specific rows.
Provides getters to find specific lineageGridRows

LineageGridRow 
![image](https://user-images.githubusercontent.com/16809856/134037294-3d012f9c-c6fe-4380-9678-1c94c91e7f3d.png)
Contains checks to replace locator usage that was in tests; e.g. find rows by type: 
seed, duplicate, firstParent, secondParent, firstChild, secondChild