### PR TITLE
Delete groups via API

### DIFF
--- a/src/org/labkey/test/tests/GroupTest.java
+++ b/src/org/labkey/test/tests/GroupTest.java
@@ -72,12 +72,13 @@ public class GroupTest extends BaseWebDriverTest
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
-        _permissionsHelper.deleteGroup(COMPOUND_GROUP);
-        _permissionsHelper.deleteGroup(SIMPLE_GROUP);
-        _permissionsHelper.deleteGroup(BAD_GROUP);
-        _permissionsHelper.deleteGroup(CHILD_GROUP);
-        _permissionsHelper.deleteGroup(SITE_USER_GROUP);
-        _permissionsHelper.deleteGroup(API_SITE_GROUP);
+        ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
+        permissionsHelper.deleteGroup(COMPOUND_GROUP);
+        permissionsHelper.deleteGroup(SIMPLE_GROUP);
+        permissionsHelper.deleteGroup(BAD_GROUP);
+        permissionsHelper.deleteGroup(CHILD_GROUP);
+        permissionsHelper.deleteGroup(SITE_USER_GROUP);
+        permissionsHelper.deleteGroup(API_SITE_GROUP);
         _userHelper.deleteUsers(false, TEST_USERS_FOR_GROUP);
         _userHelper.deleteUsers(false, SITE_USER_EMAILS);
         _containerHelper.deleteProject(getProjectName(), afterTest);


### PR DESCRIPTION
#### Rationale
One of the tests in this class leaves the browser in on a page that `UIPermissionsHelper.deleteGroup` can't handle. This causes intermittent failures on TeamCity:
```
org.openqa.selenium.NoSuchElementException: Expected condition failed: waiting for css=.navbar-nav-lk
within: FirefoxDriver: firefox on LINUX (c3959d61-657b-4b6e-bf41-7854b610e876) -> LazyWebElement{css=div.labkey-page-header} (tried for 10 second(s) with 500 milliseconds interval)
  [...]
  at app//org.labkey.test.util.PermissionsHelper.deleteGroup(PermissionsHelper.java:158)
  at app//org.labkey.test.tests.GroupTest.doCleanup(GroupTest.java:75)
  at app//org.labkey.test.BaseWebDriverTest.cleanup(BaseWebDriverTest.java:1102)
  at app//org.labkey.test.BaseWebDriverTest.doPostamble(BaseWebDriverTest.java:1036)
  at app//org.labkey.test.BaseWebDriverTest$1.succeeded(BaseWebDriverTest.java:416)
```
The `doCleanup` method has no reason to use the UI, so we can solve this by deleting the groups via API.

#### Changes
* Use `ApiPermissionsHelper` in `GroupTest.doCleanup`
