### PR TITLE
Use correct method to navigate to project

### DIFF
--- a/src/org/labkey/test/tests/ListArchiveImportTest.java
+++ b/src/org/labkey/test/tests/ListArchiveImportTest.java
@@ -69,7 +69,7 @@ public class ListArchiveImportTest extends BaseWebDriverTest
         final String listName = "People";
 
         log("Import list and test for expected validation error");
-        clickFolder(getProjectName());
+        goToProjectHome();
 
         goToManageLists().importListArchive(new ZipUtil(listArchive).tempZip());
 


### PR DESCRIPTION
#### Rationale
This test uses `clickFolder` to navigate to a project, which only works if you're already in the given project.
Fixes this failure:
```
org.openqa.selenium.NoSuchElementException: Unable to find element: xpath=//li[contains(concat(' ',normalize-space(@class),' '), ' folder-tree-node ')]/a[normalize-space()='ListArchiveImport']
within: [[[[[[[[FirefoxDriver: firefox on LINUX (fb54ec85-fa01-47bc-bb68-576dadf64499)] -> xpath: //nav[contains(concat(' ',normalize-space(@class),' '), ' labkey-page-nav ')][.//div[contains(concat(' ',normalize-space(@class),' '), ' navbar-header ')]]]] -> css selector: li[class*="dropdown"][data-name="FolderNav"]]] -> css selector: div.folder-nav]] -> xpath: ./ul/li[contains(concat(' ',normalize-space(@class),' '), ' folder-tree-node ')][*[2][normalize-space()='Home']]]
	at app//org.labkey.test.Locator.lambda$1(Locator.java:361)
	at java.base@17/java.util.Optional.orElseThrow(Optional.java:403)
	at app//org.labkey.test.Locator.findElement(Locator.java:360)
	at app//org.labkey.test.components.core.ProjectMenu.expandToFolder(ProjectMenu.java:127)
	at app//org.labkey.test.components.core.ProjectMenu.navigateToFolder(ProjectMenu.java:118)
	at app//org.labkey.test.LabKeySiteWrapper.clickFolder(LabKeySiteWrapper.java:1299)
	at app//org.labkey.test.tests.ListArchiveImportTest.testImportListArchiveWithError(ListArchiveImportTest.java:72)
```

#### Changes
* Use `clickProject` instead of `clickFolder`
