### PR TITLE
44784: IssueAPI should handle missing priority param in validation

### DIFF
--- a/src/org/labkey/test/tests/issues/IssueAPITest.java
+++ b/src/org/labkey/test/tests/issues/IssueAPITest.java
@@ -426,7 +426,7 @@ public class IssueAPITest extends BaseWebDriverTest
         }
         catch (CommandException ce)
         {
-            assertEquals("Missing value for required property: assignedto", ce.getMessage());
+            assertEquals("missing value for required property: assignedto", ce.getMessage().toLowerCase());
         }
     }
 
@@ -447,7 +447,7 @@ public class IssueAPITest extends BaseWebDriverTest
         }
         catch (CommandException ce)
         {
-            assertEquals("Missing value for required property: priority", ce.getMessage());
+            assertEquals("missing value for required property: priority", ce.getMessage().toLowerCase());
         }
     }
 

--- a/src/org/labkey/test/tests/issues/IssueAPITest.java
+++ b/src/org/labkey/test/tests/issues/IssueAPITest.java
@@ -419,28 +419,35 @@ public class IssueAPITest extends BaseWebDriverTest
                 .setPriority(3L)
                 .setType("Defect");
 
-        var issueResponse= getIssueResponse( doIssueAction(issue));
-        assertEquals("should be assigned to guest", Long.valueOf(0), issueResponse.getAssignedTo());
-        assertEquals("should be open", "open", issueResponse.getStatus());
+        try
+        {
+            var issueResponse= getIssueResponse( doIssueAction(issue));
+            fail("should produce a validation error");
+        }
+        catch (CommandException ce)
+        {
+            assertEquals("Missing value for required property: assignedto", ce.getMessage());
+        }
     }
 
     @Test
     public void testIssueWithoutPri() throws Exception
     {
         IssueModel issue = new IssueModel()
+                .setAssignedTo(TEST_USER_ID)
                 .setTitle("test with no priority")
                 .setComment("should get a CommandException")
                 .setAction(IssueModel.IssueAction.insert)
                 .setType("Defect");
 
-        // revisit when  https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44784 is resolved
-        try{
-            doIssueAction(issue);
-            fail("expect error if command is executed without required property priority");
-        }catch(CommandException success)
+        try
         {
-            assertThat(success.getMessage().toLowerCase(), containsString("data does not contain required field: priority"));
-            resetErrors();
+            var issueResponse= getIssueResponse( doIssueAction(issue));
+            fail("should produce a validation error");
+        }
+        catch (CommandException ce)
+        {
+            assertEquals("Missing value for required property: priority", ce.getMessage());
         }
     }
 


### PR DESCRIPTION
#### Rationale
Validation is handled earlier so we can modify the tests to not deal with server side errors but instead receive a normal validation error message from the service.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44784

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/3284

