### PR TITLE
Wait for spinners to disappear before returning from save button click.

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -350,6 +350,11 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     {
         String title = getSourceTitle();
         elementCache().saveButton.click();
+
+        // If save causes some update, wait until it is completed.
+        WebDriverWrapper.waitFor(()->!BootstrapLocators.loadingSpinner.existsIn(getDriver()),
+                "Save has taken too long to complete.", 5_000);
+
         return new DetailDataPanel.DetailDataPanelFinder(getDriver()).withTitle(title).waitFor();
     }
 


### PR DESCRIPTION
#### Rationale
Updating details of a sample can cause other panels on a sample's overview page to reload. This checks and waits for any spinners that may be present (evidence of a panel reloading) before returning from clicking the save button.

#### Related Pull Requests
* None

#### Changes
* Added a waitFor spinners check in the clickSave method.
