### PR TITLE
Handle import page clearing file on error

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -30,6 +30,7 @@ import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.Locators;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
@@ -260,9 +261,13 @@ public class SampleTypeTest extends BaseWebDriverTest
         drt.clickImportBulkData();
         click(Locator.tagWithText("h3", "Upload file (.xlsx, .xls, .csv, .txt)"));
         setFormElement(Locator.tagWithName("input", "file"), TestFileUtils.getSampleData("simpleSampleType.xls"));
-        clickButton("Submit", "duplicate key");
+        clickButton("Submit");
+        final String errorText = Locators.labkeyError.findElement(getDriver()).getText();
+        Assert.assertTrue("Bad error when importing duplicate samples. " + errorText,
+                errorText.contains("duplicate key") && errorText.length() < 100); // TODO: Find better condition once error message is fixed
 
         log ("Switch to 'Insert and Replace'");
+        setFormElement(Locator.tagWithName("input", "file"), TestFileUtils.getSampleData("simpleSampleType.xls"));
         sampleHelper.selectImportOption(SampleTypeHelper.MERGE_DATA_LABEL, 0);
         clickButton("Submit");
         log ("Validate data was updated and new data added");


### PR DESCRIPTION
#### Rationale
Import errors now clear the selected file. `SampleTypeTest.testImportTypeOptions`

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2716

#### Changes
* Set file input after intentionally triggered import error
* Make test check for current error message regression
<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/5263798/139305177-a6b939da-1ade-4050-95a2-34e99761f4e5.png)

</details>
