### PR TITLE
Automation to verify fix for : 44363

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -2266,12 +2266,17 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
     protected void reloadStudyFromZip(File studyFile, boolean validateQueries, int pipelineJobs)
     {
+        reloadStudyFromZip(studyFile, validateQueries, pipelineJobs, false);
+    }
+
+    protected void reloadStudyFromZip(File studyFile, boolean validateQueries, int pipelineJobs, boolean expectError)
+    {
         goToManageStudy();
         clickButton("Reload Study");
         setFormElement(Locator.name("folderZip"), studyFile);
         if(! validateQueries) {uncheckCheckbox(Locator.checkboxByName("validateQueries"));}
         clickButton("Reload Study");
-        waitForPipelineJobsToComplete(pipelineJobs, "Study Reload", false);
+        waitForPipelineJobsToComplete(pipelineJobs, "Study Reload", expectError);
     }
 
     public AbstractContainerHelper getContainerHelper()


### PR DESCRIPTION
#### Rationale
In order to add automation to verify the fix for this [issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44363) we needed to expose a method to reload studies while expecting a failure. This new method will be used in the `StudyDatasetIndexTest`.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/2950
