### PR TITLE
Various Test Fixes for Editable Grid with React Select, Assay Helper, and Editable Entity Panel

### DIFF
--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -101,7 +101,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
     {
         // if either are present, we're loading options
         return Locators.loadingSpinner.existsIn(getComponentElement()) ||
-                LOADING_TEXT.equalsIgnoreCase(getComponentElement().getText());
+                getComponentElement().getText().toLowerCase().contains(LOADING_TEXT);
     }
 
     public boolean isOpen()

--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -101,6 +101,14 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
         Locator infoPanel = Locator.tagWithClass("div", "panel-info");
         int infoCount = infoPanel.findElements(getDriver()).size();
 
+        if(infoCount > 1)
+        {
+            getWrapper().log("Whoa, there appears to be more than one panel in edit mode. That is odd.");
+        }
+
+        // Shouldn't need to do this, but when tests fail, because the panel did not exit edit mode, the button is not in view.
+        getWrapper().scrollIntoView(button);
+
         button.click();
 
         WebDriverWrapper.waitFor(()->

--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -1,5 +1,6 @@
 package org.labkey.test.components.ui.entities;
 
+import org.junit.Assert;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
@@ -101,10 +102,8 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
         Locator infoPanel = Locator.tagWithClass("div", "panel-info");
         int infoCount = infoPanel.findElements(getDriver()).size();
 
-        if(infoCount > 1)
-        {
-            getWrapper().log("Whoa, there appears to be more than one panel in edit mode. That is odd.");
-        }
+        Assert.assertTrue("Whoa, there appears to be more than one panel in edit mode. This should never happen.",
+                infoCount <= 1);
 
         // Shouldn't need to do this, but when tests fail, because the panel did not exit edit mode, the button is not in view.
         getWrapper().scrollIntoView(button);

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -459,7 +459,6 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         WebElement gridCell = getCell(row, columnName);
 
         selectCell(gridCell);
-        waitFor(()->isCellSelected(gridCell), "Grid cell is not selected, cannot get dropdown list.", 500);
 
         // Double click to make the ReactSelect active. This may expand the list.
         getWrapper().doubleClick(gridCell);

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -458,34 +458,24 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         // Get a reference to the cell.
         WebElement gridCell = getCell(row, columnName);
 
-        // If the td does not contain a 'menu-selector' then it is not a look-up.
-        WebElement div = Locator.findAnyElementOrNull(gridCell, Locator.tagWithClass("span", "cell-menu-selector"));
+        selectCell(gridCell);
+        waitFor(()->isCellSelected(gridCell), "Grid cell is not selected, cannot get dropdown list.", 500);
 
-        List<String> listText = new ArrayList<>();
+        // Double click to make the ReactSelect active. This may expand the list.
+        getWrapper().doubleClick(gridCell);
 
-        if (div != null)
+        ReactSelect lookupSelect = elementCache().lookupSelect();
+
+        // If the double click did not expand the select this will.
+        // This will have no effect if the list is expended.
+        lookupSelect.open();
+
+        if (filterText != null && !filterText.trim().isEmpty())
         {
-            selectCell(gridCell);
-            waitFor(()->isCellSelected(gridCell), "Grid cell is not selected, cannot get dropdown list.", 500);
-
-            // Double click to make the ReactSelect active. This may expand the list.
-            getWrapper().doubleClick(gridCell);
-
-            ReactSelect lookupSelect = elementCache().lookupSelect();
-
-            // If the double click did not expand the select this will.
-            // This will have no effect if the list is expended.
-            lookupSelect.open();
-
-            if (filterText != null && !filterText.trim().isEmpty())
-            {
-                lookupSelect.enterValueInTextbox(filterText);
-            }
-
-            listText = lookupSelect.getOptions();
+            lookupSelect.enterValueInTextbox(filterText);
         }
 
-        return listText;
+        return lookupSelect.getOptions();
     }
 
     /**

--- a/src/org/labkey/test/util/AbstractAssayHelper.java
+++ b/src/org/labkey/test/util/AbstractAssayHelper.java
@@ -22,6 +22,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.assay.ChooseAssayTypePage;
+import org.openqa.selenium.WebElement;
 
 import java.io.File;
 import java.io.IOException;
@@ -127,7 +128,9 @@ public abstract class AbstractAssayHelper
     public void deleteAssayDesign()
     {
         clickManageOption(true, "Delete assay design");
-        _test.clickButton("Confirm Delete");
+        WebElement confirmButton = Locator.lkButton("Confirm Delete").findWhenNeeded(_test.getDriver());
+        _test.waitFor(()->confirmButton.isDisplayed(), "'Confirm Delete' button is not visible.", 2_500);
+        _test.clickAndWait(confirmButton);
     }
 
     public File exportAssayDesign()


### PR DESCRIPTION
#### Rationale
Some various test fixes:

- Stamping out a few lingering issues with editable grids and the ReactSelect integration.
- In the AssayHelper, replaced the `_test.clickButton("Confirm Delete")` with a 'wait for button then click' code.
- Added a check to make sure that the entity panel is in view when editing.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/793

#### Changes
* Updated check for loading check (of ReactSelect drop down list).
* Added a check that only one domain panel is in edit mode at a time.
* Remove check in editable grid that returns an empty list if no dropdown is present. If the cell does not have a drop down the check fails.
