### PR TITLE
Don't publish buildInfo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,6 +205,7 @@ if (project.hasProperty('doPublishing'))
                         }
                         defaults
                                 {
+                                    publishBuildInfo = false
                                     publishPom = true
                                     publishIvy = false
                                 }


### PR DESCRIPTION
#### Rationale
We never reference the buildInfo that is currently published to Artifactory, so it's just taking up space.


#### Changes
* Stop publishing buildInfo
