### PR TITLE
Make sure experimental feature flag is turned off after test if it wasn't set before

### DIFF
--- a/src/org/labkey/test/tests/SampleStatusTest.java
+++ b/src/org/labkey/test/tests/SampleStatusTest.java
@@ -76,6 +76,8 @@ public class SampleStatusTest extends BaseWebDriverTest
         super.doCleanup(afterTest);
         if (previousSampleStatusFlag != null)
             SampleTypeHelper.setSampleStatusEnabled(previousSampleStatusFlag);
+        else
+            SampleTypeHelper.setSampleStatusEnabled(false);
         // If you are debugging tests change this function to do nothing.
         // It can make re-running faster but you need to valid the integrity of the test data on your own.
 //        log("Do nothing.");

--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -775,6 +775,8 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
 
         if (previousSampleStatusFlag != null)
             SampleTypeHelper.setSampleStatusEnabled(previousSampleStatusFlag);
+        else
+            SampleTypeHelper.setSampleStatusEnabled(false);
 
     }
 }


### PR DESCRIPTION
#### Rationale
The previous PR was careful to restore the previous setting for the experimental flag, but failed to turn it off if it wasn't previously set.

#### Related Pull Requests
#871 


