### PR TITLE
Fix intermittent test failures

### DIFF
--- a/src/org/labkey/test/tests/TabTest.java
+++ b/src/org/labkey/test/tests/TabTest.java
@@ -228,7 +228,7 @@ public class TabTest extends SimpleModuleTest
         // Delete tab folder
         log("Container tab enhancements: delete tab folder type, recreate");
         goToTabFolderManagement(STUDY_FOLDER_TAB_LABEL);
-        waitForText(STUDY_FOLDER_TAB_NAME);
+        waitForElement(Ext4Helper.Locators.folderManagementTreeSelectedNode(STUDY_FOLDER_TAB_NAME));
         clickButton("Delete", 2 * WAIT_FOR_PAGE);
         assertTextPresent("You are about to delete the following folder:");
         clickButton("Yes, delete all", 2 * WAIT_FOR_PAGE);


### PR DESCRIPTION
#### Rationale
Trying to fix a couple of intermittent TeamCity failures.
 - `TabTest`
```
org.labkey.test.TestTimeoutException: org.openqa.selenium.TimeoutException: Expected condition failed: waiting for browser to navigate (tried for 119 second(s) with 500 milliseconds interval)
  at app//org.labkey.test.WebDriverWrapper.waitForPageToLoad(WebDriverWrapper.java:1814)
  at app//org.labkey.test.WebDriverWrapper.doAndMaybeWaitForPageToLoad(WebDriverWrapper.java:1912)
  at app//org.labkey.test.WebDriverWrapper.doAndWaitForPageToLoad(WebDriverWrapper.java:1881)
  at app//org.labkey.test.WebDriverWrapper.clickAndWait(WebDriverWrapper.java:2697)
  at app//org.labkey.test.WebDriverWrapper.clickButton(WebDriverWrapper.java:3094)
  at app//org.labkey.test.WebDriverWrapper.clickButton(WebDriverWrapper.java:3085)
  at app//org.labkey.test.tests.TabTest.doTestTabbedFolder(TabTest.java:232)
  at app//org.labkey.test.tests.TabTest.doVerifySteps(TabTest.java:55)
  at app//org.labkey.test.tests.SimpleModuleTest.testSteps(SimpleModuleTest.java:247)
```

 - `SpecimenImportTest`
```
org.openqa.selenium.ElementNotInteractableException: Element <a href="/labkey/StudyVerifyProject/My%20Study/specimen-specimens.view?showVials=true"> could not be scrolled into view
[...]
  at app//org.labkey.test.WebDriverWrapper.waitAndClick(WebDriverWrapper.java:1)
  at app//org.labkey.test.tests.SpecimenImportTest.assertIdsSet(SpecimenImportTest.java:140)
  at app//org.labkey.test.tests.SpecimenImportTest.doCreateSteps(SpecimenImportTest.java:82)
  at app//org.labkey.test.tests.StudyBaseTest.runUITests(StudyBaseTest.java:137)
  at app//org.labkey.test.tests.StudyBaseTest.testSteps(StudyBaseTest.java:348)
```

#### Changes
* Wait for folder to be selected in folder tree
