### PR TITLE
When calling waitForLoaded, first ensure component is present

### DIFF
--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -111,7 +111,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
 
     protected T waitForLoaded()
     {
-        waitFor(() -> !isLoading(),
+        waitFor(() -> getComponentElement().isDisplayed() && !isLoading(),
                 "Took too long for to become loaded", WAIT_FOR_JAVASCRIPT);
         return getThis();
     }
@@ -477,7 +477,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
     {
         private Locator.XPathLocator _locator;
         private boolean _mustBeEnabled = false;
-        private boolean _findParent = true;
+        private final boolean _findParent = true;
 
         // Issue 40267: Calling findAll for the react select test component needs to be refined.
         protected BaseReactSelectFinder(WebDriver driver)

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -477,7 +477,6 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
     {
         private Locator.XPathLocator _locator;
         private boolean _mustBeEnabled = false;
-        private final boolean _findParent = true;
 
         // Issue 40267: Calling findAll for the react select test component needs to be refined.
         protected BaseReactSelectFinder(WebDriver driver)
@@ -574,8 +573,6 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
             Locator.XPathLocator tmpLoc = _locator;
             if (_mustBeEnabled)
                 tmpLoc = _locator.withoutClass("is-disabled");
-            if (_findParent)
-                tmpLoc.parent();
             return tmpLoc;
         }
     }


### PR DESCRIPTION
#### Rationale
Recently some tests have begun to fail in the call to waitForLoaded on a reactSelect in ways that suggest that the component itself is not yet present (causing the check for the presence of the "loading..." mask or the spinner to fail because the search context isn't there yet).  
Finding components lazily can result in the situation where the componentElement isn't there yet, which can be defended in the calling context by adding `.timeout(nnn)` to the finder's call- but this change causes waitForLoaded to first check to see if the componentElement is present (if it isn't it'll fail like this) before checking to see if any of the` isLoading() `conditions are true

[here](https://teamcity.labkey.org/viewLog.html?buildId=1659818&tab=buildResultsDiv&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsBPostgres&branch_LabKey_Trunk_Premium_ProductSuites_Biologics=%3Cdefault%3E#testNameId-2172338325796289313) is an example of such a failure

#### Related Pull Requests
n/a

#### Changes
don't ask if isLoading() is true until after confirming the componentElement is displayed
