### PR TITLE
Item 9720: Update Editable Grid display for Lookups to use QuerySelect

### DIFF
--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -366,10 +366,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
     {
         waitForLoaded();
         waitForInteractive();
-
-        elementCache().input.clear();
         elementCache().input.sendKeys(value);
-
         return getThis();
     }
 

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -304,11 +304,20 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
      */
     public List<String> getOptions()
     {
+
+        boolean alreadyOpened = isExpanded();
+
         // Can only get the list of items once the list has been opened.
-        open();
+        if (!alreadyOpened)
+            open();
+
         List<WebElement> selectedItems = Locators.listItems.findElements(getComponentElement());
         List<String> rawItems = getWrapper().getTexts(selectedItems);
-        close();
+
+        // If it wasn't open before close it, otherwise leave it in the open state.
+        if(!alreadyOpened)
+            close();
+
         return rawItems.stream().map(String::trim).collect(Collectors.toList());
     }
 
@@ -349,6 +358,17 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
         elementCache().input.sendKeys(Keys.ENTER);
 
         waitFor(() -> getValueLabelLocator().withText(value).existsIn(getComponentElement()), "Failed to create value \"" + value + "\".", 1_000);
+
+        return getThis();
+    }
+
+    public T enterValueInTextbox(String value)
+    {
+        waitForLoaded();
+        waitForInteractive();
+
+        elementCache().input.clear();
+        elementCache().input.sendKeys(value);
 
         return getThis();
     }

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -37,7 +37,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
 
     public BaseReactSelect(WebElement selectOrParent, WebDriver driver)
     {
-        // Component needs to be refinding because Select may go stale after loading initial selections
+        // Component needs to be a RefindingWebElement because Select may go stale after loading initial selections
         _componentElement = new RefindingWebElement(Locator.xpath("(.|./div)").withClass(SELECTOR_CLASS), selectOrParent);
         _driver = driver;
     }
@@ -176,7 +176,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
         long start = System.currentTimeMillis();
         waitFor(this::isInteractive, "The select-box did not become interactive in time", 2_000);
         long elapsed = System.currentTimeMillis() - start;
-        TestLogger.debug("waited [" + elapsed + "] msec for select to become interactive");
+        TestLogger.debug("waited [" + elapsed + "] ms for select to become interactive");
 
         return getThis();
     }
@@ -298,7 +298,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
     }
 
     /**
-     * Get the items that are in the drop down list. That is the items that may be selected.
+     * Get the items that are in the dropdown list. That is the items that may be selected.
      *
      * @return List of strings for the values in the list.
      */
@@ -362,6 +362,12 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
         return getThis();
     }
 
+    /**
+     * Enter the given value into the text box of the select control. Useful for filtering the options list.
+     *
+     * @param value Value to type in.
+     * @return Reference to the select control.
+     */
     public T enterValueInTextbox(String value)
     {
         waitForLoaded();
@@ -406,20 +412,25 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
         }
     }
 
-    public static abstract class Locators
+    public abstract static class Locators
     {
-        final public static Locator.XPathLocator option = Locator.tagWithClass("div", "select-input__option");
-        public static Locator options = Locator.tagWithClass("div", "select-input__option");
-        public static Locator placeholder = Locator.tagWithClass("div", "select-input__placeholder");
-        public static Locator clear = Locator.tagWithClass("div","select-input__clear-indicator");
-        public static Locator arrow = Locator.tagWithClass("div","select-input__dropdown-indicator");
-        public static Locator selectMenu = Locator.tagWithClass("div", "select-input__menu-list");
-        public static Locator.XPathLocator multiValue = Locator.tagWithClass("div", "select-input__multi-value");
-        public static Locator.XPathLocator multiValueLabels = Locator.tagWithClass("div", "select-input__multi-value__label");
-        public static Locator.XPathLocator multiValueRemove = Locator.tagWithClass("div", "select-input__multi-value__remove");
-        public static Locator.XPathLocator singleValueLabel = Locator.tagWithClass("div", "select-input__single-value");
-        public static Locator loadingSpinner = Locator.tagWithClass("span", "select-input__loading-indicator");
-        final public static Locator listItems = Locator.tagWithClass("div", "select-input__option");
+        private Locators()
+        {
+            // Do nothing constructor to prevent instantiation.
+        }
+
+        public static final Locator.XPathLocator option = Locator.tagWithClass("div", "select-input__option");
+        public static final Locator options = Locator.tagWithClass("div", "select-input__option");
+        public static final Locator placeholder = Locator.tagWithClass("div", "select-input__placeholder");
+        public static final Locator clear = Locator.tagWithClass("div","select-input__clear-indicator");
+        public static final Locator arrow = Locator.tagWithClass("div","select-input__dropdown-indicator");
+        public static final Locator selectMenu = Locator.tagWithClass("div", "select-input__menu-list");
+        public static final Locator.XPathLocator multiValue = Locator.tagWithClass("div", "select-input__multi-value");
+        public static final Locator.XPathLocator multiValueLabels = Locator.tagWithClass("div", "select-input__multi-value__label");
+        public static final Locator.XPathLocator multiValueRemove = Locator.tagWithClass("div", "select-input__multi-value__remove");
+        public static final Locator.XPathLocator singleValueLabel = Locator.tagWithClass("div", "select-input__single-value");
+        public static final Locator loadingSpinner = Locator.tagWithClass("span", "select-input__loading-indicator");
+        public static final Locator listItems = Locator.tagWithClass("div", "select-input__option");
 
         public static Locator.XPathLocator selectContainer()
         {
@@ -462,7 +473,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
         }
     }
 
-    public static abstract class BaseReactSelectFinder<Select extends BaseReactSelect<Select>> extends WebDriverComponent.WebDriverComponentFinder<Select, BaseReactSelectFinder<Select>>
+    public abstract static class BaseReactSelectFinder<Select extends BaseReactSelect<Select>> extends WebDriverComponent.WebDriverComponentFinder<Select, BaseReactSelectFinder<Select>>
     {
         private Locator.XPathLocator _locator;
         private boolean _mustBeEnabled = false;

--- a/src/org/labkey/test/components/react/ReactSelect.java
+++ b/src/org/labkey/test/components/react/ReactSelect.java
@@ -31,7 +31,7 @@ public class ReactSelect extends BaseReactSelect<ReactSelect>
         super(element, driver);
     }
 
-    static public ReactSelectFinder finder(WebDriver driver)
+    public static ReactSelectFinder finder(WebDriver driver)
     {
         return new ReactSelectFinder(driver);
     }
@@ -93,7 +93,7 @@ public class ReactSelect extends BaseReactSelect<ReactSelect>
 
                     // Since this is a retry method try to improve the odds of finding the item in the list by entering
                     // it into the textbox, which should filter the list. Also, closing and opening the dropdown will
-                    // clear any value that may have been entered in the text box, this should protects against that as well.
+                    // clear any value that may have been entered in the text box, this should protect against that as well.
                     enterValueInTextbox(option);
 
                     // Don't know if this is will work as expected. It may take a moment for the list to populate

--- a/src/org/labkey/test/components/react/ReactSelect.java
+++ b/src/org/labkey/test/components/react/ReactSelect.java
@@ -50,25 +50,18 @@ public class ReactSelect extends BaseReactSelect<ReactSelect>
 
     public void select(String option)
     {
-
-        if(!isOpen())
-        {
-            waitForLoaded();
-            scrollIntoView();
-            open();
-        }
+        waitForLoaded();
+        scrollIntoView();
+        open();
         clickOption(option);
         waitForClosed();
     }
 
     public void typeOptionThenSelect(String option)
     {
-        if(!isOpen())
-        {
-            waitForLoaded();
-            scrollIntoView();
-            open();
-        }
+        waitForLoaded();
+        scrollIntoView();
+        open();
         enterValueInTextbox(option);
         waitForLoaded();
 
@@ -82,9 +75,6 @@ public class ReactSelect extends BaseReactSelect<ReactSelect>
     {
         WebElement optionEl = null;
         int tryCount = 0;
-
-        // Get the value of the text box.
-        String optionTypedIn = getValue();
 
         while (null == optionEl)
         {
@@ -101,16 +91,14 @@ public class ReactSelect extends BaseReactSelect<ReactSelect>
                     close();
                     open();
 
-                    // If a value had been typed, closing and opening the list will clear it, so try to get back to the
-                    // original state and enter the value again in the textbox.
-                    if(!optionTypedIn.isEmpty())
-                    {
-                        enterValueInTextbox(option);
+                    // Since this is a retry method try to improve the odds of finding the item in the list by entering
+                    // it into the textbox, which should filter the list. Also, closing and opening the dropdown will
+                    // clear any value that may have been entered in the text box, this should protects against that as well.
+                    enterValueInTextbox(option);
 
-                        // Don't know if this is will work as expected. It may take a moment for the list to populate
-                        // after typing in a value.
-                        waitFor(()->!getOptions().contains("Loading..."), 1_000);
-                    }
+                    // Don't know if this is will work as expected. It may take a moment for the list to populate
+                    // after typing in a value.
+                    waitFor(()->!getOptions().contains("Loading..."), 1_000);
 
                 }
                 else

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -450,6 +450,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         {
             // Make the dropdown appear.
             getWrapper().doubleClick(td);
+            waitFor(()->elementCache().lookupSelect().isExpanded(), "Dropdown list for the cell did not show up.", 1_000);
             listText = elementCache().lookupSelect().getOptions();
         }
 

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -98,7 +98,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         for (int i=0; i< columnTexts.size(); i++ )
         {
             if (columnTexts.get(i).equalsIgnoreCase(columnHeader))
-                return i + 1; // Zero (0) based index in the list, one (1) based index with the controls collection.
+                return i + 1; // Zero (0) based index in the list, one (1) based index with the control collection.
         }
         return -1;
     }
@@ -162,7 +162,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
                 if (columnName.equals(SELECT_COLUMN_HEADER))
                 {
-                    // Special case the check box.
+                    // Special case the checkbox.
                     if (null == cell.findElement(By.tagName("input")).getAttribute("checked"))
                         mapData.put(columnName, "false");
                     else
@@ -268,7 +268,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
             rowCount++;
         }
 
-        return new ArrayList<List<Integer>>(Arrays.asList(unPopulatedRows, populatedRows));
+        return new ArrayList<>(Arrays.asList(unPopulatedRows, populatedRows));
     }
 
     /**
@@ -286,7 +286,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
      * </p>
      *
      * @param columnNameToSearch The name of the column to check if a row should be updated or not.
-     * @param valueToSearch The value to check for in 'columnNameToSearch' to see if a should be updated.
+     * @param valueToSearch The value to check for in 'columnNameToSearch' to see if the row should be updated.
      * @param columnNameToSet The column to update in a row.
      * @param valueToSet The new value to put into column 'columnNameToSet'.
      */
@@ -359,7 +359,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
             // Wait until the grid cell has the updated text. Check for contains, not equal, because when updating a cell
             // the cell's new value will be the old value plus the new value and the cursor may not be placed at the end
-            // of the existing value so the new value should exist some where in the cell text value not necessarily
+            // of the existing value so the new value should exist somewhere in the cell text value not necessarily
             // at the end of it.
             WebDriverWrapper.waitFor(() -> gridCell.getText().contains(value.toString()),
                     "Value entered into inputCell '" + value + "' did not appear in grid cell.", WAIT_FOR_JAVASCRIPT);
@@ -445,7 +445,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
     /**
      * For the given row and column type some text into the cell to get the 'filtered' values displayed in the dropdown list.
-     * If this cell is not a lookup cell, does not have a dropdown, the text will not be entered and a empty list will be returned.
+     * If this cell is not a lookup cell, does not have a dropdown, the text will not be entered and an empty list will be returned.
      *
      * @param row A 0 based index containing the cell.
      * @param columnName The column of the cell.
@@ -473,8 +473,8 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
             ReactSelect lookupSelect = elementCache().lookupSelect();
 
-            // If the double click did not expand the slect this will.
-            // This will also have no effect if the list was expended.
+            // If the double click did not expand the select this will.
+            // This will have no effect if the list is expended.
             lookupSelect.open();
 
             if (filterText != null && !filterText.trim().isEmpty())
@@ -507,7 +507,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
         // wait for the cell value to change or the rowcount to change, and the target cell to go into highlight,
         // ... or for a second and a half
-        getWrapper().waitFor(()-> (getRowCount() > initialRowCount || !indexValue.equals(gridCell.getText())) &&
+        WebDriverWrapper.waitFor(()-> (getRowCount() > initialRowCount || !indexValue.equals(gridCell.getText())) &&
                         isInSelection(gridCell), 1500);
         return this;
     }
@@ -540,8 +540,6 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
      * @param endRowIndex   Index of the bottom-right cell's row
      * @param endColumn     Column header of the bottom-right cell
      * @return  the text contained in the prescribed selection
-     * @throws IOException
-     * @throws UnsupportedFlavorException
      */
     public String copyCellRange(int startRowIndex, String startColumn, int endRowIndex, String endColumn) throws IOException, UnsupportedFlavorException
     {
@@ -554,19 +552,17 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
     /**
      * Selects all cells in the table, then copies their contents into delimited text
      * @return  delimited text content of the cells in the grid
-     * @throws IOException
-     * @throws UnsupportedFlavorException
      */
     public String copyAllCells() throws IOException, UnsupportedFlavorException
     {
         selectAllCells();
-        getWrapper().waitFor(()-> areAllInSelection(),
+        WebDriverWrapper.waitFor(this::areAllInSelection,
                 "expect all cells to be selected before copying grid values", 1500);
 
         String selection = copyCurrentSelection();
         if (selection.isEmpty())
         {
-            log("initial attempt to copy current selection came up empty.  re-trying after 3000 msec");
+            log("initial attempt to copy current selection came up empty.  re-trying after 3000 ms");
             new WebDriverWait(getDriver(), Duration.ofSeconds(3));
             return copyCurrentSelection();
         }
@@ -598,7 +594,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
                 .build()
                 .perform();
 
-        getWrapper().waitFor(()-> isInSelection(startCell) && isInSelection(endCell),
+        WebDriverWrapper.waitFor(()-> isInSelection(startCell) && isInSelection(endCell),
                 "Cell range did not become selected", 2000);
         return this;
     }
@@ -613,28 +609,27 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
             // use 'ctrl-a' to select the entire grid
             Keys cmdKey = SystemUtils.IS_OS_MAC ? Keys.COMMAND : Keys.CONTROL;
             new Actions(getDriver()).keyDown(cmdKey).sendKeys("a").keyUp(cmdKey).build().perform();
-            getWrapper().waitFor(() -> areAllInSelection(),
+            WebDriverWrapper.waitFor(this::areAllInSelection,
                     "the expected cells did not become selected", 3000);
         }
     }
 
     /**
      * puts the specified cell into a selected state (appears as a dark-blue outline) with an active input present in it.
-     * @param cell
      */
     private void selectCell(WebElement cell)
     {
         if (!isCellSelected(cell))
         {
             cell.click();
-            getWrapper().waitFor(()->  isCellSelected(cell),
+            WebDriverWrapper.waitFor(()->  isCellSelected(cell),
                     "the target cell did not become selected", 4000);
         }
     }
 
     private void activateCell(WebElement cell)
     {
-        // If it is a selector and it already has focus (is active) it will not have a div.cellular-display
+        // If it is a selector, and it already has focus (is active), it will not have a div.cellular-display
         if(Locator.tagWithClass("div", "select-input__control--is-focused")
                 .findElements(cell).isEmpty())
         {
@@ -713,7 +708,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
     {
         WebElement warnDiv = Locator.tagWithClass("div", "cellular-display").findElement(getCell(row, column));
         getWrapper().mouseOver(warnDiv);   // cause the tooltip to be present
-        if (getWrapper().waitFor(()-> null != warnDiv.getAttribute("aria-describedby"), 1000))
+        if (WebDriverWrapper.waitFor(()-> null != warnDiv.getAttribute("aria-describedby"), 1000))
         {
             String popoverId = warnDiv.getAttribute("aria-describedby");
             return Locator.id(popoverId).findElement(getDriver()).getText();
@@ -759,7 +754,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
     protected class ElementCache extends Component<?>.ElementCache
     {
-        public WebElement selectColumn = Locator.xpath("//th/input[@type='checkbox']").findWhenNeeded(getComponentElement());
+        public final WebElement selectColumn = Locator.xpath("//th/input[@type='checkbox']").findWhenNeeded(getComponentElement());
         public WebElement inputCell()
         {
             return Locators.inputCell.findElement(getComponentElement());
@@ -772,9 +767,14 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
     }
 
-    protected static abstract class Locators
+    protected abstract static class Locators
     {
-        static public Locator.XPathLocator editableGrid()
+        private Locators()
+        {
+            // Do nothing constructor to prevent instantiation.
+        }
+
+        public static Locator.XPathLocator editableGrid()
         {
             return Locator.byClass("table-cellular");
         }

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -339,20 +339,12 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
             waitFor(()->lookupSelect.isInteractive() && !lookupSelect.isLoading(), "Select control is not ready.", 1_000);
             lookupSelect.open();
-            List<String> valuesListed = lookupSelect.getOptions();
 
             for (String _value : values)
             {
-
-                if(!valuesListed.contains(_value))
-                {
-                    lookupSelect.typeOptionThenSelect(_value);
-                }
-                else
-                {
-                    lookupSelect.select(_value);
-                }
+                lookupSelect.typeOptionThenSelect(_value);
             }
+
         }
         else
         {

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -652,13 +652,15 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
     {
         try
         {
+            // If the cell is a reactSelect, and it is open/active, this will throw a NoSuchElementException because the
+            // div will not have the cell-selected in the class attribute.
             return Locator.tagWithClass("div", "cellular-display")
                     .findElement(cell)
                     .getAttribute("class").contains("cell-selected");
         }
         catch(NoSuchElementException nse)
         {
-            // If the cell has a reactSelect it may have a different marker to indicate it is selected.
+            // If the cell is an open/active reactSelect the class attribute is different.
             return Locator.tagWithClass("div", "select-input__control")
                     .findElement(cell)
                     .getAttribute("class").contains("select-input__control--is-focused");
@@ -672,7 +674,10 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
      */
     private boolean isInSelection(WebElement cell)  // 'in selection' shows as blue color, means it is part of one or many selected cells for copy/paste, etc
     {
-        return isCellSelected(cell);
+        // Should not need to add code for a reactSelect here. A selection involves clicking/dragging, which closes the reactSelect.
+        return Locator.tagWithClass("div", "cellular-display")
+                .findElement(cell)
+                .getAttribute("class").contains("cell-selection");
     }
 
     /**

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.labkey.test.BaseWebDriverTest.WAIT_FOR_JAVASCRIPT;
+import static org.labkey.test.WebDriverWrapper.waitFor;
 import static org.labkey.test.util.TestLogger.log;
 
 public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
@@ -336,9 +337,21 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
             ReactSelect lookupSelect = elementCache().lookupSelect();
 
+            waitFor(()->lookupSelect.isInteractive() && !lookupSelect.isLoading(), "Select control is not ready.", 1_000);
+            lookupSelect.open();
+            List<String> valuesListed = lookupSelect.getOptions();
+
             for (String _value : values)
             {
-                lookupSelect.select(_value);
+
+                if(!valuesListed.contains(_value))
+                {
+                    lookupSelect.typeOptionThenSelect(_value);
+                }
+                else
+                {
+                    lookupSelect.select(_value);
+                }
             }
         }
         else


### PR DESCRIPTION
#### Rationale
We've updated the Editable grid to use a `ReactSelect` component and need to adjust the test components accordingly.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/344
* https://github.com/LabKey/sampleManagement/pull/776
* https://github.com/LabKey/biologics/pull/1089
* https://github.com/LabKey/labkey-ui-components/pull/686

#### Changes
* Add `enterValueInTextbox` method for `BaseReactSelect`
* Add `typeOptionThenSelect` method for `ReactSelect`
* Update `EditableGrid` to account for use of `ReactSelect`
