### PR TITLE
Make Crawler.isDownloadUrl more robust

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -852,7 +852,7 @@ public class Crawler
     }
 
     private static final Pattern HEX_PATTERN = Pattern.compile("[0-9a-fA-F]{2}");
-    public static boolean isDownloadUrl(String url)
+    private static boolean isDownloadUrl(String url)
     {
         if (url.startsWith("/")) // relative URL
         {
@@ -866,11 +866,11 @@ public class Crawler
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < query.length(); i++)
             {
-                // Encode '%' characters that aren't encoding other characters
                 String c = String.valueOf(query.charAt(i));
                 switch (c)
                 {
                     case "%" -> {
+                        // Encode '%' characters that aren't encoding other characters
                         c = "%25"; // Assume "%" isn't encoding some other character
                         int remaining = query.length() - i;
                         if (remaining > 2)

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -882,7 +882,7 @@ public class Crawler
                 return true;
             }
         }
-        catch (IOException e)
+        catch (IOException | IllegalArgumentException e)
         {
             e.printStackTrace();
         }


### PR DESCRIPTION
#### Rationale
Some links have poorly encoded query parameters. We can encode some more of these that are causing trouble. Ignoring any remaining URI errors will cause fewer problems than the errors themselves.
```
java.lang.IllegalArgumentException: Illegal character in query at index 156: http://localhost:8111/labkey/StudyDatasetSharedColumnAndIndexProject/Study%20Dataset%20Shared%20Column%20and%20Index/admin-folderType.view?&TestAssayLuminex></% 1 SinglepointUnknownExclusion.containerFilterName=--%3E%22%3E%27%3E%27%22%3C%2Fscript%3E%3Cimg+src%3D%22xss%22+onerror%3D%22alert%28%278%28%27%29%22%3E&Batches.containerFilterName=Current&testMode=true&%26TestAssayLuminex%3E%3C%2F%25+1+RunExclusion.containerFilterName=Current&StatusFiles.containerFilterName=Current&query.datasetid%7Eeq=5005&level=ON&pageId=study.DATA_ANALYSIS&%26TestAssayLuminex%3E%3C%2F%25+1+TitrationExclusion.containerFilterName=Current&type=CheckForUpdates
  at java.base/java.net.URI.create(URI.java:906)
  at org.apache.http.client.methods.HttpGet.<init>(HttpGet.java:66)
  at org.labkey.test.util.Crawler.isDownloadUrl(Crawler.java:869)
```

#### Related Pull Requests
* #964 
* #972

#### Changes
* Escape '%' in URL query
* Ignore `IllegalArgumentException` from badly escaped URL query
