### PR TITLE
Update expected response now that there are now permissions assigned to editors and admins

### DIFF
--- a/data/api/security-api.xml
+++ b/data/api/security-api.xml
@@ -91,7 +91,7 @@
                                 "org.labkey.api.security.permissions.UpdatePermission",
                                 "org.labkey.announcements.model.SecureMessageBoardReadPermission",
                                 "org.labkey.api.security.permissions.SampleWorkflowJobPermission",
-                                "org.labkey.api.security.permissions.UpdateSampleStatusPermission",
+                                "org.labkey.api.security.permissions.UpdateSampleStatusPermission"
                             ],
                             "groups": []
                         },

--- a/data/api/security-api.xml
+++ b/data/api/security-api.xml
@@ -3,141 +3,130 @@
     <test name="get group permissions" type="get">
         <url>security/Security%20API%20Test%20Project/getGroupPerms.view?</url>
         <response>
-            {"container": {
-            "path": "/Security API Test Project",
-            "name": "Security API Test Project",
-            "groups": [
-            {
-            "role": "NO_PERMISSIONS",
-            "permissions": 0,
-            "isSystemGroup": true,
-            "roles": [],
-            "name": "Site Administrators",
-            "effectivePermissions": [],
-            "groups": [{
-            "isSystemGroup": true,
-            "name": "Developers",
-            "id": -4,
-            "isProjectGroup": false
-            }],
-            "id": -1,
-            "type": "g",
-            "isProjectGroup": false,
-            "roleLabel": "No Permissions"
-            },
-            {
-            "role": "NO_PERMISSIONS",
-            "permissions": 0,
-            "isSystemGroup": false,
-            "roles": [],
-            "name": "Audit Group",
-            "effectivePermissions": [],
-            "groups": [],
-            "id": 1153,
-            "type": "g",
-            "isProjectGroup": false,
-            "roleLabel": "No Permissions"
-            },
-            {
-            "role": "NO_PERMISSIONS",
-            "permissions": 0,
-            "isSystemGroup": true,
-            "roles": [],
-            "name": "Developers",
-            "effectivePermissions": [],
-            "groups": [],
-            "id": -4,
-            "type": "g",
-            "isProjectGroup": false,
-            "roleLabel": "No Permissions"
-            },
-            {
-            "role": "NO_PERMISSIONS",
-            "permissions": 0,
-            "isSystemGroup": true,
-            "roles": [],
-            "name": "Guests",
-            "effectivePermissions": [],
-            "groups": [],
-            "id": -3,
-            "type": "g",
-            "isProjectGroup": false,
-            "roleLabel": "No Permissions"
-            },
-            {
-            "role": "NO_PERMISSIONS",
-            "permissions": 0,
-            "isSystemGroup": true,
-            "roles": [],
-            "name": "All Site Users",
-            "effectivePermissions": [],
-            "groups": [],
-            "id": -2,
-            "type": "g",
-            "isProjectGroup": false,
-            "roleLabel": "No Permissions"
-            },
-            {
-            "role": "EDITOR",
-            "permissions": 15,
-            "isSystemGroup": false,
-            "roles": ["org.labkey.api.security.roles.EditorRole"],
-            "name": "testgroup1",
-            "effectivePermissions": [
-            "org.labkey.api.security.permissions.DeletePermission",
-            "org.labkey.api.security.permissions.ReadPermission",
-            "org.labkey.api.security.permissions.InsertPermission",
-            "org.labkey.api.security.permissions.ReadSomePermission",
-            "org.labkey.api.reports.permissions.EditSharedReportPermission",
-            "org.labkey.api.study.permissions.SharedParticipantGroupPermission",
-            "org.labkey.api.lists.permissions.ManagePicklistsPermission",
-            "org.labkey.api.security.permissions.SampleWorkflowJobPermission",
-            "org.labkey.api.security.permissions.UpdatePermission",
-            "org.labkey.announcements.model.SecureMessageBoardReadPermission",
-            "org.labkey.announcements.model.SecureMessageBoardRespondPermission",
-            "org.labkey.api.security.permissions.UpdateSampleStatusPermission",
-            "org.labkey.api.security.permissions.EditSharedViewPermission",
-            "org.labkey.api.reports.permissions.ShareReportPermission"
-            ],
-            "groups": [],
-            "id": 2088,
-            "type": "g",
-            "isProjectGroup": true,
-            "roleLabel": "Editor"
-            },
-            {
-            "role": "READER",
-            "permissions": 1,
-            "isSystemGroup": false,
-            "roles": ["org.labkey.api.security.roles.ReaderRole"],
-            "name": "testgroup2",
-            "effectivePermissions": [
-            "org.labkey.api.security.permissions.ReadPermission",
-            "org.labkey.api.security.permissions.ReadSomePermission"
-            ],
-            "groups": [],
-            "id": 2089,
-            "type": "g",
-            "isProjectGroup": true,
-            "roleLabel": "Reader"
-            },
-            {
-            "role": "NO_PERMISSIONS",
-            "permissions": 0,
-            "isSystemGroup": false,
-            "roles": [],
-            "name": "Users",
-            "effectivePermissions": [],
-            "groups": [],
-            "id": 2087,
-            "type": "g",
-            "isProjectGroup": true,
-            "roleLabel": "No Permissions"
+            {"container":
+                {
+                    "id": "THIS CONTAINER GUID FIELD IS IGNORED IN JSON CHECK",
+                    "name": "Security API Test Project",
+                    "path": "/Security API Test Project",
+                    "isInheritingPerms": false,
+                    "groups": [
+                        {
+                            "id": -1,
+                            "roleLabel": "No Permissions",
+                            "name": "Site Administrators",
+                            "roles": [],
+                            "isSystemGroup": true,
+                            "permissions": 0,
+                            "role": "NO_PERMISSIONS",
+                            "isProjectGroup": false,
+                            "type": "g",
+                            "effectivePermissions": [],
+                            "groups": [{
+                                "isSystemGroup": true,
+                                "name": "Developers",
+                                "id": -4,
+                                "isProjectGroup": false
+                            }],
+                        },
+                        {
+                            "role": "NO_PERMISSIONS",
+                            "permissions": 0,
+                            "isSystemGroup": true,
+                            "roles": [],
+                            "name": "Developers",
+                            "effectivePermissions": [],
+                            "groups": [],
+                            "id": -4,
+                            "type": "g",
+                            "isProjectGroup": false,
+                            "roleLabel": "No Permissions"
+                        },
+                        {
+                            "id": -3,
+                            "roleLabel": "No Permissions",
+                            "name": "Guests",
+                            "roles": [],
+                            "isSystemGroup": true,
+                            "permissions": 0,
+                            "role": "NO_PERMISSIONS",
+                            "isProjectGroup": false,
+                            "type": "g",
+                            "effectivePermissions": [],
+                            "groups": []
+                        },
+                        {
+                            "id": -2,
+                            "roleLabel": "No Permissions",
+                            "name": "All Site Users",
+                            "roles": [],
+                            "isSystemGroup": true,
+                            "permissions": 0,
+                            "role": "NO_PERMISSIONS",
+                            "isProjectGroup": false,
+                            "type": "g",
+                            "effectivePermissions": [],
+                            "groups": []
+                        },
+                        {
+                            "id": 1672,
+                            "roleLabel": "Editor",
+                            "name": "testgroup1",
+                            "roles": ["org.labkey.api.security.roles.EditorRole"],
+                            "isSystemGroup": false,
+                            "permissions": 15,
+                            "role": "EDITOR",
+                            "isProjectGroup": true,
+                            "type": "g",
+                            "effectivePermissions": [
+                                "org.labkey.api.security.permissions.InsertPermission",
+                                "org.labkey.api.security.permissions.DeletePermission",
+                                "org.labkey.api.security.permissions.EditSharedViewPermission",
+                                "org.labkey.api.reports.permissions.EditSharedReportPermission",
+                                "org.labkey.api.security.permissions.ReadPermission",
+                                "org.labkey.api.reports.permissions.ShareReportPermission",
+                                "org.labkey.api.study.permissions.SharedParticipantGroupPermission",
+                                "org.labkey.announcements.model.SecureMessageBoardRespondPermission",
+                                "org.labkey.api.security.permissions.ReadSomePermission",
+                                "org.labkey.api.lists.permissions.ManagePicklistsPermission",
+                                "org.labkey.api.security.permissions.UpdatePermission",
+                                "org.labkey.announcements.model.SecureMessageBoardReadPermission",
+                                "org.labkey.api.security.permissions.SampleWorkflowJobPermission",
+                                "org.labkey.api.security.permissions.UpdateSampleStatusPermission",
+                            ],
+                            "groups": []
+                        },
+                        {
+                            "id": 1673,
+                            "roleLabel": "Reader",
+                            "name": "testgroup2",
+                            "roles": ["org.labkey.api.security.roles.ReaderRole"],
+                            "isSystemGroup": false,
+                            "permissions": 1,
+                            "role": "READER",
+                            "isProjectGroup": true,
+                            "type": "g",
+                            "effectivePermissions": [
+                                "org.labkey.api.security.permissions.ReadPermission",
+                                "org.labkey.api.security.permissions.ReadSomePermission"
+                            ],
+                            "groups": []
+                        },
+                        {
+                            "id": 1671,
+                            "roleLabel": "No Permissions",
+                            "name": "Users",
+                            "roles": [],
+                            "isSystemGroup": false,
+                            "permissions": 0,
+                            "role": "NO_PERMISSIONS",
+                            "isProjectGroup": true,
+                            "type": "g",
+                            "effectivePermissions": [],
+                            "groups": []
+                        }
+                    ]
+                }
             }
-            ],
-            "id": "261e35e3-6756-103a-94cb-b29d14b1c5c2",
-            "isInheritingPerms": false
-            }}
         </response>
     </test>
 

--- a/data/api/security-api.xml
+++ b/data/api/security-api.xml
@@ -3,128 +3,141 @@
     <test name="get group permissions" type="get">
         <url>security/Security%20API%20Test%20Project/getGroupPerms.view?</url>
         <response>
-            {"container":
-                {
-                    "id": "THIS CONTAINER GUID FIELD IS IGNORED IN JSON CHECK",
-                    "name": "Security API Test Project",
-                    "path": "/Security API Test Project",
-                    "isInheritingPerms": false,
-                    "groups": [
-                        {
-                            "id": -1,
-                            "roleLabel": "No Permissions",
-                            "name": "Site Administrators",
-                            "roles": [],
-                            "isSystemGroup": true,
-                            "permissions": 0,
-                            "role": "NO_PERMISSIONS",
-                            "isProjectGroup": false,
-                            "type": "g",
-                            "effectivePermissions": [],
-                            "groups": [{
-                                "isSystemGroup": true,
-                                "name": "Developers",
-                                "id": -4,
-                                "isProjectGroup": false
-                            }],
-                        },
-                        {
-                            "role": "NO_PERMISSIONS",
-                            "permissions": 0,
-                            "isSystemGroup": true,
-                            "roles": [],
-                            "name": "Developers",
-                            "effectivePermissions": [],
-                            "groups": [],
-                            "id": -4,
-                            "type": "g",
-                            "isProjectGroup": false,
-                            "roleLabel": "No Permissions"
-                        },
-                        {
-                            "id": -3,
-                            "roleLabel": "No Permissions",
-                            "name": "Guests",
-                            "roles": [],
-                            "isSystemGroup": true,
-                            "permissions": 0,
-                            "role": "NO_PERMISSIONS",
-                            "isProjectGroup": false,
-                            "type": "g",
-                            "effectivePermissions": [],
-                            "groups": []
-                        },
-                        {
-                            "id": -2,
-                            "roleLabel": "No Permissions",
-                            "name": "All Site Users",
-                            "roles": [],
-                            "isSystemGroup": true,
-                            "permissions": 0,
-                            "role": "NO_PERMISSIONS",
-                            "isProjectGroup": false,
-                            "type": "g",
-                            "effectivePermissions": [],
-                            "groups": []
-                        },
-                        {
-                            "id": 1672,
-                            "roleLabel": "Editor",
-                            "name": "testgroup1",
-                            "roles": ["org.labkey.api.security.roles.EditorRole"],
-                            "isSystemGroup": false,
-                            "permissions": 15,
-                            "role": "EDITOR",
-                            "isProjectGroup": true,
-                            "type": "g",
-                            "effectivePermissions": [
-                                "org.labkey.api.security.permissions.InsertPermission",
-                                "org.labkey.api.security.permissions.DeletePermission",
-                                "org.labkey.api.security.permissions.EditSharedViewPermission",
-                                "org.labkey.api.reports.permissions.EditSharedReportPermission",
-                                "org.labkey.api.security.permissions.ReadPermission",
-                                "org.labkey.api.reports.permissions.ShareReportPermission",
-                                "org.labkey.api.study.permissions.SharedParticipantGroupPermission",
-                                "org.labkey.announcements.model.SecureMessageBoardRespondPermission",
-                                "org.labkey.api.security.permissions.ReadSomePermission",
-                                "org.labkey.api.lists.permissions.ManagePicklistsPermission",
-                                "org.labkey.api.security.permissions.UpdatePermission",
-                                "org.labkey.announcements.model.SecureMessageBoardReadPermission"
-                            ],
-                            "groups": []
-                        },
-                        {
-                            "id": 1673,
-                            "roleLabel": "Reader",
-                            "name": "testgroup2",
-                            "roles": ["org.labkey.api.security.roles.ReaderRole"],
-                            "isSystemGroup": false,
-                            "permissions": 1,
-                            "role": "READER",
-                            "isProjectGroup": true,
-                            "type": "g",
-                            "effectivePermissions": [
-                                "org.labkey.api.security.permissions.ReadPermission",
-                                "org.labkey.api.security.permissions.ReadSomePermission"
-                            ],
-                            "groups": []
-                        },
-                        {
-                            "id": 1671,
-                            "roleLabel": "No Permissions",
-                            "name": "Users",
-                            "roles": [],
-                            "isSystemGroup": false,
-                            "permissions": 0,
-                            "role": "NO_PERMISSIONS",
-                            "isProjectGroup": true,
-                            "type": "g",
-                            "effectivePermissions": [],
-                            "groups": []
-                        }
-                    ]
-                }
+            {"container": {
+            "path": "/Security API Test Project",
+            "name": "Security API Test Project",
+            "groups": [
+            {
+            "role": "NO_PERMISSIONS",
+            "permissions": 0,
+            "isSystemGroup": true,
+            "roles": [],
+            "name": "Site Administrators",
+            "effectivePermissions": [],
+            "groups": [{
+            "isSystemGroup": true,
+            "name": "Developers",
+            "id": -4,
+            "isProjectGroup": false
+            }],
+            "id": -1,
+            "type": "g",
+            "isProjectGroup": false,
+            "roleLabel": "No Permissions"
+            },
+            {
+            "role": "NO_PERMISSIONS",
+            "permissions": 0,
+            "isSystemGroup": false,
+            "roles": [],
+            "name": "Audit Group",
+            "effectivePermissions": [],
+            "groups": [],
+            "id": 1153,
+            "type": "g",
+            "isProjectGroup": false,
+            "roleLabel": "No Permissions"
+            },
+            {
+            "role": "NO_PERMISSIONS",
+            "permissions": 0,
+            "isSystemGroup": true,
+            "roles": [],
+            "name": "Developers",
+            "effectivePermissions": [],
+            "groups": [],
+            "id": -4,
+            "type": "g",
+            "isProjectGroup": false,
+            "roleLabel": "No Permissions"
+            },
+            {
+            "role": "NO_PERMISSIONS",
+            "permissions": 0,
+            "isSystemGroup": true,
+            "roles": [],
+            "name": "Guests",
+            "effectivePermissions": [],
+            "groups": [],
+            "id": -3,
+            "type": "g",
+            "isProjectGroup": false,
+            "roleLabel": "No Permissions"
+            },
+            {
+            "role": "NO_PERMISSIONS",
+            "permissions": 0,
+            "isSystemGroup": true,
+            "roles": [],
+            "name": "All Site Users",
+            "effectivePermissions": [],
+            "groups": [],
+            "id": -2,
+            "type": "g",
+            "isProjectGroup": false,
+            "roleLabel": "No Permissions"
+            },
+            {
+            "role": "EDITOR",
+            "permissions": 15,
+            "isSystemGroup": false,
+            "roles": ["org.labkey.api.security.roles.EditorRole"],
+            "name": "testgroup1",
+            "effectivePermissions": [
+            "org.labkey.api.security.permissions.DeletePermission",
+            "org.labkey.api.security.permissions.ReadPermission",
+            "org.labkey.api.security.permissions.InsertPermission",
+            "org.labkey.api.security.permissions.ReadSomePermission",
+            "org.labkey.api.reports.permissions.EditSharedReportPermission",
+            "org.labkey.api.study.permissions.SharedParticipantGroupPermission",
+            "org.labkey.api.lists.permissions.ManagePicklistsPermission",
+            "org.labkey.api.security.permissions.SampleWorkflowJobPermission",
+            "org.labkey.api.security.permissions.UpdatePermission",
+            "org.labkey.announcements.model.SecureMessageBoardReadPermission",
+            "org.labkey.announcements.model.SecureMessageBoardRespondPermission",
+            "org.labkey.api.security.permissions.UpdateSampleStatusPermission",
+            "org.labkey.api.security.permissions.EditSharedViewPermission",
+            "org.labkey.api.reports.permissions.ShareReportPermission"
+            ],
+            "groups": [],
+            "id": 2088,
+            "type": "g",
+            "isProjectGroup": true,
+            "roleLabel": "Editor"
+            },
+            {
+            "role": "READER",
+            "permissions": 1,
+            "isSystemGroup": false,
+            "roles": ["org.labkey.api.security.roles.ReaderRole"],
+            "name": "testgroup2",
+            "effectivePermissions": [
+            "org.labkey.api.security.permissions.ReadPermission",
+            "org.labkey.api.security.permissions.ReadSomePermission"
+            ],
+            "groups": [],
+            "id": 2089,
+            "type": "g",
+            "isProjectGroup": true,
+            "roleLabel": "Reader"
+            },
+            {
+            "role": "NO_PERMISSIONS",
+            "permissions": 0,
+            "isSystemGroup": false,
+            "roles": [],
+            "name": "Users",
+            "effectivePermissions": [],
+            "groups": [],
+            "id": 2087,
+            "type": "g",
+            "isProjectGroup": true,
+            "roleLabel": "No Permissions"
             }
+            ],
+            "id": "261e35e3-6756-103a-94cb-b29d14b1c5c2",
+            "isInheritingPerms": false
+            }}
         </response>
     </test>
 


### PR DESCRIPTION
#### Rationale
We assigned some new roles to editors and admins recently, but missed this test failure at the time.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2993

#### Changes
* Update expected response. (No, I don't think the indentation is important so I've not bothered.)
