### PR TITLE
Fix HTTPApiTest.testQueryTestLists

### DIFF
--- a/data/api/http-api.xml
+++ b/data/api/http-api.xml
@@ -704,7 +704,7 @@
         "value" : "2000-04-01 00:00:00.000"
       },
       "Like" : {
-        "url" : "/labkey/HTTPApiVerifyProject/list-details.view?listId=1&pk=Gray",
+        "url" : "/labkey/HTTPApiVerifyProject/list-details.view?name=Test%20List&pk=Gray",
         "value" : "Black"
       },
       "Color" : {


### PR DESCRIPTION
#### Rationale
The default list URL generated for the `list-details.view` action was adjusted with https://github.com/LabKey/platform/pull/3282. The `listId` parameter is still supported, however, this test case is doing a fresh export for comparison.

#### Changes
* Fix test snapshot.
