### PR TITLE
Fix LoggedOutDialog title

### DIFF
--- a/src/org/labkey/test/components/bootstrap/LoggedOutDialog.java
+++ b/src/org/labkey/test/components/bootstrap/LoggedOutDialog.java
@@ -28,7 +28,7 @@ public class LoggedOutDialog extends ModalDialog
 
     protected LoggedOutDialog(WebDriver driver)
     {
-        super(new ModalDialogFinder(driver).withTitle("Logged Out")
+        super(new ModalDialogFinder(driver).withTitle("Session Expired")
                 .waitFor().getComponentElement(), driver);
     }
 


### PR DESCRIPTION
#### Rationale
My platform PR removes our custom code for closing Websockets on logout, and instead lets Tomcat handle closing websockets when sessions expire. This change results in a different message and title in the modal when users log out.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3029

#### Changes
* LoggedOutDialog: Change expected title
