### PR TITLE
Don't error out if component isn't yet displayed

### DIFF
--- a/src/org/labkey/test/components/Component.java
+++ b/src/org/labkey/test/components/Component.java
@@ -20,6 +20,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.selenium.RefindingWebElement;
 import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebElement;
 
@@ -58,7 +59,15 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
     {
         if (null == _elementCache)
         {
-            getComponentElement().isEnabled(); // Trigger refind
+            try
+            {
+                getComponentElement().isEnabled(); // Trigger refind
+            }
+            catch (NoSuchElementException ignore)
+            {
+                // Pass if element doesn't exist. Might be checking if component is visible.
+            }
+
             _elementCache = newElementCache();
             waitForReady(_elementCache);
         }

--- a/src/org/labkey/test/components/Component.java
+++ b/src/org/labkey/test/components/Component.java
@@ -22,6 +22,7 @@ import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
 import java.util.ArrayList;
@@ -63,7 +64,7 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
             {
                 getComponentElement().isEnabled(); // Trigger refind
             }
-            catch (NoSuchElementException ignore)
+            catch (NoSuchElementException | StaleElementReferenceException ignore)
             {
                 // Pass if element doesn't exist. Might be checking if component is visible.
             }


### PR DESCRIPTION
#### Rationale
Previous change caused some errors when waiting for components to load via other means.

```
org.openqa.selenium.NoSuchElementException: Unable to find element: xpath=//div[contains(concat(' ',normalize-space(@class),' '), ' panel-content ')][.//div[contains(concat(' ',normalize-space(@class),' '), ' panel-content-title-medium ')][normalize-space()='Freezer Status']]
For documentation on this error, please visit: https://selenium.dev/exceptions/#no_such_element
Build info: version: '4.1.1', revision: 'e8fcc2cecf'
System info: host: 'ip-172-32-4-205', ip: '172.32.4.205', os.name: 'Linux', os.arch: 'amd64', os.version: '5.11.0-1028-aws', java.version: '17'
Driver info: driver.version: unknown
  at app//org.labkey.test.Locator.lambda$1(Locator.java:361)
  at java.base@17/java.util.Optional.orElseThrow(Optional.java:403)
  at app//org.labkey.test.Locator.findElement(Locator.java:360)
  at app//org.labkey.test.selenium.LazyWebElement.findWrappedElement(LazyWebElement.java:72)
  at app//org.labkey.test.selenium.BaseLazyWebElement.getWrappedElement(BaseLazyWebElement.java:14)
  at app//org.labkey.test.selenium.WebElementWrapper.isEnabled(WebElementWrapper.java:79)
  at app//org.labkey.test.components.Component.elementCache(Component.java:61)
  at app//org.labkey.test.components.inventory.freezer.FMFreezerStatusPanel.isPanelLoaded(FMFreezerStatusPanel.java:51)
  at app//org.labkey.test.pages.inventory.freezer.FMFreezerOverviewPage.lambda$0(FMFreezerOverviewPage.java:46)
  at app//org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2113)
  at app//org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2144)
  at app//org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2139)
  at app//org.labkey.test.pages.inventory.freezer.FMFreezerOverviewPage.waitForPage(FMFreezerOverviewPage.java:45)
  at app//org.labkey.test.pages.LabKeyPage.<init>(LabKeyPage.java:47)
  at app//org.labkey.test.pages.LabKeyPage.<init>(LabKeyPage.java:52)
  at app//org.labkey.test.pages.inventory.FMBasePage.<init>(FMBasePage.java:18)
  at app//org.labkey.test.pages.inventory.freezer.FMFreezerOverviewPage.<init>(FMFreezerOverviewPage.java:36)
  at app//org.labkey.test.pages.inventory.freezer.FMFreezerOverviewPage.beginAt(FMFreezerOverviewPage.java:31)
  at app//org.labkey.test.tests.inventory.FMTestUtils.goToStorageView(FMTestUtils.java:73)
  at app//org.labkey.test.tests.inventory.FMBaseTest.goToStorageView(FMBaseTest.java:291)
  at app//org.labkey.test.tests.inventory.FMMoveSamplesTest.testMoveToSameNoOp(FMMoveSamplesTest.java:841)
```

#### Related Pull Requests
* #1048 

#### Changes
* Ignore `NoSuchElementException` when triggering element refind
