### PR TITLE
Add a waitAndClickAndWait to UIAssayHelper.importAssay

### DIFF
--- a/src/org/labkey/test/util/UIAssayHelper.java
+++ b/src/org/labkey/test/util/UIAssayHelper.java
@@ -55,7 +55,7 @@ public class UIAssayHelper extends AbstractAssayHelper
         if (projectPath != null)
             goToProjectPath(projectPath);
 
-        _test.clickAndWait(Locator.linkWithText(assayName));
+        _test.waitAndClickAndWait(Locator.linkWithText(assayName));
         _test.clickButton("Import Data");
 
         if(null != batchProperties)


### PR DESCRIPTION
Add a waitAndClickAndWait (for the assay link) to UIAssayHelper.importAssay.

#### Rationale
Some tests have started failing in LKSM that use the LKS page to click an assay link. The assay is imported and I think it is taking a moment for the link to show up. This changed a clickAndWait for the link to a waitAndClickAndWait.

#### Related Pull Requests
* None.

#### Changes
* Added a waitAndClickAndWait.
