### PR TITLE
Avoid leaving geckodriver processes running

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -84,8 +84,10 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxDriverLogLevel;
+import org.openqa.selenium.firefox.FirefoxDriverService;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
+import org.openqa.selenium.firefox.GeckoDriverService;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.remote.RemoteWebDriver;
@@ -362,9 +364,11 @@ public abstract class WebDriverWrapper implements WrapsDriver
                     }
                     capabilities.setCapability(FirefoxDriver.BINARY, binary);
                     FirefoxOptions firefoxOptions = new FirefoxOptions(capabilities);
+
+                    newDriverService = GeckoDriverService.createDefaultService();
                     try
                     {
-                        newWebDriver = new FirefoxDriver(firefoxOptions);
+                        newWebDriver = new FirefoxDriver((FirefoxDriverService) newDriverService, firefoxOptions);
                     }
                     catch (WebDriverException retry)
                     {
@@ -372,10 +376,14 @@ public abstract class WebDriverWrapper implements WrapsDriver
                         {
                             retry.printStackTrace(System.err);
                             sleep(10000);
-                            newWebDriver = new FirefoxDriver(firefoxOptions);
+                            newWebDriver = new FirefoxDriver((FirefoxDriverService) newDriverService, firefoxOptions);
                         }
                         catch (WebDriverException rethrow)
                         {
+                            if (newDriverService.isRunning())
+                            {
+                                newDriverService.stop();
+                            }
                             throw new WebDriverException("ERROR: Failed to initialize FirefoxDriver. " +
                                     "Ensure that you are using compatible versions of Firefox and geckodriver. " +
                                     "https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html", rethrow);


### PR DESCRIPTION
#### Rationale
We run WebDriver in "detach"ed mode in order to leave browser windows open after tests. To avoid leaving driver driver processes running after tests have completed, we need to shut down the driver explicitly. This was done from [chromedriver](https://github.com/LabKey/testAutomation/commit/91243100c7acf3be2acef6c593bab531cccd32f9) but FirefoxDriver didn't support this at that time.

#### Changes
* Explicitly instantiate `GeckoDriverService` to avoid leaving zombie processes
