### PR TITLE
Clean up test logger and improve waitForPageToLoad

### DIFF
--- a/src/org/labkey/test/Runner.java
+++ b/src/org/labkey/test/Runner.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Ignore;
 import org.junit.runner.Description;
@@ -86,7 +87,7 @@ import static org.labkey.test.WebTestHelper.logToServer;
 
 public class Runner extends TestSuite
 {
-    private static final Logger LOG = TestLogger.getLogger(Runner.class);
+    private static final Logger LOG = LogManager.getLogger(Runner.class);
 
     private static final int DEFAULT_MAX_TEST_FAILURES = 10;
     private static SuiteBuilder _suites = SuiteBuilder.getInstance();

--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -22,6 +22,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
@@ -38,7 +39,6 @@ import org.bouncycastle.openpgp.operator.jcajce.JcePBEDataDecryptorFactoryBuilde
 import org.bouncycastle.util.io.Streams;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.serverapi.writer.PrintWriters;
-import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.NotFoundException;
 
 import java.io.BufferedInputStream;
@@ -76,7 +76,7 @@ import java.util.zip.ZipInputStream;
  */
 public abstract class TestFileUtils
 {
-    private static final Logger LOG = TestLogger.getLogger(TestFileUtils.class);
+    private static final Logger LOG = LogManager.getLogger(TestFileUtils.class);
 
     private static File _labkeyRoot = null;
     private static File _buildDir = null;

--- a/src/org/labkey/test/WebTestHelper.java
+++ b/src/org/labkey/test/WebTestHelper.java
@@ -35,6 +35,7 @@ import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -85,7 +86,7 @@ import java.util.Random;
 public class WebTestHelper
 {
 
-    private static final Logger LOG = TestLogger.getLogger(WebTestHelper.class);
+    private static final Logger LOG = LogManager.getLogger(WebTestHelper.class);
 
     public static final Random RANDOM = new Random();
     public static final String API_KEY = "apikey"; // Username for api/session key authentication

--- a/src/org/labkey/test/tests/JUnitTest.java
+++ b/src/org/labkey/test/tests/JUnitTest.java
@@ -28,6 +28,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.io.IoBuilder;
 import org.jetbrains.annotations.NotNull;
@@ -68,7 +69,7 @@ import java.util.function.Predicate;
 @Category({BVT.class, UnitTests.class})
 public class JUnitTest extends TestSuite
 {
-    private static final Logger LOG = TestLogger.getLogger(JUnitTest.class);
+    private static final Logger LOG = LogManager.getLogger(JUnitTest.class);
 
     public JUnitTest()
     {

--- a/src/org/labkey/test/tests/flow/BaseFlowTest.java
+++ b/src/org/labkey/test/tests/flow/BaseFlowTest.java
@@ -406,8 +406,10 @@ abstract public class BaseFlowTest extends BaseWebDriverTest
     protected void importAnalysis_selectFCSFiles(String containerPath, final SelectFCSFileOption selectFCSFilesOption, List<String> keywordDirs)
     {
         _ext4Helper.waitForOnReady();
-        if (isChecked(Locator.id(SelectFCSFileOption.Browse.name())))
+        if (Locator.id(SelectFCSFileOption.Browse.name()).waitForElement(getDriver(), 5_000).isSelected())
+        {
             _fileBrowserHelper.waitForFileGridReady();
+        }
 
         assertTitleEquals("Import Analysis: Select FCS Files: " + containerPath);
         switch (selectFCSFilesOption)

--- a/src/org/labkey/test/util/TestLogger.java
+++ b/src/org/labkey/test/util/TestLogger.java
@@ -19,24 +19,13 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
-import org.apache.logging.log4j.core.LoggerContext;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.labkey.test.TestFileUtils;
 
-import java.io.File;
 import java.util.concurrent.TimeUnit;
 
 public class TestLogger
 {
-    static
-    {
-        // 'testAutomation/resources' isn't included in classpath. Need to load config file explicitly
-        // TODO: Fixed in next gradle plugin release (>1.32.0)
-        LoggerContext context = (org.apache.logging.log4j.core.LoggerContext) LogManager.getContext(false);
-        File file = new File(TestFileUtils.getTestRoot(), "resources/log4j2.xml");
-        context.setConfigLocation(file.toURI());
-    }
-
     private static final Logger LOG = LogManager.getLogger(TestLogger.class);
     private static final Logger NO_OP = LogManager.getLogger("NoOpLogger");
 
@@ -72,29 +61,16 @@ public class TestLogger
         suppressLogging = suppress;
     }
 
-    private static String getIndentString()
-    {
-        return StringUtils.repeat(' ', Math.min(currentIndent, MAX_INDENT));
-    }
-
-    /**
-     * Temporary workaround to make sure log4j2.xml gets loaded for all loggers
-     * TODO: Remove once gradlePlugin v1.32.1 is released
-     */
-    public static Logger getLogger(final Class<?> clazz)
-    {
-        return LogManager.getLogger(clazz);
-    }
-
     public static void setTestLogContext(String testLogContext)
     {
         TestLogger.testLogContext = testLogContext;
         updateThreadContext();
     }
 
-    private static Logger getLog()
+    @Contract (pure = true)
+    public static Logger log()
     {
-        updateThreadContext();
+        updateThreadContext(); // Just to be safe
 
         if (suppressLogging)
         {
@@ -109,49 +85,53 @@ public class TestLogger
     private static void updateThreadContext()
     {
         ThreadContext.put("testLogContext", testLogContext);
-        ThreadContext.put("testLogIndent", getIndentString());
+        ThreadContext.put("testLogIndent", StringUtils.repeat(' ', Math.min(currentIndent, MAX_INDENT)));
     }
 
-    public static void debug(String msg, Throwable t)
+    public static void debug(String message, Throwable t)
     {
-        getLog().debug(msg, t);
+        log().debug(message, t);
     }
 
-    public static void debug(String msg)
+    public static void debug(String message)
     {
-        getLog().debug(msg);
+        log().debug(message);
     }
 
-    public static void info(String str, Throwable t)
+    public static void info(String message, Throwable t)
     {
-        getLog().info(str, t);
+        log().info(message, t);
     }
 
-    public static void info(String str)
+    public static void info(String message)
     {
-        getLog().info(str);
+        log().info(message);
     }
 
-    public static void warn(String str, Throwable t)
+    public static void warn(String message, Throwable t)
     {
-        getLog().warn(str, t);
+        log().warn(message, t);
     }
 
-    public static void warn(String str)
+    public static void warn(String message)
     {
-        getLog().warn(str);
+        log().warn(message);
     }
 
-    public static void error(String str, Throwable t)
+    public static void error(String message, Throwable t)
     {
-        getLog().error(str, t);
+        log().error(message, t);
     }
 
-    public static void error(String str)
+    public static void error(String message)
     {
-        getLog().error(str);
+        log().error(message);
     }
 
+    /**
+     * @deprecated Use a specific log level. Usually {@link #info(String)}
+     */
+    @Deprecated
     public static void log(String str)
     {
         info(str);

--- a/src/org/labkey/test/util/TestLogger.java
+++ b/src/org/labkey/test/util/TestLogger.java
@@ -129,9 +129,9 @@ public class TestLogger
     }
 
     /**
-     * @deprecated Use a specific log level. Usually {@link #info(String)}
+     * Prefer to use a specific log level. Usually {@link #info(String)}
+     * Not deprecating because it is too widely used.
      */
-    @Deprecated
     public static void log(String str)
     {
         info(str);


### PR DESCRIPTION
#### Rationale
Gradle plugin 1.32.1 includes the tests' log4j config file on the test classpath. Now that it is released, `TestLogger` no longer needs to go out of its way to explicitly load it.
`WebDriverWrapper.waitForPageToLoad` is returning prematurely for some pages, namely `flow-executescript-importAnalysis.view`. Trying to explicitly wait for the document root element (`Locator.css(":root")`) after a page load.

```
java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "org.labkey.test.WebDriverWrapper.executeScript(String, Object[])" is null
  at org.labkey.test.WebDriverWrapper.onLabKeyPage(WebDriverWrapper.java:1209)
  at org.labkey.test.WebDriverWrapper.doAndMaybeWaitForPageToLoad(WebDriverWrapper.java:1912)
  at org.labkey.test.WebDriverWrapper.doAndWaitForPageToLoad(WebDriverWrapper.java:1878)
  at org.labkey.test.WebDriverWrapper.clickAndWait(WebDriverWrapper.java:2688)
  at org.labkey.test.components.ext4.Window.clickButton(Window.java:99)
  at org.labkey.test.components.ext4.Window.clickButton(Window.java:91)
  at org.labkey.test.util.FileBrowserHelper.selectImportDataAction(FileBrowserHelper.java:461)
  at org.labkey.test.tests.flow.BaseFlowTest.importAnalysis_viaPipeline(BaseFlowTest.java:376)
  at org.labkey.test.tests.flow.BaseFlowTest.importAnalysis(BaseFlowTest.java:341)
  at org.labkey.test.tests.flow.BaseFlowTest.importAnalysis(BaseFlowTest.java:334)
  at org.labkey.test.tests.flow.FlowJoQueryTest.verifyNestedBooleans(FlowJoQueryTest.java:189)
  at org.labkey.test.tests.flow.FlowJoQueryTest._doTestSteps(FlowJoQueryTest.java:63)
```

#### Related Pull Requests
* #965 
* https://github.com/LabKey/server/pull/199
* https://github.com/LabKey/gradlePlugin/pull/141

#### Changes
* Inline and remove `TestLogger.getLogger`
