### PR TITLE
Update grid search to conditionally wait for grid update

### DIFF
--- a/src/org/labkey/test/components/ui/grids/GridBar.java
+++ b/src/org/labkey/test/components/ui/grids/GridBar.java
@@ -416,6 +416,11 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
         return this;
     }
 
+    public String getSearchExpression()
+    {
+        return elementCache().searchBox.get();
+    }
+
     @Override
     protected ElementCache newElementCache()
     {
@@ -492,6 +497,6 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
     {
         ALL,
         SAMPLES,
-        ALIQUOTS;
+        ALIQUOTS
     }
 }

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -175,10 +175,15 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
 
     /**
      * searches the grid, from the GridBar search input and waits for the grid to refresh
+     * if the searchTerm is different from the current searchTerm
      */
     public QueryGrid search(String searchTerm)
     {
-        doAndWaitForUpdate(()-> getGridBar().searchFor(searchTerm));
+        String currentSearchExp = getGridBar().getSearchExpression();
+        if (searchTerm.equals(currentSearchExp))
+            getGridBar().searchFor(searchTerm);
+        else
+            doAndWaitForUpdate(()-> getGridBar().searchFor(searchTerm));
         return this;
     }
 
@@ -187,7 +192,11 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
      */
     public QueryGrid clearSearch()
     {
-        doAndWaitForUpdate(()-> getGridBar().clearSearch());
+        String currentSearchExp = getGridBar().getSearchExpression();
+        if ("".equals(currentSearchExp))
+            getGridBar().clearSearch();
+        else
+            doAndWaitForUpdate(()-> getGridBar().clearSearch());
         return this;
     }
 


### PR DESCRIPTION
#### Rationale
Yesterday, I updated QueryGrid to wait for the grid to update when a test calls its `search()` method, which solved one sort of problem (that another test was failing because it didn't wait for the grid to update) but created another:
Several tests call clearSearch() to protect against the possibility that a searchTerm is in the search box, but when the expression is already empty and clearSearch() is called, it no-ops and the grid doesn't refresh- and the QueryGrid helper fails while waiting for the grid refresh that never happens.

This change modifies helper behavior as follows:

-` clearSearch()` doesn't wait for refresh unless there was a search expression in the searchBox to clear
-` search()` doesn't wait for refresh unless the supplied search expression is different from the contents of the searchBox

#### Related Pull Requests
n/a

#### Changes

