### PR TITLE
data views fixes for failed tests

### DIFF
--- a/src/org/labkey/test/tests/ReportAndDatasetNotificationTest.java
+++ b/src/org/labkey/test/tests/ReportAndDatasetNotificationTest.java
@@ -178,7 +178,7 @@ public class ReportAndDatasetNotificationTest extends StudyBaseTest
 
         openCustomizePanel("Data Views");
         _ext4Helper.uncheckCheckbox("datasets");
-        _ext4Helper.uncheckCheckbox("queries");
+        _ext4Helper.uncheckCheckbox("grid views");
         clickButton("Save", 0);
         _ext4Helper.waitForMaskToDisappear();
 


### PR DESCRIPTION
#### Rationale
A recent change resulted in the renaming of `queries` to `grid views` for the data views types. We needed to make a small adjustment to the test to handle this label change.

https://github.com/LabKey/platform/pull/3033