### PR TITLE
Check for expected error case-insensitively in IssueAPITest

### DIFF
--- a/src/org/labkey/test/tests/issues/IssueAPITest.java
+++ b/src/org/labkey/test/tests/issues/IssueAPITest.java
@@ -439,7 +439,7 @@ public class IssueAPITest extends BaseWebDriverTest
             fail("expect error if command is executed without required property priority");
         }catch(CommandException success)
         {
-            assertThat(success.getMessage(), containsString("Data does not contain required field: priority"));
+            assertThat(success.getMessage().toLowerCase(), containsString("data does not contain required field: priority"));
             resetErrors();
         }
     }


### PR DESCRIPTION
#### Rationale
IssueAPITest.testIssueWithoutPri() has been failing consistently on SQL but passing on PG, because it checks for expected text in an API response and SQL capitalizes one of the words ("Priority") in the expected string, while PG does not.

#### Related Pull Requests
n/a

#### Changes
Single-line change: convert the error to lower case, then ensure the expected error message in lower case
