### PR TITLE
Issue 44835: LKSM: Unable to use MaterialInputs/SampleTypeName in naming pattern

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
+++ b/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
@@ -123,6 +123,20 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
                 "Name\tB\tMaterialInputs/InputsExpressionTest",
                 "${Inputs:first:defaultValue('" + DEFAULT_SAMPLE_PARENT_VALUE + "')}_${batchRandomId}",
                 null, "Pat");
+
+
+        verifyNames(
+                "InputsWithDataTypeExpression",
+                "Name\tB\tMaterialInputs/InputsWithDataTypeExpression",
+                "${Inputs/InputsWithDataTypeExpression:first:defaultValue('" + DEFAULT_SAMPLE_PARENT_VALUE + "')}_${batchRandomId}",
+                null, "Red");
+
+        verifyNames(
+                "MaterialWithDataTypeExpression",
+                "Name\tB\tMaterialInputs/MaterialWithDataTypeExpression",
+                "${MaterialInputs/MaterialWithDataTypeExpression:first:defaultValue('" + DEFAULT_SAMPLE_PARENT_VALUE + "')}_${batchRandomId}",
+                null, "Ned");
+
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3036

#### Changes
* add test for Inputs/X, MaterialInputs/Y