### PR TITLE
Issue 45087: Remove slf4j dependency and add configuration for commons logging to turn off extraneous logs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ project.dependencies {
     implementation("net.sf.opencsv:opencsv:${opencsvVersion}")
     implementation("javax.servlet:javax.servlet-api:${servletApiVersion}") // originally 3.1.0
     aspectj "org.aspectj:aspectjtools:${aspectjVersion}"
-    implementation "org.slf4j:slf4j-log4j12:${slf4jLog4j12Version}" // Suppresses unwanted logging from remoteapi and webdriver
     implementation "org.apache.logging.log4j:log4j-core:${log4j2Version}"
     implementation "org.apache.logging.log4j:log4j-iostreams:${log4j2Version}"
     api "com.github.lookfirst:sardine:${project.lookfirstSardineVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ project.dependencies {
     implementation("net.sf.opencsv:opencsv:${opencsvVersion}")
     implementation("javax.servlet:javax.servlet-api:${servletApiVersion}") // originally 3.1.0
     aspectj "org.aspectj:aspectjtools:${aspectjVersion}"
-    implementation "org.slf4j:slf4j-api:${slf4jLog4jApiVersion}"
     implementation "org.apache.logging.log4j:log4j-core:${log4j2Version}"
     implementation "org.apache.logging.log4j:log4j-iostreams:${log4j2Version}"
     api "com.github.lookfirst:sardine:${project.lookfirstSardineVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ project.dependencies {
     implementation("net.sf.opencsv:opencsv:${opencsvVersion}")
     implementation("javax.servlet:javax.servlet-api:${servletApiVersion}") // originally 3.1.0
     aspectj "org.aspectj:aspectjtools:${aspectjVersion}"
+    implementation "org.slf4j:slf4j-api:${slf4jLog4jApiVersion}"
     implementation "org.apache.logging.log4j:log4j-core:${log4j2Version}"
     implementation "org.apache.logging.log4j:log4j-iostreams:${log4j2Version}"
     api "com.github.lookfirst:sardine:${project.lookfirstSardineVersion}"

--- a/resources/commons-logging.properties
+++ b/resources/commons-logging.properties
@@ -1,0 +1,2 @@
+# Disable commons logging from remoteapi
+org.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog


### PR DESCRIPTION
#### Rationale
We want to remove our dependencies on the old version of log4j that may have security issues.  The inclusion of the dependency on `slf4j-log4j12` here was added only to silence some logging from other libraries that happens when running tests in IntelliJ.  Including the dependency on the `slf4j-api` will, according to the manual: "If no binding is found on the class path, then SLF4J will default to a no-operation implementation".  This is better than spurious logs that are not useful.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/223

#### Changes
* Use `org.slf4j:slf4j-api` instead of `org.slf4j:slf4j-log4j12`
