### PR TITLE
Fix NPE after page load

### DIFF
--- a/src/org/labkey/test/util/LabKeyExpectedConditions.java
+++ b/src/org/labkey/test/util/LabKeyExpectedConditions.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.util;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.test.Locator;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
@@ -27,8 +28,12 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Wait;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 public class LabKeyExpectedConditions
 {
@@ -284,4 +289,29 @@ public class LabKeyExpectedConditions
                 : ExpectedConditions.invisibilityOf(element);
     }
 
+    /**
+     * Wraps a 'Wait' to terminate after function return a non-null value.
+     * Normally, 'Wait' expects a non-null, non-false return value
+     * @param <T> Argument type to pass into wait function
+     */
+    public static class BooleanWait<T> implements Wait<T>
+    {
+        private final Wait<T> _wrapped;
+
+        public BooleanWait(FluentWait<T> wrapped)
+        {
+            _wrapped = wrapped;
+        }
+
+        @Override @NotNull
+        public <V> V until(Function<? super T, V> isTrue)
+        {
+            List<V> result;
+            result = _wrapped.until(input -> {
+                V value = isTrue.apply(input);
+                return value == null ? null : Collections.singletonList(value);
+            });
+            return result.get(0);
+        }
+    }
 }


### PR DESCRIPTION
#### Rationale
Getting some NPEs when navigating to certain pages (currently the Flow import wizard is the biggest culprit). 
```
java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "org.labkey.test.WebDriverWrapper.executeScript(String, Object[])" is null
  at org.labkey.test.WebDriverWrapper.onLabKeyPage(WebDriverWrapper.java:1209)
  at org.labkey.test.WebDriverWrapper.doAndMaybeWaitForPageToLoad(WebDriverWrapper.java:1923)
  at org.labkey.test.WebDriverWrapper.doAndWaitForPageToLoad(WebDriverWrapper.java:1883)
  at org.labkey.test.WebDriverWrapper.clickAndWait(WebDriverWrapper.java:2699)
  at org.labkey.test.components.ext4.Window.clickButton(Window.java:99)
  at org.labkey.test.components.ext4.Window.clickButton(Window.java:91)
  at org.labkey.test.util.FileBrowserHelper.selectImportDataAction(FileBrowserHelper.java:461)
  at org.labkey.test.tests.flow.BaseFlowTest.importAnalysis_viaPipeline(BaseFlowTest.java:376)
  at org.labkey.test.tests.flow.BaseFlowTest.importAnalysis(BaseFlowTest.java:341)
  at org.labkey.test.tests.flow.BaseFlowTest.importAnalysis(BaseFlowTest.java:334)
  at org.labkey.test.tests.flow.FlowJoQueryTest.verifyNestedBooleans(FlowJoQueryTest.java:189)
  at org.labkey.test.tests.flow.FlowJoQueryTest._doTestSteps(FlowJoQueryTest.java:63)
```

#### Changes
* Prevent NPE from `WebDriverWrapper.onLabKeyPage`
* Don't stop waiting for previous page to go stale when encountering an NPE
