### PR TITLE
Item 10203: Support sample type and data class renaming

### DIFF
--- a/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
@@ -81,6 +81,12 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
         return getThis();
     }
 
+    public boolean isNameFieldEnabled()
+    {
+        String disabledValue = Locator.tagWithId("input", "entity-name").findWhenNeeded(getDriver()).getAttribute("disabled");
+        return (null == disabledValue) || (!disabledValue.equalsIgnoreCase("true"));
+    }
+
     public String getNameExpression()
     {
         expandPropertiesPanel();

--- a/src/org/labkey/test/tests/DataClassTest.java
+++ b/src/org/labkey/test/tests/DataClassTest.java
@@ -20,6 +20,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.domain.BaseDomainDesigner;
@@ -79,7 +80,7 @@ public class DataClassTest extends BaseWebDriverTest
         goToProjectHome();
 
         log("Create an initial data class");
-        String name = "Name Already Exists Test";
+        final String name = "Name Already Exists Test";
         CreateDataClassPage createPage = goToCreateNewDataClass();
         createPage.setName(name).clickSave();
 
@@ -98,6 +99,34 @@ public class DataClassTest extends BaseWebDriverTest
                 "DataClass 'Name Already Exists Test' already exists."),
                 createPage.clickSaveExpectingErrors());
         createPage.clickCancel();
+
+        final String anotherName = "Another Name";
+        log("Try creating data class with a different name");
+        goToCreateNewDataClass().setName(anotherName).clickSave();
+
+        final String renamed = "Updated Name";
+        log("Renaming a data class to a new name");
+        CreateDataClassPage updatePage = goToDataClass(anotherName);
+        updatePage.setName(renamed).clickSave();
+        goToProjectHome();
+
+        log("Try renaming a data class to an existing name");
+        updatePage = goToDataClass(renamed);
+        updatePage = updatePage.setName(name);
+
+        assertEquals("Data class name conflict error", Arrays.asList(
+                        "DataClass 'Name Already Exists Test' already exists.",
+                        "Please correct errors in Name Already Exists Test before saving."),
+                updatePage.clickSaveExpectingErrors());
+        updatePage.clickCancel();
+    }
+
+    private CreateDataClassPage goToDataClass(String dataClassName)
+    {
+        clickAndWait(Locator.linkWithText(dataClassName));
+        assertElementPresent(Locator.tagWithText("h3", dataClassName));
+        clickButton("Edit");
+        return new CreateDataClassPage(getDriver());
     }
 
     @Test
@@ -187,7 +216,7 @@ public class DataClassTest extends BaseWebDriverTest
         domainFormPanel.addField(new FieldDefinition("Duplicate", FieldDefinition.ColumnType.Boolean));
         assertEquals("Data class unique field name error", Arrays.asList(
                 "The field name 'Duplicate' is already taken. Please provide a unique name for each field.",
-                "Please correct errors in Fields before saving."),
+                "Please correct errors in Unique Field Names Test before saving."),
                 createPage.clickSaveExpectingErrors());
         domainFormPanel.removeAllFields(false);
 

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -1153,7 +1153,7 @@ public class SampleTypeTest extends BaseWebDriverTest
     }
 
     @Test
-    public void testCaseSensitivity()
+    public void testSampleTypeNames()
     {
         SampleTypeHelper sampleHelper = new SampleTypeHelper(this);
 
@@ -1161,6 +1161,7 @@ public class SampleTypeTest extends BaseWebDriverTest
         clickProject(PROJECT_NAME);
         sampleHelper.createSampleType(new SampleTypeDefinition(CASE_INSENSITIVE_SAMPLE_TYPE));
 
+        log("Creating sample type with same name but different casing should fail");
         clickProject(PROJECT_NAME);
         List<String> errors = sampleHelper
                 .goToCreateNewSampleType()
@@ -1170,6 +1171,24 @@ public class SampleTypeTest extends BaseWebDriverTest
         clickProject(PROJECT_NAME);
         assertElementPresent(Locator.linkWithText(CASE_INSENSITIVE_SAMPLE_TYPE));
         assertElementNotPresent(Locator.linkWithText(LOWER_CASE_SAMPLE_TYPE));
+
+        log("Sample type can be renamed");
+        goToProjectHome();
+        final String anotherSampleType = "AnotherSampleType";
+        sampleHelper.createSampleType(new SampleTypeDefinition(anotherSampleType));
+
+        final String updatedSampleType = "UpdatedSampleType";
+        goToProjectHome();
+        UpdateSampleTypePage updatePage = sampleHelper.goToEditSampleType(anotherSampleType);
+        updatePage.setName(updatedSampleType).clickSave();
+
+        log("Sample type cannot be renamed to an existing name");
+        goToProjectHome();
+        updatePage = sampleHelper.goToEditSampleType(updatedSampleType);
+        updatePage.setName(CASE_INSENSITIVE_SAMPLE_TYPE.toUpperCase());
+        assertTrue("Sample type rename conflict error",
+                updatePage.clickSaveExpectingErrors().contains("A Sample Type with name 'CASEINSENSITIVESAMPLETYPE' already exists."));
+        updatePage.clickCancel();
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
Adding test coverage for sample type and data class renaming in LKS.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/808
* https://github.com/LabKey/platform/pull/3256
* https://github.com/LabKey/commonAssays/pull/458
* https://github.com/LabKey/sampleManagement/pull/922
* https://github.com/LabKey/biologics/pull/1255

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
