### PR TITLE
Improve test handling of ElementClickInterceptedException

### DIFF
--- a/src/org/labkey/test/components/bootstrap/ModalDialog.java
+++ b/src/org/labkey/test/components/bootstrap/ModalDialog.java
@@ -121,7 +121,7 @@ public class ModalDialog extends WebDriverComponent<ModalDialog.ElementCache>
         {
             List<WebElement> elements = new ArrayList<>();
             elements.add(getComponentElement());
-            WebElement modalBackdrop = Locator.byClass("modal-backdrop").findElementOrNull(getDriver());
+            WebElement modalBackdrop = Locator.byClass("modal").findElementOrNull(getDriver());
             if (modalBackdrop != null)
                 elements.add(modalBackdrop);
             new WebDriverWait(getDriver(), waitSeconds)

--- a/src/org/labkey/test/components/bootstrap/ModalDialog.java
+++ b/src/org/labkey/test/components/bootstrap/ModalDialog.java
@@ -121,9 +121,7 @@ public class ModalDialog extends WebDriverComponent<ModalDialog.ElementCache>
         {
             List<WebElement> elements = new ArrayList<>();
             elements.add(getComponentElement());
-            WebElement modalBackdrop = Locator.byClass("modal").findElementOrNull(getDriver());
-            if (modalBackdrop != null)
-                elements.add(modalBackdrop);
+            elements.addAll(Locator.byClass("modal").findElements(getDriver()));
             new WebDriverWait(getDriver(), waitSeconds)
                     .until(ExpectedConditions.invisibilityOfAllElements(elements));
         }

--- a/src/org/labkey/test/components/core/ProjectMenu.java
+++ b/src/org/labkey/test/components/core/ProjectMenu.java
@@ -39,10 +39,20 @@ public class ProjectMenu extends WebDriverComponent<ProjectMenu.ElementCache>
     final WebElement _el;
     final WebDriver _driver;
 
+    private ProjectMenu(WebElement el, WebDriver driver)
+    {
+        _el = el;
+        _driver = driver;
+    }
+
     public ProjectMenu(WebDriver driver)
     {
-        _driver = driver;
-        _el = Locators.labkeyPageNavbar.refindWhenNeeded(driver).withTimeout(WAIT_FOR_JAVASCRIPT);
+        this(Locators.labkeyPageNavbar.refindWhenNeeded(driver).withTimeout(WAIT_FOR_JAVASCRIPT), driver);
+    }
+
+    public static SimpleWebDriverComponentFinder<ProjectMenu> finder(WebDriver driver)
+    {
+        return new SimpleWebDriverComponentFinder<>(driver, Locators.labkeyPageNavbar, ProjectMenu::new);
     }
 
     @Override

--- a/src/org/labkey/test/components/core/ProjectMenu.java
+++ b/src/org/labkey/test/components/core/ProjectMenu.java
@@ -76,13 +76,20 @@ public class ProjectMenu extends WebDriverComponent<ProjectMenu.ElementCache>
         return this;
     }
 
-    public ProjectMenu close()
+    /**
+     * close project menu
+     * @return true if project menu was open
+     */
+    public boolean close()
     {
         if (isOpen())
+        {
             elementCache().menuToggle.click();
-        WebDriverWrapper.waitFor(()-> !isOpen(), "Menu didn't close", 1000);
-        clearElementCache();
-        return this;
+            WebDriverWrapper.waitFor(() -> !isOpen(), "Menu didn't close", 1000);
+            clearElementCache();
+            return true;
+        }
+        return false;
     }
 
     public void navigateToProject(String projectName)

--- a/src/org/labkey/test/components/core/ProjectMenu.java
+++ b/src/org/labkey/test/components/core/ProjectMenu.java
@@ -76,20 +76,13 @@ public class ProjectMenu extends WebDriverComponent<ProjectMenu.ElementCache>
         return this;
     }
 
-    /**
-     * close project menu
-     * @return true if project menu was open
-     */
-    public boolean close()
+    public ProjectMenu close()
     {
         if (isOpen())
-        {
             elementCache().menuToggle.click();
-            WebDriverWrapper.waitFor(() -> !isOpen(), "Menu didn't close", 1000);
-            clearElementCache();
-            return true;
-        }
-        return false;
+        WebDriverWrapper.waitFor(()-> !isOpen(), "Menu didn't close", 1000);
+        clearElementCache();
+        return this;
     }
 
     public void navigateToProject(String projectName)

--- a/src/org/labkey/test/selenium/ReclickingWebElement.java
+++ b/src/org/labkey/test/selenium/ReclickingWebElement.java
@@ -193,25 +193,21 @@ public class ReclickingWebElement extends WebElementDecorator
     {
         try
         {
-            if (new ProjectMenu(getDriver()).close()) // Project menu often gets in the way after scrolling
-            {
-                return; // closed project menu
-            }
+            new ProjectMenu(getDriver()).close(); // Project menu often gets in the way after scrolling
         }
         catch (WebDriverException ignore) {}
 
         WebDriverUtils.ScrollUtil scrollUtil = new WebDriverUtils.ScrollUtil(getDriver());
-        if (!scrollUtil.scrollUnderFloatingHeader(el))
+        scrollUtil.scrollUnderFloatingHeader(el);
+
+        Locator.XPathLocator interceptingElLoc = parseInterceptingElementLoc(shortMessage);
+        if (interceptingElLoc != null)
         {
-            Locator.XPathLocator interceptingElLoc = parseInterceptingElementLoc(shortMessage);
-            if (interceptingElLoc != null)
+            List<WebElement> interceptingElement = interceptingElLoc.findElements(getDriver());
+            if (interceptingElement.size() == 1) // If multiple elements match, don't wait for them to disappear
             {
-                List<WebElement> interceptingElement = interceptingElLoc.findElements(getDriver());
-                if (interceptingElement.size() == 1) // If multiple elements match, don't wait for them to disappear
-                {
-                    new WebDriverWait(getDriver(), 5)
-                            .until(ExpectedConditions.invisibilityOf(interceptingElement.get(0)));
-                }
+                new WebDriverWait(getDriver(), 5)
+                        .until(ExpectedConditions.invisibilityOf(interceptingElement.get(0)));
             }
         }
     }
@@ -247,7 +243,7 @@ public class ReclickingWebElement extends WebElementDecorator
         return _webDriver.getValue();
     }
 
-    public static class TempTest
+    public static class TempEceptionParser
     {
         @Test
         public void testInterceptinElLoc()

--- a/src/org/labkey/test/selenium/ReclickingWebElement.java
+++ b/src/org/labkey/test/selenium/ReclickingWebElement.java
@@ -18,6 +18,9 @@ package org.labkey.test.selenium;
 import org.apache.commons.lang3.mutable.Mutable;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+import org.labkey.test.Locator;
 import org.labkey.test.components.core.ProjectMenu;
 import org.labkey.test.util.TestLogger;
 import org.labkey.test.util.selenium.WebDriverUtils;
@@ -38,10 +41,16 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class ReclickingWebElement extends WebElementDecorator
 {
+    // Extract the element info from ElementClickInterceptedException message.
+    private static final Pattern interceptingElPattern = Pattern.compile("Element .* is not clickable .*<(?<tag>[a-zA-Z]+) (?<attributes>.+)> obscures it");
+    private static final Pattern elAttributePattern = Pattern.compile("(?<name>[a-zA-Z-]+)=\"(?<value>[^\"]+)\"");
+
     public ReclickingWebElement(@NotNull WebElement decoratedElement)
     {
         super(decoratedElement);
@@ -54,17 +63,18 @@ public class ReclickingWebElement extends WebElementDecorator
         {
             super.click();
         }
-        catch (ElementClickInterceptedException tryAgain)
+        catch (ElementClickInterceptedException ex)
         {
             if (getDriver() != null)
             {
-                TestLogger.debug("Retry click: " + tryAgain.getMessage().split("\n")[0]);
-                revealElement(getWrappedElement());
+                final String shortMessage = ex.getMessage().split("\n")[0];
+                TestLogger.debug("Retry click: " + shortMessage);
+                revealElement(getWrappedElement(), shortMessage);
                 super.click();
             }
             else
             {
-                throw tryAgain;
+                throw ex;
             }
         }
         catch (ElementNotInteractableException e)
@@ -179,16 +189,52 @@ public class ReclickingWebElement extends WebElementDecorator
     }
 
     // Allows interaction with elements that have been obscured by floating headers or tooltips
-    private void revealElement(WebElement el)
+    private void revealElement(WebElement el, String shortMessage)
     {
-        WebDriverUtils.ScrollUtil scrollUtil = new WebDriverUtils.ScrollUtil(getDriver());
-        scrollUtil.scrollUnderFloatingHeader(el);
         try
         {
-            new ProjectMenu(getDriver()).close(); // Project menu often gets in the way after scrolling
+            if (new ProjectMenu(getDriver()).close()) // Project menu often gets in the way after scrolling
+            {
+                return; // closed project menu
+            }
         }
         catch (WebDriverException ignore) {}
-        new WebDriverWait(getDriver(), 10).until(ExpectedConditions.elementToBeClickable(el));
+
+        WebDriverUtils.ScrollUtil scrollUtil = new WebDriverUtils.ScrollUtil(getDriver());
+        if (!scrollUtil.scrollUnderFloatingHeader(el))
+        {
+            Locator.XPathLocator interceptingElLoc = parseInterceptingElementLoc(shortMessage);
+            if (interceptingElLoc != null)
+            {
+                List<WebElement> interceptingElement = interceptingElLoc.findElements(getDriver());
+                if (interceptingElement.size() == 1) // If multiple elements match, don't wait for them to disappear
+                {
+                    new WebDriverWait(getDriver(), 5)
+                            .until(ExpectedConditions.invisibilityOf(interceptingElement.get(0)));
+                }
+            }
+        }
+    }
+
+    private static Locator.XPathLocator parseInterceptingElementLoc(String shortMessage)
+    {
+        Locator.XPathLocator interceptingElLoc = null;
+        Matcher matcher = interceptingElPattern.matcher(shortMessage);
+        if (matcher.matches())
+        {
+            // Try to parse exception message to learn about intercepting element.
+            String tag = matcher.group("tag");
+            String attributes = matcher.group("attributes");
+            Matcher attributeMatcher = elAttributePattern.matcher(attributes);
+            interceptingElLoc = Locator.tag(tag);
+            while (attributeMatcher.find())
+            {
+                String name = attributeMatcher.group("name");
+                String value = attributeMatcher.group("value");
+                interceptingElLoc = interceptingElLoc.withAttribute(name, value);
+            }
+        }
+        return interceptingElLoc;
     }
 
     private Mutable<WebDriver> _webDriver = null;
@@ -199,5 +245,16 @@ public class ReclickingWebElement extends WebElementDecorator
             _webDriver = new MutableObject<>(WebDriverUtils.extractWrappedDriver(getWrappedElement()));
         }
         return _webDriver.getValue();
+    }
+
+    public static class TempTest
+    {
+        @Test
+        public void testInterceptinElLoc()
+        {
+            final Locator.XPathLocator xPathLocator = parseInterceptingElementLoc("Element <a href=\"something\"> is not clickable at point (732,301) because another element " +
+                    "<div id=\"elId\" class=\"cls1 cls2\"> obscures it");
+            Assert.assertEquals(Locator.tag("div").withAttribute("id", "elId").withAttribute("class", "cls1 cls2"), xPathLocator);
+        }
     }
 }

--- a/src/org/labkey/test/selenium/ReclickingWebElement.java
+++ b/src/org/labkey/test/selenium/ReclickingWebElement.java
@@ -193,7 +193,7 @@ public class ReclickingWebElement extends WebElementDecorator
     {
         try
         {
-            new ProjectMenu(getDriver()).close(); // Project menu often gets in the way after scrolling
+            ProjectMenu.finder(getDriver()).findOptional().ifPresent(ProjectMenu::close); // Project menu often gets in the way after scrolling
         }
         catch (WebDriverException ignore) {}
 


### PR DESCRIPTION
#### Rationale
Newer versions of Firefox have better performance and have revealed places where we aren't waiting for some transitions to happen correctly. This is leading to `ElementClickInterceptedException` in numerous places. `ReclickingWebElement` already attempts to manage these exceptions but isn't effective for this. The `ElementClickInterceptedException` message includes a description of the intercepting element (e.g. `<div class="modal">`). This change will parse that message, use it to construct a `Locator`, and wait for the element to disappear.

#### Changes
* Update `ModalDialog` to wait for the correct element to disappear
* Update `ProjectMenu` to not force a wait
* Update `ReclickingWebElement` to wait for intercepting elements to disappear
