### PR TITLE
Fix NPE from cache cleared by refinding element

### DIFF
--- a/src/org/labkey/test/components/BodyWebPart.java
+++ b/src/org/labkey/test/components/BodyWebPart.java
@@ -49,9 +49,6 @@ public class BodyWebPart<EC extends BodyWebPart.ElementCache> extends WebPart<EC
     }
 
     @Override
-    protected void waitForReady() {}
-
-    @Override
     protected EC newElementCache()
     {
         return (EC) new ElementCache();

--- a/src/org/labkey/test/components/Component.java
+++ b/src/org/labkey/test/components/Component.java
@@ -58,6 +58,7 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
     {
         if (null == _elementCache)
         {
+            getComponentElement().isEnabled(); // Trigger refind
             _elementCache = newElementCache();
             waitForReady(_elementCache);
         }

--- a/src/org/labkey/test/components/SideWebPart.java
+++ b/src/org/labkey/test/components/SideWebPart.java
@@ -44,9 +44,6 @@ public class SideWebPart extends WebPart
     }
 
     @Override
-    protected void waitForReady() {}
-
-    @Override
     protected ElementCache newElementCache()
     {
         return new ElementCache();

--- a/src/org/labkey/test/components/WebPart.java
+++ b/src/org/labkey/test/components/WebPart.java
@@ -68,8 +68,6 @@ public abstract class WebPart<EC extends WebPart.ElementCache> extends WebPartPa
         return _wDriver;
     }
 
-    protected abstract void waitForReady();
-
     private void waitForStale()
     {
         getWrapper().shortWait().until(ExpectedConditions.invisibilityOfAllElements(Arrays.asList(getComponentElement())));

--- a/src/org/labkey/test/components/html/SiteNavBar.java
+++ b/src/org/labkey/test/components/html/SiteNavBar.java
@@ -42,17 +42,20 @@ import static org.junit.Assert.assertTrue;
 public class SiteNavBar extends WebDriverComponent<SiteNavBar.Elements>
 {
     protected final WebDriver _driver;
-    protected WebElement _componentElement;
+    protected final WebElement _componentElement;
 
     public SiteNavBar(WebDriver driver)
     {
         _driver = driver;
+        _componentElement = Locator.byClass("navbar-nav-lk")
+                .findWhenNeeded(driver)
+                .withTimeout(WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
     }
 
     @Override
     public WebElement getComponentElement()
     {
-        return elementCache().navbarNavBlock;
+        return _componentElement;
     }
     @Override
     protected WebDriver getDriver()
@@ -191,26 +194,18 @@ public class SiteNavBar extends WebDriverComponent<SiteNavBar.Elements>
         return new SiteNavBar.Elements();
     }
 
-    protected class Elements extends Component.ElementCache
+    protected class Elements extends Component<?>.ElementCache
     {
-        public final WebElement headerBlock = Locator.tagWithClass("div", "labkey-page-header")
-                .findWhenNeeded(getDriver())
-                .withTimeout(WebDriverWrapper.WAIT_FOR_PAGE);
-
-        public final WebElement navbarNavBlock = Locator.byClass("navbar-nav-lk")
-                .findWhenNeeded(headerBlock)
-                .withTimeout(WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
-
         public final WebElement searchContainer = Locator.byClass("navbar-search")
-                .findWhenNeeded(headerBlock).withTimeout(WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
+                .findWhenNeeded(this).withTimeout(WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
         public final WebElement searchToggle = Locator.id("global-search-trigger")
-                .findWhenNeeded(headerBlock).withTimeout(WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
+                .findWhenNeeded(this).withTimeout(WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
         public final WebElement searchInput = Locator.input("q")
-                .findWhenNeeded(headerBlock).withTimeout(WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
+                .findWhenNeeded(this).withTimeout(WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
         public final WebElement searchSubmitInput = Locator.tagWithClass("a", "btn-search")
                 .findWhenNeeded(searchContainer).withTimeout(WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
-        public final AdminMenu adminMenu = adminMenuFinder().findWhenNeeded(navbarNavBlock).withExpandRetries(4);
-        public final UserMenu userMenu = userMenuFinder().findWhenNeeded(navbarNavBlock).withExpandRetries(4);
+        public final AdminMenu adminMenu = adminMenuFinder().findWhenNeeded(this).withExpandRetries(4);
+        public final UserMenu userMenu = userMenuFinder().findWhenNeeded(this).withExpandRetries(4);
     }
 
     protected SimpleWebDriverComponentFinder<AdminMenu> adminMenuFinder()

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -69,12 +69,6 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
     }
 
     @Override
-    protected void clearElementCache()
-    {
-        super.clearElementCache();
-    }
-
-    @Override
     public void doAndWaitForUpdate(Runnable func)
     {
         // Look at WebDriverWrapper.doAndWaitForElementToRefresh for an example.


### PR DESCRIPTION
#### Rationale
`Component.elementCache` can NPE if it triggers a refind of the component's element:
```
java.lang.NullPointerException: Cannot read field "newBatchButton" because the return value of "org.labkey.test.components.response.TokenBatchesWebPart.elementCache()" is null
  at org.labkey.test.components.response.TokenBatchesWebPart.isNewBatchPresent(TokenBatchesWebPart.java:47)
  at org.labkey.test.tests.response.TokenValidationTest.testMyStudiesCoordinatorRole(TokenValidationTest.java:248)
```
We can avoid this by preemptively triggering the refind by calling `getComponentElement().isEnabled()`. There was one component (`SiteNavBar`) that stored its component element in the element cache, causing a stack overflow; this has been fixed.

#### Related Pull Requests
* #1038 

#### Changes
* Preemptively trigger element refresh
* Fix Improperly scoped `SiteNavBar`
