### PR TITLE
Don't attempt to save a pdf when it isn't supported

### DIFF
--- a/src/org/labkey/test/util/ArtifactCollector.java
+++ b/src/org/labkey/test/util/ArtifactCollector.java
@@ -233,6 +233,12 @@ public class ArtifactCollector
 
     public File dumpPdf(File dir, String baseName)
     {
+        if (_test.getBrowserType() == WebDriverWrapper.BrowserType.CHROME && !TestProperties.isRunWebDriverHeadless())
+        {
+            // Avoid error: "PrintToPDF is only supported in headless mode"
+            return null;
+        }
+
         File pdfFile = new File(dir, baseName + ".pdf");
         try
         {


### PR DESCRIPTION
#### Rationale
Chrome only supports the 'PrintToPDF' method when running in headless mode.

#### Related Pull Requests
* #904 

#### Changes
* Skip PDF dump on non-headless Chrome
