### PR TITLE
Use correct row collection for TestDataValidator

### DIFF
--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -491,7 +491,7 @@ public class TestDataGenerator
 
     public TestDataValidator getValidator()
     {
-        return new TestDataValidator(_insertedRows);
+        return new TestDataValidator(_rows);
     }
 
     /**


### PR DESCRIPTION
#### Rationale
`TestDataGenerator.getValidator` is sometimes used for data that was inserted by non-API means. In such cases `_insertedRows` will not contain the rows that need to be validated.
This fixes `SampleTypeRemoteAPITest.importMissingValueSampleType`

#### Related Pull Requests
* #1065 

#### Changes
* Use generated rows for `TestDataValidator`, not inserted rows.
