### PR TITLE
Dump threads when page loads timeout

### DIFF
--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -411,11 +411,12 @@ public class NabAssayTest extends AbstractAssayTest
 
         if (isStudyModuleInstalled())
         {
+            log("Link to Study");
             region.checkAllOnPage();
             region.clickHeaderButton("Link to Study");
 
             selectOptionByText(Locator.name("targetStudy"), "/" + TEST_ASSAY_PRJ_NAB + "/" + TEST_ASSAY_FLDR_STUDY1 + " (" + TEST_ASSAY_FLDR_STUDY1 + " Study)");
-            clickButton("Next");
+            clickButton("Next", 300_000);
 
             region = new DataRegionTable("Data", this);
             region.clickHeaderButtonAndWait("Link to Study");

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -413,13 +413,14 @@ public class NabAssayTest extends AbstractAssayTest
         {
             log("Link to Study");
             region.checkAllOnPage();
-            region.clickHeaderButton("Link to Study");
+            region.clickHeaderButtonAndWait("Link to Study");
 
             selectOptionByText(Locator.name("targetStudy"), "/" + TEST_ASSAY_PRJ_NAB + "/" + TEST_ASSAY_FLDR_STUDY1 + " (" + TEST_ASSAY_FLDR_STUDY1 + " Study)");
-            clickButton("Next", 300_000);
+            clickButton("Next");
 
             region = new DataRegionTable("Data", this);
             region.clickHeaderButtonAndWait("Link to Study");
+            log("Link to Study complete.");
             assertStudyData(4);
 
             assertAliasedAUCStudyData();

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -34,6 +34,8 @@ import org.labkey.test.pages.admin.PermissionsPage;
 import org.labkey.test.pages.assay.RunQCPage;
 import org.labkey.test.pages.assay.plate.PlateDesignerPage;
 import org.labkey.test.pages.assay.plate.PlateTemplateListPage;
+import org.labkey.test.pages.query.NewQueryPage;
+import org.labkey.test.pages.query.SourceQueryPage;
 import org.labkey.test.tests.AbstractAssayTest;
 import org.labkey.test.util.AssayImportOptions;
 import org.labkey.test.util.AssayImporter;
@@ -509,14 +511,11 @@ public class NabAssayTest extends AbstractAssayTest
     {
         final String QUERY_NAME = "Data";
 
-        navigateToFolder(getProjectName(), TEST_ASSAY_FLDR_NAB);
-        clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));
-        goToSchemaBrowser();
-        selectQuery("assay.NAb.TestAssayNab", QUERY_NAME);
-        createNewQuery("assay.NAb.TestAssayNab");
-        setFormElement(Locator.name("ff_newQueryName"), "New NabQuery");
-        clickAndWait(Locator.lkButton("Create and Edit Source"));
-        setCodeEditorValue("queryText",
+        SourceQueryPage queryPage = NewQueryPage.beginAt(this, getProjectName() + "/" + TEST_ASSAY_FLDR_NAB, "assay.NAb.TestAssayNab")
+                .setName("New NabQuery")
+                .setBaseTable(QUERY_NAME)
+                .clickCreate();
+        queryPage.setSource(
                 "SELECT \n" +
                         QUERY_NAME + ".Properties.AUC As AUC,\n" +
                         QUERY_NAME + ".Properties.CurveIC50_4pl,\n" +
@@ -525,7 +524,7 @@ public class NabAssayTest extends AbstractAssayTest
                         QUERY_NAME + ".WellgroupName\n" +
                         "FROM " + QUERY_NAME + "\n"
         );
-        clickButton("Save & Finish");
+        queryPage.clickSaveAndFinish();
         assertTextPresent("AUC", "Curve IC50 4pl", "Curve IC50 4pl OOR Indicator", "Participant ID", "Wellgroup Name",
                           "<20.0", "ptid 1 C", "473.94");
     }

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -416,7 +416,7 @@ public class NabAssayTest extends AbstractAssayTest
             region.clickHeaderButtonAndWait("Link to Study");
 
             selectOptionByText(Locator.name("targetStudy"), "/" + TEST_ASSAY_PRJ_NAB + "/" + TEST_ASSAY_FLDR_STUDY1 + " (" + TEST_ASSAY_FLDR_STUDY1 + " Study)");
-            clickButton("Next");
+            clickButton("Next", 300_000); // Triggers a query that is, sometimes, very slow on SQL Server
 
             region = new DataRegionTable("Data", this);
             region.clickHeaderButtonAndWait("Link to Study");


### PR DESCRIPTION
#### Rationale
Tests should trigger a thread dump when a page load times out. We have a special exception that triggers this and should throw it at appropriate times.

#### Changes
* Throw `TestTimeoutException` when navigation times out
* Increase timeout for NAb link to study
