### PR TITLE
Add property to force local API dependency on TeamCity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,14 +69,13 @@ project.dependencies {
     implementation "org.reflections:reflections:${reflectionsVersion}"
     uiTestRuntimeOnly "org.aspectj:aspectjrt:${aspectjVersion}"
 
-    if (project.hasProperty("teamcity") || project.findProject(BuildUtils.getApiProjectPath(project.gradle)) == null)
-    {
+    if (!project.hasProperty('testWithLocalApi') && // Use this property temporarily when upgrading XMLBeans
+            (project.hasProperty("teamcity") || project.findProject(BuildUtils.getApiProjectPath(project.gradle)) == null)) {
         // LabKey XML schemas are used to decode exported folder XMLs and test case XMLs
         // Don't include local version so that running tests doesn't require building API module
         implementation("org.labkey.api:api:${labkeySchemasTestVersion}") { transitive = false }
     }
-    else
-    {
+    else {
         // Use local version outside of TeamCity so as to not confuse IntelliJ
         BuildUtils.addLabKeyDependency(
                 project: project,

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ jettyRepackagedVersion=9.4.12.v20180830
 seleniumVersion=4.1.1
 mockserverNettyVersion=5.5.1
 
-labkeySchemasTestVersion=21.7.0
+labkeySchemasTestVersion=22.3-SNAPSHOT


### PR DESCRIPTION
#### Rationale
We pull API schemas from Artifactory to avoid building the API module before each test suite. Sometimes we might need to use the cutting edge version of the labkey schemas. 

#### Related Pull Requests
* https://github.com/LabKey/server/pull/204

#### Changes
* Add test dependency override mechanism
* Update test's dependency on the LabKey API module
