### PR TITLE
Add test for issues notification details link

### DIFF
--- a/src/org/labkey/test/components/dumbster/EmailRecordTable.java
+++ b/src/org/labkey/test/components/dumbster/EmailRecordTable.java
@@ -21,6 +21,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.components.html.Table;
 import org.labkey.test.selenium.RefindingWebElement;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -115,6 +116,11 @@ public class EmailRecordTable extends Table
     public EmailMessage getMessage(String subject)
     {
         return getMessage(actualSubject -> actualSubject.equals(subject));
+    }
+
+    public WebElement getRowEl(EmailMessage message)
+    {
+        return Locator.xpath("./tbody/tr[" + message.getRowIndex() + "]").findElement(this);
     }
 
     public EmailMessage getMessageRegEx(String regExp)

--- a/src/org/labkey/test/tests/issues/IssuesTest.java
+++ b/src/org/labkey/test/tests/issues/IssuesTest.java
@@ -52,6 +52,7 @@ import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.Maps;
 import org.labkey.test.util.PortalHelper;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
 
 import java.io.IOException;
@@ -452,11 +453,7 @@ public class IssuesTest extends BaseWebDriverTest
         clickButton("Cancel");
         assertTitleContains(ISSUE.get("title"));
 
-        //("Dumbster");
-        goToModule("Dumbster");
-        pushLocation();
-
-        EmailRecordTable emailTable = new EmailRecordTable(this);
+        EmailRecordTable emailTable = goToEmailRecord();
         EmailMessage message = emailTable.getMessageWithSubjectContaining(ISSUE.get("title") + ",\" has been opened and assigned to " + _userHelper.getDisplayNameForEmail(USER1));
 
         // Presumed to get the first message
@@ -468,6 +465,11 @@ public class IssuesTest extends BaseWebDriverTest
         assertTrue("Issue Message does not contain title", message.getSubject().contains(ISSUE.get("title")));
 
         assertTextNotPresent("This line shouldn't appear");
+        emailTable.clickMessage(message);
+        WebElement detailsLink = Locator.linkContainingText("issues-details").findElement(emailTable.getRowEl(message));
+        shortWait().until(ExpectedConditions.visibilityOf(detailsLink));
+        clickAndWait(detailsLink);
+        assertTextPresent(ISSUE.get("title"), ISSUE.get("comment"));
     }
 
     private void updateIssue()


### PR DESCRIPTION
#### Rationale
Issues notifications were broken but our tests didn't catch it. We should have a more thorough regression test for notification emails.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3039

#### Changes
* Verify details link in notification emails
