### PR TITLE
Fix ModeratorReviewTest pre-test cleanup

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -48,7 +48,6 @@ import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.labkey.remoteapi.query.ContainerFilter;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.SelectRowsResponse;
-import org.labkey.remoteapi.query.TruncateTableCommand;
 import org.labkey.serverapi.reader.TabLoader;
 import org.labkey.serverapi.writer.PrintWriters;
 import org.labkey.test.components.CustomizeView;
@@ -64,6 +63,7 @@ import org.labkey.test.pages.query.SourceQueryPage;
 import org.labkey.test.pages.search.SearchResultsPage;
 import org.labkey.test.teamcity.TeamCityUtils;
 import org.labkey.test.util.*;
+import org.labkey.test.util.query.QueryUtils;
 import org.labkey.test.util.core.webdav.WebDavUploadHelper;
 import org.labkey.test.util.ext4cmp.Ext4FieldRef;
 import org.openqa.selenium.By;
@@ -2128,11 +2128,10 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         validateQueries(validateSubfolders, 120000);
     }
 
+    @Deprecated
     public void deleteAllRows(String projectName, String schema, String table) throws IOException, CommandException
     {
-        Connection cn = WebTestHelper.getRemoteApiConnection();
-        TruncateTableCommand cmd = new TruncateTableCommand(schema, table);
-        cmd.execute(cn, projectName);
+        QueryUtils.truncateTable(projectName, schema, table);
     }
 
     // This class makes it easier to start a specimen import early in a test and wait for completion later.

--- a/src/org/labkey/test/tests/announcements/ModeratorReviewTest.java
+++ b/src/org/labkey/test/tests/announcements/ModeratorReviewTest.java
@@ -29,6 +29,7 @@ import org.labkey.test.pages.announcements.ModeratorReviewPage;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.PermissionsHelper;
 import org.labkey.test.util.PortalHelper;
+import org.labkey.test.util.query.QueryUtils;
 
 import java.util.Arrays;
 import java.util.List;
@@ -94,7 +95,7 @@ public class ModeratorReviewTest extends BaseWebDriverTest
     public void preTest() throws Exception
     {
         log("Delete all existing messages in project");
-        deleteAllRows(getProjectName(), "announcement", "Announcement");
+        QueryUtils.selectAndDeleteRows(getProjectName(), "announcement", "Announcement");
     }
 
     @Test

--- a/src/org/labkey/test/tests/announcements/ModeratorReviewTest.java
+++ b/src/org/labkey/test/tests/announcements/ModeratorReviewTest.java
@@ -95,7 +95,7 @@ public class ModeratorReviewTest extends BaseWebDriverTest
     public void preTest() throws Exception
     {
         log("Delete all existing messages in project");
-        QueryUtils.selectAndDeleteRows(getProjectName(), "announcement", "Announcement");
+        QueryUtils.selectAndDeleteAllRows(getProjectName(), "announcement", "Announcement");
     }
 
     @Test

--- a/src/org/labkey/test/util/query/QueryUtils.java
+++ b/src/org/labkey/test/util/query/QueryUtils.java
@@ -1,0 +1,42 @@
+package org.labkey.test.util.query;
+
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.query.DeleteRowsCommand;
+import org.labkey.remoteapi.query.SelectRowsCommand;
+import org.labkey.remoteapi.query.SelectRowsResponse;
+import org.labkey.remoteapi.query.TruncateTableCommand;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.util.TestLogger;
+
+import java.io.IOException;
+
+public class QueryUtils
+{
+    private QueryUtils()
+    {
+        // Prevent instantiation
+    }
+
+    public static void truncateTable(String containerPath, String schema, String table) throws IOException, CommandException
+    {
+        Connection cn = WebTestHelper.getRemoteApiConnection();
+        TruncateTableCommand cmd = new TruncateTableCommand(schema, table);
+        cmd.execute(cn, containerPath);
+    }
+
+    public static void selectAndDeleteRows(String containerPath, String schema, String table) throws IOException, CommandException
+    {
+        Connection cn = WebTestHelper.getRemoteApiConnection();
+        SelectRowsCommand cmd = new SelectRowsCommand(schema, table);
+        SelectRowsResponse resp = cmd.execute(cn, containerPath);
+        if (resp.getRowCount().intValue() > 0)
+        {
+            TestLogger.log("Deleting rows from " + schema + "." + table);
+            DeleteRowsCommand delete = new DeleteRowsCommand(schema, table);
+            resp.getRows().forEach(delete::addRow);
+            delete.execute(cn, containerPath);
+        }
+    }
+
+}

--- a/src/org/labkey/test/util/search/SearchAdminAPIHelper.java
+++ b/src/org/labkey/test/util/search/SearchAdminAPIHelper.java
@@ -118,6 +118,7 @@ public abstract class SearchAdminAPIHelper
     @LogMethod(quiet = true)
     public static void setDirectoryType(@LoggedParam DirectoryType type, WebDriver driver)
     {
+        pauseCrawler(driver);
         SimpleHttpRequest request = new SimpleHttpRequest(WebTestHelper.buildURL("search", "admin",
                 Maps.of("directory", "true", "directoryType", type.toString())));
         request.copySession(driver);
@@ -131,6 +132,7 @@ public abstract class SearchAdminAPIHelper
         {
             throw new RuntimeException("Failed to set search directoryType", e);
         }
+        startCrawler(driver);
     }
 
     @LogMethod(quiet = true)


### PR DESCRIPTION
#### Rationale
Not all tables support `TruncateTableCommand`. Also helpers like this don't really belong in `BaseWebDriverTest`

#### Related Pull Requests
* #863 

#### Changes
* Add distinct methods for deleting rows via `TruncateTable` and `DeleteRows`
* Create `QueryUtils`
* Pause search indexer while switching directory type
