### PR TITLE
Item 10275: Grid panel updates to make button/menu bar display responsive to screen width

### DIFF
--- a/src/org/labkey/test/components/ui/Pager.java
+++ b/src/org/labkey/test/components/ui/Pager.java
@@ -60,7 +60,6 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
         if(currentPageSize != Integer.parseInt(pageSize))
         {
             _pagedComponent.doAndWaitForUpdate(() -> elementCache().jumpToDropdown.clickSubMenu(pageSize));
-            WebDriverWrapper.waitFor(()-> currentPageSize != getPageSize(), 1_000);
         }
         return this;
     }

--- a/src/org/labkey/test/components/ui/Pager.java
+++ b/src/org/labkey/test/components/ui/Pager.java
@@ -59,7 +59,7 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
         int currentPageSize = getPageSize();
         if(currentPageSize != Integer.parseInt(pageSize))
         {
-            _pagedComponent.doAndWaitForUpdate(() -> elementCache().pageSizeDropdown.clickSubMenu(pageSize));
+            _pagedComponent.doAndWaitForUpdate(() -> elementCache().jumpToDropdown.clickSubMenu(pageSize));
             WebDriverWrapper.waitFor(()-> currentPageSize != getPageSize(), 1_000);
         }
         return this;
@@ -67,7 +67,7 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
 
     public int getPageSize()                // only works on GridPanel
     {
-        return Integer.parseInt(elementCache().pageSizeDropdown.getButtonText());
+        return Integer.parseInt(elementCache().jumpToDropdown.getButtonText());
     }
 
     public Pager clickPrevious()
@@ -179,8 +179,6 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
     {
         DropdownButtonGroup jumpToDropdown = new DropdownButtonGroup.DropdownButtonGroupFinder(getDriver())
                 .withButtonClass("current-page-dropdown").findWhenNeeded(this);
-        DropdownButtonGroup pageSizeDropdown = new DropdownButtonGroup.DropdownButtonGroupFinder(getDriver())
-                .withButtonClass("page-size-dropdown").findWhenNeeded(this);
 
         final Locator.XPathLocator pagingCountsSpan = Locator.tagWithClass("span", "pagination-info");
 


### PR DESCRIPTION
#### Rationale
Next round of changes for the Entity Grid Actions update. This set of PRs includes changes to make the grid panel buttons/menu bar display be responsive to screen width. In XL screensizes we will show all buttons/menus in the button bar. In Large screen size we will collapse the non-primary menus into a "More" menu. And in screensizes below Large, we will move the filter/search and pagination info to a 2nd button bar row.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/820
* https://github.com/LabKey/biologics/pull/1269
* https://github.com/LabKey/sampleManagement/pull/934
* https://github.com/LabKey/inventory/pull/424
* https://github.com/LabKey/testAutomation/pull/1097

#### Changes
* Update test locator for grid page size menu options
