### PR TITLE
Use a fresh GeckoDriverService to retry when browser startup fails

### DIFF
--- a/src/org/labkey/test/ExtraSiteWrapper.java
+++ b/src/org/labkey/test/ExtraSiteWrapper.java
@@ -15,30 +15,36 @@
  */
 package org.labkey.test;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.service.DriverService;
 
 import java.io.File;
 
 public class ExtraSiteWrapper extends LabKeySiteWrapper implements AutoCloseable
 {
-    private WebDriver extraDriver;
+    private final Pair<WebDriver, DriverService> extraDriver;
 
     public ExtraSiteWrapper(BrowserType browserType, File downloadDir)
     {
         super();
-        this.extraDriver = createNewWebDriver(browserType, downloadDir).getKey();
+        this.extraDriver = createNewWebDriver(browserType, downloadDir);
     }
 
     @Override
     public void close()
     {
         getDriver().quit();
+        if (extraDriver.getRight() != null)
+        {
+            extraDriver.getRight().stop();
+        }
     }
 
     @Override
     public WebDriver getWrappedDriver()
     {
-        return extraDriver;
+        return extraDriver.getLeft();
     }
 
     @Override

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -375,15 +375,14 @@ public abstract class WebDriverWrapper implements WrapsDriver
                         try
                         {
                             retry.printStackTrace(System.err);
+                            newDriverService.stop();
+                            newDriverService = GeckoDriverService.createDefaultService();
                             sleep(10000);
                             newWebDriver = new FirefoxDriver((FirefoxDriverService) newDriverService, firefoxOptions);
                         }
                         catch (WebDriverException rethrow)
                         {
-                            if (newDriverService.isRunning())
-                            {
-                                newDriverService.stop();
-                            }
+                            newDriverService.stop();
                             throw new WebDriverException("ERROR: Failed to initialize FirefoxDriver. " +
                                     "Ensure that you are using compatible versions of Firefox and geckodriver. " +
                                     "https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html", rethrow);


### PR DESCRIPTION
#### Rationale
When using Firefox 91 with Selenium 4, we're seeing intermittent intermittent failures starting the browser. Our existing retry doesn't resolve the problem effectively.

```
org.labkey.test.Runner STANDARD_ERROR
17:32:11       org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 500. Message: Process unexpectedly closed with status 0
         at org.openqa.selenium.remote.ProtocolHandshake.createSession(ProtocolHandshake.java:126)
         at org.openqa.selenium.remote.ProtocolHandshake.createSession(ProtocolHandshake.java:84)
         at org.openqa.selenium.remote.ProtocolHandshake.createSession(ProtocolHandshake.java:62)
         at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:156)
         at org.openqa.selenium.remote.service.DriverCommandExecutor.invokeExecute(DriverCommandExecutor.java:164)
         at org.openqa.selenium.remote.service.DriverCommandExecutor.execute(DriverCommandExecutor.java:139)
         at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:559)
         at org.openqa.selenium.remote.RemoteWebDriver.startSession(RemoteWebDriver.java:246)
         at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:168)
         at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:198)
         at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:194)
         at org.labkey.test.WebDriverWrapper.createNewWebDriver(WebDriverWrapper.java:371)
```

#### Changes
* Use a fresh `GeckoDriverService` to retry when browser startup fails
