### PR TITLE
Test Issue: Filters not being removed from grid.

### DIFF
--- a/src/org/labkey/test/components/ui/FilterStatusValue.java
+++ b/src/org/labkey/test/components/ui/FilterStatusValue.java
@@ -54,6 +54,7 @@ public class FilterStatusValue extends WebDriverComponent<FilterStatusValue.Elem
     public void remove()
     {
         String originalText = getText();
+        getWrapper().mouseOver(getComponentElement());
         getWrapper().mouseOver(elementCache().icon);
         WebDriverWrapper.waitFor(()-> isActive() && isClose(),
                 "the filter status item with text ["+getText()+"] did not become active", 500);


### PR DESCRIPTION
#### Rationale
Some tests failures are happening because the filter "pill" is not being removed from the grid. For some tests it is intermittent for others it is more consistent.
<img width="748" alt="Screen Shot 2022-04-25 at 10 45 46 AM" src="https://user-images.githubusercontent.com/12738200/165144812-4874ddd6-feb8-442e-934a-68a9cede6f21.png">
Looking at the failures, like the screen shot above, the pill is not active which means the mouse is not over it. 
I'm not sure that this is the best fix, but it does appear to be working. If there is a more appropriate change please let me know.

#### Related Pull Requests
* None

#### Changes
* Explicitly move the mouse over the pill before clicking the remove icon.
