### PR TITLE
Trigger heap dump when folder delete is blocked

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1030,7 +1030,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     {
         while (throwable != null)
         {
-            if (throwable instanceof RuntimeException)
+            if (throwable.getClass() == RuntimeException.class)
             {
                 throwable = throwable.getCause();
             }

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1000,7 +1000,10 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                     TestLogger.error("Remaining files after attempting to delete: " + path + "\n\t" + String.join("\t\n", subdirs), notEmpty);
                     getArtifactCollector().dumpHeap();
                 }
-                catch (IOException ignore) { }
+                catch (IOException e)
+                {
+                    TestLogger.warn("Unable to collect extra info about 'DirectoryNotEmptyException'", e);
+                }
             }
         }
         finally

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -990,7 +990,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             }
 
             // Do last. Heap dump will navigate
-            if (error instanceof DirectoryNotEmptyException notEmpty)
+            if (unwrapRuntimeException(error) instanceof DirectoryNotEmptyException notEmpty)
             {
                 try
                 {
@@ -1024,6 +1024,22 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             throwable = throwable.getCause();
         }
         return false;
+    }
+
+    private Throwable unwrapRuntimeException(Throwable throwable)
+    {
+        while (throwable != null)
+        {
+            if (throwable instanceof RuntimeException)
+            {
+                throwable = throwable.getCause();
+            }
+            else
+            {
+                return throwable;
+            }
+        }
+        return null;
     }
 
     protected void disablePageUnloadEvents()

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -91,7 +91,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.SocketTimeoutException;
 import java.net.URL;
+import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.Duration;
@@ -840,6 +842,18 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         {
             log("Test interrupted. Skipping failure handling");
             return;
+        }
+
+        if (error instanceof DirectoryNotEmptyException notEmpty)
+        {
+            try
+            {
+                Path path = Paths.get(notEmpty.getFile());
+                List<String> subdirs = Files.walk(path).map(p -> path.relativize(p).toString())
+                        .filter(s -> !s.isEmpty()).collect(Collectors.toList());
+                TestLogger.error("Remaining files after attempting to delete: " + path + "\n\t" + String.join("\t\n", subdirs), notEmpty);
+            }
+            catch (IOException ignore) { }
         }
 
         try

--- a/src/org/labkey/test/tests/filecontent/FileRootMigrationTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileRootMigrationTest.java
@@ -31,14 +31,10 @@ import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PipelineStatusTable;
 import org.labkey.test.util.PortalHelper;
-import org.labkey.test.util.TestLogger;
 import org.labkey.test.util.TextSearcher;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.DirectoryNotEmptyException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -80,18 +76,7 @@ public class FileRootMigrationTest extends BaseWebDriverTest
     @Before
     public void cleanFiles() throws IOException
     {
-        try
-        {
-            FileUtils.deleteDirectory(targetFileRoot);
-        }
-        catch (DirectoryNotEmptyException e)
-        {
-            Path path = targetFileRoot.toPath();
-            List<String> subdirs = Files.walk(path).map(p -> path.relativize(p).toString())
-                    .filter(s -> !s.isEmpty()).collect(Collectors.toList());
-            TestLogger.error("Remaining files after delete attempt: " + path + "\n\t" + String.join("\t\n", subdirs), e);
-            throw e;
-        }
+        FileUtils.deleteDirectory(targetFileRoot);
         targetFileRoot.mkdirs();
         FileRootsManagementPage.beginAt(this, getProjectName())
                 .useDefaultFileRoot()

--- a/src/org/labkey/test/tests/filecontent/FileRootMigrationTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileRootMigrationTest.java
@@ -31,16 +31,19 @@ import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PipelineStatusTable;
 import org.labkey.test.util.PortalHelper;
+import org.labkey.test.util.TestLogger;
 import org.labkey.test.util.TextSearcher;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @Category({Daily.class})
@@ -77,7 +80,18 @@ public class FileRootMigrationTest extends BaseWebDriverTest
     @Before
     public void cleanFiles() throws IOException
     {
-        FileUtils.deleteDirectory(targetFileRoot);
+        try
+        {
+            FileUtils.deleteDirectory(targetFileRoot);
+        }
+        catch (DirectoryNotEmptyException e)
+        {
+            Path path = targetFileRoot.toPath();
+            List<String> subdirs = Files.walk(path).map(p -> path.relativize(p).toString())
+                    .filter(s -> !s.isEmpty()).collect(Collectors.toList());
+            TestLogger.error("Remaining files after delete attempt: " + path + "\n\t" + String.join("\t\n", subdirs), e);
+            throw e;
+        }
         targetFileRoot.mkdirs();
         FileRootsManagementPage.beginAt(this, getProjectName())
                 .useDefaultFileRoot()


### PR DESCRIPTION
#### Rationale
On Windows, sometimes tests are unable to clean up files between tests because the server is holding onto a file. The test should trigger a heap dump for investigation purposes.

#### Changes
* Trigger a heap dump after `DirectoryNotEmptyException`
