### PR TITLE
testLinkToStudy fix

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -34,10 +34,11 @@ import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 12)
@@ -138,7 +139,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(SAMPLE_TYPE1));
         String expectedComment = "2 row(s) were linked to a study from the sample type: " + SAMPLE_TYPE1;
         verifyLinkToHistory(expectedComment);
-        verifyAuditLogEvents(expectedComment, numOfRowsLinked, Arrays.asList("stool", "plasma"));
+        verifyAuditLogEvents(expectedComment, numOfRowsLinked, Set.of("stool", "plasma"));
     }
 
     @Test
@@ -708,7 +709,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         checker().verifyEquals("Mismatch in the comment", expectedComments, table.getDataAsText(0, "Comment"));
     }
 
-    private void verifyAuditLogEvents(String Comment, @Nullable Integer numOfRowsLinked, @Nullable List<String> linkedSamples)
+    private void verifyAuditLogEvents(String Comment, @Nullable Integer numOfRowsLinked, @Nullable Set<String> linkedSamples)
     {
         goToAdminConsole().clickAuditLog();
         doAndWaitForPageToLoad(() -> selectOptionByText(Locator.name("view"), "Link to Study events"));
@@ -720,7 +721,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         {
             doAndWaitForPageToLoad(() -> selectOptionByText(Locator.name("view"), "Sample timeline events"));
             auditTable = DataRegionTable.DataRegion(getDriver()).withName("query").waitFor();
-            List<String> samples = new ArrayList<>();
+            Set<String> samples = new HashSet<>();
             for (int i = 0; i < numOfRowsLinked; i++)
                 samples.add(auditTable.getDataAsText(i, "SampleName"));
             checker().verifyEquals("Incorrect sample names in the audit log", linkedSamples, samples);


### PR DESCRIPTION
#### Rationale
The `SampleTypeLinkToStudyTest.testLinkToStudy` test began to fail because the order of the audit records in the sample timeline audit events appeared in a different order from what the test expected: 

https://teamcity.labkey.org/test/-376634581250720409?currentProjectId=LabKey_223Release_Community_DailySuites&expandTestHistoryInvestigationsSection=true&expandTestHistoryChartSection=true

In general when assay or sample data is linked to a study we create a single audit event and note the number of records created. For samples there is an additional step for sample timeline to create additional events, one per each sample copied, see `StudyPublishManager.logPublishEvent`. The test expects a specific order but the code doesn't guarantee a specific ordering of individual samples other than they are part of the same batch.  At line 626 of `logPublishEvent` we ask the `ExperimentService` for the list of `ExpMaterials` given a list of rowIds, this results in a query to the table using an `IN CLAUSE` which makes no guarantees on the order of the rows returned. I think we were just getting lucky with the order of the records being created.

Looking closer at the audit logging code, it doesn't seem that timeline events have the expectation of ordering so it didn't make sense to try to enforce ordering to get the test to pass again.

#### Changes
- Update the test to compare using a `Set` instead of a `List`.