### PR TITLE
Reconcile AttachmentCard and FileUploadField components

### DIFF
--- a/src/org/labkey/test/components/Component.java
+++ b/src/org/labkey/test/components/Component.java
@@ -242,10 +242,6 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
             return component;
         }
 
-        /**
-         * @deprecated Use {@link #findOptional(SearchContext)}
-         */
-        @Deprecated
         public C findOrNull(S context)
         {
             return findOptional(context).orElse(null);

--- a/src/org/labkey/test/components/WebDriverComponent.java
+++ b/src/org/labkey/test/components/WebDriverComponent.java
@@ -86,10 +86,6 @@ public abstract class WebDriverComponent<EC extends Component.ElementCache> exte
             return super.waitFor(getDriver());
         }
 
-        /**
-         * @deprecated Use {@link #findOptional()}
-         */
-        @Deprecated
         public C findOrNull()
         {
             return super.findOrNull(getDriver());

--- a/src/org/labkey/test/components/ui/files/AttachmentCard.java
+++ b/src/org/labkey/test/components/ui/files/AttachmentCard.java
@@ -42,7 +42,9 @@ public class AttachmentCard extends WebDriverComponent<AttachmentCard.ElementCac
 
     public String getFileName()
     {
-        return getComponentElement().getAttribute("title");
+        String title = getComponentElement().getAttribute("title");
+        String[] filePath = title.split("/");
+        return filePath[filePath.length - 1];
     }
 
     public String getSize()

--- a/src/org/labkey/test/components/ui/files/FileUploadField.java
+++ b/src/org/labkey/test/components/ui/files/FileUploadField.java
@@ -4,14 +4,14 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
-import org.labkey.test.components.react.MultiMenu;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
+import java.util.Optional;
 
-// AttachmentCard.tsx
-// TODO: reconcile with AttachmentCard.java
+// File upload field for 'DetailsTableEdit'. Interacts with several possible underlying components
 public class FileUploadField extends WebDriverComponent<FileUploadField.ElementCache>
 {
     final WebElement _el;
@@ -25,89 +25,32 @@ public class FileUploadField extends WebDriverComponent<FileUploadField.ElementC
 
     public FileUploadField setFile(File file)
     {
+        removeFile();
+        elementCache().fileInput.sendKeys(file.getAbsolutePath());
+        getWrapper().shortWait().until(ExpectedConditions.textToBe(elementCache().tempFileLoc, file.getName()));
+        return this;
+    }
+
+    public void removeFile()
+    {
         if (hasAttachedFile())
         {
-            removeFile();
+            if (elementCache().removeBtn.isDisplayed())
+            {
+                elementCache().removeBtn.click();
+            }
+            else
+            {
+                elementCache().getExistingAttachment().ifPresent(AttachmentCard::clickRemove);
+            }
+            WebDriverWrapper.waitFor(() -> !hasAttachedFile(),
+                    "the file was not removed", 2000);
         }
-        if (hasTempAttachedFile())
-        {
-            removeTempFile();
-        }
-        elementCache().fileInput.sendKeys(file.getAbsolutePath());
-        WebDriverWrapper.waitFor(()-> hasFile() && getAttachedFileName().equals(file.getName()),
-                "the file did not get attached", 4000);
-        return this;
-    }
-
-    public ImageFileViewDialog viewImgFile()
-    {
-        String filename = getAttachedFileName();
-        elementCache().fileContent.click();
-        return new ImageFileViewDialog(getDriver(), filename);
-    }
-
-    public File clickOnNonImgFile()
-    {
-        return getWrapper()
-                .doAndWaitForDownload(() -> elementCache().fileContent.click(), 1)[0];
-    }
-    
-    public FileUploadField removeFile(String fileNoun)
-    {
-        getActionMenu().doMenuAction("Remove " + fileNoun);
-        WebDriverWrapper.waitFor(()-> !hasAttachedFile(),
-                "the file was not removed", 2000);
-        return this;
-    }
-
-    public FileUploadField removeFile()
-    {
-        return removeFile("file");
-    }
-
-    public FileUploadField removeTempFile()
-    {
-        elementCache().removeBtn.click();
-        WebDriverWrapper.waitFor(()-> !hasAttachedFile(),
-                "the file was not removed", 2000);
-        return this;
-    }
-
-    public boolean hasFile()
-    {
-        return hasAttachedFile() || hasTempAttachedFile();
     }
 
     public boolean hasAttachedFile()
     {
-        return elementCache().fileNameLoc.existsIn(this);
-    }
-
-    public boolean hasTempAttachedFile()
-    {
-        return elementCache().tempFileLoc.existsIn(this);
-    }
-
-    public String getAttachedFileName()
-    {
-        if (hasFile())
-        {
-            return (hasAttachedFile() ? elementCache().fileNameLoc : elementCache().tempFileLoc)
-                    .waitForElement(this, 2000).getText();
-        }
-        else
-            return "";
-    }
-
-    public MultiMenu getActionMenu()
-    {
-        return elementCache().actionMenu;
-    }
-
-    public File download()
-    {
-        return getWrapper()
-                .doAndWaitForDownload(() -> getActionMenu().doMenuAction("Download"), 1)[0];
+        return !elementCache().fileInputLabel.isDisplayed();
     }
 
     @Override
@@ -132,57 +75,22 @@ public class FileUploadField extends WebDriverComponent<FileUploadField.ElementC
     protected class ElementCache extends Component<?>.ElementCache
     {
 
+        // Elements when no attachment is set
+        WebElement fileInputLabel = Locator.tagWithClass("label", "file-upload--compact-label")
+                .refindWhenNeeded(this);
         WebElement fileInput = Locator.tagWithClass("input", "file-upload--input")
-                .refindWhenNeeded(this).withTimeout(4000);
+                .refindWhenNeeded(this);
 
-        Locator menuBtnLoc = Locator.tagWithId("div", "attachment-card__menu");
-
-        Locator fileNameLoc = Locator.tagWithClass("div", "attachment-card__name");
-
+        // Elements for new attachment
         Locator tempFileLoc = Locator.tagWithClass("div", "attached-file--inline-container");
-
-        WebElement fileContent = Locator.tagWithClass("div", "attachment-card__content")
-                .refindWhenNeeded(this).withTimeout(4000);
-
-        WebElement menuBtn = menuBtnLoc
-                .refindWhenNeeded(this).withTimeout(4000);
-
         WebElement removeBtn = Locator.tagWithClass("span", "file-upload__remove--icon")
-                .refindWhenNeeded(this).withTimeout(4000);
+                .refindWhenNeeded(this);
 
-        MultiMenu actionMenu = new MultiMenu.MultiMenuFinder(getDriver()).withButtonId("attachment-card__menu").findWhenNeeded(this);
-    }
-
-
-    public static class FileUploadFieldFinder extends WebDriverComponent.WebDriverComponentFinder<FileUploadField, FileUploadFieldFinder>
-    {
-        private final Locator.XPathLocator _baseLocator = Locator.tag("tr");
-        private String _label = null;
-
-        public FileUploadFieldFinder(WebDriver driver)
+        // Component for existing attachment
+        Optional<AttachmentCard> getExistingAttachment()
         {
-            super(driver);
-        }
-
-        public FileUploadFieldFinder withLabel(String label)
-        {
-            _label = label;
-            return this;
-        }
-
-        @Override
-        protected FileUploadField construct(WebElement el, WebDriver driver)
-        {
-            return new FileUploadField(el, driver);
-        }
-
-        @Override
-        protected Locator locator()
-        {
-            if (_label != null)
-                return _baseLocator.withChild(Locator.tag("td").withChild(Locator.tagContainingText("span", _label)));
-            else
-                return _baseLocator;
+            return new AttachmentCard.FileAttachmentCardFinder(getDriver()).findOptional(this);
         }
     }
+
 }

--- a/src/org/labkey/test/components/ui/grids/DetailDataPanel.java
+++ b/src/org/labkey/test/components/ui/grids/DetailDataPanel.java
@@ -3,7 +3,7 @@ package org.labkey.test.components.ui.grids;
 import org.labkey.test.Locator;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
-import org.labkey.test.components.ui.files.FileUploadField;
+import org.labkey.test.components.ui.files.AttachmentCard;
 import org.labkey.test.components.ui.files.ImageFileViewDialog;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
@@ -123,30 +123,24 @@ public class DetailDataPanel extends WebDriverComponent<DetailDataPanel.ElementC
         return tables.get(0);
     }
 
-    public FileUploadField getFileField(String fieldCaption)
+    public AttachmentCard getFileField(String fieldCaption)
     {
-        return elementCache()
-                .fileField(fieldCaption)
-                .timeout(4000)
-                .find(getComponentElement());
+        return elementCache().fileField(fieldCaption);
     }
 
     public String getFileName(String fieldCaption)
     {
-        return getFileField(fieldCaption)
-                .getAttachedFileName();
+        return getFileField(fieldCaption).getFileName();
     }
 
     public boolean isFileFieldBlank(String fieldCaption)
     {
-        return !getFileField(fieldCaption)
-                .hasAttachedFile();
+        return getFileField(fieldCaption) == null;
     }
 
     public File downloadFileField(String fieldCaption)
     {
-        return getFileField(fieldCaption)
-                .download();
+        return getFileField(fieldCaption).clickDownload();
     }
 
     public ImageFileViewDialog viewImgFile(String fieldCaption)
@@ -181,10 +175,14 @@ public class DetailDataPanel extends WebDriverComponent<DetailDataPanel.ElementC
             return new DetailTable.DetailTableFinder(getDriver()).findAll(this);
         }
 
-        public FileUploadField.FileUploadFieldFinder fileField(String caption)
+        public WebElement findValueEl(String caption)
         {
-            return new FileUploadField.FileUploadFieldFinder(getDriver())
-                    .withLabel(caption);
+            return Locator.tagWithAttribute("td", "data-caption", caption).waitForElement(this, 4_000);
+        }
+
+        public AttachmentCard fileField(String caption)
+        {
+            return new AttachmentCard.FileAttachmentCardFinder(getDriver()).findOrNull(findValueEl(caption));
         }
     }
 

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -6,10 +6,10 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
-import org.labkey.test.components.react.FilteringReactSelect;
-import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
+import org.labkey.test.components.react.FilteringReactSelect;
+import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.components.ui.files.FileUploadField;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -65,7 +65,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     public boolean isFieldEditable(String fieldCaption)
     {
         // TODO Could put a check here to see if a field is loading then return false, or wait.
-        WebElement fieldValueElement = elementCache().fieldValue(fieldCaption).findElement(elementCache().editPanel);
+        WebElement fieldValueElement = elementCache().fieldValue(fieldCaption);
         return isEditableField(fieldValueElement);
     }
 
@@ -83,7 +83,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
      **/
     public String getReadOnlyField(String fieldCaption)
     {
-        WebElement fieldValueElement = elementCache().fieldValue(fieldCaption).findElement(elementCache().editPanel);
+        WebElement fieldValueElement = elementCache().fieldValue(fieldCaption);
         return fieldValueElement.findElement(By.xpath("./div/*")).getText();
     }
 
@@ -95,7 +95,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
      **/
     public String getTextField(String fieldCaption)
     {
-        WebElement fieldValueElement = elementCache().fieldValue(fieldCaption).findElement(elementCache().editPanel);
+        WebElement fieldValueElement = elementCache().fieldValue(fieldCaption);
         WebElement textElement = fieldValueElement.findElement(By.xpath("./div/div/*"));
         if(textElement.getTagName().equalsIgnoreCase("textarea"))
             return textElement.getText();
@@ -114,7 +114,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     {
         if(isFieldEditable(fieldCaption))
         {
-            WebElement fieldValueElement = elementCache().fieldValue(fieldCaption).findElement(getComponentElement());
+            WebElement fieldValueElement = elementCache().fieldValue(fieldCaption);
 
             WebElement editableElement = fieldValueElement.findElement(By.xpath("./div/div/*"));
             String elementType = editableElement.getTagName().toLowerCase().trim();
@@ -176,7 +176,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     public DetailTableEdit setBooleanField(String fieldCaption, boolean value)
     {
 
-        WebElement fieldValueElement = elementCache().fieldValue(fieldCaption).findElement(getComponentElement());
+        WebElement fieldValueElement = elementCache().fieldValue(fieldCaption);
         Assert.assertTrue(String.format("Field '%s' is not editable and cannot be set.", fieldCaption), isEditableField(fieldValueElement));
 
         // The text used in the field caption and the value of the name attribute in the checkbox don't always have the same case.
@@ -217,10 +217,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
 
     public FileUploadField getFileField(String fieldCaption)
     {
-        return elementCache()
-                .fileField(fieldCaption)
-                .timeout(4000)
-                .find(getComponentElement());
+        return elementCache().fileField(fieldCaption);
     }
 
     public DetailTableEdit setFileField(String fieldCaption, File file)
@@ -233,13 +230,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
 
     public DetailTableEdit removeFileField(String fieldCaption)
     {
-        return removeFileField(fieldCaption, "file");
-    }
-
-    public DetailTableEdit removeFileField(String fieldCaption, String fileNoun)
-    {
-        getFileField(fieldCaption)
-                .removeFile(fileNoun);
+        getFileField(fieldCaption).removeFile();
 
         return this;
     }
@@ -397,15 +388,14 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         public WebElement editPanel = Locator.tagWithClass("div", "detail__editing")
                 .findWhenNeeded(this);
 
-        public Locator fieldValue(String caption)
+        public WebElement fieldValue(String caption)
         {
-            return Locator.tagWithAttribute("td", "data-caption", caption);
+            return Locator.tagWithAttribute("td", "data-caption", caption).findElement(editPanel);
         }
 
-        public FileUploadField.FileUploadFieldFinder fileField(String caption)
+        public FileUploadField fileField(String caption)
         {
-            return new FileUploadField.FileUploadFieldFinder(getDriver())
-                    .withLabel(caption);
+            return new FileUploadField(fieldValue(caption), getDriver());
         }
 
         public Locator validationMsg = Locator.tagWithClass("span", "validation-message");

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -448,6 +448,7 @@ public class FieldDefinition extends PropertyDescriptor
         Sample("Sample", "int", "http://www.labkey.org/exp/xml#sample", new LookupInfo(null, "exp", "Materials")),
         Barcode("Unique ID", "string", "http://www.labkey.org/types#storageUniqueId", null),
         TextChoice("Text Choice", "string", "http://www.labkey.org/types#textChoice", null),
+        SMILES("SMILES", "string", "http://www.labkey.org/exp/xml#smiles", null),
         ;
 
         private final String _label; // the display value in the UI for this kind of field
@@ -491,7 +492,7 @@ public class FieldDefinition extends PropertyDescriptor
         LINEAR("Linear"),
         LOG("Log");
 
-        String _text;
+        private final String _text;
 
         ScaleType(String text)
         {
@@ -517,7 +518,7 @@ public class FieldDefinition extends PropertyDescriptor
         LAST_ENTERED("Last entered"),
         FIXED_NON_EDITABLE("Fixed value");
 
-        String _text;
+        private final String _text;
 
         DefaultType(String text)
         {

--- a/src/org/labkey/test/util/query/QueryApiHelper.java
+++ b/src/org/labkey/test/util/query/QueryApiHelper.java
@@ -14,6 +14,8 @@ import org.labkey.remoteapi.query.SaveRowsResponse;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.remoteapi.query.Sort;
+import org.labkey.remoteapi.query.TruncateTableCommand;
+import org.labkey.remoteapi.query.TruncateTableResponse;
 import org.labkey.remoteapi.query.UpdateRowsCommand;
 
 import java.io.IOException;
@@ -104,6 +106,16 @@ public class QueryApiHelper
         DeleteRowsCommand cmd = new DeleteRowsCommand(_schema, _query);
         cmd.setRows(rowsToDelete);
         return cmd.execute(_connection, _containerPath);
+    }
+
+    /**
+     * Delete all rows in table
+     * @return response object
+     */
+    public TruncateTableResponse truncateTable() throws IOException, CommandException
+    {
+        TruncateTableCommand truncateCommand = new TruncateTableCommand(_schema, _query);
+        return truncateCommand.execute(_connection, _containerPath);
     }
 
     public DomainResponse getDomain() throws IOException, CommandException


### PR DESCRIPTION
#### Rationale
`FileUploadField` wraps functionality for several components, including `AttachmentCard`. Some components were using `FileUploadField` where `AttachmentCard` would be more appropriate.
I've moved some `FileUploadField` functions that `AttachmentCard` was missing and updated `DetailDataPanel` to use `AttachmentCard`.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1322
* https://github.com/LabKey/sampleManagement/pull/961

#### Changes
* Reconcile `AttachmentCard` and `FileUploadField` components
* Un-deprecate `Component.findOrNull`
* Remove log-spam from `GridRow`
* Add `truncateTable` functionality to `QueryAPIHelper`
