### PR TITLE
Wait data views links to settle down before attempting to click

### DIFF
--- a/src/org/labkey/test/tests/ReportTest.java
+++ b/src/org/labkey/test/tests/ReportTest.java
@@ -20,7 +20,9 @@ import org.labkey.test.Locator;
 import org.labkey.test.components.ChartQueryDialog;
 import org.labkey.test.components.ChartTypeDialog;
 import org.labkey.test.pages.reports.ManageViewsPage;
+import org.labkey.test.util.LabKeyExpectedConditions;
 import org.labkey.test.util.LogMethod;
+import org.openqa.selenium.WebElement;
 
 public abstract class ReportTest extends StudyBaseTest
 {
@@ -67,16 +69,16 @@ public abstract class ReportTest extends StudyBaseTest
 
     protected void clickReportDetailsLink(String reportName)
     {
-        Locator link = Locator.xpath("//tr").withClass("x4-grid-row").containing(reportName).append("//a[contains(@data-qtip, 'Click to navigate to the Detail View')]");
-
-        waitAndClickAndWait(link);
+        Locator loc = Locator.xpath("//tr").withClass("x4-grid-row").containing(reportName).append("//a[contains(@data-qtip, 'Click to navigate to the Detail View')]");
+        WebElement link = shortWait().until(LabKeyExpectedConditions.animationIsDone(loc));
+        clickAndWait(link);
     }
 
     protected void clickReportPermissionsLink(String reportName)
     {
-        Locator link = Locator.xpath("//tr").withClass("x4-grid-row").withPredicate(Locator.linkWithText(reportName)).append("//a[contains(@data-qtip, 'Click to customize the permissions')]");
-
-        waitAndClickAndWait(link);
+        Locator loc = Locator.xpath("//tr").withClass("x4-grid-row").withPredicate(Locator.linkWithText(reportName)).append("//a[contains(@data-qtip, 'Click to customize the permissions')]");
+        WebElement link = shortWait().until(LabKeyExpectedConditions.animationIsDone(loc));
+        clickAndWait(link);
     }
 
     @Override

--- a/src/org/labkey/test/util/LabKeyExpectedConditions.java
+++ b/src/org/labkey/test/util/LabKeyExpectedConditions.java
@@ -76,7 +76,7 @@ public class LabKeyExpectedConditions
                     WebElement el = loc.findElement(driver);
                     return animationIsDone(el).apply(driver);
                 }
-                catch (StaleElementReferenceException recheck)
+                catch (StaleElementReferenceException | NoSuchElementException recheck)
                 {
                     return null;
                 }


### PR DESCRIPTION
#### Rationale
Tooltips sometimes get in the way of clicks in the data views grid. The tooltip is from a different row, implying that rows move around a bit when the page is loading.

#### Changes
* Wait for data views grid rows to finish loading
