### PR TITLE
Update `ExportFolderPage`

### DIFF
--- a/src/org/labkey/test/components/ext4/RadioButton.java
+++ b/src/org/labkey/test/components/ext4/RadioButton.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.components.ext4;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.labkey.test.Locator;
 import org.labkey.test.util.Ext4Helper;
@@ -30,6 +31,16 @@ public class RadioButton extends Checkbox
     public static RadioButtonFinder RadioButton()
     {
         return new RadioButtonFinder();
+    }
+
+    @Override
+    public void set(@NotNull Boolean checked)
+    {
+        if (!checked)
+        {
+            throw new IllegalArgumentException("Unable to uncheck radio button");
+        }
+        super.set(checked);
     }
 
     @Override

--- a/src/org/labkey/test/util/StudyHelper.java
+++ b/src/org/labkey/test/util/StudyHelper.java
@@ -26,6 +26,7 @@ import org.labkey.test.Locators;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.components.DomainDesignerPage;
 import org.labkey.test.pages.ManageDatasetsPage;
+import org.labkey.test.pages.admin.ExportFolderPage;
 import org.labkey.test.pages.study.CreateStudyPage;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.pages.study.ManageVisitPage;
@@ -287,8 +288,8 @@ public class StudyHelper
         _test.clickFolder(folder);
         _test.clickTab("Manage");
         _test.clickButton("Export Study");
+        ExportFolderPage exportFolderPage = new ExportFolderPage(_test.getDriver());
 
-        _test.waitForElement(Locator.tagWithClass("table", "export-location"));
         List<String> studyObjects = Arrays.asList("Visit Map", "Cohort Settings", "QC State Settings", "Datasets: Study Dataset Definitions", "Datasets: Study Dataset Data", "Datasets: Assay Dataset Definitions", "Datasets: Assay Dataset Data", "Participant Comment Settings", "Participant Groups", "Protocol Documents");
         if (isSpecimenModuleActive())
         {
@@ -304,8 +305,14 @@ public class StudyHelper
         }
         assertTrue("Missing study objects: " + String.join(", ", missingObjects), missingObjects.isEmpty());
 
-        _test.checkRadioButton(Locator.tagWithClass("table", "export-location").index(zipFile ? 1 : 0)); // zip file vs. individual files
-        _test.clickButton("Export");
+        if (zipFile)
+        {
+            exportFolderPage.exportToPipelineAsZip();
+        }
+        else
+        {
+            exportFolderPage.exportToPipelineAsIndividualFiles();
+        }
     }
 
     @LogMethod


### PR DESCRIPTION
#### Rationale
Numerous tests and helpers export studies and folders without using `ExportFolderPage` as much as the could. Also, there is some page functionality in `BaseWebDriverTest` that belongs in the export page.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3082
* https://github.com/LabKey/compliance/pull/149
* https://github.com/LabKey/cloud/pull/96

#### Changes
* Move PHI and export options to `ExportFolderPage`
* Refactor study export helpers to use `ExportFolderPage`
