### PR TITLE
Pre-check URLs for downloads before attempting navigation

### DIFF
--- a/src/org/labkey/test/tests/CrawlerTest.java
+++ b/src/org/labkey/test/tests/CrawlerTest.java
@@ -71,7 +71,7 @@ public class CrawlerTest extends BaseWebDriverTest
         log("Verify that page is vulnerable");
         try
         {
-            beginAt(getInjectUrl(Crawler.injectScriptBlock), 10_000, true);
+            beginAt(getInjectUrl(Crawler.injectScriptBlock), 10_000);
             Assert.fail("Expected an injection alert.");
         }
         catch (UnhandledAlertException alert)
@@ -83,7 +83,7 @@ public class CrawlerTest extends BaseWebDriverTest
         }
         try
         {
-            beginAt(getInjectUrl(Crawler.injectAttributeScript), 10_000, true);
+            beginAt(getInjectUrl(Crawler.injectAttributeScript), 10_000);
             Assert.fail("Expected an injection alert.");
         }
         catch (UnhandledAlertException alert)

--- a/src/org/labkey/test/util/ArtifactCollector.java
+++ b/src/org/labkey/test/util/ArtifactCollector.java
@@ -249,7 +249,7 @@ public class ArtifactCollector
             }
             return pdfFile;
         }
-        catch (IOException ioe)
+        catch (Exception ioe)
         {
             TestLogger.log("Failed dump page pdf: " + ioe.getMessage());
         }

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -21,7 +21,13 @@ import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.EntityUtils;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.labkey.test.BaseWebDriverTest;
@@ -37,6 +43,7 @@ import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriverException;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -55,6 +62,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Random;
 import java.util.Set;
@@ -131,14 +139,14 @@ public class Crawler
         }
         if (projects.isEmpty())
         {
-            _startingUrls.add(new UrlToCheck(null, "/admin-showAdmin.view#links", 0));
-            _startingUrls.add(new UrlToCheck(null, "/admin-spider.view", 2));
+//            _startingUrls.add(new UrlToCheck(null, "/admin-showAdmin.view#links", 0));
+//            _startingUrls.add(new UrlToCheck(null, "/admin-spider.view", 2));
         }
         if (injectionTest)
         {
             test.getUrlsSeen().stream()
                 .filter(url -> !StringUtils.isBlank(url))
-                .map(url -> new UrlToCheck(null, url, 1))
+                .map(url -> new UrlToCheck(null, url, 0))
                 .filter(UrlToCheck::isVisitableURL)
                 .filter(UrlToCheck::isInjectableURL)
                 .forEach(_startingUrls::add);
@@ -333,8 +341,8 @@ public class Crawler
         if (!_projects.contains(project))
         {
             _projects.add(project);
-            _startingUrls.add(new UrlToCheck(null, WebTestHelper.buildRelativeUrl("project", project, "start"), 0));
-            _startingUrls.add(new UrlToCheck(null, WebTestHelper.buildRelativeUrl("admin", project, "spider"), 2));
+//            _startingUrls.add(new UrlToCheck(null, WebTestHelper.buildRelativeUrl("project", project, "start"), 0));
+//            _startingUrls.add(new UrlToCheck(null, WebTestHelper.buildRelativeUrl("admin", project, "spider"), 2));
         }
     }
 
@@ -465,8 +473,17 @@ public class Crawler
                 else
                 {
                     int relativeURLStart = urlText.lastIndexOf(WebTestHelper.getBaseURL()) + WebTestHelper.getBaseURL().length();
-                    _relativeURL = urlText.substring(relativeURLStart);
-                    _actionId = new ControllerActionId(_relativeURL);
+                    final String relativeURL = urlText.substring(relativeURLStart);
+                    if (!relativeURL.isBlank())
+                    {
+                        _relativeURL = relativeURL;
+                        _actionId = new ControllerActionId(_relativeURL);
+                    }
+                    else
+                    {
+                        _relativeURL = null;
+                        _actionId = null;
+                    }
                 }
             }
             else
@@ -822,6 +839,11 @@ public class Crawler
     private boolean beginAt(String relativeUrl)
     {
         deleteCrawlerDownloads();
+        if (isDownloadUrl(relativeUrl))
+        {
+            TestLogger.log("Skip download URL: " + relativeUrl.replace(WebTestHelper.getBaseURL(), ""));
+            return false;
+        }
         // Escape brackets to prevent 400 errors
         relativeUrl = relativeUrl
                 .replace("[", "%5B")
@@ -829,7 +851,40 @@ public class Crawler
                 .replace("{", "%7B")
                 .replace("}", "%7D");
         _urlsVisited.add(relativeUrl);
-        return _test.beginAt(relativeUrl, WebDriverWrapper.WAIT_FOR_PAGE, true) == null;
+        _test.beginAt(relativeUrl, WebDriverWrapper.WAIT_FOR_PAGE);
+        return true;
+    }
+
+    private boolean isDownloadUrl(String url)
+    {
+        if (url.startsWith("/")) // relative URL
+        {
+            url = WebTestHelper.getBaseURL() + url;
+        }
+        HttpContext context = WebTestHelper.getBasicHttpContext();
+        HttpResponse response = null;
+
+        try (CloseableHttpClient httpClient = (CloseableHttpClient)WebTestHelper.getHttpClient())
+        {
+            var method = new HttpGet(url);
+            APITestHelper.injectCookies(method);
+            response = httpClient.execute(method, context);
+            final Optional<Header> content_disposition = Arrays.stream(response.getHeaders("Content-Disposition")).findFirst();
+            if (content_disposition.isPresent() && content_disposition.get().getValue().startsWith("attachment"))
+            {
+                return true;
+            }
+        }
+        catch (IOException e)
+        {
+            e.printStackTrace();
+        }
+        finally
+        {
+            if (null != response)
+                EntityUtils.consumeQuietly(response.getEntity());
+        }
+        return false;
     }
 
     private void deleteCrawlerDownloads()
@@ -951,7 +1006,7 @@ public class Crawler
             else
             {
                 // Did not navigate. Test download URL for injection
-                actualUrl = new URL(WebTestHelper.getBaseURL() + urlToCheck.getUrlText());
+                actualUrl = new URL(WebTestHelper.getBaseURL() + relativeURL);
             }
         }
         catch (RuntimeException | AssertionError rethrow)

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -139,14 +139,14 @@ public class Crawler
         }
         if (projects.isEmpty())
         {
-//            _startingUrls.add(new UrlToCheck(null, "/admin-showAdmin.view#links", 0));
-//            _startingUrls.add(new UrlToCheck(null, "/admin-spider.view", 2));
+            _startingUrls.add(new UrlToCheck(null, "/admin-showAdmin.view#links", 0));
+            _startingUrls.add(new UrlToCheck(null, "/admin-spider.view", 2));
         }
         if (injectionTest)
         {
             test.getUrlsSeen().stream()
                 .filter(url -> !StringUtils.isBlank(url))
-                .map(url -> new UrlToCheck(null, url, 0))
+                .map(url -> new UrlToCheck(null, url, 1))
                 .filter(UrlToCheck::isVisitableURL)
                 .filter(UrlToCheck::isInjectableURL)
                 .forEach(_startingUrls::add);
@@ -341,8 +341,8 @@ public class Crawler
         if (!_projects.contains(project))
         {
             _projects.add(project);
-//            _startingUrls.add(new UrlToCheck(null, WebTestHelper.buildRelativeUrl("project", project, "start"), 0));
-//            _startingUrls.add(new UrlToCheck(null, WebTestHelper.buildRelativeUrl("admin", project, "spider"), 2));
+            _startingUrls.add(new UrlToCheck(null, WebTestHelper.buildRelativeUrl("project", project, "start"), 0));
+            _startingUrls.add(new UrlToCheck(null, WebTestHelper.buildRelativeUrl("admin", project, "spider"), 2));
         }
     }
 


### PR DESCRIPTION
#### Rationale
The Firefox `browser.helperApps.neverAsk.saveToDisk` parameter isn't functioning correctly for some XML files under Firefox 91. A browser download dialog appears, which WebDriver is unable to interact with, causing the crawler fail. Navigating to downloads isn't necessary for crawler coverage so we can just check the "Content-Disposition" of the HTTP response to skip URLs that would trigger a download.
This change to the crawler also makes unnecessary the `beginAt` that permits unexpected downloads.

#### Related Pull Requests
* #749 

#### Changes
* Use direct HTTP request to identify and skip download URLs
* Remove `beginAt` that permits downloads
