### PR TITLE
update unused setSelectValue/clearSelectValue methods

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -295,7 +295,8 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
      **/
     public DetailTableEdit setSelectValue(String fieldCaption, List<String> selectValues)
     {
-        FilteringReactSelect reactSelect =  FilteringReactSelect.finder(_driver).followingLabelWithSpan(fieldCaption).find();
+        WebElement container = Locator.tag("td").withAttribute("data-caption", fieldCaption).findElement(this);
+        FilteringReactSelect reactSelect =  FilteringReactSelect.finder(_driver).find(container);
         selectValues.forEach(s -> {reactSelect.typeAheadSelect(s);});
         return this;
     }
@@ -308,7 +309,8 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
      **/
     public DetailTableEdit clearSelectValue(String fieldCaption)
     {
-        ReactSelect.finder(_driver).followingLabelWithSpan(fieldCaption).find().clearSelection();
+        WebElement container = Locator.tag("td").withAttribute("data-caption", fieldCaption).findElement(this);
+        ReactSelect.finder(_driver).find(container).clearSelection();
         return this;
     }
 
@@ -407,7 +409,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
 
     public static class DetailTableEditFinder extends WebDriverComponent.WebDriverComponentFinder<DetailTableEdit, DetailTableEditFinder>
     {
-        private Locator.XPathLocator _baseLocator = Locator.tag("form")
+        private final Locator.XPathLocator _baseLocator = Locator.tag("form")
                 .withDescendant(Locator.tagWithClass("table", "detail-component--table__fixed"));
         private Locator _locator;
 

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -295,8 +295,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
      **/
     public DetailTableEdit setSelectValue(String fieldCaption, List<String> selectValues)
     {
-        WebElement container = Locator.tag("td").withAttribute("data-caption", fieldCaption).findElement(this);
-        FilteringReactSelect reactSelect =  FilteringReactSelect.finder(_driver).find(container);
+        FilteringReactSelect reactSelect = elementCache().findSelect(fieldCaption);
         selectValues.forEach(s -> {reactSelect.typeAheadSelect(s);});
         return this;
     }
@@ -309,8 +308,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
      **/
     public DetailTableEdit clearSelectValue(String fieldCaption)
     {
-        WebElement container = Locator.tag("td").withAttribute("data-caption", fieldCaption).findElement(this);
-        ReactSelect.finder(_driver).find(container).clearSelection();
+        elementCache().findSelect(fieldCaption).clearSelection();
         return this;
     }
 
@@ -405,6 +403,12 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
                 .findWhenNeeded(this);
         public WebElement cancelButton = Locator.tagWithAttribute("button", "type", "button")
                 .findWhenNeeded(this);
+
+        public FilteringReactSelect findSelect(String fieldCaption)
+        {
+            WebElement container = Locator.tag("td").withAttribute("data-caption", fieldCaption).findElement(this);
+            return FilteringReactSelect.finder(_driver).find(container);
+        }
     }
 
     public static class DetailTableEditFinder extends WebDriverComponent.WebDriverComponentFinder<DetailTableEdit, DetailTableEditFinder>


### PR DESCRIPTION
#### Rationale
this re-implements `setSelectValue `and `clearSelectValue` on DetailTableEdit (which are currently not in use) to find the intended reactSelect by searching in its scope, instead of searching for it by way of it following a label.  

This seemed like a reasonable idea when I wanted to edit Run Details in Biologics (see related PR) and noticed that these methods 1) did not work, and 2) were not in use.
My best guess is these methods worked at one point, but the components changed (the label isn't in a label tag) and when it didn't cause any tests to fail, there wasn't need to update these

#### Related Pull Requests
TBD

#### Changes
Find the select in a search context by its data-caption attribute (which is also the text on the label)
![image](https://user-images.githubusercontent.com/16809856/144685357-8929a611-e2e9-4a74-80f5-a3762c7e87d2.png)

