### PR TITLE
Update Locators in `ImportDataPage`

### DIFF
--- a/src/org/labkey/test/pages/ImportDataPage.java
+++ b/src/org/labkey/test/pages/ImportDataPage.java
@@ -156,7 +156,7 @@ public class ImportDataPage extends LabKeyPage<ImportDataPage.ElementCache>
         WebElement uploadFileFilePath = Locator.input("file").findWhenNeeded(uploadFileDiv);
 
         // Paste data
-        WebElement copyPastePanel = Locator.tagWithAttribute("div", "data-panel-name", "uploadFilePanel").findWhenNeeded(this);
+        WebElement copyPastePanel = Locator.tagWithAttribute("div", "data-panel-name", "copyPastePanel").findWhenNeeded(this);
         WebElement copyPasteDiv = Locator.byClass("panel-body").findWhenNeeded(copyPastePanel);
         WebElement copyPasteExpando = Locator.byClass("lk-import-expando").findWhenNeeded(copyPastePanel);
         WebElement pasteDataTextArea = Locator.tag("textarea").findWhenNeeded(copyPasteDiv);

--- a/src/org/labkey/test/pages/ImportDataPage.java
+++ b/src/org/labkey/test/pages/ImportDataPage.java
@@ -147,18 +147,20 @@ public class ImportDataPage extends LabKeyPage<ImportDataPage.ElementCache>
         return new ElementCache();
     }
 
-    protected class ElementCache extends LabKeyPage.ElementCache
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
         // Upload file
-        WebElement uploadFileDiv = Locator.id("uploadFileDiv2").findWhenNeeded(this);
-        WebElement uploadExpando = Locator.id("uploadFileDiv2Expando").findWhenNeeded(this);
+        WebElement uploadPanel = Locator.tagWithAttribute("div", "data-panel-name", "uploadFilePanel").findWhenNeeded(this);
+        WebElement uploadFileDiv = Locator.byClass("panel-body").findWhenNeeded(uploadPanel);
+        WebElement uploadExpando = Locator.byClass("lk-import-expando").findWhenNeeded(uploadPanel);
         WebElement uploadFileFilePath = Locator.input("file").findWhenNeeded(uploadFileDiv);
 
         // Paste data
-        WebElement copyPasteDiv = Locator.id("copypasteDiv1").findWhenNeeded(this);
-        WebElement copyPasteExpando = Locator.id("copyPasteDiv1Expando").findWhenNeeded(this);
+        WebElement copyPastePanel = Locator.tagWithAttribute("div", "data-panel-name", "uploadFilePanel").findWhenNeeded(this);
+        WebElement copyPasteDiv = Locator.byClass("panel-body").findWhenNeeded(copyPastePanel);
+        WebElement copyPasteExpando = Locator.byClass("lk-import-expando").findWhenNeeded(copyPastePanel);
         WebElement pasteDataTextArea = Locator.tag("textarea").findWhenNeeded(copyPasteDiv);
-        ComboBox formatCombo = new ComboBox.ComboBoxFinder(getDriver()).withLabel("Format:").findWhenNeeded(this);
+        ComboBox formatCombo = new ComboBox.ComboBoxFinder(getDriver()).withLabel("Format:").findWhenNeeded(copyPastePanel);
 
         WebElement getExpandedPanel()
         {


### PR DESCRIPTION
#### Rationale
Locators shouldn't depend on generated IDs.
[Issue 45133: ImportDataPage is fragile](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45133)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3350

#### Changes
* Update locators in `ImportDataPage` to not use generated element IDs
