### PR TITLE
Stop creating shared datasets when importing folder archives

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1932,12 +1932,25 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
     public void importFolderFromPipeline(String folderFile, int completedJobsExpected, boolean validateQueries)
     {
+        importFolderFromPipeline(folderFile, completedJobsExpected, validateQueries, null);
+    }
+
+    // The "Shared Datasets" section won't appear in most cases, so most callers should set createSharedDatasets == null (don't care).
+    public void importFolderFromPipeline(String folderFile, int completedJobsExpected, boolean validateQueries, Boolean createSharedDatasets)
+    {
         goToFolderManagement();
         clickAndWait(Locator.linkWithText("Import"));
         clickButtonContainingText("Use Pipeline");
         _fileBrowserHelper.importFile(folderFile, "Import Folder");
 
         waitForText("Import Folder from Pipeline");
+        if (null != createSharedDatasets)
+        {
+            Locator createSharedDatasetsCheckbox = Locator.name("createSharedDatasets");
+            waitForElement(createSharedDatasetsCheckbox);
+            if (!createSharedDatasets)
+                uncheckCheckbox(createSharedDatasetsCheckbox);
+        }
         Locator validateQueriesCheckbox = Locator.name("validateQueries");
         waitForElement(validateQueriesCheckbox);
         if (!validateQueries)


### PR DESCRIPTION
#### Rationale
The folder import page now offers the "create shared datasets" option when in a dataspace folder. Dataspace tests need a way to control this checkbox.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3069