### PR TITLE
Fix inadvertent change to link locator

### DIFF
--- a/src/org/labkey/test/tests/ReportTest.java
+++ b/src/org/labkey/test/tests/ReportTest.java
@@ -77,7 +77,7 @@ public abstract class ReportTest extends StudyBaseTest
     protected void clickReportPermissionsLink(String reportName)
     {
         WebElement row = findReportGridRow(reportName);
-        WebElement link = Locator.tagWithAttribute("a", "data-qtip", "Click to customize the permissions").findElement(row);
+        WebElement link = Locator.tagWithAttributeContaining("a", "data-qtip", "Click to customize the permissions").findElement(row);
         clickAndWait(link);
     }
 


### PR DESCRIPTION
#### Rationale
Accidentally changed a locator from using a partial text match to requiring an exact text match.

#### Related Pull Requests
* #1034 

#### Changes
* Use `tagWithAttributeContaining` for finding the report permissions link
