### PR TITLE
Fix SampleTypeNameExpressionTest.testInputsExpressions

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
+++ b/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
@@ -272,6 +272,8 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
 
     private void verifyNames(String sampleTypeName, String header, String nameExpression, @Nullable String currentTypeAlias, String namePrefix)
     {
+        goToProjectHome();
+
         String name1 = namePrefix + "_1";
         String name2 = namePrefix + "_2";
         String data = header + "\n" +


### PR DESCRIPTION
#### Rationale
Test needed to go to the project home before starting next check.

#### Related Pull Requests
* None

#### Changes
* Added a goToProjectHome in SampleTypeNameExpressionTest.verifyNames.
