### PR TITLE
Update text for EntityInsertPanel mode

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -257,21 +257,24 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     public boolean isBulkUpdateVisible()
     {
-        return modeSelectListItem("from Grid").withClass("active").findOptionalElement(this).isPresent() &&
+        // for sample upload, text is 'Create Samples from Grid', for assay it is 'Enter Data into Grid'
+        return modeSelectListItem(" Grid").withClass("active").findOptionalElement(this).isPresent() &&
                 elementCache().bulkUpdateBtnLoc.existsIn(this) &&
                 isElementVisible(elementCache().bulkUpdateBtn);
     }
 
     public boolean isDeleteRowsVisible()
     {
-        return modeSelectListItem("from Grid").withClass("active").findOptionalElement(this).isPresent() &&
+        // text for this is sometimes 'Create Samples from Grid', sometimes 'Enter Data into Grid'
+        return modeSelectListItem(" Grid").withClass("active").findOptionalElement(this).isPresent() &&
                 elementCache().deleteRowsBtnLoc.existsIn(this) &&
                 isElementVisible(elementCache().deleteRowsBtn);
     }
 
     public boolean isFileUploadVisible()
     {
-        return modeSelectListItem("from File").withClass("active").findOptionalElement(this).isPresent() &&
+        // for sample upload, text is 'Import Samples from File', for assay: 'Upload Files'
+        return modeSelectListItem(" File").withClass("active").findOptionalElement(this).isPresent() &&
                 optionalFileUploadPanel().isPresent() &&
                 isElementVisible(fileUploadPanel().getComponentElement());
     }
@@ -399,7 +402,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     public static class EntityInsertPanelFinder extends WebDriverComponent.WebDriverComponentFinder<EntityInsertPanel, EntityInsertPanelFinder>
     {
-        private Locator _locator;
+        private final Locator _locator;
 
         public EntityInsertPanelFinder(WebDriver driver)
         {


### PR DESCRIPTION
#### Rationale
The `EntityInsertPanel `component uses different text for its mode-select toggles (to select between file upload, edit grid, copy/paste), this change attempts to make the component be able to correctly find these mode-select elements for assay upload as well as for sample upload 

assay upload:
![image](https://user-images.githubusercontent.com/16809856/143304014-4660c291-a9b8-4eaa-8df7-71b18786f4bc.png)
sample upload:
![image](https://user-images.githubusercontent.com/16809856/143304230-6a2c31cd-78db-4f29-ba37-286006bef283.png)

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/917  <-- contains new tests for job-related sample auto-population of assay samples; calls for the ability to check whether `EntityInsertPanel `is in file-upload vs grid mode

#### Changes
This changes the text by which the mode-select list-items are found, hopefully to work as well for assay upload as for samples
