### PR TITLE
Give domainPanel time to appear before giving up

### DIFF
--- a/src/org/labkey/test/components/domain/DomainDesigner.java
+++ b/src/org/labkey/test/components/domain/DomainDesigner.java
@@ -2,6 +2,8 @@ package org.labkey.test.components.domain;
 
 import org.openqa.selenium.WebDriver;
 
+import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+
 /**
  * A simple domain designer with a properties panel and a single field panel.
  */
@@ -24,8 +26,10 @@ public abstract class DomainDesigner<EC extends DomainDesigner.ElementCache> ext
 
     public class ElementCache extends BaseDomainDesigner.ElementCache
     {
-        protected final DomainPanel propertiesPanel = new DomainPanel.DomainPanelFinder(getDriver()).index(0).findWhenNeeded(this);
-        protected final DomainFormPanel fieldsPanel = new DomainFormPanel.DomainFormPanelFinder(getDriver()).index(getFieldPanelIndex()).timeout(1000).findWhenNeeded();
+        protected final DomainPanel propertiesPanel = new DomainPanel.DomainPanelFinder(getDriver()).index(0)
+                .timeout(WAIT_FOR_JAVASCRIPT).findWhenNeeded(this);
+        protected final DomainFormPanel fieldsPanel = new DomainFormPanel.DomainFormPanelFinder(getDriver())
+                .index(getFieldPanelIndex()).timeout(1000).findWhenNeeded();
 
         protected int getFieldPanelIndex()
         {

--- a/src/org/labkey/test/components/domain/DomainPanel.java
+++ b/src/org/labkey/test/components/domain/DomainPanel.java
@@ -9,6 +9,8 @@ import org.openqa.selenium.WebElement;
 
 import java.util.Optional;
 
+import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+
 /**
  * Wraps the functionality of the LabKey ui component defined in domainproperties/CollapsiblePanelHeader.tsx
  * Subclasses should add panel-specific functionality.
@@ -94,7 +96,8 @@ public abstract class DomainPanel<EC extends DomainPanel<EC, T>.ElementCache, T 
 
     public abstract class ElementCache extends Component<EC>.ElementCache
     {
-        protected final WebElement expandToggle = Locator.css(".domain-form-expand-btn, .domain-form-collapse-btn").findWhenNeeded(this);
+        protected final WebElement expandToggle = Locator.css(".domain-form-expand-btn, .domain-form-collapse-btn")
+                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
         protected final WebElement headerStatusIcon = Locator.css(".domain-panel-status-icon > svg").findWhenNeeded(this);
         protected final WebElement panelTitle = panelTitleLocator.findWhenNeeded(this);
         protected final WebElement panelBody = Locator.byClass("panel-body").findWhenNeeded(this);


### PR DESCRIPTION
#### Rationale
Some tests that use helpers to navigate to the Domain Designer and immediately interact with the page have been intermittently failing to find the domain properties field 
![image](https://user-images.githubusercontent.com/16809856/151597366-1ba3ea36-dd28-474d-8add-2a37ede0d900.png)
[AuditLogTest.testSteps](https://teamcity.labkey.org/viewLog.html?buildId=1688017&tab=buildResultsDiv&buildTypeId=bt21#testNameId-7655478016300148252) <-- is one such

#### Related Pull Requests
n/a

#### Changes
This adds waitTimeouts to the finders for the domainPanel to be present, as well as for the panel expander
