### PR TITLE
SimpleFSDirectory has been removed from Lucene 9.0.0

### DIFF
--- a/src/org/labkey/test/util/search/SearchAdminAPIHelper.java
+++ b/src/org/labkey/test/util/search/SearchAdminAPIHelper.java
@@ -156,7 +156,6 @@ public abstract class SearchAdminAPIHelper
     {
         Default,
         MMapDirectory,
-        NIOFSDirectory,
-        SimpleFSDirectory
+        NIOFSDirectory
     }
 }


### PR DESCRIPTION
#### Rationale
No need to test a file system that doesn't exist