### PR TITLE
Item 9192: Initial modifications to support sample status

### DIFF
--- a/src/org/labkey/test/tests/SampleStatusTest.java
+++ b/src/org/labkey/test/tests/SampleStatusTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2011-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.labkey.test.tests;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
+import org.labkey.test.categories.Daily;
+import org.labkey.test.params.experiment.SampleTypeDefinition;
+import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.PortalHelper;
+import org.labkey.test.util.SampleTypeHelper;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Category({Daily.class})
+public class SampleStatusTest extends BaseWebDriverTest
+{
+    private static final String PROJECT_NAME = "SampleStatusTestProject";
+
+    private Boolean previousSampleStatusFlag = null;
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Arrays.asList("experiment");
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return PROJECT_NAME;
+    }
+
+    @BeforeClass
+    public static void setupProject()
+    {
+        SampleStatusTest init = (SampleStatusTest) getCurrentTest();
+
+        // Comment out this line (after you run once) it will make iterating on tests much easier.
+        init.doSetup();
+    }
+
+    private void doSetup()
+    {
+        PortalHelper portalHelper = new PortalHelper(this);
+        _containerHelper.createProject(PROJECT_NAME, null);
+        portalHelper.enterAdminMode();
+        portalHelper.addWebPart("Sample Types");
+
+        portalHelper.exitAdminMode();
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest)
+    {
+        super.doCleanup(afterTest);
+        if (previousSampleStatusFlag != null)
+            SampleTypeHelper.setSampleStatusEnabled(previousSampleStatusFlag);
+        // If you are debugging tests change this function to do nothing.
+        // It can make re-running faster but you need to valid the integrity of the test data on your own.
+//        log("Do nothing.");
+    }
+
+    @Test
+    public void testDeleteSampleTypeWithLockedSamples()
+    {
+        SampleTypeHelper sampleTypeHelper = new SampleTypeHelper(this);
+        previousSampleStatusFlag = SampleTypeHelper.setSampleStatusEnabled(true);
+
+        log("Add a locked sample status.");
+        goToProjectHome();
+        goToSchemaBrowser();
+        selectQuery("core", "DataStates");
+        sampleTypeHelper.addSampleStates(Map.of("TestLocked", "Locked"));
+
+        log("Add a sample type so we can lock some samples");
+        final String sampleTypeName = "SamplesWithLocks";
+        SampleTypeDefinition sampleTypeDefinition = new SampleTypeDefinition(sampleTypeName);
+        goToProjectHome();
+        sampleTypeHelper.createSampleType(sampleTypeDefinition);
+        sampleTypeHelper.goToSampleType(sampleTypeName);
+        log("Add a single unlocked sample");
+        Map<String, String> fieldMap = Map.of("Name", "U-1");
+        sampleTypeHelper.insertRow(fieldMap);
+        log("Add a single locked sample");
+        fieldMap = Map.of("Name", "L-1", "SampleState", "TestLocked");
+        sampleTypeHelper.insertRow(fieldMap);
+        log("Delete the sample type, which should produce no errors.");
+        Locator.linkWithText("Sample Types").findElement(this.getDriver()).click();
+        DataRegionTable drt = sampleTypeHelper.getSampleTypesList();
+        drt.checkCheckbox(drt.getRowIndex("Name", sampleTypeName));
+        drt.clickHeaderButton("Delete");
+        waitForText(WAIT_FOR_JAVASCRIPT, "Confirm Deletion");
+        clickButton("Confirm Delete");
+        waitForText(WAIT_FOR_JAVASCRIPT, "Sample Types");
+    }
+
+
+    @Override
+    public BrowserType bestBrowser()
+    {
+        return BrowserType.CHROME;
+    }
+}

--- a/src/org/labkey/test/tests/SampleStatusTest.java
+++ b/src/org/labkey/test/tests/SampleStatusTest.java
@@ -61,6 +61,7 @@ public class SampleStatusTest extends BaseWebDriverTest
 
     private void doSetup()
     {
+        previousSampleStatusFlag = SampleTypeHelper.setSampleStatusEnabled(true);
         PortalHelper portalHelper = new PortalHelper(this);
         _containerHelper.createProject(PROJECT_NAME, null);
         portalHelper.enterAdminMode();
@@ -84,13 +85,12 @@ public class SampleStatusTest extends BaseWebDriverTest
     public void testDeleteSampleTypeWithLockedSamples()
     {
         SampleTypeHelper sampleTypeHelper = new SampleTypeHelper(this);
-        previousSampleStatusFlag = SampleTypeHelper.setSampleStatusEnabled(true);
 
         log("Add a locked sample status.");
         goToProjectHome();
         goToSchemaBrowser();
         selectQuery("core", "DataStates");
-        sampleTypeHelper.addSampleStates(Map.of("TestLocked", "Locked"));
+        sampleTypeHelper.addSampleStates(Map.of("TestLocked", SampleTypeHelper.StatusType.Locked));
 
         log("Add a sample type so we can lock some samples");
         final String sampleTypeName = "SamplesWithLocks";

--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -638,7 +638,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         goToSchemaBrowser();
         selectQuery("core", "DataStates");
         SampleTypeHelper sampleTypeHelper = new SampleTypeHelper(this);
-        sampleTypeHelper.addSampleStates(Map.of("TestLocked", "Locked", "TestAvailable", "Available"));
+        sampleTypeHelper.addSampleStates(Map.of("TestLocked", SampleTypeHelper.StatusType.Locked, "TestAvailable", SampleTypeHelper.StatusType.Available));
     }
 
     private DataRegionTable linkToStudy(String targetStudy, String sampleTypeName, List<String> sampleIds, @Nullable String categoryName)

--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -602,6 +602,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         table.checkCheckbox(table.getRowIndex("Name", "S3-1"));
         table.clickHeaderButton("Recall");
         acceptAlert();
+        waitForElement(Locators.labkeyError);
         checker().verifyEquals("Error message text after linking locked sample not as expected",
                 "Sample S3-1 has status TestLocked, which prevents recalling from a study.",
                 Locators.labkeyError.findElement(this.getDriver()).getText());

--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -8,6 +8,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.Locators;
 import org.labkey.test.SortDirection;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
@@ -18,6 +19,7 @@ import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.admin.ExportFolderPage;
 import org.labkey.test.pages.admin.ImportFolderPage;
 import org.labkey.test.pages.query.ExecuteQueryPage;
+import org.labkey.test.pages.query.UpdateQueryRowPage;
 import org.labkey.test.pages.study.ManageStudyPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
@@ -48,8 +50,8 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
     final static String ASSAY_NAME = "Test assay";
     final static String SAMPLE_TYPE1 = "Sample type 1";
     final static String SAMPLE_TYPE2 = "Sample type 2";
-
-    private static int cnt = 0; // to keep count of rows which are already linked.
+    final static String SAMPLE_TYPE3 = "Sample type 3";
+    private Boolean previousSampleStatusFlag = null;
 
     protected DateTimeFormatter _dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     protected String now = LocalDateTime.now().format(_dateTimeFormatter);
@@ -546,6 +548,66 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         checker().verifyEquals("Category should not have overridden", categoryName, getCategory(DATE_BASED_STUDY, SAMPLE_TYPE2));
     }
 
+    @Test
+    public void testLinkAndRecallLockedSampleFromStudy()
+    {
+        enableSampleStatus();
+        addSampleStates();
+        SampleTypeHelper sampleHelper = new SampleTypeHelper(this);
+        log("Create a sample type to hold some samples with status");
+        goToProjectHome(SAMPLE_TYPE_PROJECT);
+        String data3 = "Name\tVisitId\tParticipantId\tStatus\n" +
+                "S3-1\t3.1\tP1\t\n" +
+                "S3-2\t3.2\tP2\tTestAvailable\n" +
+                "S3-3\t3.3\tP3\tTestAvailable\n" +
+                "S3-4\t3.4\tP4\tTestLocked\n";
+        sampleHelper.createSampleType(new SampleTypeDefinition(SAMPLE_TYPE3)
+                .setFields(List.of(
+                        new FieldDefinition("VisitId", FieldDefinition.ColumnType.VisitId),
+                        new FieldDefinition("ParticipantId", FieldDefinition.ColumnType.Subject))));
+        sampleHelper.goToSampleType(SAMPLE_TYPE3);
+        sampleHelper.getSamplesDataRegionTable()
+                .clickImportBulkData()
+                .setImportLookupByAlternateKey(true)
+                .setText(data3)
+                .submit();
+        goToProjectHome(SAMPLE_TYPE_PROJECT);
+
+        log("Attempt to linking all samples");
+        linkToStudy(VISIT_BASED_STUDY, SAMPLE_TYPE3, List.of("S3-1", "S3-2", "S3-3", "S3-4"), null);
+        checker().verifyEquals("Error message text after linking locked sample not as expected",
+                "Sample S3-4 has status TestLocked, which prevents linking to study.",
+                Locators.labkeyError.findElement(this.getDriver()).getText());
+
+        log("Uncheck the locked sample and link the rest");
+        DataRegionTable table =  new DataRegionTable("query", getDriver());
+        table.uncheckCheckbox(table.getRowIndex("Name", "S3-4"));
+        table.clickHeaderButtonAndWait("Link to Study");
+
+        log("Change the status of one of the linked samples to locked.");
+        goToProjectHome(SAMPLE_TYPE_PROJECT);
+        sampleHelper.goToSampleType(SAMPLE_TYPE3);
+        DataRegionTable samples = sampleHelper.getSamplesDataRegionTable();
+        int rowIndex = samples.getRowIndex("Name", "S3-1");
+        UpdateQueryRowPage updatePage = samples.clickEditRow(rowIndex);
+        updatePage.setField("SampleState", "TestLocked");
+        updatePage.submit();
+
+        log("Go back to the linked sample dataset");
+        samples = sampleHelper.getSamplesDataRegionTable();
+        clickAndWait(Locator.linkWithText("linked").findElement(samples));
+
+        log("Attempt to recall the linked sample that was locked.");
+        table = new DataRegionTable("Dataset", getDriver());
+        table.checkCheckbox(table.getRowIndex("Name", "S3-1"));
+        table.clickHeaderButton("Recall");
+        acceptAlert();
+        checker().verifyEquals("Error message text after linking locked sample not as expected",
+                "Sample S3-1 has status TestLocked, which prevents recalling from a study.",
+                Locators.labkeyError.findElement(this.getDriver()).getText());
+    }
+
+
     @Before
     public void preTest() throws Exception
     {
@@ -558,12 +620,54 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
             TestDataGenerator.deleteDomain(VISIT_BASED_STUDY, "study", "Sample type 1");
         if(TestDataGenerator.doesDomainExists(VISIT_BASED_STUDY, "study", "Sample type 2"))
             TestDataGenerator.deleteDomain(VISIT_BASED_STUDY, "study", "Sample type 2");
-        cnt = 0; //Resetting the counter between the tests.
     }
 
-    private void linkToStudy(String targetStudy, String sampleName, int numOfRowsToBeLinked, @Nullable String categoryName)
+    private void enableSampleStatus()
     {
-        clickAndWait(Locator.linkWithText(sampleName));
+        log("Enabling sample status feature");
+        Boolean previousSetting = SampleTypeHelper.setSampleStatusEnabled(true);
+        if (previousSampleStatusFlag == null)
+            previousSampleStatusFlag = previousSetting;
+    }
+
+    private void addSampleStates()
+    {
+        log("Adding sample states");
+        goToProjectHome(SAMPLE_TYPE_PROJECT);
+        goToSchemaBrowser();
+        selectQuery("core", "DataStates");
+        SampleTypeHelper sampleTypeHelper = new SampleTypeHelper(this);
+        sampleTypeHelper.addSampleStates(Map.of("TestLocked", "Locked", "TestAvailable", "Available"));
+    }
+
+    private DataRegionTable linkToStudy(String targetStudy, String sampleTypeName, List<String> sampleIds, @Nullable String categoryName)
+    {
+        clickAndWait(Locator.linkWithText(sampleTypeName));
+        DataRegionTable samplesTable = DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
+        for (String sampleId : sampleIds)
+        {
+            int rowNum = samplesTable.getRowIndex("Name", sampleId);
+            if (rowNum >= 0)
+                samplesTable.checkCheckbox(rowNum);
+            else
+                checker().fatal().error(String.format("Could not find sample %s in table to link", sampleId));
+        }
+        samplesTable.clickHeaderButtonAndWait("Link to Study");
+
+        log("Link to study: Choose target");
+        selectOptionByText(Locator.id("targetStudy"), "/" + targetStudy + " (" + targetStudy + " Study)");
+        if (categoryName != null)
+            setFormElement(Locator.name("autoLinkCategory"), categoryName);
+        clickButton("Next");
+
+        DataRegionTable table =  new DataRegionTable("query", getDriver());
+        table.clickHeaderButtonAndWait("Link to Study");
+        return table;
+    }
+
+    private void linkToStudy(String targetStudy, String sampleTypeName, int numOfRowsToBeLinked, @Nullable String categoryName)
+    {
+        clickAndWait(Locator.linkWithText(sampleTypeName));
         DataRegionTable samplesTable = DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
         for (int i = 0; i < numOfRowsToBeLinked; i++)
             samplesTable.checkCheckbox(i);
@@ -667,6 +771,9 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         _containerHelper.deleteProject(DATE_BASED_STUDY, afterTest);
         _containerHelper.deleteProject(SAMPLE_TYPE_PROJECT + " Study 1", afterTest);
         _containerHelper.deleteProject(SAMPLE_TYPE_PROJECT + " Study 2", afterTest);
+
+        if (previousSampleStatusFlag != null)
+            SampleTypeHelper.setSampleStatusEnabled(previousSampleStatusFlag);
 
     }
 }

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -83,8 +83,6 @@ public class SampleTypeTest extends BaseWebDriverTest
     private static final String CASE_INSENSITIVE_SAMPLE_TYPE = "CaseInsensitiveSampleType";
     private static final String LOWER_CASE_SAMPLE_TYPE = "caseinsensitivesampletype";
 
-    private Boolean previousSampleStatusFlag = null;
-
     @Override
     public List<String> getAssociatedModules()
     {
@@ -125,45 +123,9 @@ public class SampleTypeTest extends BaseWebDriverTest
     protected void doCleanup(boolean afterTest)
     {
         super.doCleanup(afterTest);
-        if (previousSampleStatusFlag != null)
-            SampleTypeHelper.setSampleStatusEnabled(previousSampleStatusFlag);
         // If you are debugging tests change this function to do nothing.
         // It can make re-running faster but you need to valid the integrity of the test data on your own.
 //        log("Do nothing.");
-    }
-
-    @Test
-    public void testDeleteSampleTypeWithLockedSamples()
-    {
-        SampleTypeHelper sampleTypeHelper = new SampleTypeHelper(this);
-        previousSampleStatusFlag = SampleTypeHelper.setSampleStatusEnabled(true);
-
-        log("Add a locked sample status.");
-        projectMenu().navigateToFolder(PROJECT_NAME, FOLDER_NAME);
-        goToSchemaBrowser();
-        selectQuery("core", "DataStates");
-        sampleTypeHelper.addSampleStates(Map.of("TestLocked", "Locked"));
-
-        log("Add a sample type so we can lock some samples");
-        final String sampleTypeName = "SamplesWithLocks";
-        SampleTypeDefinition sampleTypeDefinition = new SampleTypeDefinition(sampleTypeName);
-        projectMenu().navigateToFolder(PROJECT_NAME, FOLDER_NAME);
-        sampleTypeHelper.createSampleType(sampleTypeDefinition);
-        sampleTypeHelper.goToSampleType(sampleTypeName);
-        log("Add a single unlocked sample");
-        Map<String, String> fieldMap = Map.of("Name", "U-1");
-        sampleTypeHelper.insertRow(fieldMap);
-        log("Add a single locked sample");
-        fieldMap = Map.of("Name", "L-1", "SampleState", "TestLocked");
-        sampleTypeHelper.insertRow(fieldMap);
-        log("Delete the sample type, which should produce no errors.");
-        Locator.linkWithText("Sample Types").findElement(this.getDriver()).click();
-        DataRegionTable drt = sampleTypeHelper.getSampleTypesList();
-        drt.checkCheckbox(drt.getRowIndex("Name", sampleTypeName));
-        drt.clickHeaderButton("Delete");
-        waitForText(WAIT_FOR_JAVASCRIPT, "Confirm Deletion");
-        clickButton("Confirm Delete");
-        waitForText(WAIT_FOR_JAVASCRIPT, "Sample Types");
     }
 
     @Test

--- a/src/org/labkey/test/util/SampleTypeHelper.java
+++ b/src/org/labkey/test/util/SampleTypeHelper.java
@@ -16,6 +16,7 @@
 package org.labkey.test.util;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
@@ -308,5 +309,35 @@ public class SampleTypeHelper extends WebDriverWrapper
     {
         Locator loc = Locator.tag("td").withClass("lk-form-label").withText(label + ":").followingSibling("td");
         return loc.findElement(getDriver()).getText();
+    }
+
+    public static Boolean setSampleStatusEnabled(boolean enabled)
+    {
+        return ExperimentalFeaturesHelper.setExperimentalFeature(WebTestHelper.getRemoteApiConnection(false), "experimental-sample-status", enabled);
+    }
+    
+    public void addSampleStates(Map<String, String> states)
+    {
+        waitForText("view data");
+        clickAndWait(Locator.linkContainingText("view data"));
+        DataRegionTable drt = new DataRegionTable("query", this);
+        for (Map.Entry<String, String> statePair : states.entrySet())
+        {
+            if (drt.getRowIndex("Label", statePair.getKey()) < 0)
+            {
+                drt.clickInsertNewRow();
+                addSampleState(statePair.getKey(), statePair.getValue());
+            }
+        }
+    }
+
+    public void addSampleState(String label, @Nullable String stateType)
+    {
+        setFormElement(Locator.name("quf_Label"), label);
+        if (stateType != null)
+        {
+            setFormElement(Locator.name("quf_stateType"), stateType);
+        }
+        clickButton("Submit");
     }
 }

--- a/src/org/labkey/test/util/SampleTypeHelper.java
+++ b/src/org/labkey/test/util/SampleTypeHelper.java
@@ -48,6 +48,12 @@ public class SampleTypeHelper extends WebDriverWrapper
     public static final String MERGE_DATA_LABEL = "Insert and Replace";
     private final WebDriver _driver;
 
+    public enum StatusType {
+        Available,
+        Consumed,
+        Locked
+    }
+
     public SampleTypeHelper(WebDriverWrapper driverWrapper)
     {
         this(driverWrapper.getDriver());
@@ -316,21 +322,22 @@ public class SampleTypeHelper extends WebDriverWrapper
         return ExperimentalFeaturesHelper.setExperimentalFeature(WebTestHelper.getRemoteApiConnection(false), "experimental-sample-status", enabled);
     }
     
-    public void addSampleStates(Map<String, String> states)
+    public void addSampleStates(Map<String, StatusType> states)
     {
         waitForText("view data");
         clickAndWait(Locator.linkContainingText("view data"));
         DataRegionTable drt = new DataRegionTable("query", this);
-        for (Map.Entry<String, String> statePair : states.entrySet())
+        for (Map.Entry<String, StatusType> statePair : states.entrySet())
         {
             if (drt.getRowIndex("Label", statePair.getKey()) < 0)
             {
                 drt.clickInsertNewRow();
-                addSampleState(statePair.getKey(), statePair.getValue());
+                addSampleState(statePair.getKey(), statePair.getValue().name());
             }
         }
     }
 
+    // we use the string here for stateType instead of the enum to allow for setting values outside the enum (error conditions)
     public void addSampleState(String label, @Nullable String stateType)
     {
         setFormElement(Locator.name("quf_Label"), label);


### PR DESCRIPTION
#### Rationale
We are developing support for adding a status field to samples, which will determine which actions can be taken on the samples.  Here we add a few tests for this experimental feature that validate behavior when linking and recalling samples from a study dataset and when deleting a sample type containing locked samples.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2636

#### Changes
* Add test case in `SampleTypeLinkToStudyTest` for linking and recalling locked samples
* Add test case in `SampleTypeTest` for deleting a sample type with locked samples
* Add some helper methods in SampleTypeHelper for creating statuses and the like.
