### PR TITLE
Changes for grid header-menu interactions

### DIFF
--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -182,7 +182,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
 
         // scroll the header cell into view plus some extra vertical scroll to make sure the menu is visible
         getWrapper().scrollIntoView(headerCell);
-        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(headerCell));    //
+        getWrapper().scrollBy(0, 1); // First scroll fails sometimes
         getWrapper().scrollBy(0, 250);
 
         WebElement toggle = Locator.tagWithClass("span", "fa-chevron-circle-down")

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -92,8 +92,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
      */
     public T sortColumnAscending(String columnLabel)
     {
-        doAndWaitForUpdate(()->
-            sortColumn(columnLabel, SortDirection.ASC));
+        sortColumn(columnLabel, SortDirection.ASC);
         return getThis();
     }
 
@@ -104,8 +103,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
      */
     public T sortColumnDescending(String columnLabel)
     {
-        doAndWaitForUpdate(()->
-            sortColumn(columnLabel, SortDirection.DESC));
+        sortColumn(columnLabel, SortDirection.DESC);
         return getThis();
     }
 
@@ -183,12 +181,13 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
         WebElement headerCell = elementCache().getColumnHeaderCell(columnLabel);
 
         // scroll the header cell into view plus some extra vertical scroll to make sure the menu is visible
-        getWrapper().scrollIntoView(headerCell);
+        getWrapper().scrollIntoView(headerCell, true);
         getWrapper().scrollBy(0, 250);
 
-        Locator.tagWithClass("span", "fa-chevron-circle-down")
-                .findElement(headerCell)
-                .click();
+        WebElement toggle = Locator.tagWithClass("span", "fa-chevron-circle-down")
+                .findElement(headerCell);
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(toggle));
+        toggle.click();
 
         WebElement menuItem = Locator.css("li > a").containing(menuText).findElement(headerCell);
         waitFor(()-> menuItem.isDisplayed(), 1000);

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -181,7 +181,8 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
         WebElement headerCell = elementCache().getColumnHeaderCell(columnLabel);
 
         // scroll the header cell into view plus some extra vertical scroll to make sure the menu is visible
-        getWrapper().scrollIntoView(headerCell, true);
+        getWrapper().scrollIntoView(headerCell);
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(headerCell));    //
         getWrapper().scrollBy(0, 250);
 
         WebElement toggle = Locator.tagWithClass("span", "fa-chevron-circle-down")


### PR DESCRIPTION
#### Rationale
This works around a change in scroll behavior, perhaps(?) to bring the header cell into view when sorting on a column menu.  It also stops wrapping the column sort in a doAndWaitForUpdate() call when column sort already does that, to avoid having wait-within-a-wait situations.

This was found when investigating [BiologicsAssayQCTest.testUpdateQCStateFromRunDetailsPage](https://teamcity.labkey.org/viewLog.html?buildId=1829901&tab=buildResultsDiv&buildTypeId=LabKey_Trunk_Premium_GitExtraPostgres&branch_LabKey_Trunk_Premium=%3Cdefault%3E#testNameId6310373606914595483), which interacts with a table at the bottom of the screen (which needs to scroll into view) - and this showed two things:
1) the menu fly-up behavior for column header sort menus is weird- as in, the menu for the QC History Grid's Date column disappears or appears elsewhere (as in this image:) 
![image](https://user-images.githubusercontent.com/16809856/169906225-ecff0e16-810e-4388-9f8a-25d95a7fb38a.png)

The code in ResponsiveGrid.clickColumnMenuItem attempts to scroll the header cell into view, and then attempts to scroll by another 250px, but this does not happen reliably at regular run-time.  This means the menu toggle is clicked at a time where the header cell is at the bottom of the viewport, forcing the menu to fly up (and do whatever it is that it's doing in that screenshot above).

It turns out that using the scrollToTop argument in scrollIntoView() (which attempts to scroll the target element to the top of the viewport) does reliably bring the header cell up into the viewport enough to allow that menu to drop down.
The weird fly-up behavior may be a product or U/X issue worth its own investigation  

#### Related Pull Requests
n/a>

#### Changes
remove redundant doandWaitFor -> on a call to a method already doing and waiting for update
scroll more aggressively
