### PR TITLE
Make `addSideWebPart` work after the first

### DIFF
--- a/src/org/labkey/test/util/PortalHelper.java
+++ b/src/org/labkey/test/util/PortalHelper.java
@@ -25,6 +25,7 @@ import org.labkey.test.components.WebPart;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.components.html.SiteNavBar;
 import org.labkey.test.components.labkey.PortalTab;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WrapsDriver;
@@ -291,12 +292,15 @@ public class PortalHelper extends WebDriverWrapper
     {
         doInAdminMode(() -> {
             waitForElement(Locator.xpath("//option").withText(webPartName));
-            Locator.XPathLocator formLocator = Locator.tag("form").withAttributeContaining("action", "addWebPart.view");
+            Locator.XPathLocator formLocatorBase = Locator.tag("form").withAttributeContaining("action", "addWebPart.view");
+            final Locator.XPathLocator formLocator;
             if (formLocation == null)
-                formLocator = formLocator.withDescendant(Locator.tagWithText("option", webPartName));
+                formLocator = formLocatorBase.withDescendant(Locator.tagWithText("option", webPartName));
             else
-                formLocator = formLocator.withChild(Locator.input("location").withAttribute("value", formLocation));
-            WebElement form = formLocator.findElement(getDriver());
+                formLocator = formLocatorBase.withChild(Locator.input("location").withAttribute("value", formLocation));
+            List<WebElement> forms = formLocator.findElements(getDriver());
+            WebElement form = forms.stream().filter(WebElement::isDisplayed).findFirst()
+                    .orElseThrow(() -> new NoSuchElementException("No visible webpart form: " + formLocator));
             selectOptionByText(Locator.tag("select").findElement(form), webPartName);
             doAndWaitForPageToLoad(form::submit);
         });


### PR DESCRIPTION
#### Rationale
If you inspect the portal in page admin mode, you can see two side webpart forms (and two body webpart forms). They have styles that show/hide them based on the viewport size. Unfortunately, because of the structure, `PortalHelper.addWebPart` is finding the form that is hidden with a normal browser window size.
https://www.labkey.org/ONPRC/Support%20Tickets/issues-details.view?issueId=44225

#### Related Pull Requests
* https://github.com/BimberLab/DiscvrLabKeyModules/pull/109

#### Changes
* Use the visible `<select>` to add webparts.
