### PR TITLE
Remove unnecessary xmlbeansVersion reference - just pull in POI's version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ project.dependencies {
     implementation "org.apache.pdfbox:pdfbox:${pdfboxVersion}"
     api "org.apache.poi:poi:${poiVersion}"
     implementation "org.apache.poi:poi-ooxml:${poiVersion}"
-    implementation "org.apache.xmlbeans:xmlbeans:${xmlbeansVersion}"
     implementation "org.bouncycastle:bcpg-jdk15on:${bouncycastleVersion}"
     implementation "org.jetbrains:annotations:${annotationsVersion}"
     implementation "org.mock-server:mockserver-netty:${mockserverNettyVersion}" // used by test classes in accounts


### PR DESCRIPTION
#### Rationale
Pull in POI's version of XMLBeans as we do in platform

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3051