### PR TITLE
Don't assume intercepting element will disappear

### DIFF
--- a/src/org/labkey/test/components/html/SiteNavBar.java
+++ b/src/org/labkey/test/components/html/SiteNavBar.java
@@ -30,6 +30,7 @@ import org.labkey.test.pages.search.SearchResultsPage;
 import org.labkey.test.pages.user.ShowUsersPage;
 import org.labkey.test.util.AbstractUserHelper;
 import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.LoggedParam;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -230,7 +231,7 @@ public class SiteNavBar extends WebDriverComponent<SiteNavBar.Elements>
         }
 
         @LogMethod (quiet = true)
-        public void goToModule(String moduleName)
+        public void goToModule(@LoggedParam String moduleName)
         {
             WebElement moreModulesElement = openMenuTo("Go To Module", "More Modules");
         /* at this point, we want to know if the module link is visible above the 'more modules' break.

--- a/src/org/labkey/test/selenium/ReclickingWebElement.java
+++ b/src/org/labkey/test/selenium/ReclickingWebElement.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.test.Locator;
 import org.labkey.test.components.core.ProjectMenu;
+import org.labkey.test.util.LabKeyExpectedConditions;
 import org.labkey.test.util.TestLogger;
 import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.By;
@@ -34,6 +35,7 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.FluentWait;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -203,11 +205,13 @@ public class ReclickingWebElement extends WebElementDecorator
         Locator.XPathLocator interceptingElLoc = parseInterceptingElementLoc(shortMessage);
         if (interceptingElLoc != null)
         {
-            List<WebElement> interceptingElement = interceptingElLoc.findElements(getDriver());
-            if (interceptingElement.size() == 1) // If multiple elements match, don't wait for them to disappear
+            List<WebElement> interceptingElements = interceptingElLoc.findElements(getDriver());
+            if (!interceptingElements.isEmpty())
             {
+                final ExpectedCondition<?>[] expectations = (ExpectedCondition<?>[]) interceptingElements.stream()
+                        .map(LabKeyExpectedConditions::animationIsDone).toArray();
                 new WebDriverWait(getDriver(), 5)
-                        .until(ExpectedConditions.invisibilityOf(interceptingElement.get(0)));
+                        .until(ExpectedConditions.and(expectations));
             }
         }
     }

--- a/src/org/labkey/test/selenium/ReclickingWebElement.java
+++ b/src/org/labkey/test/selenium/ReclickingWebElement.java
@@ -209,7 +209,10 @@ public class ReclickingWebElement extends WebElementDecorator
             if (!interceptingElements.isEmpty())
             {
                 final ExpectedCondition<?>[] expectations = (ExpectedCondition<?>[]) interceptingElements.stream()
-                        .map(LabKeyExpectedConditions::animationIsDone).toArray();
+                        .map(interceptingElement -> ExpectedConditions.or(
+                                LabKeyExpectedConditions.animationIsDone(interceptingElement),
+                                ExpectedConditions.invisibilityOf(interceptingElement)
+                        )).toArray();
                 new WebDriverWait(getDriver(), 5)
                         .until(ExpectedConditions.and(expectations));
             }

--- a/src/org/labkey/test/util/LabKeyExpectedConditions.java
+++ b/src/org/labkey/test/util/LabKeyExpectedConditions.java
@@ -18,6 +18,7 @@ package org.labkey.test.util;
 import org.labkey.test.Locator;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.StaleElementReferenceException;
@@ -80,23 +81,32 @@ public class LabKeyExpectedConditions
                 Point secondPosition;
                 Dimension firstDimension;
                 Dimension secondDimension;
+                String firstOpacity;
+                String secondOpacity;
                 try
                 {
                     firstDimension = el.getSize();
                     firstPosition = el.getLocation();
+                    firstOpacity = getOpacity(driver);
                     Thread.sleep(100);
                     secondDimension = el.getSize();
                     secondPosition = el.getLocation();
+                    secondOpacity = getOpacity(driver);
                 }
                 catch (InterruptedException fail)
                 {
                     throw new IllegalStateException(fail);
                 }
 
-                if (secondPosition.equals(firstPosition) && secondDimension.equals(firstDimension))
+                if (secondPosition.equals(firstPosition) && secondDimension.equals(firstDimension) && secondOpacity.equals(firstOpacity))
                     return el;
                 else
                     return null;
+            }
+
+            private String getOpacity(WebDriver driver)
+            {
+                return (String) ((JavascriptExecutor)driver).executeScript("return getComputedStyle(arguments[0]).getPropertyValue(\"opacity\");", el);
             }
 
             @Override


### PR DESCRIPTION
#### Rationale
Previous fix assumed that elements causing `ElementClickInterceptedException` would disappear. Sometimes they will move out of the way.

#### Related Pull Requests
* #879 

#### Changes
* Wait for animation of intercepting elements
