### PR TITLE
Fix some race conditions in survey tests

### DIFF
--- a/src/org/labkey/test/tests/StudySurveyTest.java
+++ b/src/org/labkey/test/tests/StudySurveyTest.java
@@ -7,7 +7,9 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.PortalHelper;
+import org.openqa.selenium.WebElement;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -93,7 +95,9 @@ public class StudySurveyTest extends BaseWebDriverTest
         setFormElement(Locator.name("date"), getDate(0));
         doAndWaitForPageToLoad(() ->
         {
-            clickButton("Submit completed form", 0);
+            final WebElement submitButton = Ext4Helper.Locators.ext4Button("Submit completed form").findElement(getDriver());
+            shortWait().withMessage("Submit button not enabled").until(wd -> !submitButton.getAttribute("class").contains("disabled"));
+            submitButton.click();
             _extHelper.waitForExtDialog("Success");
         });
 

--- a/src/org/labkey/test/tests/SurveyTest.java
+++ b/src/org/labkey/test/tests/SurveyTest.java
@@ -29,6 +29,7 @@ import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.WikiHelper;
+import org.openqa.selenium.WebElement;
 
 import java.io.File;
 import java.util.Collections;
@@ -146,7 +147,9 @@ public class SurveyTest extends BaseWebDriverTest
         setFormElement(Locator.name(DATETIME_DATE_FIELD_NAME), dateTimeFieldDateValue);
 
         var dateTimeFieldTimeValue = "12:45";
-        setFormElement(Locator.name(DATETIME_TIME_FIELD_NAME), dateTimeFieldTimeValue);
+        final WebElement timeInput = Locator.name(DATETIME_TIME_FIELD_NAME).findElement(getDriver());
+        timeInput.clear();
+        timeInput.sendKeys(dateTimeFieldTimeValue);
 
         log("Save the survey.");
         clickSaveButton();
@@ -190,7 +193,9 @@ public class SurveyTest extends BaseWebDriverTest
 
     private void clickSaveButton()
     {
-        clickButton("Save", 0);
+        final WebElement saveButton = Ext4Helper.Locators.ext4Button("Save").findElement(getDriver());
+        shortWait().withMessage("Save button not enabled").until(wd -> !saveButton.getAttribute("class").contains("disabled"));
+        saveButton.click();
         _extHelper.waitForExtDialog(SUCCESS_DIALOG_TITLE);
         _extHelper.waitForExtDialogToDisappear(SUCCESS_DIALOG_TITLE);
     }


### PR DESCRIPTION
#### Rationale
These survey tests started failing intermittently because they don't wait for the save button to be enabled after filling in the form.

#### Related Pull Requests
* #904 

#### Changes
* Wait for save button to be enabled
