### PR TITLE
Update OntologyTreeSearch component for use in insert/update

### DIFF
--- a/src/org/labkey/test/components/ui/ontology/OntologyTreeSearch.java
+++ b/src/org/labkey/test/components/ui/ontology/OntologyTreeSearch.java
@@ -139,7 +139,7 @@ public class OntologyTreeSearch extends WebDriverComponent<OntologyTreeSearch.El
 
     protected class ElementCache extends Component<?>.ElementCache
     {
-        final Input searchInput = Input.Input(Locator.input("concept-search"), getDriver())
+        final Input searchInput = Input.Input(Locator.tagWithClass("input", "form-control"), getDriver())
                 .timeout(2000).findWhenNeeded(this);
 
         WebElement resultContainer()
@@ -159,7 +159,7 @@ public class OntologyTreeSearch extends WebDriverComponent<OntologyTreeSearch.El
     public static class OntologyTreeSearchFinder extends WebDriverComponentFinder<OntologyTreeSearch, OntologyTreeSearchFinder>
     {
         private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "concept-search-container");
-        private String _title = null;
+        private final String _title = null;
 
         public OntologyTreeSearchFinder(WebDriver driver)
         {

--- a/src/org/labkey/test/components/ui/ontology/OntologyTreeSearch.java
+++ b/src/org/labkey/test/components/ui/ontology/OntologyTreeSearch.java
@@ -93,7 +93,7 @@ public class OntologyTreeSearch extends WebDriverComponent<OntologyTreeSearch.El
     {
         var input = elementCache().searchInput;
         String placeholder = input.getComponentElement().getAttribute("placeholder");
-        input.set("");
+        getWrapper().actionClear(elementCache().searchInput.getComponentElement());
         // wait for the results container to collapse, and for the placeholder for the input to be shown
         getWrapper().waitFor(()-> !isResultContainerExpanded() &&
                 Locator.css("input:placeholder-shown").withAttribute("placeholder", placeholder)

--- a/src/org/labkey/test/components/ui/ontology/OntologyTreeSearch.java
+++ b/src/org/labkey/test/components/ui/ontology/OntologyTreeSearch.java
@@ -159,7 +159,6 @@ public class OntologyTreeSearch extends WebDriverComponent<OntologyTreeSearch.El
     public static class OntologyTreeSearchFinder extends WebDriverComponentFinder<OntologyTreeSearch, OntologyTreeSearchFinder>
     {
         private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "concept-search-container");
-        private final String _title = null;
 
         public OntologyTreeSearchFinder(WebDriver driver)
         {


### PR DESCRIPTION
#### Rationale
Until now, the only product use of the OntologyTreeSearch component was in the ConceptPickerDialog, or in the Ontology page- in which cases, the search input's name was always "concept-search".  When in use in insert and update forms, the name is something different, but it is always the only input.form-control in the component.

#### Related Pull Requests
tbd- <- ontology test changes 

#### Changes
Update the locator for the search input
