### PR TITLE
Various Test Automation Fixes and Extra Debugging

### DIFF
--- a/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
+++ b/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
@@ -49,7 +49,7 @@ public class TabbedGridPanel extends WebDriverComponent<TabbedGridPanel.ElementC
     private boolean isSelected(String tabText)
     {
         String tabClass = elementCache().navTab(tabText).getAttribute("class");
-        return "active".equals(tabClass);
+        return tabClass.toLowerCase().contains("active");
     }
 
     public QueryGrid selectGrid(String tabText)

--- a/src/org/labkey/test/pages/DatasetPropertiesPage.java
+++ b/src/org/labkey/test/pages/DatasetPropertiesPage.java
@@ -51,7 +51,12 @@ public class DatasetPropertiesPage extends LabKeyPage<DatasetPropertiesPage.Elem
     public DatasetDesignerPage clickEditDefinition()
     {
         doAndWaitForPageToLoad(() -> shortWait().until(LabKeyExpectedConditions.clickUntilStale(elementCache().editDefinitionButton)));
-        return new DatasetDesignerPage(getDriver());
+
+        // Wait until a panel body is displayed before returning.
+        DatasetDesignerPage ddp = new DatasetDesignerPage(getDriver());
+        ddp.waitForPage();
+
+        return ddp;
     }
 
     public ViewDatasetDataPage clickViewData()

--- a/src/org/labkey/test/pages/study/DatasetDesignerPage.java
+++ b/src/org/labkey/test/pages/study/DatasetDesignerPage.java
@@ -42,7 +42,9 @@ public class DatasetDesignerPage extends DomainDesigner<DatasetDesignerPage.Elem
 
     public void waitForPage()
     {
-        waitFor(()-> getFieldsPanel().getComponentElement().isDisplayed(),
+        // Wait for a panel body to be displayed.
+        WebElement panelBody = Locator.tagWithClass("div", "panel-body").findWhenNeeded(getDriver());
+        waitFor(panelBody::isDisplayed,
                 "The page did not render in time", WAIT_FOR_PAGE);
     }
 

--- a/src/org/labkey/test/tests/ReportThumbnailTest.java
+++ b/src/org/labkey/test/tests/ReportThumbnailTest.java
@@ -41,7 +41,6 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
@@ -391,7 +390,12 @@ public class ReportThumbnailTest extends BaseWebDriverTest
         waitForElement(Locator.name("viewName"));
         _ext4Helper.clickExt4Tab("Images");
         waitForElement(Locator.id("customThumbnail"));
-        checker().verifyEquals("Thumbnail Revision number is not correct", String.valueOf(currentRevNum), getRevisionNumber(Locator.xpath("//div[contains(@class, 'thumbnail')]//img")));
+
+        checker()
+                .withScreenshot("InitialThumbnailRevisionNumberIncorrect")
+                .verifyEquals("Thumbnail Revision number is not correct.",
+                        currentRevNum, getRevisionNumber(Locator.xpath("//div[contains(@class, 'thumbnail')]//img")));
+
         setFormElement(Locator.xpath("//input[@id='customThumbnail-button-fileInputEl']"), thumbnail);
         _ext4Helper.clickWindowButton(chart, "Save", 0, 0);
         _ext4Helper.waitForMaskToDisappear();
@@ -400,7 +404,12 @@ public class ReportThumbnailTest extends BaseWebDriverTest
         waitForElement(Locator.name("viewName"));
         _ext4Helper.clickExt4Tab("Images");
         waitForElement(Locator.id("customThumbnail"));
-        checker().verifyEquals("Thumbnail Revision number is not correct", String.valueOf(nextRevNum), getRevisionNumber(Locator.xpath("//div[contains(@class, 'thumbnail')]//img")));
+
+        checker()
+                .withScreenshot("UpdatedThumbnailRevisionNumberIncorrect")
+                .verifyEquals("Updated Thumbnail Revision number is not correct.",
+                        nextRevNum, getRevisionNumber(Locator.xpath("//div[contains(@class, 'thumbnail')]//img")));
+
         _ext4Helper.clickWindowButton(chart, "Save", 0, 0);
         _ext4Helper.waitForMaskToDisappear();
     }
@@ -427,13 +436,13 @@ public class ReportThumbnailTest extends BaseWebDriverTest
         _ext4Helper.waitForMaskToDisappear();
     }
 
-    protected String getRevisionNumber(Locator loc)
+    protected int getRevisionNumber(Locator loc)
     {
         String url = waitForElement(loc).getAttribute("src");
 
         try
         {
-            return WebTestHelper.parseUrlQuery(new URL(url)).get("revision");
+            return Integer.parseInt(WebTestHelper.parseUrlQuery(new URL(url)).get("revision"));
         }
         catch (MalformedURLException e)
         {
@@ -511,7 +520,7 @@ public class ReportThumbnailTest extends BaseWebDriverTest
         waitForElement(Locator.name("viewName"));
         _ext4Helper.clickExt4Tab("Images");
         waitForElement(Locator.id("customIcon"));
-        assertEquals("Icon Revision number is not correct", String.valueOf(customRevNum), getRevisionNumber(Locator.xpath("//div[contains(@class, 'icon')]//img")));
+        assertEquals("Icon Revision number is not correct", customRevNum, getRevisionNumber(Locator.xpath("//div[contains(@class, 'icon')]//img")));
         _ext4Helper.clickWindowButton(chart, "Save", 0, 0);
         _ext4Helper.waitForMaskToDisappear();
     }


### PR DESCRIPTION
#### Rationale
Various fixes to address some test automation failures and add extra debugging to other tests that are difficult to nail down.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2973

#### Changes
* Fix TabbedGridPanel to better identify active tab with no data.
* Add screenshots to help debug failures in the thumbnail test.
* Fixed DatasetDesignerPage.waitForPage to wait for a panel, not expand a specific panel and then wait.
* Updated DatasetPropertiesPage.clickEditDefinition to wait until a panel body is displayed.