### PR TITLE
Wait longer for measures grid to load

### DIFF
--- a/src/org/labkey/test/tests/ParticipantReportTest.java
+++ b/src/org/labkey/test/tests/ParticipantReportTest.java
@@ -323,7 +323,7 @@ public class ParticipantReportTest extends ReportTest
         // select some measures from a dataset
         clickButton("Choose Measures", 0);
         Window chooseMeasureWindow = new Window.WindowFinder(getDriver()).withTitle(ADD_MEASURE_TITLE).waitFor();
-        Locator.tagWithClass("tr", "x4-grid-row").waitForElement(chooseMeasureWindow, 1000);
+        Locator.tagWithClass("tr", "x4-grid-row").waitForElement(chooseMeasureWindow, 10_000);
 
         String columnHeader = "17a. Preg. test result";
         _ext4Helper.selectGridItem("label", columnHeader, -1, "measuresGridPanel", true);


### PR DESCRIPTION
#### Rationale
This test has started failing in 21.11. The "Add Measures..." dialog is taking longer than one second to load its options. Running locally, it only takes a few seconds and other places in this test wait ten seconds for the same dialog to load. Just updating the timeout to match elsewhere.

#### Changes
* Wait longer for participant measure to load.
