### PR TITLE
Improve performance of domain designer helpers

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -35,6 +35,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
     final WebElement _el;
     final WebDriver _driver;
     final DomainFormPanel _formPanel;
+    private boolean _advanceSettingsSet = false;
 
     public DomainFieldRow(DomainFormPanel panel, WebElement element, WebDriver driver)
     {
@@ -164,6 +165,16 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         return this;
     }
 
+    private AdvancedSettingsDialog _clickAdvancedSettings()
+    {
+        if (_advanceSettingsSet)
+        {
+            throw new IllegalStateException("Use 'clickAdvancedSettings' or 'setAdvancedSettings' to set multiple advanced settings.");
+        }
+        _advanceSettingsSet = true;
+        return clickAdvancedSettings();
+    }
+
     public AdvancedSettingsDialog clickAdvancedSettings()
     {
         expand();
@@ -172,7 +183,10 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         int trycount = 0;
         do
         {
-            getWrapper().log("clicking advanced settings button try=[" + trycount + "]");
+            if (trycount > 0)
+            {
+                getWrapper().log("clicking advanced settings button retry=[" + trycount + "]");
+            }
             elementCache().advancedSettingsBtn.click();
             getWrapper().shortWait().until(LabKeyExpectedConditions.animationIsDone(getComponentElement()));
             trycount++;
@@ -581,7 +595,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
     public DomainFieldRow showFieldOnDefaultView(boolean checked)
     {
-        clickAdvancedSettings()
+        _clickAdvancedSettings()
                 .showInDefaultView(checked)
                 .apply();
         return this;
@@ -589,7 +603,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
     public DomainFieldRow showFieldOnInsertView(boolean checked)
     {
-        clickAdvancedSettings()
+        _clickAdvancedSettings()
                 .showInInsertView(checked)
                 .apply();
         return this;
@@ -597,7 +611,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
     public DomainFieldRow showFieldOnUpdateView(boolean checked)
     {
-        clickAdvancedSettings()
+        _clickAdvancedSettings()
                 .showInUpdateView(checked)
                 .apply();
         return this;
@@ -605,7 +619,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
     public DomainFieldRow showFieldOnDetailsView(boolean checked)
     {
-        clickAdvancedSettings()
+        _clickAdvancedSettings()
                 .showInDetailsView(checked)
                 .apply();
         return this;
@@ -613,7 +627,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
     public DomainFieldRow setPHILevel(FieldDefinition.PhiSelectType phiLevel)
     {
-        clickAdvancedSettings()
+        _clickAdvancedSettings()
                 .setPHILevel(phiLevel)
                 .apply();
         return this;
@@ -621,7 +635,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
     public DomainFieldRow setExcludeFromDateShifting(boolean shift)
     {
-        clickAdvancedSettings()
+        _clickAdvancedSettings()
                 .excludeFromDateShifting(shift)
                 .apply();
         return this;
@@ -629,7 +643,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
     public DomainFieldRow setMeasure(boolean checked)
     {
-        clickAdvancedSettings()
+        _clickAdvancedSettings()
                 .setMeasure(checked)
                 .apply();
         return this;
@@ -637,7 +651,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
     public DomainFieldRow setDimension(boolean checked)
     {
-        clickAdvancedSettings()
+        _clickAdvancedSettings()
                 .setDimension(checked)
                 .apply();
         return this;
@@ -645,7 +659,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
     public DomainFieldRow setRecommendedVariable(boolean checked)
     {
-        clickAdvancedSettings()
+        _clickAdvancedSettings()
                 .setRecommendedVariable(checked)
                 .apply();
         return this;
@@ -653,7 +667,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
     public DomainFieldRow setMissingValuesEnabled(boolean checked)
     {
-        clickAdvancedSettings()
+        _clickAdvancedSettings()
                 .setMissingValuesEnabled(checked)
                 .apply();
         return this;

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -259,7 +259,6 @@ public class DomainDesignerTest extends BaseWebDriverTest
 
         domainFormPanel.addField("addedField")
                 .setType(FieldDefinition.ColumnType.DateAndTime)
-                .expand()
                 .setDateFormat("yyyy-MM-dd HH:mm")
                 .setExcludeFromDateShifting(false)
                 .setDescription("simplest date format of all")

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -36,6 +36,7 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Data;
 import org.labkey.test.categories.Hosting;
+import org.labkey.test.components.domain.AdvancedFieldSetting;
 import org.labkey.test.components.domain.BaseDomainDesigner;
 import org.labkey.test.components.domain.ConditionalFormatDialog;
 import org.labkey.test.components.domain.DomainFieldRow;
@@ -305,10 +306,11 @@ public class ListTest extends BaseWebDriverTest
         // Create "Hidden Field" and remove from all views.
         fieldsPanel.addField(_listCol5);
         fieldsPanel.getField(_listCol5.getName())
-            .showFieldOnDefaultView(false)
-            .showFieldOnInsertView(false)
-            .showFieldOnUpdateView(false)
-            .showFieldOnDetailsView(false);
+                .setAdvancedSettings(Map.of(
+                        AdvancedFieldSetting.showInDefault, false,
+                        AdvancedFieldSetting.shownInInsertView, false,
+                        AdvancedFieldSetting.shownInUpdateView, false,
+                        AdvancedFieldSetting.shownInDetailsView, false));
 
         fieldsPanel.addField(_listCol6);
         fieldsPanel.getField(_listCol6.getName())
@@ -408,8 +410,9 @@ public class ListTest extends BaseWebDriverTest
         listDefinitionPage = _listHelper.goToEditDesign(LIST_NAME_COLORS);
         fieldsPanel = listDefinitionPage.getFieldsPanel();
         fieldsPanel.getField(5) // Select Hidden field.
-            .showFieldOnDefaultView(false)
-            .showFieldOnInsertView(true);
+                .setAdvancedSettings(Map.of(
+                        AdvancedFieldSetting.showInDefault, false,
+                        AdvancedFieldSetting.shownInInsertView, true));
         listDefinitionPage.clickSave();
 
         assertTextNotPresent(HIDDEN_TEXT); // Hidden from grid view.
@@ -426,8 +429,9 @@ public class ListTest extends BaseWebDriverTest
         listDefinitionPage = _listHelper.goToEditDesign(LIST_NAME_COLORS);
         fieldsPanel = listDefinitionPage.getFieldsPanel();
         fieldsPanel.getField(5) // Select Hidden field.
-            .showFieldOnInsertView(false)
-            .showFieldOnUpdateView(true);
+                .setAdvancedSettings(Map.of(
+                        AdvancedFieldSetting.shownInInsertView, false,
+                        AdvancedFieldSetting.shownInUpdateView, true));
         listDefinitionPage.clickSave();
 
         assertTextNotPresent(HIDDEN_TEXT); // Hidden from grid view.
@@ -444,8 +448,9 @@ public class ListTest extends BaseWebDriverTest
         listDefinitionPage = _listHelper.goToEditDesign(LIST_NAME_COLORS);
         fieldsPanel = listDefinitionPage.getFieldsPanel();
         fieldsPanel.getField(5) // Select Hidden field.
-            .showFieldOnUpdateView(false)
-            .showFieldOnDetailsView(true);
+                .setAdvancedSettings(Map.of(
+                        AdvancedFieldSetting.shownInUpdateView, false,
+                        AdvancedFieldSetting.shownInDetailsView, true));
         listDefinitionPage.clickSave();
 
         assertTextNotPresent(HIDDEN_TEXT); // Hidden from grid view.

--- a/src/org/labkey/test/tests/visualization/BarPlotTest.java
+++ b/src/org/labkey/test/tests/visualization/BarPlotTest.java
@@ -241,11 +241,6 @@ public class BarPlotTest extends GenericChartsTest
         waitAndClickAndWait(Locator.linkWithText(DATA_SOURCE_1));
 
         dataRegionTable = new DataRegionTable("Dataset", getDriver());
-        plotRegion = dataRegionTable.getColumnPlotRegion();
-
-        log("If the plot view is visible, revert it.");
-        if(plotRegion.isViewModified())
-            plotRegion.revertView();
 
         log("Create a bar plot.");
         dataRegionTable.createBarChart(COL_NAME_BAR);

--- a/src/org/labkey/test/tests/visualization/ColumnChartTest.java
+++ b/src/org/labkey/test/tests/visualization/ColumnChartTest.java
@@ -28,6 +28,7 @@ import org.labkey.test.categories.Hosting;
 import org.labkey.test.components.ColumnChartComponent;
 import org.labkey.test.components.ColumnChartRegion;
 import org.labkey.test.components.CustomizeView;
+import org.labkey.test.components.domain.AdvancedFieldSetting;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.util.DataRegionTable;
@@ -87,37 +88,43 @@ public class ColumnChartTest extends BaseWebDriverTest
         DatasetDesignerPage datasetDesignerPage = new DatasetDesignerPage(getDriver());
         DomainFormPanel domainFormPanel = datasetDesignerPage.getFieldsPanel();
         domainFormPanel.getField(PREGNANCY_COLUMN_NAME)
-                .setDimension(true)
-                .setMeasure(false);
+                .setAdvancedSettings(Map.of(
+                        AdvancedFieldSetting.dimension, true,
+                        AdvancedFieldSetting.measure, false));
         DATA_SOURCE_1_DIMENSIONS.add(PREGNANCY_COLUMN_NAME);
 
         domainFormPanel.getField(LANGUAGE_COLUMN_NAME)
-            .setDimension(true)
-            .setMeasure(false);
+                .setAdvancedSettings(Map.of(
+                        AdvancedFieldSetting.dimension, true,
+                        AdvancedFieldSetting.measure, false));
         DATA_SOURCE_1_DIMENSIONS.add(LANGUAGE_COLUMN_NAME);
 
         domainFormPanel.getField(SIGNATURE_COLUMN_NAME)
-            .setDimension(true)
-            .setMeasure(false);
+                .setAdvancedSettings(Map.of(
+                        AdvancedFieldSetting.dimension, true,
+                        AdvancedFieldSetting.measure, false));
         DATA_SOURCE_1_DIMENSIONS.add(SIGNATURE_COLUMN_NAME);
 
         log("Set the '" + RESPIRATIONS_COLUMN_NAME + "' and '" + WEIGHT_COLUMN_NAME + "' fields to be both dimensions and measures.");
         domainFormPanel.getField(RESPIRATIONS_COLUMN_NAME)
-            .setDimension(true)
-            .setMeasure(true);
+                .setAdvancedSettings(Map.of(
+                        AdvancedFieldSetting.dimension, true,
+                        AdvancedFieldSetting.measure, true));
         DATA_SOURCE_1_DIMENSIONS.add(RESPIRATIONS_COLUMN_NAME);
         DATA_SOURCE_1_MEASURES.add(RESPIRATIONS_COLUMN_NAME);
 
         domainFormPanel.getField(WEIGHT_COLUMN_NAME)
-            .setDimension(true)
-            .setMeasure(true);
+                .setAdvancedSettings(Map.of(
+                        AdvancedFieldSetting.dimension, true,
+                        AdvancedFieldSetting.measure, true));
         DATA_SOURCE_1_DIMENSIONS.add(WEIGHT_COLUMN_NAME);
         DATA_SOURCE_1_MEASURES.add(WEIGHT_COLUMN_NAME);
 
         log("Set '" + PULSE_COLUMN_NAME + "' to not be a measure or dimensions");
         domainFormPanel.getField(PULSE_COLUMN_NAME)
-            .setDimension(false)
-            .setMeasure(false);
+                .setAdvancedSettings(Map.of(
+                        AdvancedFieldSetting.dimension, false,
+                        AdvancedFieldSetting.measure, false));
 
         log("Add the default measures to the ArrayList");
         DATA_SOURCE_1_MEASURES.add("Temp_C");


### PR DESCRIPTION
#### Rationale
There have been complaints that tests are too slow when they have to use the UI domain designer.

#### Changes
* Refactor tests to set advanced field options in one go
* Make `DomainFieldRow` complain if the advanced options dialog is opened more than once
* Remove some (hopefully unnecessary) retries that might be slowing things down
