### PR TITLE
give DetailTable a waitForReady()

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailTable.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTable.java
@@ -1,6 +1,7 @@
 package org.labkey.test.components.ui.grids;
 
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
 import org.openqa.selenium.By;
@@ -41,6 +42,12 @@ public class DetailTable extends WebDriverComponent<DetailTable.ElementCache>
     public WebElement getComponentElement()
     {
         return _tableElement;
+    }
+
+    @Override
+    protected void waitForReady()
+    {
+        getWrapper().shortWait().withMessage("waiting for detailTable to load").until(wd -> isLoaded());
     }
 
     public Boolean isLoaded()
@@ -104,8 +111,7 @@ public class DetailTable extends WebDriverComponent<DetailTable.ElementCache>
      */
     public String getFieldValueByKey(String fieldKey)
     {
-        return Locator.tagWithAttribute("td", "data-fieldkey", fieldKey)
-                .findElement(this).getText();
+        return elementCache().dataFieldByKey(fieldKey).getText();
     }
 
     /**
@@ -128,9 +134,6 @@ public class DetailTable extends WebDriverComponent<DetailTable.ElementCache>
      **/
     public Map<String, String> getTableData()
     {
-        // Explicitly check that the table has been loaded before trying to get the data.
-        getWrapper().waitFor(this::isLoaded, "Cannot get the table data because the table is not loaded.", 500);
-
         Map<String, String> tableData = new HashMap<>();
 
         for(WebElement tableRow : getComponentElement().findElements(By.cssSelector("tr")))
@@ -156,6 +159,7 @@ public class DetailTable extends WebDriverComponent<DetailTable.ElementCache>
     @Override
     protected ElementCache newElementCache()
     {
+        waitForReady();
         return new ElementCache();
     }
 
@@ -164,6 +168,11 @@ public class DetailTable extends WebDriverComponent<DetailTable.ElementCache>
         public final WebElement dataCaptionField(String caption)
         {
             return Locator.tagWithAttribute("td", "data-caption", caption).findWhenNeeded(this);
+        }
+
+        public final WebElement dataFieldByKey(String fieldKey)
+        {
+            return Locator.tagWithAttribute("td", "data-fieldkey", fieldKey).findElement(this);
         }
 
         // Some tables will show a value in a td with no attributes, use the td that has the text (label) to find the value.
@@ -176,7 +185,7 @@ public class DetailTable extends WebDriverComponent<DetailTable.ElementCache>
 
     public static class DetailTableFinder extends WebDriverComponent.WebDriverComponentFinder<DetailTable, DetailTableFinder>
     {
-        private Locator.XPathLocator _baseLocator = Locators.detailTable;
+        private final Locator.XPathLocator _baseLocator = Locators.detailTable;
         private Locator _locator;
 
         public DetailTableFinder(WebDriver driver)

--- a/src/org/labkey/test/components/ui/grids/DetailTable.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTable.java
@@ -159,7 +159,6 @@ public class DetailTable extends WebDriverComponent<DetailTable.ElementCache>
     @Override
     protected ElementCache newElementCache()
     {
-        waitForReady();
         return new ElementCache();
     }
 


### PR DESCRIPTION
#### Rationale
Occasionally some tests in Biologics (such as [this one](https://teamcity.labkey.org/viewLog.html?buildId=1755004&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsBPostgres&fromExperimentalUI=true#testNameId-8112779387230223933))  will fail because an expected value wasn't in the value extracted from a cell in a DetailTable- but in after screenshots, the value is present (which suggests that the test got the value before the app populated the table with it).  
This approach waits once, when getting the `DetailTable`'s `elementCache()`, so it's lazy-initialization-friendly.
It also moves finder methods into the elementCache() if they weren't already.

This approach may make a lot of calls to DetailTable.isLoaded() in page class waitForPage() methods redundant, (so might call for making isLoaded() private and not calling it from page classes, or perhaps we don't need this change and every page or test using this component should be responsible for knowing when the table is ready for interaction)

#### Related Pull Requests
n/a

#### Changes
* overrides and implements `waitForReady()` on `DetailTable`
* moves table element finders that weren't already in elementCache() there, to ensure synchronization
