### PR TITLE
Fix crawler's identification of download URLs

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -856,6 +856,12 @@ public class Crawler
         {
             url = WebTestHelper.getBaseURL() + url;
         }
+        final String[] splitUrl = url.split("\\?", 2);
+        if (splitUrl.length > 1)
+        {
+            // Properly encode spaces in the URL query
+            url = splitUrl[0] + "?" + splitUrl[1].replace(" ", "+");
+        }
         HttpContext context = WebTestHelper.getBasicHttpContext();
         HttpResponse response = null;
 
@@ -865,7 +871,9 @@ public class Crawler
             APITestHelper.injectCookies(method);
             response = httpClient.execute(method, context);
             final Optional<Header> content_disposition = Arrays.stream(response.getHeaders("Content-Disposition")).findFirst();
-            if (content_disposition.isPresent() && content_disposition.get().getValue().startsWith("attachment"))
+            if (content_disposition.isPresent() &&
+                    (content_disposition.get().getValue().startsWith("attachment")
+                    || content_disposition.get().getValue().startsWith("inline")))
             {
                 return true;
             }

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -859,8 +859,12 @@ public class Crawler
         final String[] splitUrl = url.split("\\?", 2);
         if (splitUrl.length > 1)
         {
-            // Properly encode spaces in the URL query
-            url = splitUrl[0] + "?" + splitUrl[1].replace(" ", "+");
+            // Properly encode characters that tend to be unencoded in the URL query
+            final String query = splitUrl[1]
+                    .replace(" ", "+")
+                    .replace("<", "%3C")
+                    .replace(">", "%3E");
+            url = splitUrl[0] + "?" + query;
         }
         HttpContext context = WebTestHelper.getBasicHttpContext();
         HttpResponse response = null;


### PR DESCRIPTION
#### Rationale
The crawler now attempts to identify and skip download URLs without involving the browser. It does so by checking the HTTP response header of the URL. There have been two sorts of failures from this crawler change.
1. Some URLs have illegal characters in their query (looks like spaces are the problem). Browsers tend to automatically encode various parts of the URL when needed; the crawler needs to do similarly (`' '` -> `'+'`).
2. Some downloads use the "inline" content disposition instead of "attachment"; the crawler needs to check for these cases.

#### Related Pull Requests
* #964 

#### Changes
* Properly encode URLs before checking HTTP response
* Stop tracking and cleaning up crawler downloads
