### PR TITLE
Try to get info for troubleshooting WebDriver stack overflow

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -910,7 +910,17 @@ public abstract class WebDriverWrapper implements WrapsDriver
     {
         waitFor(() -> getDriver().getWindowHandles().size() > index, WAIT_FOR_JAVASCRIPT);
         List<String> windows = new ArrayList<>(getDriver().getWindowHandles());
-        getDriver().switchTo().window(windows.get(index));
+        try
+        {
+            getDriver().switchTo().window(windows.get(index));
+        }
+        catch (StackOverflowError soe)
+        {
+            // Try to get info for troubleshooting WebDriver issue
+            // https://github.com/SeleniumHQ/selenium/issues/6081
+            throw new RuntimeException("Internal WebDriver error attempting to switch to window '" +
+                    windows.get(index) + "'. Available windows: " + windows, soe);
+        }
     }
 
     protected void closeExtraWindows()


### PR DESCRIPTION
#### Rationale
Test suites have started failing recently with a stack overflow when attempting to switch browser windows. The problem seems to be `WebDriver.getWindowHandles` returning invalid handles. This change logs with window handles when the

#### Changes
* Log more info from StackOverflowException when switching windows fails
