### PR TITLE
Issue 45033: Missing / can't set folder descriptions (comments)

### DIFF
--- a/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
@@ -159,19 +159,20 @@ public class FileContentUploadTest extends BaseWebDriverTest
         fileProperties.add(new FileBrowserExtendedProperty("LookupColumn:", LOOKUP_VALUE_1, true));
         _fileBrowserHelper.uploadFile(testFile, FILE_DESCRIPTION, fileProperties, true);
 
-        log("test folder");
-        final String folderName = "Test folder";
-        final String folderDescription = "TestFolderDesc";
-        _fileBrowserHelper.createFolder(folderName);
-        _fileBrowserHelper.setDescription(folderName, folderDescription);
-        assertEquals("Folder description is not as expected", folderDescription, _fileBrowserHelper.getFileDescription(folderName));
-
         log("move file");
+        final String folderName = "Test folder";
+        _fileBrowserHelper.createFolder(folderName);
         _fileBrowserHelper.moveFile(filename, folderName);
 
         log("rename file");
         final String newFileName = "changedFilename.html";
         _fileBrowserHelper.renameFile(folderName + "/" + filename, newFileName);
+
+        log("test folder");
+        final String folderDescription = "TestFolderDesc";
+        _fileBrowserHelper.selectFileBrowserRoot();
+        _fileBrowserHelper.setDescription(folderName, folderDescription);
+        assertEquals("Folder description is not as expected", folderDescription, _fileBrowserHelper.getFileDescription(folderName));
 
         _searchHelper.enqueueSearchItem(filename); // No results for old file name
         _searchHelper.enqueueSearchItem(newFileName, folderName, Locator.linkContainingText(newFileName));

--- a/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
@@ -178,6 +178,7 @@ public class FileContentUploadTest extends BaseWebDriverTest
         _searchHelper.enqueueSearchItem(newFileName, folderName, Locator.linkContainingText(newFileName));
         _searchHelper.enqueueSearchItem(FILE_DESCRIPTION, folderName, Locator.linkContainingText(newFileName));
         _searchHelper.enqueueSearchItem(CUSTOM_PROPERTY_VALUE, folderName, Locator.linkContainingText(newFileName));
+        _searchHelper.enqueueSearchItem(folderDescription, folderName, Locator.linkWithText(folderName));
 
         _searchHelper.verifySearchResults(getProjectName(), "searchAfterRename");
 

--- a/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
@@ -159,9 +159,14 @@ public class FileContentUploadTest extends BaseWebDriverTest
         fileProperties.add(new FileBrowserExtendedProperty("LookupColumn:", LOOKUP_VALUE_1, true));
         _fileBrowserHelper.uploadFile(testFile, FILE_DESCRIPTION, fileProperties, true);
 
-        log("move file");
+        log("test folder");
         final String folderName = "Test folder";
+        final String folderDescription = "TestFolderDesc";
         _fileBrowserHelper.createFolder(folderName);
+        _fileBrowserHelper.setDescription(folderName, folderDescription);
+        assertEquals("Folder description is not as expected", folderDescription, _fileBrowserHelper.getFileDescription(folderName));
+
+        log("move file");
         _fileBrowserHelper.moveFile(filename, folderName);
 
         log("rename file");

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -374,6 +374,33 @@ public class FileBrowserHelper extends WebDriverWrapper
         waitForElement(fileGridCell.withText(folderName));
     }
 
+    public void setDescription(String fileName, String description)
+    {
+        Window propWindow = editProperty(fileName);
+        setFormElement(Locator.name("Flag/Comment"), description);
+        propWindow.clickButton("Save", true);
+        _ext4Helper.waitForMaskToDisappear();
+    }
+
+    public String getFileDescription(String fileName)
+    {
+        List<String> fileList = getFileList();
+        int fileInd = fileList.indexOf(fileName);
+        if (fileInd > -1)
+        {
+            return getTexts(Locators.gridRow().childTag("td").position(7).findElements(getDriver())).get(fileInd);
+        }
+
+        return null;
+    }
+
+    public Window editProperty(String fileName)
+    {
+        selectFileBrowserItem(fileName);
+        clickFileBrowserButton(BrowserAction.EDIT_PROPERTIES);
+        return Window(getDriver()).withTitle("Extended File Properties").waitFor();
+    }
+
     public void addToolbarButton(String buttonId)
     {
         String checkboxXpath = "//*[contains(@class, 'x4-grid-checkcolumn')]";

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -388,7 +388,7 @@ public class FileBrowserHelper extends WebDriverWrapper
         int fileInd = fileList.indexOf(fileName);
         if (fileInd > -1)
         {
-            return getTexts(Locators.gridRow().childTag("td").position(7).findElements(getDriver())).get(fileInd);
+            return Locators.gridRow(fileName).childTag("td").position(7).findElement(getDriver()).getText();
         }
 
         return null;


### PR DESCRIPTION
#### Rationale
Adding test coverage for setting folder description in file browser.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3272

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
