### PR TITLE
Don't call 'mouseOut' after page loads

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -64,6 +64,7 @@ import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Cookie;
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.HasCapabilities;
 import org.openqa.selenium.JavascriptException;
 import org.openqa.selenium.JavascriptExecutor;
@@ -2803,7 +2804,8 @@ public abstract class WebDriverWrapper implements WrapsDriver
         {
             scrollTo(0, 0);
             WebElement root = Locators.documentRoot.findElement(getDriver());
-            new Actions(getDriver()).moveToElement(root, 0, 0).perform();
+            final Dimension rootSize = root.getSize();
+            new Actions(getDriver()).moveToElement(root, - (rootSize.getWidth() / 2), - (rootSize.getHeight() / 2)).perform();
         }
         catch (WebDriverException ignore) { }
     }

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1909,7 +1909,6 @@ public abstract class WebDriverWrapper implements WrapsDriver
                     }
                 }), "App didn't seem to load. No visible content. " + app.toString(), 10000);
         }
-        mouseOut();
         _testTimeout = false;
     }
 


### PR DESCRIPTION
#### Rationale
This `mouseOut` was added to prevent tooltips from popping up under the mouse after navigation by moving the mouse to the corner of the page. At some point, Selenium changed/standardized the behavior of `moveToElement` (used by `mouseOut`) to move relative to the center of the element instead of the upper left corner. As far as I can tell, the mouse defaults to `0, 0` after navigating, so this attempt to move there is unnecessary.
The current behavior actually moves the mouse to the center of the window, which frequently causes failures in tests interacting with the data views webpart because large portions of it show tooltips when hovered over.

#### Changes
* Don't call `mouseOut` after page loads
* Fix offsets in `mouseOut` to move to upper left corner