### PR TITLE
Add 'Ext4Helper.elementIfEnabled'

### DIFF
--- a/src/org/labkey/test/util/Ext4Helper.java
+++ b/src/org/labkey/test/util/Ext4Helper.java
@@ -985,7 +985,7 @@ public class Ext4Helper
      */
     public static WebElement elementIfEnabled(WebElement el)
     {
-        if (!el.isEnabled() || Locator.xpath("*::ancestor-or-self").withAttributeContaining("class", "disabled").existsIn(el))
+        if (!el.isEnabled() || Locator.xpath("ancestor-or-self::*").withAttributeContaining("class", "disabled").existsIn(el))
         {
             return null;
         }

--- a/src/org/labkey/test/util/Ext4Helper.java
+++ b/src/org/labkey/test/util/Ext4Helper.java
@@ -976,4 +976,19 @@ public class Ext4Helper
             return Locator.tagWithText("span", label).withClass(_cssPrefix + "tab-button").withDescendant(Locator.tagWithText("span", label).withClass(_cssPrefix + "tab-inner")).notHidden();
         }
     }
+
+    /**
+     * Ext uses non-standard markup to disable elements. Need to check for a 'disabled' class on the element or one of its ancestors.
+     * For use with {@link org.openqa.selenium.support.ui.WebDriverWait}
+     * <br>
+     * Ex: <code>shortWait().until(wd -&gt; elementIfEnabled(ext4Button("Request").findElement(getDriver()))).click();</code>
+     */
+    public static WebElement elementIfEnabled(WebElement el)
+    {
+        if (!el.isEnabled() || Locator.xpath("*::ancestor-or-self").withAttributeContaining("class", "disabled").existsIn(el))
+        {
+            return null;
+        }
+        return el;
+    }
 }


### PR DESCRIPTION
#### Rationale
Ext uses non-standard markup to disable elements. Adding a method to check for a 'disabled' class on an element or one of its ancestors. The pattern used (return null if the element is not enabled) makes this compatible with the `WebDriverWait` API.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/278
* https://github.com/LabKey/tnprc_ehr/pull/675

#### Changes
* Add method to Ext4Helper for determining if an Ext element is disabled
