### PR TITLE
Remove permission class that was deleted

### DIFF
--- a/data/api/security-api.xml
+++ b/data/api/security-api.xml
@@ -91,7 +91,6 @@
                                 "org.labkey.api.security.permissions.UpdatePermission",
                                 "org.labkey.announcements.model.SecureMessageBoardReadPermission",
                                 "org.labkey.api.security.permissions.SampleWorkflowJobPermission",
-                                "org.labkey.api.security.permissions.UpdateSampleStatusPermission",
                                 "org.labkey.api.security.permissions.AssayReadPermission",
                                 "org.labkey.api.security.permissions.NotebookReadPermission",
                                 "org.labkey.api.security.permissions.DataClassReadPermission",


### PR DESCRIPTION
#### Rationale
A permission class was removed when the other Read permission classes were added.  Need to adjust test accordingly

#### Related Pull Requests
* #1020 

#### Changes
* Remove UpdateSampleStatusPermission as it no longer exists.
