### PR TITLE
Init test.properties before the `uiTests` task on a new enlistment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,7 @@ def initPropertiesTask = project.tasks.register("initProperties", Task) {
         })
 }
 
+project.tasks.uiTests.dependsOn(initPropertiesTask)
 project.parent.parent.tasks.ijConfigure.dependsOn(initPropertiesTask)
 
 if (project.hasProperty('doPublishing'))


### PR DESCRIPTION
#### Rationale
If you attempt to run the `uiTests` task on a new enlistment without generating the `test.properties` file, it will throw an error because the `selenium.debug.port` property isn't defined. [[Issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44331)]

This will still fail the first time somebody tries to run tests because gradle has already tried and failed to load `test.properties` by the time the `initProperties` task runs. Subsequent attempts will succeed. A more effective fix is in the gradle plugin, which will go into develop with our next plugin release.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/142

#### Changes
* Run `initProperties` before running ui tests from the command line
