### PR TITLE
AssayExportImportTest fix by removing extra run import click after all files have been used

### DIFF
--- a/src/org/labkey/test/tests/AssayExportImportTest.java
+++ b/src/org/labkey/test/tests/AssayExportImportTest.java
@@ -187,6 +187,7 @@ public class AssayExportImportTest extends BaseWebDriverTest
         {
             clickAndWait(Locator.linkWithText(assayName));
             waitForElement(Locator.lkButton("Import Data"));
+            checker().takeScreenShot("assay_grid_import");
             clickAndWait(Locator.lkButton("Import Data"));
         }
 
@@ -211,6 +212,7 @@ public class AssayExportImportTest extends BaseWebDriverTest
                 waitForElementToBeVisible(Locator.tagWithAttribute("input", "type", "file"));
                 setFormElement(Locator.tagWithAttribute("input", "type", "file"), runFiles.get(fileIndex++));
 
+                checker().takeScreenShot("before_assay_save_file");
                 if (isElementPresent(Locator.lkButton("Save and Import Another Run")))
                 {
                     clickAndWait(Locator.lkButton("Save and Import Another Run"));
@@ -220,7 +222,7 @@ public class AssayExportImportTest extends BaseWebDriverTest
             }
             else
             {
-                checker().takeScreenShot("before_assay_save");
+                checker().takeScreenShot("before_assay_save_pipeline");
                 if (isElementPresent(Locator.lkButton("Save and Import Another Run")))
                 {
                     clickAndWait(Locator.lkButton("Save and Import Another Run"));

--- a/src/org/labkey/test/tests/AssayExportImportTest.java
+++ b/src/org/labkey/test/tests/AssayExportImportTest.java
@@ -213,7 +213,7 @@ public class AssayExportImportTest extends BaseWebDriverTest
                 setFormElement(Locator.tagWithAttribute("input", "type", "file"), runFiles.get(fileIndex++));
 
                 checker().takeScreenShot("before_assay_save_file");
-                if (isElementPresent(Locator.lkButton("Save and Import Another Run")))
+                if (fileIndex < runProperties.size())
                 {
                     clickAndWait(Locator.lkButton("Save and Import Another Run"));
                     waitForElement(Locator.tagWithName("input", "instrumentSetting"));

--- a/src/org/labkey/test/tests/AssayExportImportTest.java
+++ b/src/org/labkey/test/tests/AssayExportImportTest.java
@@ -227,10 +227,10 @@ public class AssayExportImportTest extends BaseWebDriverTest
             }
         }
 
+        checker().takeScreenShot("before_assay_finish");
         clickAndWait(Locator.lkButton("Save and Finish"));
 
         // make sure we end up on the assay runs grid with the expected number of runs
-        scrollBy(0, 100); // testing screenshot info below view frame
         assertTitleContains(assayName + " Runs");
         DataRegionTable runs = new DataRegionTable("Runs", this.getDriver());
         Assert.assertEquals("Unexpected number of assay runs", runFiles.size(), runs.getDataRowCount());

--- a/src/org/labkey/test/tests/AssayExportImportTest.java
+++ b/src/org/labkey/test/tests/AssayExportImportTest.java
@@ -179,6 +179,7 @@ public class AssayExportImportTest extends BaseWebDriverTest
 
             runFiles.forEach(file -> _fileBrowserHelper.selectFileBrowserItem(file.getName()));
 
+            checker().takeScreenShot("file_webpart_selection");
             _fileBrowserHelper.selectImportDataAction(assayName);
 
         }
@@ -219,6 +220,7 @@ public class AssayExportImportTest extends BaseWebDriverTest
             }
             else
             {
+                checker().takeScreenShot("before_assay_save");
                 if (isElementPresent(Locator.lkButton("Save and Import Another Run")))
                 {
                     clickAndWait(Locator.lkButton("Save and Import Another Run"));
@@ -227,7 +229,6 @@ public class AssayExportImportTest extends BaseWebDriverTest
             }
         }
 
-        checker().takeScreenShot("before_assay_finish");
         clickAndWait(Locator.lkButton("Save and Finish"));
 
         // make sure we end up on the assay runs grid with the expected number of runs

--- a/src/org/labkey/test/tests/AssayExportImportTest.java
+++ b/src/org/labkey/test/tests/AssayExportImportTest.java
@@ -230,6 +230,10 @@ public class AssayExportImportTest extends BaseWebDriverTest
 
         clickAndWait(Locator.lkButton("Save and Finish"));
 
+        // make sure we end up on the assay runs grid with the expected number of runs
+        assertTitleContains(assayName + " Runs");
+        DataRegionTable runs = new DataRegionTable("Runs", this.getDriver());
+        Assert.assertEquals("Unexpected number of assay runs", runFiles.size(), runs.getDataRowCount());
     }
 
     private void setFieldValues(String projectName, String assayName, String runId, Map<Integer, Map<String, String>> fieldValues)

--- a/src/org/labkey/test/tests/AssayExportImportTest.java
+++ b/src/org/labkey/test/tests/AssayExportImportTest.java
@@ -179,7 +179,6 @@ public class AssayExportImportTest extends BaseWebDriverTest
 
             runFiles.forEach(file -> _fileBrowserHelper.selectFileBrowserItem(file.getName()));
 
-            checker().takeScreenShot("file_webpart_selection");
             _fileBrowserHelper.selectImportDataAction(assayName);
 
         }
@@ -187,7 +186,6 @@ public class AssayExportImportTest extends BaseWebDriverTest
         {
             clickAndWait(Locator.linkWithText(assayName));
             waitForElement(Locator.lkButton("Import Data"));
-            checker().takeScreenShot("assay_grid_import");
             clickAndWait(Locator.lkButton("Import Data"));
         }
 
@@ -212,7 +210,6 @@ public class AssayExportImportTest extends BaseWebDriverTest
                 waitForElementToBeVisible(Locator.tagWithAttribute("input", "type", "file"));
                 setFormElement(Locator.tagWithAttribute("input", "type", "file"), runFiles.get(fileIndex++));
 
-                checker().takeScreenShot("before_assay_save_file");
                 if (fileIndex < runProperties.size())
                 {
                     clickAndWait(Locator.lkButton("Save and Import Another Run"));
@@ -222,7 +219,6 @@ public class AssayExportImportTest extends BaseWebDriverTest
             }
             else
             {
-                checker().takeScreenShot("before_assay_save_pipeline");
                 if (isElementPresent(Locator.lkButton("Save and Import Another Run")))
                 {
                     clickAndWait(Locator.lkButton("Save and Import Another Run"));

--- a/src/org/labkey/test/tests/AssayExportImportTest.java
+++ b/src/org/labkey/test/tests/AssayExportImportTest.java
@@ -202,8 +202,7 @@ public class AssayExportImportTest extends BaseWebDriverTest
         int fileIndex = 0;
         for(Map<String, String> runProperty : runProperties)
         {
-            runProperty.keySet().forEach((property)->setFormElement(Locator.name(property), runProperty.get(property))
-            );
+            runProperty.keySet().forEach((property)->setFormElement(Locator.name(property), runProperty.get(property)));
 
             if(!useFilesWebPart)
             {
@@ -231,6 +230,7 @@ public class AssayExportImportTest extends BaseWebDriverTest
         clickAndWait(Locator.lkButton("Save and Finish"));
 
         // make sure we end up on the assay runs grid with the expected number of runs
+        scrollBy(0, 100); // testing screenshot info below view frame
         assertTitleContains(assayName + " Runs");
         DataRegionTable runs = new DataRegionTable("Runs", this.getDriver());
         Assert.assertEquals("Unexpected number of assay runs", runFiles.size(), runs.getDataRowCount());


### PR DESCRIPTION
#### Rationale
This test started failing because it couldn't find all of the expected runs for the assay import. I added a check for the run count after the last import (i.e. after the 4th file is used to import an assay run). I also noticed that one of the cases was doing an extra assay import after the 4th run and this was resulting in a "no data found" error since no file/data was provided. Some combination of those changes looks to have fixed the test failure.

#### Changes
* add assay run count check from assay runs grid
* remove extra empty assay run import after 4th run is imported
