### PR TITLE
Wait for facet panel to load selections

### DIFF
--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -1346,6 +1346,8 @@ public class DataRegionTable extends DataRegion
             clickHeaderButton("Filter");
             getWrapper().waitForElement(Locator.css(".lk-filter-panel-label"));
         }
+        // See handleAfterInitGroupConfig in ReportFilterPanel.js
+        org.labkey.test.Locators.pageSignal("initSelectionComplete").waitForElement(getDriver(), 5_000);
         WebElement panelEl = getWrapper().waitForElement(DatasetFacetPanel.Locators.expandedFacetPanel(getDataRegionName()));
         return new DatasetFacetPanel(panelEl, this);
     }


### PR DESCRIPTION
#### Rationale
`StudyDatasetsTest` has been failing because it opens the filter panel and makes a selection before the initial state has been applied, then the initial state gets applied, clearing the test's selection. `DataRegionTable.openSideFilterPanel` should wait for the facet panel's initial selections state has been fully applied.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2976

#### Changes
* Wait for initial selections when opening the group filter panel
