### PR TITLE
Twiddle spinner to try to get height setting to stick

### DIFF
--- a/src/org/labkey/test/tests/DataViewsTest.java
+++ b/src/org/labkey/test/tests/DataViewsTest.java
@@ -33,7 +33,6 @@ import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.RReportHelper;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
 import static org.junit.Assert.assertEquals;
@@ -548,8 +547,8 @@ public class DataViewsTest extends ParticipantListTest
         // specify a custom height
         WebElement heightInput = Locator.name("height").withoutAttribute("disabled").waitForElement(getDriver(), 1000);
         setFormElement(heightInput, String.valueOf(NEW_CUSTOM_HEIGHT));
-        heightInput.sendKeys(Keys.ARROW_DOWN, Keys.ARROW_UP);
-        fireEvent(heightInput, SeleniumEvent.blur);
+        Locator.byClass("x4-form-spinner-down").findElement(getDriver()).click();
+        Locator.byClass("x4-form-spinner-up").findElement(getDriver()).click();
         clickButton("Save", 0);
         _ext4Helper.waitForMaskToDisappear();
 


### PR DESCRIPTION
#### Rationale
The data views webpart custom height test fails regularly on TeamCity. Going to try to click up and down instead of pressing the arrow keys.

#### Changes
* Click up and down on the spinner input to try to get value to stick before saving.
 
![image](https://user-images.githubusercontent.com/5263798/147779364-9e48aa30-4836-467a-a2d8-504071b90e71.png)

