### PR TITLE
AssayExportImportTest fix by adding some time between assay run creation

### DIFF
--- a/src/org/labkey/test/tests/AssayExportImportTest.java
+++ b/src/org/labkey/test/tests/AssayExportImportTest.java
@@ -202,6 +202,7 @@ public class AssayExportImportTest extends BaseWebDriverTest
         int fileIndex = 0;
         for(Map<String, String> runProperty : runProperties)
         {
+            sleep(1000); // give it a second to finish the import of the last run in the "Save and Import Another Run" case
             runProperty.keySet().forEach((property)->setFormElement(Locator.name(property), runProperty.get(property)));
 
             if(!useFilesWebPart)


### PR DESCRIPTION
#### Rationale
As mentioned in the TeamCity triage note for this failure, it looks like if "Save and Import Another Run" is used by the tests for multiple assay run creation, it can go so fast the the temp file names used for the assay data aren't unique and some runs are stomping on each other. This PR isn't perfect, but it adds a 1s sleep between assay run creation since it is unlikely that actual users could click this fast to create assay runs in sequence.
