### PR TITLE
Add method clickLinkWithTitle to GridRow

### DIFF
--- a/src/org/labkey/test/components/ui/grids/GridRow.java
+++ b/src/org/labkey/test/components/ui/grids/GridRow.java
@@ -119,6 +119,14 @@ public class GridRow extends WebDriverComponent<GridRow.ElementCache>
                 getWrapper().shortWait().until(ExpectedConditions.stalenessOf(link)), 1000);
     }
 
+    public void clickLinkWithTitle(String text)
+    {
+        log("seeking link with title [" + text + "]");
+        WebElement link = Locator.linkWithTitle(text).waitForElement(getComponentElement(), WAIT_FOR_JAVASCRIPT);
+        log("found element with title [" + text + "]");
+        link.click();
+    }
+
     /**
      * finds a AttachmentCard specified filename, clicks it, and waits for the image to display in a modal
      */


### PR DESCRIPTION
#### Rationale
We have some Grids that contain button-link links that are more easily found using the title attribute

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1203

#### Changes
* Add method clickLinkWithTitle to GridRow
