### PR TITLE
Mouse over to avoid tooltip

### DIFF
--- a/src/org/labkey/test/tests/ReportTest.java
+++ b/src/org/labkey/test/tests/ReportTest.java
@@ -69,16 +69,24 @@ public abstract class ReportTest extends StudyBaseTest
 
     protected void clickReportDetailsLink(String reportName)
     {
-        Locator loc = Locator.xpath("//tr").withClass("x4-grid-row").containing(reportName).append("//a[contains(@data-qtip, 'Click to navigate to the Detail View')]");
-        WebElement link = shortWait().until(LabKeyExpectedConditions.animationIsDone(loc));
+        WebElement row = findReportGridRow(reportName);
+        WebElement link = Locator.tagWithAttribute("a", "data-qtip", "Click to navigate to the Detail View").findElement(row);
         clickAndWait(link);
     }
 
     protected void clickReportPermissionsLink(String reportName)
     {
-        Locator loc = Locator.xpath("//tr").withClass("x4-grid-row").withPredicate(Locator.linkWithText(reportName)).append("//a[contains(@data-qtip, 'Click to customize the permissions')]");
-        WebElement link = shortWait().until(LabKeyExpectedConditions.animationIsDone(loc));
+        WebElement row = findReportGridRow(reportName);
+        WebElement link = Locator.tagWithAttribute("a", "data-qtip", "Click to customize the permissions").findElement(row);
         clickAndWait(link);
+    }
+
+    private WebElement findReportGridRow(String reportName)
+    {
+        WebElement row = Locator.tagWithClass("tr", "x4-grid-row").withPredicate(Locator.linkWithText(reportName)).waitForElement(getDriver(), 5_000);
+        shortWait().until(LabKeyExpectedConditions.animationIsDone(row));
+        mouseOver(Locator.tag("td").last().findElement(row)); // Try to avoid triggering tooltip from other reports
+        return row;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Another attempt to fix an intermittent failure with tooltips blocking the details link in the report grid.
```
org.openqa.selenium.ElementClickInterceptedException: Element <a href="/labkey/ReportVerifyProject/reports-details.view?reportId=db%3A31"> is not clickable at point (1112,447) because another element <div id="tooltip-1023_header-body" class="x4-header-body x4-tip-header-body x4-tip-header-body-default x4-tip-header-body-horizontal x4-tip-header-body-default-horizontal x4-tip-header-body-top x4-tip-header-body-default-top x4-tip-header-body-docked-top x4-tip-header-body-default-docked-top x4-box-layout-ct x4-tip-header-body-default-horizontal x4-tip-header-body-default-top x4-tip-header-body-default-docked-top"> obscures it
[...]
Element: [[FirefoxDriver: firefox on LINUX (701f6dfa-6177-4903-b2c4-f83108ae8de6)] -> xpath: //tr[contains(concat(' ',normalize-space(@class),' '), ' x4-grid-row ')][contains(normalize-space(), concat('Attachment report 1-->">',"'>'",'"<script>alert(',"'8(')</script>"))]//a[contains(@data-qtip, 'Click to navigate to the Detail View')]]
  [...]
  at app//org.labkey.test.tests.ReportTest.clickReportDetailsLink(ReportTest.java:74)
  at app//org.labkey.test.tests.NonStudyReportsTest.doUpdateAttachmentReportTest(NonStudyReportsTest.java:146)
  at app//org.labkey.test.tests.NonStudyReportsTest.doAttachmentReportTest(NonStudyReportsTest.java:135)
  at app//org.labkey.test.tests.NonStudyReportsTest.doVerifySteps(NonStudyReportsTest.java:87)
  at app//org.labkey.test.tests.StudyBaseTest.runUITests(StudyBaseTest.java:138)
  at app//org.labkey.test.tests.StudyBaseTest.testSteps(StudyBaseTest.java:348)
```

#### Related Pull Requests
* Previous attempt: #1007 

#### Changes
* Mouse over desired row before clicking
