### PR TITLE
new subcomponent wrapper for omnibox values

### DIFF
--- a/src/org/labkey/test/components/ui/OmniBox.java
+++ b/src/org/labkey/test/components/ui/OmniBox.java
@@ -19,6 +19,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.labkey.test.BaseWebDriverTest.WAIT_FOR_JAVASCRIPT;
 
@@ -47,17 +48,18 @@ public class OmniBox extends WebDriverComponent<OmniBox.ElementCache>
 
     public OmniBox clearAll()
     {
-        for (WebElement e : getValues())
+        List<OmniBoxValue> valueItems = getValues();
+        for (int i=getValues().size()-1 ; i >= 0; i--)
         {
-            sendClearValue();
+            valueItems.get(i).dismiss();        // dismiss from the right first;
         }
 
         // dismiss any filter/search/sort dropdown prompts
         if (isOpen())
             close();
 
-        new WebDriverWait(_driver, 1).until(
-                ExpectedConditions.numberOfElementsToBe(Locators.values, 0));
+        getWrapper().waitFor(()-> getValues().size() == 0,
+                "not all of the omnibox values were cleared", 1000);
 
         return this;
     }
@@ -69,7 +71,7 @@ public class OmniBox extends WebDriverComponent<OmniBox.ElementCache>
         {
             sendClearValue();
             new WebDriverWait(_driver, 1).until(
-                    wd -> Locators.values.findElements(this).size() == numValues - 1);
+                    wd -> getValues().size() == numValues - 1);
         }
 
         return this;
@@ -95,18 +97,19 @@ public class OmniBox extends WebDriverComponent<OmniBox.ElementCache>
         return this;
     }
 
-    public List<WebElement> getValues()
+    public List<OmniBoxValue> getValues()
     {
-        return Locators.values.findElements(this);
+        return new OmniBoxValue.OmniBoxValueFinder(getDriver()).findAll(this);
     }
 
-    // TODO Consider making these getValue* methods private. Knowing what to do with the returned elements
-    //  would be very unclear outside this class. I would also expect them to return Strings so maybe create public
-    //  getters that return the selected values as Strings and rename the existing methods something
-    //  like getSelectedValueElement.
-    public WebElement getValue(String expected)
+    public OmniBoxValue getValue(String expected)
     {
-        return Locators.values.containingIgnoreCase(expected).findElementOrNull(this);
+        return new OmniBoxValue.OmniBoxValueFinder(getDriver()).withText(expected).find(this);
+    }
+
+    public Optional<OmniBoxValue> getOptionalValue(String expected)
+    {
+        return new OmniBoxValue.OmniBoxValueFinder(getDriver()).withText(expected).findOptional(this);
     }
 
     private WebElement editingValueElement()
@@ -116,9 +119,9 @@ public class OmniBox extends WebDriverComponent<OmniBox.ElementCache>
 
     public OmniBox editValue(String expectedValue, String newValue)
     {
-        getValue(expectedValue).click();
+        var input = getValue(expectedValue).openEdit();
         WebDriverWrapper.waitFor(()-> isEditing(), "did not begin editing", 1500);
-        getWrapper().setFormElement(editingValueElement(), newValue);
+        input.set(newValue);
         stopEditing();
         return this;
     }
@@ -198,7 +201,7 @@ public class OmniBox extends WebDriverComponent<OmniBox.ElementCache>
         }
 
         this.setText(commandExpression.toString());
-        if (WebDriverWrapper.waitFor(()->  getValue(expectedFilterText.toString()) != null, 2500))
+        if (WebDriverWrapper.waitFor(()->  getOptionalValue(expectedFilterText.toString()).isEmpty(), 2500))
             return this;
 
         // try again if necessary and fail if it doesn't work

--- a/src/org/labkey/test/components/ui/OmniBoxValue.java
+++ b/src/org/labkey/test/components/ui/OmniBoxValue.java
@@ -1,0 +1,145 @@
+package org.labkey.test.components.ui;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.Input;
+import org.labkey.test.pages.LabKeyPage;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.labkey.test.components.html.Input.Input;
+
+public class OmniBoxValue extends WebDriverComponent<OmniBoxValue.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected OmniBoxValue(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    public String getText()
+    {
+        return elementCache().textSpan().getText();
+    }
+
+    public boolean isActive()
+    {
+        return getComponentElement().getAttribute("class").contains("is-active");
+    }
+
+    public boolean isSort()
+    {
+        return getComponentElement().getAttribute("class").contains("fa-sort");
+    }
+
+    public boolean isFilter()
+    {
+        return elementCache().icon().getAttribute("class").contains("fa-filter");
+    }
+
+    public boolean isSearch()
+    {
+        return elementCache().icon().getAttribute("class").contains("fa-search");
+    }
+
+    public boolean isClose()
+    {
+        return elementCache().icon().getAttribute("class").contains("fa-close");
+    }
+
+    public Input openEdit()
+    {
+        getWrapper().mouseOver(getComponentElement());
+        getWrapper().waitFor(()-> isActive() && isClose(),
+                "the omnibox item with text ["+getText()+"] did not become active", 500);
+        elementCache().textSpan().click();
+        return Input.Input(Locator.tagWithClass("div", "OmniBox-input")
+                .child(Locator.tag("input").withAttribute("value")), getDriver()).waitFor();
+    }
+
+    public void dismiss()
+    {
+        String originalText = getText();
+        getWrapper().mouseOver(getComponentElement());
+        getWrapper().waitFor(()-> isActive() && isClose(),
+                "the omnibox item with text ["+getText()+"] did not become active", 500);
+        elementCache().icon().click();
+
+        // if the item you're dismissing is not the rightmost, it won't become stale; instead, its text will
+        // be swapped out with the one to its right.  So, we check to see that either the text has changed or
+        // the item became stale.
+        getWrapper().waitFor(()->  {
+                return ExpectedConditions.stalenessOf(getComponentElement()).apply(getDriver())
+                        || !getText().equals(originalText);
+        }, "the value item ["+originalText+"] did not disappear", 1000);
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        public WebElement textSpan()
+        {
+            return Locator.tag("span").findElement(getComponentElement());
+        }
+
+        public WebElement icon()
+        {
+            return Locator.tag("i").findElement(getComponentElement());
+        }
+    }
+
+
+    public static class OmniBoxValueFinder extends WebDriverComponentFinder<OmniBoxValue, OmniBoxValueFinder>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "OmniBox-value");
+        private String _text = null;
+
+        public OmniBoxValueFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        public OmniBoxValueFinder withText(String text)
+        {
+            _text = text;
+            return this;
+        }
+
+        @Override
+        protected OmniBoxValue construct(WebElement el, WebDriver driver)
+        {
+            return new OmniBoxValue(el, driver);
+        }
+
+        @Override
+        protected Locator locator()
+        {
+            if (_text != null)
+                return _baseLocator.withDescendant(Locator.tag("span").containingIgnoreCase(_text));
+            else
+                return _baseLocator;
+        }
+    }
+}


### PR DESCRIPTION
#### Rationale
Occasionally we've seen tests fail because calls into OmniBox.clearAll() would blindly fire backspaces into the omnibox edit (one per value-item) without synchronizing removals. Occasionally, in tests where the OmniBox contains multiple sort or filter or search items, this would race ahead of the UI and cause the test to fail because it expected all items to be cleared, but one or more were left.

This change adds a new wrapper class to encapsulate sort, filter, or search items that appear as div.OmniBox elements inside the OmniBox: 
![image](https://user-images.githubusercontent.com/16809856/137386689-da82d612-767a-47ea-84d2-b1dd545e3d89.png)

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/1025 <-- test code changes to align with new components

#### Changes
* new component wrapper for OmniBox items
* update OmniBox to use new subcomponent
* refactor calls to setFilter overloads to use non-deprecated overloads (for example, pass in a FilterOperator vs. a string)
