### PR TITLE
Fb notebook editor test

### DIFF
--- a/src/org/labkey/test/components/html/BootstrapMenu.java
+++ b/src/org/labkey/test/components/html/BootstrapMenu.java
@@ -198,6 +198,23 @@ public class BootstrapMenu extends BaseBootstrapMenu
             return this;
         }
 
+        /**
+         * Some menu controls have IDs prepended with dynamic numbers, like 123-special-menu
+         * @param substring the part of the ID that isn't dynamic
+         * @return
+         */
+        public BootstrapMenuFinder withToggleIdContaining(String substring)
+        {
+            _locator = Locators.dropdownMenu(Locators.dropdownToggle().withAttributeContaining("id", substring));
+            return this;
+        }
+
+        public BootstrapMenuFinder withTitle(String title)
+        {
+            _locator = Locators.dropdownMenu().withAttribute("title", title);
+            return this;
+        }
+
         public BootstrapMenuFinder withButtonText(String text)
         {
             _locator = Locators.dropdownMenu(Locators.dropdownToggle().withText(text));


### PR DESCRIPTION
#### Rationale
This adds two new locator functions to BootstrapMenu's finder to support:

1. The menu with a partial toggleID (in this use case, the ID has a number that changes followed by an identifier that doesn't change from execution to execution)
2. The menu with a title attribute on the component element
![image](https://user-images.githubusercontent.com/16809856/145487615-68b54791-ea7e-404d-844b-867f32412cf2.png)


#### Related Pull Requests
https://github.com/LabKey/biologics/pull/1087 <-- the notebook editor's toolbar uses menus that have title attributes on their componentElement, and toggleIDs that start with generated numbers but end with invariant strings

#### Changes
Adds new finder methods on the BootstrapMenuFinder class
