### PR TITLE
Wait for grid update when searching

### DIFF
--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -178,7 +178,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
      */
     public QueryGrid search(String searchTerm)
     {
-        getGridBar().searchFor(searchTerm);
+        doAndWaitForUpdate(()-> getGridBar().searchFor(searchTerm));
         return this;
     }
 
@@ -187,7 +187,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
      */
     public QueryGrid clearSearch()
     {
-        getGridBar().clearSearch();
+        doAndWaitForUpdate(()-> getGridBar().clearSearch());
         return this;
     }
 


### PR DESCRIPTION
#### Rationale
[BiologicsSampleUpdateTest.testWithInjectionChars](https://teamcity.labkey.org/viewLog.html?buildId=1805058&buildTypeId=LabKey_HostingAndEvaluationInfrastructure_AutomatedTest_AutomatedTestForTrunk_TrialBiologicsIntegrationTest&fromExperimentalUI=true#testNameId-2865518464828825953) recently began failing with complaints that the row elements it was searching for have gone stale.

At its point of failure, the test has just applied a search expression to the search box, and then requested the text in the "String Column" column, only to fail with the complaint that the table-row (from which it is extracting data) has gone stale.

This adds synchronization to `QueryGrid's `calls to `search`() and `clearSearch`() to have it wait for the grid to update.

Incidentally, this change allows the test to get farther along on its scenario, only to fail because the search is intended to show fields with the expression 'argybargyandotherthings' in the Alias field.  FWIW, putting that expression in the 'Description' column instead causes the test to pass.

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/1280

#### Changes
just touches search() and clearSearch()
