### PR TITLE
Add WaitForLoaded After Changing Filtering/Ordering in a Table

### DIFF
--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -182,6 +182,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
     public QueryGrid search(String searchTerm)
     {
         doAndWaitForUpdate(()-> getOmniBox().setSearch(searchTerm));
+        waitForLoaded();
         return this;
     }
 
@@ -194,6 +195,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
     public QueryGrid sortOn(String column, SortDirection direction)
     {
         doAndWaitForUpdate(()-> getOmniBox().setSort(column, direction));
+        waitForLoaded();
         return this;
     }
 
@@ -223,6 +225,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
     public QueryGrid filterOn(String columnName, String operator, String value)
     {
         doAndWaitForUpdate(()-> getOmniBox().setFilter(columnName, operator, value));
+        waitForLoaded();
         return this;
     }
 
@@ -233,6 +236,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
     public QueryGrid clearSortsAndFilters()
     {
         doAndWaitForUpdate(()-> getOmniBox().clearAll());
+        waitForLoaded();
         return this;
     }
 


### PR DESCRIPTION
#### Rationale
Changing things like filtering or ordering can cause a table content to refresh. After calling a method that will modify the filter or ordering on a table the method should wait for the table to refresh before returning.

#### Related Pull Requests
* None

#### Changes
* Added a call to waitForLoaded to search, sort and filter methods on the table.
