### PR TITLE
Issue 44711: DomainFieldTypeChangeTest fix for new field editor data type change confirm modal

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -97,11 +97,28 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
     }
 
     /**
-     * selects the field data type.  Note: after the field is initially created, the select will be disabled
+     * Selects the field data type.
      */
     public DomainFieldRow setType(FieldDefinition.ColumnType columnType)
     {
+        return setType(columnType, false);
+    }
+
+    /**
+     * Selects the field data type.
+     * @param confirmDialogExpected boolean indicating if this field data type change expects a confirm dialog
+     */
+    public DomainFieldRow setType(FieldDefinition.ColumnType columnType, boolean confirmDialogExpected)
+    {
         elementCache().fieldTypeSelectInput.selectByVisibleText(columnType.getLabel());
+
+        if (confirmDialogExpected)
+        {
+            ModalDialog confirmDialog = new ModalDialog.ModalDialogFinder(getDriver())
+                    .withTitle("Confirm Data Type Change").timeout(1000).waitFor();
+            confirmDialog.dismiss("Yes, Change Data Type");
+        }
+
         return this;
     }
 

--- a/src/org/labkey/test/tests/DomainFieldTypeChangeTest.java
+++ b/src/org/labkey/test/tests/DomainFieldTypeChangeTest.java
@@ -86,7 +86,7 @@ public class DomainFieldTypeChangeTest extends BaseWebDriverTest
         log("Verifying Integer to Decimal change");
         DomainDesignerPage domainDesignerPage = DomainDesignerPage.beginAt(this, getProjectName(), "lists", listName);
         DomainFormPanel domainFormPanel = domainDesignerPage.fieldsPanel();
-        domainFormPanel.getField("testInteger").setType(FieldDefinition.ColumnType.Decimal);
+        domainFormPanel.getField("testInteger").setType(FieldDefinition.ColumnType.Decimal, true);
         domainFormPanel.getField("testBoolean").setNumberFormat("yes;no");
         domainDesignerPage.clickFinish();
 
@@ -98,10 +98,10 @@ public class DomainFieldTypeChangeTest extends BaseWebDriverTest
         log("Verifying changing data fields to string");
         domainDesignerPage = DomainDesignerPage.beginAt(this, getProjectName(), "lists", listName);
         domainFormPanel = domainDesignerPage.fieldsPanel();
-        domainFormPanel.getField("testInteger").setType(FieldDefinition.ColumnType.String);
-        domainFormPanel.getField("testDecimal").setType(FieldDefinition.ColumnType.String);
-        domainFormPanel.getField("testDate").setType(FieldDefinition.ColumnType.String);
-        domainFormPanel.getField("testBoolean").setType(FieldDefinition.ColumnType.String);
+        domainFormPanel.getField("testInteger").setType(FieldDefinition.ColumnType.String, true);
+        domainFormPanel.getField("testDecimal").setType(FieldDefinition.ColumnType.String, true);
+        domainFormPanel.getField("testDate").setType(FieldDefinition.ColumnType.String, true);
+        domainFormPanel.getField("testBoolean").setType(FieldDefinition.ColumnType.String, true);
         domainDesignerPage.clickFinish();
 
         clickAndWait(Locator.linkWithText(listName));
@@ -178,17 +178,17 @@ public class DomainFieldTypeChangeTest extends BaseWebDriverTest
         click(Locator.linkWithText("Manage assay design"));
         assayDesignerPage = _assayHelper.clickEditAssayDesign();
         runFields = assayDesignerPage.goToRunFields();
-        runFields.getField("runTestInteger").setType(FieldDefinition.ColumnType.Decimal);
+        runFields.getField("runTestInteger").setType(FieldDefinition.ColumnType.Decimal, true);
         runFields.getField("runTestBoolean").setNumberFormat("yes;no");
 
         batchFields = assayDesignerPage.goToBatchFields();
-        batchFields.getField("batchTestDate").setType(FieldDefinition.ColumnType.String);
-        batchFields.getField("batchTestDecimal").setType(FieldDefinition.ColumnType.String);
+        batchFields.getField("batchTestDate").setType(FieldDefinition.ColumnType.String, true);
+        batchFields.getField("batchTestDecimal").setType(FieldDefinition.ColumnType.String, true);
         assayDesignerPage.clickFinish();
 
         assayDesignerPage = _assayHelper.clickEditAssayDesign();
         runFields = assayDesignerPage.goToRunFields();
-        runFields.getField("runTestBoolean").setType(FieldDefinition.ColumnType.String);
+        runFields.getField("runTestBoolean").setType(FieldDefinition.ColumnType.String, true);
         assayDesignerPage.clickFinish();
 
         goToManageAssays();


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44711

With the related PR, we added a confirmation modal to the field editor for when a saved field changes data types which will result in a one-way type change (ex. boolean -> string, integer -> double, etc.). This PR fixes up the DomainFieldTypeChangeTest to account for the new modal.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/728

#### Changes
* DomainFieldRow test component helper for expecting the confirm modal on data type change
* Update DomainFieldTypeChangeTest usages that change data type for a saved field
