### PR TITLE
Use `ImportDataPage` instead of hard coded Locators and `ListHelper`

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -969,7 +969,8 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                 for (String windowHandle : otherWindowHandles)
                 {
                     getDriver().switchTo().window(windowHandle);
-                    getArtifactCollector().dumpPageSnapshot(testName + "-" + windowHandle, "otherWindows");
+                    String windowName = StringUtils.trimToEmpty(executeScript("return window.name;", String.class));
+                    getArtifactCollector().dumpPageSnapshot(testName + "-" + (windowName.isEmpty() ? windowHandle : windowName), "otherWindows");
                 }
                 if (!otherWindowHandles.isEmpty())
                 {

--- a/src/org/labkey/test/pages/ImportDataPage.java
+++ b/src/org/labkey/test/pages/ImportDataPage.java
@@ -167,7 +167,7 @@ public class ImportDataPage extends LabKeyPage<ImportDataPage.ElementCache>
         WebElement uploadFileFilePath = Locator.input("file").findWhenNeeded(uploadFileDiv);
 
         // Paste data
-        WebElement copyPastePanel = Locator.tagWithAttribute("div", "data-panel-name", "uploadFilePanel").findWhenNeeded(this);
+        WebElement copyPastePanel = Locator.tagWithAttribute("div", "data-panel-name", "copyPastePanel").findWhenNeeded(this);
         WebElement copyPasteDiv = Locator.byClass("panel-body").findWhenNeeded(copyPastePanel);
         WebElement copyPasteExpando = Locator.byClass("lk-import-expando").findWhenNeeded(copyPastePanel);
         WebElement pasteDataTextArea = Locator.tag("textarea").findWhenNeeded(copyPasteDiv);

--- a/src/org/labkey/test/pages/ImportDataPage.java
+++ b/src/org/labkey/test/pages/ImportDataPage.java
@@ -17,6 +17,8 @@ package org.labkey.test.pages;
 
 import org.apache.commons.lang3.mutable.Mutable;
 import org.apache.commons.lang3.mutable.MutableObject;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.components.ext4.Checkbox;
@@ -40,12 +42,12 @@ public class ImportDataPage extends LabKeyPage<ImportDataPage.ElementCache>
     {
         super(driver);
     }
-
-    @Override
-    protected void waitForPage()
-    {
-        shortWait().until(ExpectedConditions.visibilityOf(elementCache().uploadPanel));
-    }
+//
+//    @Override
+//    protected void waitForPage()
+//    {
+//        shortWait().until(ExpectedConditions.visibilityOf(elementCache().uploadPanel));
+//    }
 
     public ImportDataPage setText(String text)
     {
@@ -95,6 +97,13 @@ public class ImportDataPage extends LabKeyPage<ImportDataPage.ElementCache>
     {
         clickAndWait(elementCache().getSubmitButton());
         clearCache();
+        return this;
+    }
+
+    public ImportDataPage submitExpectingErrorContaining(String partialError)
+    {
+        String actualError = submitExpectingError();
+        MatcherAssert.assertThat("Import error message.", partialError, CoreMatchers.containsString(actualError));
         return this;
     }
 
@@ -160,6 +169,11 @@ public class ImportDataPage extends LabKeyPage<ImportDataPage.ElementCache>
 
     protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
+        public ElementCache()
+        {
+            shortWait().until(ExpectedConditions.visibilityOf(uploadPanel));
+        }
+
         // Upload file
         WebElement uploadPanel = Locator.tagWithAttribute("div", "data-panel-name", "uploadFilePanel").findWhenNeeded(this);
         WebElement uploadFileDiv = Locator.byClass("panel-body").findWhenNeeded(uploadPanel);

--- a/src/org/labkey/test/pages/ImportDataPage.java
+++ b/src/org/labkey/test/pages/ImportDataPage.java
@@ -147,18 +147,20 @@ public class ImportDataPage extends LabKeyPage<ImportDataPage.ElementCache>
         return new ElementCache();
     }
 
-    protected class ElementCache extends LabKeyPage.ElementCache
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
         // Upload file
-        WebElement uploadFileDiv = Locator.id("uploadFileDiv2").findWhenNeeded(this);
-        WebElement uploadExpando = Locator.id("uploadFileDiv2Expando").findWhenNeeded(this);
+        WebElement uploadPanel = Locator.tagWithAttribute("div", "data-panel-name", "uploadFilePanel").findWhenNeeded(this);
+        WebElement uploadFileDiv = Locator.byClass("panel-body").findWhenNeeded(uploadPanel);
+        WebElement uploadExpando = Locator.byClass("lk-import-expando").findWhenNeeded(uploadPanel);
         WebElement uploadFileFilePath = Locator.input("file").findWhenNeeded(uploadFileDiv);
 
         // Paste data
-        WebElement copyPasteDiv = Locator.id("copypasteDiv1").findWhenNeeded(this);
-        WebElement copyPasteExpando = Locator.id("copyPasteDiv1Expando").findWhenNeeded(this);
+        WebElement copyPastePanel = Locator.tagWithAttribute("div", "data-panel-name", "uploadFilePanel").findWhenNeeded(this);
+        WebElement copyPasteDiv = Locator.byClass("panel-body").findWhenNeeded(copyPastePanel);
+        WebElement copyPasteExpando = Locator.byClass("lk-import-expando").findWhenNeeded(copyPastePanel);
         WebElement pasteDataTextArea = Locator.tag("textarea").findWhenNeeded(copyPasteDiv);
-        ComboBox formatCombo = new ComboBox.ComboBoxFinder(getDriver()).withLabel("Format:").findWhenNeeded(this);
+        ComboBox formatCombo = new ComboBox.ComboBoxFinder(getDriver()).withLabel("Format:").findWhenNeeded(copyPastePanel);
 
         WebElement getExpandedPanel()
         {

--- a/src/org/labkey/test/pages/ImportDataPage.java
+++ b/src/org/labkey/test/pages/ImportDataPage.java
@@ -42,12 +42,6 @@ public class ImportDataPage extends LabKeyPage<ImportDataPage.ElementCache>
     {
         super(driver);
     }
-//
-//    @Override
-//    protected void waitForPage()
-//    {
-//        shortWait().until(ExpectedConditions.visibilityOf(elementCache().uploadPanel));
-//    }
 
     public ImportDataPage setText(String text)
     {

--- a/src/org/labkey/test/pages/ImportDataPage.java
+++ b/src/org/labkey/test/pages/ImportDataPage.java
@@ -103,7 +103,7 @@ public class ImportDataPage extends LabKeyPage<ImportDataPage.ElementCache>
     public ImportDataPage submitExpectingErrorContaining(String partialError)
     {
         String actualError = submitExpectingError();
-        MatcherAssert.assertThat("Import error message.", partialError, CoreMatchers.containsString(actualError));
+        MatcherAssert.assertThat("Import error message.", actualError, CoreMatchers.containsString(partialError));
         return this;
     }
 

--- a/src/org/labkey/test/pages/ImportDataPage.java
+++ b/src/org/labkey/test/pages/ImportDataPage.java
@@ -24,6 +24,7 @@ import org.labkey.test.components.ext4.ComboBox;
 import org.labkey.test.util.Ext4Helper;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
 
@@ -32,9 +33,18 @@ import static org.labkey.test.components.ext4.Checkbox.Ext4Checkbox;
 
 public class ImportDataPage extends LabKeyPage<ImportDataPage.ElementCache>
 {
+
+    public static final String IMPORT_ERROR_SIGNAL = "importFailureSignal"; // See query/import.jsp
+
     public ImportDataPage(WebDriver driver)
     {
         super(driver);
+    }
+
+    @Override
+    protected void waitForPage()
+    {
+        shortWait().until(ExpectedConditions.visibilityOf(elementCache().uploadPanel));
     }
 
     public ImportDataPage setText(String text)
@@ -97,7 +107,8 @@ public class ImportDataPage extends LabKeyPage<ImportDataPage.ElementCache>
 
     public String submitExpectingError()
     {
-        elementCache().getSubmitButton().click();
+        doAndWaitForPageSignal(() -> elementCache().getSubmitButton().click(),
+                IMPORT_ERROR_SIGNAL);
         clearCache();
         return waitForErrors();
     }

--- a/src/org/labkey/test/pages/assay/DataImportPage.java
+++ b/src/org/labkey/test/pages/assay/DataImportPage.java
@@ -16,26 +16,19 @@
 package org.labkey.test.pages.assay;
 
 import org.labkey.test.Locator;
-import org.labkey.test.components.html.RadioButton;
 import org.labkey.test.pages.LabKeyPage;
-import org.labkey.test.selenium.LazyWebElement;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 
 import java.io.File;
 
-
-public class DataImportPage extends LabKeyPage<DataImportPage.Elements>
+/**
+ * Import page for test assay upload page (miniassay module)
+ */
+public class DataImportPage extends LabKeyPage
 {
     public DataImportPage(WebDriver driver)
     {
         super(driver);
-    }
-
-    public void insertTsvData(String data)
-    {
-        setFormElement(elementCache().inputTsvField, data);
-        clickButton("Submit");
     }
 
     public void uploadFile(File dataFile)
@@ -46,34 +39,9 @@ public class DataImportPage extends LabKeyPage<DataImportPage.Elements>
         waitForElement(Locator.linkWithText(dataFile.getName()));   // the link will be in a dataRegion below
     }
 
-    public File downloadTemplate()
-    {
-        return clickAndWaitForDownload(elementCache().downloadTemplateButton);
-    }
-
     public DataImportPage setField(String fieldId, String value)
     {
         setFormElement(Locator.id(fieldId), value);
         return this;
-    }
-
-    @Override
-    protected Elements newElementCache()
-    {
-        return new Elements();
-    }
-
-    public class Elements extends LabKeyPage.ElementCache
-    {
-
-        final RadioButton uploadFileButton = new RadioButton(
-                new LazyWebElement(Locator.radioButtonById("FileUpload"), this));
-        final WebElement inputTsvField = new LazyWebElement(Locator.xpath(".//textarea[@id='tsv3']"), this);
-
-        //final WebElement formatSelect = new LazyWebElement(Locator.xpath("//[]"))
-        final WebElement importByAltKeyCheckbox = new LazyWebElement(Locator.checkboxByName("importLookupByAlternateKey"), this);
-        final WebElement downloadTemplateButton = new LazyWebElement(Locator.lkButton("Download Template"), this);
-        final WebElement submitButton = new LazyWebElement(Locator.lkButton("Submit"), this);
-        final WebElement cancelButton = new LazyWebElement(Locator.lkButton("Cancel"), this);
     }
 }

--- a/src/org/labkey/test/tests/AliquotTest.java
+++ b/src/org/labkey/test/tests/AliquotTest.java
@@ -24,6 +24,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Specimen;
 import org.labkey.test.components.html.BootstrapMenu;
+import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.StudyHelper;
@@ -184,16 +185,18 @@ public class AliquotTest extends SpecimenBaseTest
         assertTextNotPresent("Complete");
 
         clickAndWait(Locator.linkWithText("Upload Specimen Ids"));
-        setFormElement(Locator.xpath("//textarea[@id='tsv3']"), ALIQUOT_TWO);     // add specimen
-        clickButton("Submit");    // Submit button
+        new ImportDataPage(getDriver())
+                .setText(ALIQUOT_TWO)
+                .submit();
         assertTextPresent(ALIQUOT_ONE, ALIQUOT_TWO);
         checkCheckbox(Locator.checkboxByTitle("Select/unselect row"));      // all individual item checkboxes have same name/title; should be first one
         clickButton("Remove Selected");
         assertTextNotPresent(ALIQUOT_ONE);
         assertTextPresent(ALIQUOT_TWO);
         clickAndWait(Locator.linkWithText("Upload Specimen Ids"));
-        setFormElement(Locator.xpath("//textarea[@id='tsv3']"), ALIQUOT_ONE);     // add specimen
-        clickButton("Submit");    // Submit button
+        new ImportDataPage(getDriver())
+                .setText(ALIQUOT_ONE)
+                .submit();
         assertTextPresent(ALIQUOT_ONE, ALIQUOT_TWO);
     }
 

--- a/src/org/labkey/test/tests/AuditLogTest.java
+++ b/src/org/labkey/test/tests/AuditLogTest.java
@@ -468,8 +468,9 @@ public class AuditLogTest extends BaseWebDriverTest
         if(null != tsvData)
         {
             _listHelper.goToList(listName);
-            _listHelper.clickImportData();
-            _listHelper.submitTsvData(tsvData);
+            _listHelper.clickImportData()
+                    .setText(tsvData)
+                    .submit();
         }
     }
 

--- a/src/org/labkey/test/tests/FacetedFilterCutoffTest.java
+++ b/src/org/labkey/test/tests/FacetedFilterCutoffTest.java
@@ -60,8 +60,9 @@ public class FacetedFilterCutoffTest extends BaseWebDriverTest
         ListHelper.ListColumn col2 = new ListHelper.ListColumn(AT_CUTOFF, AT_CUTOFF, ListHelper.ListColumnType.Integer, "");
         _listHelper.createList(getProjectName(), LIST_NAME, ListHelper.ListColumnType.AutoInteger, "Key", col1, col2);
         _listHelper.goToList(LIST_NAME);
-        _listHelper.clickImportData();
-        _listHelper.submitTsvData(getListData());
+        _listHelper.clickImportData()
+                .setText(getListData())
+                .submit();
     }
 
     @Before

--- a/src/org/labkey/test/tests/FieldValidatorTest.java
+++ b/src/org/labkey/test/tests/FieldValidatorTest.java
@@ -73,7 +73,7 @@ public class FieldValidatorTest extends BaseWebDriverTest
         _listHelper.goToList(LIST_NAME);
         ImportDataPage importDataPage = _listHelper.clickImportData();
         importDataPage.setText(TEST_DATA_FAIL);
-        importDataPage.submitExpectingError(SEX_ERROR_MSG);
+        importDataPage.submitExpectingErrorContaining(SEX_ERROR_MSG);
         assertTextPresent(ID_ERROR_MSG, AGE_ERROR_MSG);
 
         importDataPage.setText(TEST_DATA_PASS).submit();

--- a/src/org/labkey/test/tests/FieldValidatorTest.java
+++ b/src/org/labkey/test/tests/FieldValidatorTest.java
@@ -21,6 +21,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ListHelper;
@@ -70,12 +71,12 @@ public class FieldValidatorTest extends BaseWebDriverTest
 
         log("Test upload data");
         _listHelper.goToList(LIST_NAME);
-        _listHelper.clickImportData();
-        setFormElement(Locator.name("text"), TEST_DATA_FAIL);
-        _listHelper.submitImportTsv_error(SEX_ERROR_MSG);
+        ImportDataPage importDataPage = _listHelper.clickImportData();
+        importDataPage.setText(TEST_DATA_FAIL);
+        importDataPage.submitExpectingError(SEX_ERROR_MSG);
         assertTextPresent(ID_ERROR_MSG, AGE_ERROR_MSG);
 
-        _listHelper.submitTsvData(TEST_DATA_PASS);
+        importDataPage.setText(TEST_DATA_PASS).submit();
         assertTextPresent("Ted", "Alice", "Bob");
 
         // ID regex validation

--- a/src/org/labkey/test/tests/HTTPApiTest.java
+++ b/src/org/labkey/test/tests/HTTPApiTest.java
@@ -100,8 +100,9 @@ public class HTTPApiTest extends BaseWebDriverTest
         waitForText("Like");
 
         log("Upload data");
-        _listHelper.clickImportData();
-        _listHelper.submitTsvData(LIST_DATA);
+        _listHelper.clickImportData()
+                .setText(LIST_DATA)
+                .submit();
     }
 
     @Test

--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -501,8 +501,9 @@ public class LinkedSchemaTest extends BaseWebDriverTest
                 ListHelper.ListColumnType.String, "GlobalPid",
                 new ListHelper.ListColumn("Study", "Study", ListHelper.ListColumnType.String, "Study"));
         _listHelper.goToList(STUDY_LIST_NAME);
-        _listHelper.clickImportData();
-        _listHelper.submitTsvData(STUDY_LIST_DATA);
+        _listHelper.clickImportData()
+                .setText(STUDY_LIST_DATA)
+                .submit();
 
         log("Create the linked schema to the study.");
         String sourceContainerPath = "/" + getProjectName() + "/" + STUDY_FOLDER;
@@ -644,8 +645,9 @@ public class LinkedSchemaTest extends BaseWebDriverTest
         log("** Importing some data...");
         beginAt("/" + PROJECT_NAME + "/" + SOURCE_FOLDER + "/list-begin.view");
         _listHelper.goToList(LIST_NAME);
-        _listHelper.clickImportData();
-        _listHelper.submitTsvData(LIST_DATA);
+        _listHelper.clickImportData()
+                .setText(LIST_DATA)
+                .submit();
 
         log("** Applying metadata xml override to list...");
         beginAt("/query/" + PROJECT_NAME + "/" + SOURCE_FOLDER + "/sourceQuery.view?schemaName=lists&query.queryName=" + LIST_NAME + "#metadata");

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -1309,9 +1309,9 @@ public class SampleTypeTest extends BaseWebDriverTest
         String tsvString =
                 "Name\tKey\n" +
                 "2\t" + missingPk;
-        table.clickImportBulkData();
-        setFormElement(Locator.id("tsv3"), tsvString);
-        _listHelper.submitImportTsv_error("Value '" + missingPk + "' was not present in lookup target 'lists." + listName + "' for field '" + lookupColumnLabel + "'");
+        ImportDataPage importDataPage = table.clickImportBulkData();
+        importDataPage.setText(tsvString);
+        importDataPage.submitExpectingError("Value '" + missingPk + "' was not present in lookup target 'lists." + listName + "' for field '" + lookupColumnLabel + "'");
     }
 
     @Test

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -1066,8 +1066,9 @@ public class SimpleModuleTest extends BaseWebDriverTest
 
         log("Importing some data...");
         _listHelper.goToList(LIST_NAME);
-        _listHelper.clickImportData();
-        _listHelper.submitTsvData(LIST_DATA);
+        _listHelper.clickImportData()
+                .setText(LIST_DATA)
+                .submit();
 
         log("Create list in subfolder to prevent query validation failure");
         createPeopleListInFolder(FOLDER_NAME);

--- a/src/org/labkey/test/tests/SpecimenTest.java
+++ b/src/org/labkey/test/tests/SpecimenTest.java
@@ -30,6 +30,7 @@ import org.labkey.test.categories.Specimen;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.components.dumbster.EmailRecordTable;
 import org.labkey.test.components.html.BootstrapMenu;
+import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.study.specimen.ManageNotificationsPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
@@ -273,24 +274,21 @@ public class SpecimenTest extends SpecimenBaseTest
 
         clickAndWait(Locator.linkWithText("Upload Specimen Ids"));
 
-        waitForElement(Locator.id("tsv3"));
-        setFormElement(Locator.id("tsv3"), SPECIMEN_IDS[0]); // add specimen
-        clickButton("Submit");
+        new ImportDataPage(getDriver())
+                .setText(SPECIMEN_IDS[0])
+                .submit();
 
-        waitForElement(Locator.linkWithText("Upload Specimen Ids"));
-        clickAndWait(Locator.linkWithText("Upload Specimen Ids"));
+        waitAndClickAndWait(Locator.linkWithText("Upload Specimen Ids"));
 
-        waitForElement(Locator.id("tsv3"));
-        setFormElement(Locator.id("tsv3"), SPECIMEN_IDS[0]); // try to add again
-        clickButton("Submit", 0);
+        ImportDataPage importDataPage = new ImportDataPage(getDriver());
+        importDataPage.setText(SPECIMEN_IDS[0]);
+        importDataPage.submitExpectingError("Specimen " + SPECIMEN_IDS[0] + " is unavailable");
 
-        waitForText(20000, "Specimen " + SPECIMEN_IDS[0] + " is unavailable");
-        setFormElement(Locator.id("tsv3"), SPECIMEN_IDS[1]); // try to add one that doesn't exist
-        clickButton("Submit", 0);
+        importDataPage.setText(SPECIMEN_IDS[1]);
+        importDataPage.submitExpectingError( "Specimen " + SPECIMEN_IDS[1] + " is unavailable");
 
-        waitForText(20000, "Specimen " + SPECIMEN_IDS[1] + " is unavailable");
-        setFormElement(Locator.id("tsv3"),  "AAA07XK5-04\nAAA07XK5-06\nAAA07XSF-03"); // add different ones
-        clickButton("Submit");
+        importDataPage.setText("AAA07XK5-04\nAAA07XK5-06\nAAA07XSF-03"); // add different ones
+        importDataPage.submit();
     }
 
     @LogMethod (quiet = true)

--- a/src/org/labkey/test/tests/SpecimenTest.java
+++ b/src/org/labkey/test/tests/SpecimenTest.java
@@ -282,10 +282,10 @@ public class SpecimenTest extends SpecimenBaseTest
 
         ImportDataPage importDataPage = new ImportDataPage(getDriver());
         importDataPage.setText(SPECIMEN_IDS[0]);
-        importDataPage.submitExpectingError("Specimen " + SPECIMEN_IDS[0] + " is unavailable");
+        importDataPage.submitExpectingErrorContaining("Specimen " + SPECIMEN_IDS[0] + " is unavailable");
 
         importDataPage.setText(SPECIMEN_IDS[1]);
-        importDataPage.submitExpectingError( "Specimen " + SPECIMEN_IDS[1] + " is unavailable");
+        importDataPage.submitExpectingErrorContaining( "Specimen " + SPECIMEN_IDS[1] + " is unavailable");
 
         importDataPage.setText("AAA07XK5-04\nAAA07XK5-06\nAAA07XSF-03"); // add different ones
         importDataPage.submit();

--- a/src/org/labkey/test/tests/TimelineTest.java
+++ b/src/org/labkey/test/tests/TimelineTest.java
@@ -175,8 +175,7 @@ public class TimelineTest extends BaseWebDriverTest
         }
 
         _listHelper.goToList(LIST_NAME);
-        _listHelper.clickImportData();
-        _listHelper.submitTsvData(data.toString());
+        _listHelper.clickImportData().setText(data.toString()).submit();
         for (String[] rowData : TEST_DATA)
         {
             // check that all the data is in the grid (skipping the key column at index 0)

--- a/src/org/labkey/test/tests/TriggerScriptTest.java
+++ b/src/org/labkey/test/tests/TriggerScriptTest.java
@@ -282,7 +282,7 @@ public class TriggerScriptTest extends BaseWebDriverTest
 
         ImportDataPage importDataPage = new ImportDataPage(getDriver());
         importDataPage.setText(tsvData);
-        importDataPage.submitExpectingError(AFTER_INSERT_ERROR);
+        importDataPage.submitExpectingErrorContaining(AFTER_INSERT_ERROR);
 
         //Check BeforeInsert event
         step = "BeforeInsert";

--- a/src/org/labkey/test/tests/TriggerScriptTest.java
+++ b/src/org/labkey/test/tests/TriggerScriptTest.java
@@ -35,6 +35,7 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Data;
+import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.DataClassDefinition;
 import org.labkey.test.util.DataRegionTable;
@@ -279,17 +280,17 @@ public class TriggerScriptTest extends BaseWebDriverTest
         tsvData += caughtAfter.toDelimitedString(delimiter);
         tsvData += changedBefore.toDelimitedString(delimiter);
 
-        setFormElement(Locator.id("tsv3"), tsvData);
-        _listHelper.submitImportTsv_error(AFTER_INSERT_ERROR);
+        ImportDataPage importDataPage = new ImportDataPage(getDriver());
+        importDataPage.setText(tsvData);
+        importDataPage.submitExpectingError(AFTER_INSERT_ERROR);
 
         //Check BeforeInsert event
         step = "BeforeInsert";
         log("** " + testName + " " + step + " Event");
-        Locator.id("tsv3").findElement(getDriver()).clear();
         tsvData = EmployeeRecord.getTsvHeaders();
         tsvData += changedBefore.toDelimitedString(delimiter);
-        setFormElement(Locator.id("tsv3"), tsvData);
-        _listHelper.submitImportTsv_success();
+        importDataPage.setText(tsvData);
+        importDataPage.submit();
 
         assertElementPresent(Locator.tagWithText("td","Importing TSV"));
         cleanUpListRows();
@@ -388,7 +389,6 @@ public class TriggerScriptTest extends BaseWebDriverTest
 
     @Ignore("Issue 25741: JS triggers for bulk import data (CSV or Excel) of datasets don't fire\n")
     @Test
-    //TODO: enable this test when Issue 25741 is resolved
     public void testDatasetImportTriggers() throws Exception
     {
         String flagField = COMMENTS_FIELD; //Field to watch in trigger script
@@ -424,7 +424,9 @@ public class TriggerScriptTest extends BaseWebDriverTest
 
         goToDataset(DATASET_NAME);
         clickButton("Import Data");
-        setFormElement(Locator.id("tsv3"), tsvData);
+        new ImportDataPage(getDriver())
+                .setText(tsvData)
+                .submit();
     }
 
     @Test

--- a/src/org/labkey/test/tests/list/ListMissingValuesTest.java
+++ b/src/org/labkey/test/tests/list/ListMissingValuesTest.java
@@ -6,6 +6,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.tests.MissingValueIndicatorsTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ListHelper;
@@ -78,13 +79,12 @@ public class ListMissingValuesTest extends MissingValueIndicatorsTest
 
         log("Test upload list data with a combined data and MVI column");
         _listHelper.goToList(LIST_NAME);
-        _listHelper.clickImportData();
-        setFormElementJS(Locator.id("tsv3"), TEST_DATA_SINGLE_COLUMN_LIST_BAD);
-        _listHelper.submitImportTsv_error(null);
-        assertLabKeyErrorPresent();
+        ImportDataPage importDataPage = _listHelper.clickImportData();
+        importDataPage.setText(TEST_DATA_SINGLE_COLUMN_LIST_BAD);
+        importDataPage.submitExpectingError();
 
-        setFormElementJS(Locator.id("tsv3"), TEST_DATA_SINGLE_COLUMN_LIST);
-        _listHelper.submitImportTsv_success();
+        importDataPage.setText(TEST_DATA_SINGLE_COLUMN_LIST);
+        importDataPage.submit();
         validateSingleColumnData();
         testMvFiltering(List.of("age with space", "sex"));
 
@@ -102,13 +102,12 @@ public class ListMissingValuesTest extends MissingValueIndicatorsTest
         deleteListData();
 
         log("Test separate MVIndicator column");
-        DataRegion(getDriver()).find().clickImportBulkData();
-        setFormElementJS(Locator.id("tsv3"), TEST_DATA_TWO_COLUMN_LIST_BAD);
-        _listHelper.submitImportTsv_error(null);
-        assertLabKeyErrorPresent();
+        importDataPage = DataRegion(getDriver()).find().clickImportBulkData();
+        importDataPage.setText(TEST_DATA_TWO_COLUMN_LIST_BAD);
+        importDataPage.submitExpectingError();
 
-        setFormElementJS(Locator.id("tsv3"), TEST_DATA_TWO_COLUMN_LIST);
-        _listHelper.submitImportTsv_success();
+        importDataPage.setText(TEST_DATA_TWO_COLUMN_LIST);
+        importDataPage.submit();
         validateTwoColumnData("query", "name");
         testMvFiltering(List.of("age with space", "sex"));
     }

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -252,16 +252,16 @@ public class ListTest extends BaseWebDriverTest
 
         log("Test upload data");
         ImportDataPage importDataPage = _listHelper.clickImportData();
-        importDataPage.submitExpectingError("Form contains no data");
+        importDataPage.submitExpectingErrorContaining("Form contains no data");
 
         importDataPage.setText(TEST_FAIL);
-        importDataPage.submitExpectingError("No rows were inserted.");
+        importDataPage.submitExpectingErrorContaining("No rows were inserted.");
 
         importDataPage.setText(TEST_FAIL2);
-        importDataPage.submitExpectingError("Data does not contain required field: Color");
+        importDataPage.submitExpectingErrorContaining("Data does not contain required field: Color");
 
         importDataPage.setText(TEST_FAIL3);
-        importDataPage.submitExpectingError("Could not convert");
+        importDataPage.submitExpectingErrorContaining("Could not convert");
 
         importDataPage.setText(LIST_DATA);
         importDataPage.submit();

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -16,6 +16,8 @@
 
 package org.labkey.test.tests.list;
 
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -42,6 +44,7 @@ import org.labkey.test.components.domain.DomainFieldRow;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.ext4.Checkbox;
 import org.labkey.test.components.list.AdvancedListSettingsDialog;
+import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.LookupInfo;
@@ -227,9 +230,9 @@ public class ListTest extends BaseWebDriverTest
         table.checkAllOnPage();
         table.deleteSelectedRows();
         // load test data
-        _listHelper.clickImportData();
-        setFormElement(Locator.name("text"), LIST_DATA2);
-        submitImportTsv();
+        _listHelper.clickImportData()
+                .setText(LIST_DATA2)
+                .submit();
     }
 
     @LogMethod
@@ -248,19 +251,20 @@ public class ListTest extends BaseWebDriverTest
             .clickSave();
 
         log("Test upload data");
-        _listHelper.clickImportData();
-        submitImportTsv("Form contains no data");
+        ImportDataPage importDataPage = _listHelper.clickImportData();
+        importDataPage.submitExpectingError("Form contains no data");
 
-        setFormElement(Locator.id("tsv3"), TEST_FAIL);
-        submitImportTsv("No rows were inserted.");
+        importDataPage.setText(TEST_FAIL);
+        importDataPage.submitExpectingError("No rows were inserted.");
 
-        setFormElement(Locator.id("tsv3"), TEST_FAIL2);
-        submitImportTsv("Data does not contain required field: Color");
+        importDataPage.setText(TEST_FAIL2);
+        importDataPage.submitExpectingError("Data does not contain required field: Color");
 
-        setFormElement(Locator.id("tsv3"), TEST_FAIL3);
-        submitImportTsv("Could not convert");
-        setFormElement(Locator.id("tsv3"), LIST_DATA);
-        submitImportTsv();
+        importDataPage.setText(TEST_FAIL3);
+        importDataPage.submitExpectingError("Could not convert");
+
+        importDataPage.setText(LIST_DATA);
+        importDataPage.submit();
 
         log("Check upload worked correctly");
         assertTextPresent(
@@ -1403,18 +1407,6 @@ public class ListTest extends BaseWebDriverTest
         return sb.toString();
     }
 
-
-    void submitImportTsv(String error)
-    {
-        _listHelper.submitImportTsv_error(error);
-    }
-
-    void submitImportTsv()
-    {
-        _listHelper.submitImportTsv_success();
-    }
-
-
     void createList(String name, List<FieldDefinition> cols, String[][] data)
     {
         log("Add List -- " + name);
@@ -1427,14 +1419,19 @@ public class ListTest extends BaseWebDriverTest
 
     private void setListImportAsTestDataField(String data, String... expectedErrors)
     {
-        setFormElement(Locator.name("text"), data);
+        ImportDataPage importDataPage = new ImportDataPage(getDriver());
+        importDataPage.setText(data);
         if (expectedErrors.length == 0)
         {
-            submitImportTsv();
+            importDataPage.submit();
         }
         else
         {
-            _listHelper.submitImportTsv_errors(Arrays.asList(expectedErrors));
+            String errors = importDataPage.submitExpectingError();
+            for (String expectedError : expectedErrors)
+            {
+                MatcherAssert.assertThat("Import errors", errors, CoreMatchers.containsString(expectedError));
+            }
         }
 
     }

--- a/src/org/labkey/test/tests/study/StudyMissingValuesTest.java
+++ b/src/org/labkey/test/tests/study/StudyMissingValuesTest.java
@@ -10,6 +10,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.DatasetPropertiesPage;
+import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.tests.MissingValueIndicatorsTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
@@ -101,16 +102,17 @@ public class StudyMissingValuesTest extends MissingValueIndicatorsTest
 
         log("Import dataset data");
         clickAndWait(Locator.linkWithText(datasetName));
-        new DatasetPropertiesPage(getDriver())
+        ImportDataPage importDataPage = new DatasetPropertiesPage(getDriver())
                 .clickViewData()
                 .getDataRegion()
                 .clickImportBulkData();
 
-        setFormElementJS(Locator.id("tsv3"), TEST_DATA_SINGLE_COLUMN_DATASET_BAD);
-        _listHelper.submitImportTsv_error(null);
+        importDataPage.setText(TEST_DATA_SINGLE_COLUMN_DATASET_BAD)
+                .submitExpectingError();
 
-        setFormElementJS(Locator.id("tsv3"), TEST_DATA_SINGLE_COLUMN_DATASET);
-        _listHelper.submitImportTsv_success();
+        importDataPage.setText(TEST_DATA_SINGLE_COLUMN_DATASET)
+                .submit();
+
         validateSingleColumnData();
         testMvFiltering(List.of("Age with space", "Sex"));
 
@@ -129,12 +131,14 @@ public class StudyMissingValuesTest extends MissingValueIndicatorsTest
         deleteDatasetData(1);
 
         log("Import dataset data with two mv columns");
-        DataRegion(getDriver()).find().clickImportBulkData();
+        importDataPage = DataRegion(getDriver()).find().clickImportBulkData();
 
-        setFormElementJS(Locator.id("tsv3"), TEST_DATA_TWO_COLUMN_DATASET_BAD);
-        _listHelper.submitImportTsv_error("Value is not a valid missing value indicator: .Q");
+        importDataPage.setText(TEST_DATA_TWO_COLUMN_DATASET_BAD);
+        importDataPage.submitExpectingError("Value is not a valid missing value indicator: .Q");
 
-        _listHelper.submitTsvData(TEST_DATA_TWO_COLUMN_DATASET);
+        importDataPage.setText(TEST_DATA_TWO_COLUMN_DATASET);
+        importDataPage.submit();
+
         validateTwoColumnData("Dataset", "ParticipantId");
         testMvFiltering(List.of("Age with space", "Sex"));
 

--- a/src/org/labkey/test/tests/study/StudyMissingValuesTest.java
+++ b/src/org/labkey/test/tests/study/StudyMissingValuesTest.java
@@ -134,7 +134,7 @@ public class StudyMissingValuesTest extends MissingValueIndicatorsTest
         importDataPage = DataRegion(getDriver()).find().clickImportBulkData();
 
         importDataPage.setText(TEST_DATA_TWO_COLUMN_DATASET_BAD);
-        importDataPage.submitExpectingError("Value is not a valid missing value indicator: .Q");
+        importDataPage.submitExpectingErrorContaining("Value is not a valid missing value indicator: .Q");
 
         importDataPage.setText(TEST_DATA_TWO_COLUMN_DATASET);
         importDataPage.submit();


### PR DESCRIPTION
#### Rationale
We should use shared components to avoid maintaining Locators in multiple locations. `Locator.id("tsv3")` is referenced by numerous tests and helpers but that ID is not reliable; `ImportDataPage` knows how to find the field and should be used instead.
`ListHelper` is a relic of a time before we had page classes. There are several methods in it that overlap with the functionality of `ImportDataPage` so I've refactored some `ListHelper` uses to use the page class instead.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3353/files

#### Changes
* Remove references to `#tsv3` in various tests and helpers
* Clean up some more cruft in `ListHelper`
