### PR TITLE
Don't repeatedly publish ActionCoverage.tsv

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1395,25 +1395,18 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
         // Download full action coverage table and add to TeamCity artifacts.
         File downloadActions = downloadFromUrl("admin-exportActions.view");
-        File actionCoverageFile = new File(TestProperties.getDumpDir(), "ActionCoverage.tsv");
-        replaceArtifact(downloadActions, actionCoverageFile, "exported action coverage");
-
-        if (BROWSER_TYPE == BrowserType.CHROME)
-            refresh(); // Chrome blocks sequential downloads from javascript
-    }
-
-    private void replaceArtifact(File downloadedFile, File artifactFile, String description)
-    {
+        File actionCoverageFile = new File(TestFileUtils.getGradleReportDir(), "ActionCoverage.tsv");
         try
         {
-            Files.move(downloadedFile.toPath(), artifactFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            getArtifactCollector().publishArtifact(artifactFile);
+            Files.move(downloadActions.toPath(), actionCoverageFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
         catch (IOException e)
         {
-            TestLogger.error("Failed to move " + description + " file.");
-            e.printStackTrace();
+            TestLogger.error("Failed to move " + "exported action coverage" + " file.", e);
         }
+
+        if (BROWSER_TYPE == BrowserType.CHROME)
+            refresh(); // Chrome blocks sequential downloads from javascript
     }
 
     @LogMethod

--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -174,6 +174,11 @@ public abstract class TestFileUtils
         return _buildDir;
     }
 
+    public static File getGradleReportDir()
+    {
+        return new File(getTestBuildDir(), "test/logs/reports");
+    }
+
     public static File getDefaultDeployDir()
     {
         return new File(getLabKeyRoot(), "build/deploy");


### PR DESCRIPTION
#### Rationale
The tests update their action coverage after each test. This is unnecessarily frequent and is causing TeamCity to complain fairly regularly: `Failed to publish artifacts: Failed to upload artifact ActionCoverage.tsv: Got response code 400.`
We can just put the file in a place that TeamCity will grab after the suite is complete.

#### Changes
* Let TeamCity pick up ActionCoverage.tsv once
