### PR TITLE
Sample Finder test components

### DIFF
--- a/src/org/labkey/test/BootstrapLocators.java
+++ b/src/org/labkey/test/BootstrapLocators.java
@@ -14,7 +14,7 @@ public abstract class BootstrapLocators
 
     public static Locator.XPathLocator button()
     {
-        return Locator.tagWithClass("a", "btn");
+        return Locator.byClass("btn");
     }
 
     public static Locator.XPathLocator button(String text)

--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -429,6 +429,12 @@ public abstract class Locator extends By
         return findElementOrNull(context) != null;
     }
 
+    public boolean isDisplayed(SearchContext context)
+    {
+        WebElement element = findElementOrNull(context);
+        return element != null && element.isDisplayed();
+    }
+
     protected final List<WebElement> decorateWebElements(List<WebElement> elements)
     {
         List<WebElement> decoratedElements = new ArrayList<>(elements.size());

--- a/src/org/labkey/test/components/Component.java
+++ b/src/org/labkey/test/components/Component.java
@@ -64,7 +64,16 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
         return _elementCache;
     }
 
-    protected void waitForReady(EC ec) { }
+    /**
+     * @deprecated Passing in the ElementCache is unnecessary
+     */
+    @Deprecated (since = "22.4")
+    protected void waitForReady(EC ec)
+    {
+        waitForReady();
+    }
+
+    protected void waitForReady() { }
 
     protected EC newElementCache()
     {

--- a/src/org/labkey/test/components/react/Tabs.java
+++ b/src/org/labkey/test/components/react/Tabs.java
@@ -147,7 +147,7 @@ public class Tabs extends WebDriverComponent<Tabs.ElementCache>
 
     public static class TabsFinder extends WebDriverComponentFinder<Tabs, TabsFinder>
     {
-        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("ul", "tablist").parent();
+        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("ul", "nav-tabs").parent();
 
         public TabsFinder(WebDriver driver)
         {

--- a/src/org/labkey/test/components/ui/navigation/FindByIdsDialog.java
+++ b/src/org/labkey/test/components/ui/navigation/FindByIdsDialog.java
@@ -9,7 +9,11 @@ import org.openqa.selenium.WebElement;
 
 import java.util.List;
 
-public class FindByIdsDialog  extends ModalDialog
+/**
+ * Wraps 'labkey-ui-component' defined in <code>internal/components/search/FindByIdsModal.tsx</code>
+ * TODO: Move to package: 'org.labkey.test.components.ui.search'
+ */
+public class FindByIdsDialog extends ModalDialog
 {
     public static final String TITLE = "Find Samples";
 

--- a/src/org/labkey/test/components/ui/navigation/NavBar.java
+++ b/src/org/labkey/test/components/ui/navigation/NavBar.java
@@ -8,6 +8,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.html.Input;
+import org.labkey.test.components.react.MultiMenu;
 import org.labkey.test.components.ui.notifications.ServerNotificationMenu;
 import org.labkey.test.util.search.HasSearchResults;
 import org.openqa.selenium.Keys;
@@ -15,7 +16,6 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
-import static org.labkey.test.WebDriverWrapper.waitFor;
 
 public abstract class NavBar extends WebDriverComponent<NavBar.ElementCache>
 {
@@ -52,17 +52,19 @@ public abstract class NavBar extends WebDriverComponent<NavBar.ElementCache>
 
     public FindByIdsDialog findBySampleIds()
     {
-        elementCache().findAndSearchMenuButton.click();
-        waitFor(()->elementCache().findSamplesByIdsOption.isDisplayed(), "Find samples by ID menu option did not show up.", 500);
-        elementCache().findSamplesByIdsOption.click();
+        elementCache().searchMenu.doMenuAction(" Find Samples by ID");
         return new FindByIdsDialog(getDriver());
     }
 
     public FindByIdsDialog findByBarcodes()
     {
-        elementCache().findAndSearchMenuButton.click();
-        waitFor(()->elementCache().findSamplesByBarcodesOption.isDisplayed(), "Find samples by Barcode menu option did not show up.", 500);
-        elementCache().findSamplesByBarcodesOption.click();
+        elementCache().searchMenu.doMenuAction(" Find Samples by Barcode");
+        return new FindByIdsDialog(getDriver());
+    }
+
+    public FindByIdsDialog goToSampleFinder()
+    {
+        elementCache().searchMenu.doMenuAction(" Sample Finder");
         return new FindByIdsDialog(getDriver());
     }
 
@@ -113,10 +115,6 @@ public abstract class NavBar extends WebDriverComponent<NavBar.ElementCache>
         public WebElement userIcon = Locator.tagWithAttribute("img", "alt", "User Avatar").findWhenNeeded(this);
         public WebElement projectNameDisplay = Locator.tagWithClass("span", "project-name").findWhenNeeded(this);
         public Input searchBox = Input.Input(Locator.tagWithClass("input", "navbar__search-input"), getDriver()).findWhenNeeded(this);
-        public WebElement searchForm = Locator.tagWithClass("form", "navbar__search-form").findWhenNeeded(this);
-        public WebElement findAndSearchMenuButton = Locator.tagWithId("button", "find-and-search-menu").findWhenNeeded(searchForm);
-        public WebElement findSamplesOption = Locator.linkContainingText("Find Samples").findWhenNeeded(searchForm);
-        public WebElement findSamplesByIdsOption = Locator.linkContainingText("Find Samples by ID").findWhenNeeded(searchForm);
-        public WebElement findSamplesByBarcodesOption = Locator.linkContainingText("Find Samples by Barcode").findWhenNeeded(searchForm);
+        public MultiMenu searchMenu = new MultiMenu.MultiMenuFinder(getDriver()).withButtonId("find-and-search-menu").findWhenNeeded(this);
     }
 }

--- a/src/org/labkey/test/components/ui/navigation/NavBar.java
+++ b/src/org/labkey/test/components/ui/navigation/NavBar.java
@@ -52,19 +52,19 @@ public abstract class NavBar extends WebDriverComponent<NavBar.ElementCache>
 
     public FindByIdsDialog findBySampleIds()
     {
-        elementCache().searchMenu.doMenuAction(" Find Samples by ID");
+        elementCache().searchMenu.doMenuAction("Find Samples by ID");
         return new FindByIdsDialog(getDriver());
     }
 
     public FindByIdsDialog findByBarcodes()
     {
-        elementCache().searchMenu.doMenuAction(" Find Samples by Barcode");
+        elementCache().searchMenu.doMenuAction("Find Samples by Barcode");
         return new FindByIdsDialog(getDriver());
     }
 
     public FindByIdsDialog goToSampleFinder()
     {
-        elementCache().searchMenu.doMenuAction(" Sample Finder");
+        elementCache().searchMenu.doMenuAction("Sample Finder");
         return new FindByIdsDialog(getDriver());
     }
 

--- a/src/org/labkey/test/components/ui/navigation/NavBar.java
+++ b/src/org/labkey/test/components/ui/navigation/NavBar.java
@@ -10,6 +10,7 @@ import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.react.MultiMenu;
 import org.labkey.test.components.ui.notifications.ServerNotificationMenu;
+import org.labkey.test.components.ui.search.SampleFinder;
 import org.labkey.test.util.search.HasSearchResults;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
@@ -62,10 +63,10 @@ public abstract class NavBar extends WebDriverComponent<NavBar.ElementCache>
         return new FindByIdsDialog(getDriver());
     }
 
-    public FindByIdsDialog goToSampleFinder()
+    public SampleFinder goToSampleFinder()
     {
         elementCache().searchMenu.doMenuAction("Sample Finder");
-        return new FindByIdsDialog(getDriver());
+        return new SampleFinder(getDriver());
     }
 
     public String getDisplayedProjectName()

--- a/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
+++ b/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
@@ -33,9 +33,14 @@ public class EntityFieldFilterModal extends ModalDialog
                 .visibilityOfNestedElementsLocatedBy(elementCache().querySelectionPanel, listItem));
     }
 
-    public EntityFieldFilterModal selectParentQuery(String query)
+    /**
+     * Select parent
+     * @param parentName name of parent type
+     * @return this component
+     */
+    public EntityFieldFilterModal selectParent(String parentName)
     {
-        WebElement queryItem = listItem.withText(query).findElement(elementCache().querySelectionPanel);
+        WebElement queryItem = listItem.withText(parentName).findElement(elementCache().querySelectionPanel);
         getWrapper().doAndWaitForElementToRefresh(queryItem::click,
                 () -> listItem.findElement(elementCache().fieldsSelectionPanel), getWrapper().shortWait());
 
@@ -44,13 +49,17 @@ public class EntityFieldFilterModal extends ModalDialog
         return this;
     }
 
+    /**
+     * Select field to configure filters for
+     * @param fieldLabel Field's label
+     * @return this component
+     */
     public EntityFieldFilterModal selectField(String fieldLabel)
     {
         WebElement fieldItem = listItem.withText(fieldLabel).findElement(elementCache().fieldsSelectionPanel);
         fieldItem.click();
-        getWrapper().shortWait().until(wd -> elementCache().filterPanel.isDisplayed() &&
-                Locator.byClass("parent-search-panel__col-sub-title").findElement(this)
-                        .getText().equals("Find values for " + fieldLabel));
+        Locator.byClass("parent-search-panel__col-sub-title").withText("Find values for " + fieldLabel)
+                .waitForElement(elementCache().filterPanel, 10_000);
 
         return this;
     }
@@ -109,7 +118,7 @@ public class EntityFieldFilterModal extends ModalDialog
      * Save current changes to the search criteria.
      * Throw <code>IllegalStateException</code> if the save button is disabled because no changes have been made.
      */
-    public void clickFindSamples()
+    public void confirm()
     {
         if (!elementCache().submitButton.isEnabled())
         {

--- a/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
+++ b/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
@@ -3,6 +3,7 @@ package org.labkey.test.components.ui.search;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
+import org.labkey.test.components.UpdatingComponent;
 import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.components.react.Tabs;
 import org.openqa.selenium.WebDriver;
@@ -16,9 +17,12 @@ public class EntityFieldFilterModal extends ModalDialog
 {
     private static final Locator listItem = Locator.byClass("list-group-item");
 
-    protected EntityFieldFilterModal(WebDriver driver)
+    private final UpdatingComponent _linkedComponent;
+
+    protected EntityFieldFilterModal(WebDriver driver, UpdatingComponent linkedComponent)
     {
         super(new ModalDialog.ModalDialogFinder(driver));
+        _linkedComponent = linkedComponent;
     }
 
     @Override

--- a/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
+++ b/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
@@ -65,6 +65,20 @@ public class EntityFieldFilterModal extends ModalDialog
     }
 
     /**
+     * Select parent and field to configure filters for
+     * @param parentName name of parent type
+     * @param fieldLabel Field's label
+     * @return this component
+     */
+    public EntityFieldFilterModal selectParentField(String parentName, String fieldLabel)
+    {
+        selectParent(parentName);
+        selectField(fieldLabel);
+
+        return this;
+    }
+
+    /**
      * @see FilterExpressionPanel#setFilterValue(Operator)
      * @return this component
      */

--- a/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
+++ b/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
@@ -1,6 +1,6 @@
 package org.labkey.test.components.ui.search;
 
-import org.labkey.remoteapi.query.Filter;
+import org.labkey.remoteapi.query.Filter.Operator;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.components.UpdatingComponent;
@@ -55,32 +55,76 @@ public class EntityFieldFilterModal extends ModalDialog
         return this;
     }
 
-    public EntityFieldFilterModal setFilterValue(Filter filter)
+    /**
+     * @see FilterExpressionPanel#setFilterValue(Operator)
+     * @return this component
+     */
+    public EntityFieldFilterModal setFilterValue(Operator operator)
     {
-        return setFilterValue(filter, null, null);
-    }
-
-    public EntityFieldFilterModal setFilterValue(Filter filter, String value)
-    {
-        return setFilterValue(filter, value, null);
-    }
-
-    public EntityFieldFilterModal setFilterValue(Filter filter, String value1, String value2)
-    {
-        selectExpressionTab().setFilterValue(filter, value1, value2);
+        selectExpressionTab().setFilterValue(operator);
         return this;
     }
 
+    /**
+     * @see FilterExpressionPanel#setFilterValue(Operator, String)
+     * @return this component
+     */
+    public EntityFieldFilterModal setFilterValue(Operator operator, String value)
+    {
+        selectExpressionTab().setFilterValue(operator, value);
+        return this;
+    }
+
+    /**
+     * @see FilterExpressionPanel#setFilterValue(Operator, String, String)
+     * @return this component
+     */
+    public EntityFieldFilterModal setFilterValue(Operator operator, String value1, String value2)
+    {
+        selectExpressionTab().setFilterValue(operator, value1, value2);
+        return this;
+    }
+
+    /**
+     * Select the filter expression tab for the current field.
+     * @return panel for configuring the filter expression
+     */
     public FilterExpressionPanel selectExpressionTab()
     {
         elementCache().filterTabs.selectTab("Filter");
         return elementCache().filterExpressionPanel;
     }
 
+    /**
+     * Select the facet tab for the current field. Will throw <code>NoSuchElementException</code> if tab isn't present.
+     * @return panel for configuring faceted filter
+     */
     public FilterFacetedPanel selectFacetTab()
     {
         elementCache().filterTabs.selectTab("Choose values");
         return elementCache().filterFacetedPanel;
+    }
+
+    /**
+     * Save current changes to the search criteria.
+     * Throw <code>IllegalStateException</code> if the save button is disabled because no changes have been made.
+     */
+    public void clickFindSamples()
+    {
+        if (!elementCache().submitButton.isEnabled())
+        {
+            throw new IllegalStateException("Confirmation button is not enabled.");
+        }
+
+        _linkedComponent.doAndWaitForUpdate(() -> {
+            elementCache().submitButton.click();
+            waitForClose();
+        });
+    }
+
+    public void cancel()
+    {
+        dismiss("Cancel");
     }
 
     @Override
@@ -114,6 +158,7 @@ public class EntityFieldFilterModal extends ModalDialog
         protected final FilterFacetedPanel filterFacetedPanel =
                 new FilterFacetedPanel.FilterFacetedPanelFinder(getDriver()).refindWhenNeeded(filterPanel);
 
+        protected final WebElement submitButton = Locator.css(".modal-footer .btn-success").findWhenNeeded(this);
     }
 
 }

--- a/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
+++ b/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
@@ -1,0 +1,115 @@
+package org.labkey.test.components.ui.search;
+
+import org.labkey.remoteapi.query.Filter;
+import org.labkey.test.BootstrapLocators;
+import org.labkey.test.Locator;
+import org.labkey.test.components.bootstrap.ModalDialog;
+import org.labkey.test.components.react.Tabs;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+/**
+ * Wraps 'labkey-ui-component' defined in <code>internal/components/search/EntityFieldFilterModal.tsx</code>
+ */
+public class EntityFieldFilterModal extends ModalDialog
+{
+    private static final Locator listItem = Locator.byClass("list-group-item");
+
+    protected EntityFieldFilterModal(WebDriver driver)
+    {
+        super(new ModalDialog.ModalDialogFinder(driver));
+    }
+
+    @Override
+    protected void waitForReady(ModalDialog.ElementCache ec)
+    {
+        super.waitForReady(ec);
+        getWrapper().shortWait().until(ExpectedConditions
+                .visibilityOfNestedElementsLocatedBy(elementCache().querySelectionPanel, listItem));
+    }
+
+    public EntityFieldFilterModal selectParentQuery(String query)
+    {
+        WebElement queryItem = listItem.withText(query).findElement(elementCache().querySelectionPanel);
+        getWrapper().doAndWaitForElementToRefresh(queryItem::click,
+                () -> listItem.findElement(elementCache().fieldsSelectionPanel), getWrapper().shortWait());
+
+        getWrapper().shortWait().until(ExpectedConditions.invisibilityOfElementLocated(BootstrapLocators.loadingSpinner));
+
+        return this;
+    }
+
+    public EntityFieldFilterModal selectField(String fieldLabel)
+    {
+        WebElement fieldItem = listItem.withText(fieldLabel).findElement(elementCache().fieldsSelectionPanel);
+        fieldItem.click();
+        getWrapper().shortWait().until(wd -> elementCache().filterPanel.isDisplayed() &&
+                Locator.byClass("parent-search-panel__col-sub-title").findElement(this)
+                        .getText().equals("Find values for " + fieldLabel));
+
+        return this;
+    }
+
+    public EntityFieldFilterModal setFilterValue(Filter filter)
+    {
+        return setFilterValue(filter, null, null);
+    }
+
+    public EntityFieldFilterModal setFilterValue(Filter filter, String value)
+    {
+        return setFilterValue(filter, value, null);
+    }
+
+    public EntityFieldFilterModal setFilterValue(Filter filter, String value1, String value2)
+    {
+        selectExpressionTab().setFilterValue(filter, value1, value2);
+        return this;
+    }
+
+    public FilterExpressionPanel selectExpressionTab()
+    {
+        elementCache().filterTabs.selectTab("Filter");
+        return elementCache().filterExpressionPanel;
+    }
+
+    public FilterFacetedPanel selectFacetTab()
+    {
+        elementCache().filterTabs.selectTab("Choose values");
+        return elementCache().filterFacetedPanel;
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends ModalDialog.ElementCache
+    {
+        // Entities column
+        protected final WebElement querySelectionPanel = Locator.byClass("parent-search-panel__col_queries")
+                .findWhenNeeded(this);
+
+        // Fields column
+        protected final WebElement fieldsSelectionPanel = Locator.byClass("parent-search-panel__col_fields")
+                .findWhenNeeded(this);
+
+        // Values column
+        protected final WebElement filterPanel = Locator.byClass("parent-search-panel__col_filter_exp")
+                .findWhenNeeded(this);
+        protected final Tabs filterTabs = new Tabs.TabsFinder(getDriver()).refindWhenNeeded(filterPanel);
+        protected final FilterExpressionPanel filterExpressionPanel =
+                new FilterExpressionPanel.FilterExpressionPanelFinder(getDriver()).refindWhenNeeded(filterPanel);
+        protected final FilterFacetedPanel filterFacetedPanel =
+                new FilterFacetedPanel.FilterFacetedPanelFinder(getDriver()).refindWhenNeeded(filterPanel);
+
+    }
+
+}

--- a/src/org/labkey/test/components/ui/search/FilterExpressionPanel.java
+++ b/src/org/labkey/test/components/ui/search/FilterExpressionPanel.java
@@ -82,9 +82,9 @@ public class FilterExpressionPanel extends WebDriverComponent<FilterExpressionPa
 
     protected class ElementCache extends Component<?>.ElementCache
     {
-        final ReactSelect filterTypeSelect = new ReactSelect.ReactSelectFinder(getDriver()).findWhenNeeded(this);
-        final Input filterValue1 = Input.Input(Locator.name("field-value-text"), getDriver()).refindWhenNeeded(this);
-        final Input filterValue2 = Input.Input(Locator.name("field-value-text-second"), getDriver()).refindWhenNeeded(this);;
+        protected final ReactSelect filterTypeSelect = new ReactSelect.ReactSelectFinder(getDriver()).findWhenNeeded(this);
+        protected final Input filterValue1 = Input.Input(Locator.name("field-value-text"), getDriver()).refindWhenNeeded(this);
+        protected final Input filterValue2 = Input.Input(Locator.name("field-value-text-second"), getDriver()).refindWhenNeeded(this);;
     }
 
     public static class FilterExpressionPanelFinder extends WebDriverComponentFinder<FilterExpressionPanel, FilterExpressionPanelFinder>

--- a/src/org/labkey/test/components/ui/search/FilterExpressionPanel.java
+++ b/src/org/labkey/test/components/ui/search/FilterExpressionPanel.java
@@ -10,10 +10,19 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
+import java.util.Map;
+
 public class FilterExpressionPanel extends WebDriverComponent<FilterExpressionPanel.ElementCache>
 {
     private final WebElement _el;
     private final WebDriver _driver;
+
+    private final Map<Operator, String> filterTypesLabelOverrides = Map.of(
+            Operator.CONTAINS_ONE_OF, "Contains One Of",
+            Operator.CONTAINS_NONE_OF, "Does Not Contain Any Of",
+            Operator.BETWEEN, "Between",
+            Operator.NOT_BETWEEN, "Not Between"
+    );
 
     protected FilterExpressionPanel(WebElement element, WebDriver driver)
     {
@@ -39,7 +48,7 @@ public class FilterExpressionPanel extends WebDriverComponent<FilterExpressionPa
      */
     public void setFilterValue(Operator operator)
     {
-        elementCache().filterTypeSelect.select(operator.getDisplayValue());
+        setFilterType(operator);
     }
 
     /**
@@ -49,7 +58,7 @@ public class FilterExpressionPanel extends WebDriverComponent<FilterExpressionPa
      */
     public void setFilterValue(Operator operator, String value)
     {
-        elementCache().filterTypeSelect.select(operator.getDisplayValue());
+        setFilterType(operator);
         elementCache().filterValue1.set(value);
     }
 
@@ -61,7 +70,7 @@ public class FilterExpressionPanel extends WebDriverComponent<FilterExpressionPa
      */
     public void setFilterValue(Operator operator, String value1, String value2)
     {
-        elementCache().filterTypeSelect.select(operator.getDisplayValue());
+        setFilterType(operator);
         elementCache().filterValue1.set(value1);
         elementCache().filterValue2.set(value2);
     }
@@ -72,6 +81,18 @@ public class FilterExpressionPanel extends WebDriverComponent<FilterExpressionPa
         getWrapper().shortWait().until(ExpectedConditions.invisibilityOfAllElements(
                 elementCache().filterValue1.getComponentElement(),
                 elementCache().filterValue2.getComponentElement()));
+    }
+
+    private void setFilterType(Operator operator)
+    {
+        if (filterTypesLabelOverrides.containsKey(operator))
+        {
+            elementCache().filterTypeSelect.select(filterTypesLabelOverrides.get(operator));
+        }
+        else
+        {
+            elementCache().filterTypeSelect.select(operator.getDisplayValue());
+        }
     }
 
     @Override

--- a/src/org/labkey/test/components/ui/search/FilterExpressionPanel.java
+++ b/src/org/labkey/test/components/ui/search/FilterExpressionPanel.java
@@ -1,11 +1,14 @@
 package org.labkey.test.components.ui.search;
 
-import org.labkey.remoteapi.query.Filter;
+import org.labkey.remoteapi.query.Filter.Operator;
 import org.labkey.test.Locator;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.Input;
+import org.labkey.test.components.react.ReactSelect;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class FilterExpressionPanel extends WebDriverComponent<FilterExpressionPanel.ElementCache>
 {
@@ -30,19 +33,45 @@ public class FilterExpressionPanel extends WebDriverComponent<FilterExpressionPa
         return _driver;
     }
 
-    public void setFilterValue(Filter filter)
+    /**
+     * Set a valueless filter expression (e.g. 'Not Blank')
+     * @param operator filter type
+     */
+    public void setFilterValue(Operator operator)
     {
-        setFilterValue(filter, null, null);
+        elementCache().filterTypeSelect.select(operator.getDisplayValue());
     }
 
-    public void setFilterValue(Filter filter, String value)
+    /**
+     * Set a single value filter expression (e.g. 'Greater Than')
+     * @param operator filter type
+     * @param value filter value
+     */
+    public void setFilterValue(Operator operator, String value)
     {
-        setFilterValue(filter, value, null);
+        elementCache().filterTypeSelect.select(operator.getDisplayValue());
+        elementCache().filterValue1.set(value);
     }
 
-    public void setFilterValue(Filter filter, String value1, String value2)
+    /**
+     * Set a two-value filter expression (e.g. 'Between')
+     * @param operator filter type
+     * @param value1 first value
+     * @param value2 second value
+     */
+    public void setFilterValue(Operator operator, String value1, String value2)
     {
+        elementCache().filterTypeSelect.select(operator.getDisplayValue());
+        elementCache().filterValue1.set(value1);
+        elementCache().filterValue2.set(value2);
+    }
 
+    public void clearFilter()
+    {
+        elementCache().filterTypeSelect.clearSelection();
+        getWrapper().shortWait().until(ExpectedConditions.invisibilityOfAllElements(
+                elementCache().filterValue1.getComponentElement(),
+                elementCache().filterValue2.getComponentElement()));
     }
 
     @Override
@@ -53,6 +82,9 @@ public class FilterExpressionPanel extends WebDriverComponent<FilterExpressionPa
 
     protected class ElementCache extends Component<?>.ElementCache
     {
+        final ReactSelect filterTypeSelect = new ReactSelect.ReactSelectFinder(getDriver()).findWhenNeeded(this);
+        final Input filterValue1 = Input.Input(Locator.name("field-value-text"), getDriver()).refindWhenNeeded(this);
+        final Input filterValue2 = Input.Input(Locator.name("field-value-text-second"), getDriver()).refindWhenNeeded(this);;
     }
 
     public static class FilterExpressionPanelFinder extends WebDriverComponentFinder<FilterExpressionPanel, FilterExpressionPanelFinder>

--- a/src/org/labkey/test/components/ui/search/FilterExpressionPanel.java
+++ b/src/org/labkey/test/components/ui/search/FilterExpressionPanel.java
@@ -1,0 +1,79 @@
+package org.labkey.test.components.ui.search;
+
+import org.labkey.remoteapi.query.Filter;
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class FilterExpressionPanel extends WebDriverComponent<FilterExpressionPanel.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected FilterExpressionPanel(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    public void setFilterValue(Filter filter)
+    {
+        setFilterValue(filter, null, null);
+    }
+
+    public void setFilterValue(Filter filter, String value)
+    {
+        setFilterValue(filter, value, null);
+    }
+
+    public void setFilterValue(Filter filter, String value1, String value2)
+    {
+
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+    }
+
+    public static class FilterExpressionPanelFinder extends WebDriverComponentFinder<FilterExpressionPanel, FilterExpressionPanelFinder>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.byClass("search-filter__input-wrapper").parent();
+
+        public FilterExpressionPanelFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        @Override
+        protected FilterExpressionPanel construct(WebElement el, WebDriver driver)
+        {
+            return new FilterExpressionPanel(el, driver);
+        }
+
+        @Override
+        protected Locator locator()
+        {
+            return _baseLocator;
+        }
+    }
+}

--- a/src/org/labkey/test/components/ui/search/FilterFacetedPanel.java
+++ b/src/org/labkey/test/components/ui/search/FilterFacetedPanel.java
@@ -1,0 +1,83 @@
+package org.labkey.test.components.ui.search;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.Input;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import static org.labkey.test.components.html.Input.Input;
+
+public class FilterFacetedPanel extends WebDriverComponent<FilterFacetedPanel.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected FilterFacetedPanel(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    public void selectValue(String value)
+    {
+
+    }
+
+    public void checkValues(String... values)
+    {
+
+    }
+
+    public void uncheckValues(String... values)
+    {
+
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        Input filterInput = Input(Locator.id("find-filter-typeahead-input"), getDriver()).findWhenNeeded(this);
+        WebElement selectedItemsSection = Locator.byClass("search-filter-tags__div").refindWhenNeeded(this);
+    }
+
+    public static class FilterFacetedPanelFinder extends WebDriverComponentFinder<FilterFacetedPanel, FilterFacetedPanelFinder>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.byClass("search-filter-values__panel").parent();
+
+        public FilterFacetedPanelFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        @Override
+        protected FilterFacetedPanel construct(WebElement el, WebDriver driver)
+        {
+            return new FilterFacetedPanel(el, driver);
+        }
+
+        @Override
+        protected Locator locator()
+        {
+            return _baseLocator;
+        }
+    }
+}

--- a/src/org/labkey/test/components/ui/search/FilterFacetedPanel.java
+++ b/src/org/labkey/test/components/ui/search/FilterFacetedPanel.java
@@ -3,9 +3,12 @@ package org.labkey.test.components.ui.search;
 import org.labkey.test.Locator;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+
+import java.util.List;
 
 import static org.labkey.test.components.html.Input.Input;
 
@@ -47,6 +50,16 @@ public class FilterFacetedPanel extends WebDriverComponent<FilterFacetedPanel.El
 
     }
 
+    public List<String> getAvailableValues()
+    {
+        return null;
+    }
+
+    public List<String> getSelectedValues()
+    {
+        return null;
+    }
+
     @Override
     protected ElementCache newElementCache()
     {
@@ -56,7 +69,19 @@ public class FilterFacetedPanel extends WebDriverComponent<FilterFacetedPanel.El
     protected class ElementCache extends Component<?>.ElementCache
     {
         Input filterInput = Input(Locator.id("find-filter-typeahead-input"), getDriver()).findWhenNeeded(this);
-        WebElement selectedItemsSection = Locator.byClass("search-filter-tags__div").refindWhenNeeded(this);
+        WebElement checkboxSection = Locator.byClass("labkey-wizard-pills").index(0).findWhenNeeded(this);
+        WebElement selectedItemsSection = Locator.byClass("search-filter-tags__div").findWhenNeeded(this);
+
+        Checkbox findCheckbox(String value)
+        {
+            return Checkbox.Checkbox(Locator.byClass("search-filter-values__value").withText(value)
+                    .precedingSibling("input")).find(checkboxSection);
+        }
+
+        WebElement findCheckboxLabel(String value)
+        {
+            return Locator.byClass("search-filter-values__value").withText(value).findElement(checkboxSection);
+        }
     }
 
     public static class FilterFacetedPanelFinder extends WebDriverComponentFinder<FilterFacetedPanel, FilterFacetedPanelFinder>

--- a/src/org/labkey/test/components/ui/search/SampleFinder.java
+++ b/src/org/labkey/test/components/ui/search/SampleFinder.java
@@ -1,0 +1,62 @@
+package org.labkey.test.components.ui.search;
+
+import org.labkey.test.BootstrapLocators;
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+/**
+ * Wraps 'labkey-ui-component' defined in <code>internal/components/search/SampleFinderSection.tsx</code>
+ */
+public class SampleFinder extends WebDriverComponent<SampleFinder.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected SampleFinder(WebDriver driver)
+    {
+        _el = Locator.byClass("g-section")
+                .withDescendant(Locator.byClass("panel-content-title-large").withText("Find Samples"))
+                .waitForElement(getDriver(), 10_000);
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    public EntityFieldFilterModal addEntityParentProperties(String parentNoun)
+    {
+        elementCache().findAddParentButton(parentNoun).click();
+        return new EntityFieldFilterModal(getDriver());
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        final WebElement panelHeading = Locator.byClass("panel-heading").findWhenNeeded(this);
+
+        WebElement findAddParentButton(String parentNoun)
+        {
+            return BootstrapLocators.button(" " + parentNoun + " Properties")
+                    .withChild(Locator.byClass("container--addition-icon")).findElement(panelHeading);
+        }
+
+
+    }
+}

--- a/src/org/labkey/test/components/ui/search/SampleFinder.java
+++ b/src/org/labkey/test/components/ui/search/SampleFinder.java
@@ -4,8 +4,15 @@ import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.ui.grids.TabbedGridPanel;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Wraps 'labkey-ui-component' defined in <code>internal/components/search/SampleFinderSection.tsx</code>
@@ -19,7 +26,7 @@ public class SampleFinder extends WebDriverComponent<SampleFinder.ElementCache>
     {
         _el = Locator.byClass("g-section")
                 .withDescendant(Locator.byClass("panel-content-title-large").withText("Find Samples"))
-                .waitForElement(getDriver(), 10_000);
+                .waitForElement(getDriver(), 5_000);
         _driver = driver;
     }
 
@@ -35,10 +42,62 @@ public class SampleFinder extends WebDriverComponent<SampleFinder.ElementCache>
         return _driver;
     }
 
-    public EntityFieldFilterModal addEntityParentProperties(String parentNoun)
+    /**
+     * Open the entity filter dialog for the specified parent type.
+     *
+     * @param parentNoun "Source" or "Parent" in SM. "Registry Parent" or "SampleParent" in Biologics
+     * @return component wrapper for the EntityFieldFilterModal
+     */
+    public EntityFieldFilterModal clickAddParent(String parentNoun)
     {
         elementCache().findAddParentButton(parentNoun).click();
-        return new EntityFieldFilterModal(getDriver());
+        return new EntityFieldFilterModal(getDriver(), this::doAndWaitForUpdate);
+    }
+
+    public TabbedGridPanel getResultsGrid()
+    {
+        if (!elementCache().resultsGrid.getComponentElement().isDisplayed())
+        {
+            throw new NoSuchElementException("No search results currently shown");
+        }
+        return elementCache().resultsGrid;
+    }
+
+    /**
+     * Waiter that will wait for the search results to load. This is a hook for perf tests to support longer waits.
+     * @return WebDriverWait to be used by {@link #waitForReady()}
+     */
+    protected WebDriverWait loadWait()
+    {
+        return getWrapper().shortWait();
+    }
+
+    /**
+     * Waits for initial state (empty filter card panel) or for search results grid to appear
+     */
+    @Override
+    protected void waitForReady()
+    {
+        loadWait().withMessage("Sample finder loading").until(wd -> !BootstrapLocators.loadingSpinner.existsIn(this) &&
+        (Locator.css(".filter-cards.empty").isDisplayed(this)
+                || elementCache().resultsGrid.getComponentElement().isDisplayed()));
+    }
+
+    private void doAndWaitForUpdate(Runnable func)
+    {
+        WebElement resultsGridEl = elementCache().resultsGrid.getComponentElement();
+        if (resultsGridEl.isDisplayed())
+        {
+            func.run();
+            getWrapper().shortWait().until(ExpectedConditions.stalenessOf(resultsGridEl));
+        }
+        else
+        {
+            func.run();
+        }
+
+        clearElementCache();
+        elementCache(); // waitForReady
     }
 
     @Override
@@ -57,6 +116,65 @@ public class SampleFinder extends WebDriverComponent<SampleFinder.ElementCache>
                     .withChild(Locator.byClass("container--addition-icon")).findElement(panelHeading);
         }
 
+        final WebElement filterCardsSection = Locator.byClass("filter-cards").findWhenNeeded(this);
+        List<FilterCard> findFilterCards()
+        {
+            return Locator.byClass("filter-cards__card").findElements(filterCardsSection)
+                    .stream().map(FilterCard::new).collect(Collectors.toList());
+        }
 
+        FilterCard findFilterCard(String queryName)
+        {
+            return new FilterCard(Locator.byClass("filter-cards__card").withDescendant(
+                    Locator.byClass("primary-text").withText(queryName)).findElement(filterCardsSection));
+        }
+
+        final TabbedGridPanel resultsGrid = new TabbedGridPanel.TabbedGridPanelFinder(getDriver()).findWhenNeeded(this);
+    }
+
+    /**
+     * Represents a single filter card. Don't expose outside this class because its lifecycle is confusing
+     */
+    private class FilterCard extends Component<Component<?>.ElementCache>
+    {
+        private final WebElement cardEl;
+        private final WebElement name = Locator.byClass("primary-text").findWhenNeeded(this);
+        private final WebElement editButton =
+                Locator.tagWithAttribute("i", "title", "Edit filter").findWhenNeeded(this);
+        private final WebElement removeButton =
+                Locator.tagWithAttribute("i", "title", "Remove filter").findWhenNeeded(this);
+
+        private FilterCard(WebElement el)
+        {
+            this.cardEl = el;
+        }
+
+        @Override
+        public WebElement getComponentElement()
+        {
+            return cardEl;
+        }
+
+        EntityFieldFilterModal clickEdit()
+        {
+            editButton.click();
+            return new EntityFieldFilterModal(getDriver(), SampleFinder.this::doAndWaitForUpdate);
+        }
+
+        void clickRemove()
+        {
+            doAndWaitForUpdate(() -> {
+                int initialCount = SampleFinder.this.elementCache().findFilterCards().size();
+                removeButton.click();
+                // This card's element isn't removed from the DOM if it isn't the farthest right card
+                getWrapper().shortWait().until(wd ->
+                        SampleFinder.this.elementCache().findFilterCards().size() == initialCount - 1);
+            });
+        }
+
+        String getQueryName()
+        {
+            return name.getText();
+        }
     }
 }

--- a/src/org/labkey/test/components/ui/search/SampleFinder.java
+++ b/src/org/labkey/test/components/ui/search/SampleFinder.java
@@ -23,11 +23,11 @@ public class SampleFinder extends WebDriverComponent<SampleFinder.ElementCache>
     private final WebElement _el;
     private final WebDriver _driver;
 
-    protected SampleFinder(WebDriver driver)
+    public SampleFinder(WebDriver driver)
     {
         _el = Locator.byClass("g-section")
-                .withDescendant(Locator.byClass("panel-content-title-large").withText("Find Samples"))
-                .waitForElement(getDriver(), 5_000);
+                .withDescendant(Locator.byClass("filter-cards"))
+                .waitForElement(driver, 5_000);
         _driver = driver;
     }
 
@@ -153,7 +153,7 @@ public class SampleFinder extends WebDriverComponent<SampleFinder.ElementCache>
 
         WebElement findAddParentButton(String parentNoun)
         {
-            return BootstrapLocators.button(" " + parentNoun + " Properties")
+            return BootstrapLocators.button(parentNoun + " Properties")
                     .withChild(Locator.byClass("container--addition-icon")).findElement(panelHeading);
         }
 


### PR DESCRIPTION
#### Rationale
Need test components for testing the Sample Finder [[Product Spec]](https://docs.google.com/document/d/1AhHrWcvegLUyXku50FXXcxXkFMGL3-A62nXy-wttKxQ/edit#heading=h.weqfca5zq4ni). They are not yet in use and will likely need further refinement to make them reliable.

These wrap `labkey-ui-components` indicated in their class documentation:
 * `SampleFinder` is the top-level component
 * `EntityFieldFilterModal` represents the dialog that opens when adding/editing search criteria.
 * `FilterExpressionPanel` controls filter expressions (e.g. "Less Than 5") in the `EntityFieldFilterModal`
 * `FilterFacetedPanel` controls faceted filtering in the `EntityFieldFilterModal`

The Filter*Panel product components might be shared by a future OmniBox iteration. In anticipation, the associated test components are intended to be able to be used in other contexts if needed.

#### Changes
* Add test components for Sample Finder
* Update `BootstrapLocators.button` to work with more buttons
* Add `Locator.isDisplayed`
* Simplify `Component.waitForReady`
* Update `NavBar` to support Sample Finder
