### PR TITLE
Automation Test for Remote API ETL not copying over last row of data …

### DIFF
--- a/modules/ETLtest/resources/ETLs/remoteConnectionWithFilterAndRemoteQueryTransformStep.xml
+++ b/modules/ETLtest/resources/ETLs/remoteConnectionWithFilterAndRemoteQueryTransformStep.xml
@@ -6,7 +6,11 @@
         <transform id="step1" type="RemoteQueryTransformStep">
             <description>Copy to target</description>
             <source remoteSource="EtlTest_RemoteConnection" schemaName="lists" queryName="SourceList" />
-            <destination schemaName="etltest" queryName="target" targetOption="merge"/>
+            <destination schemaName="etltest" queryName="target" targetOption="merge">
+            <alternateKeys>
+                <column name="id"/>
+            </alternateKeys>
+            </destination>
         </transform>
     </transforms>
     <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified"/>

--- a/modules/ETLtest/resources/ETLs/remoteConnectionWithFilterAndRemoteQueryTransformStep.xml
+++ b/modules/ETLtest/resources/ETLs/remoteConnectionWithFilterAndRemoteQueryTransformStep.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>Remote connection with RemoteQueryTransformStep type with incremental filter Test</name>
+    <description>Merge rows from List source to target</description>
+    <transforms>
+        <transform id="step1" type="RemoteQueryTransformStep">
+            <description>Copy to target</description>
+            <source remoteSource="EtlTest_RemoteConnection" schemaName="lists" queryName="SourceList" />
+            <destination schemaName="etltest" queryName="target" targetOption="merge"/>
+        </transform>
+    </transforms>
+    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified"/>
+</etl>


### PR DESCRIPTION
…from incremental filter

#### Rationale
Automation test for Issue 43513: Remote API ETL not copying over last row of data from incremental filter

#### Related Pull Requests
(https://github.com/LabKey/dataintegration/pull/151)

#### Changes
New ETL modules/ETLtest/resources/ETLs/remoteConnectionWithFilterAndRemoteQueryTransformStep.xml
