### PR TITLE
Make Gradle pass 'selenium.firefox.binary' to tests on TeamCity

### DIFF
--- a/test.properties.template
+++ b/test.properties.template
@@ -72,7 +72,7 @@ selenium.browser=firefox
 ## Absolute location of geckodriver executable. Used to run tests on Firefox
 #webdriver.gecko.driver=
 ## Absolute location of Firefox executable
-#selenium.firefox.binary=
+selenium.firefox.binary=
 ## Set to 'false' to have each test use a fresh browser instance
 selenium.reuseWebDriver=true
 ## Enable debug logging for geckodriver/chromedriver. Log files end up in browser download dir


### PR DESCRIPTION
#### Rationale
Gradle uses the properties defined in `test.properties` (or `test.properties.template`) to decide which properties to pass through from TeamCity. I inadvertently commented `selenium.firefox.binary` when creating the template file so it isn't getting passed through and tests end up running on whatever version of Firefox is on the system PATH.

#### Related Pull Requests
* #870 

#### Changes
* Uncomment `selenium.firefox.binary` property in `test.properties.template`
