### PR TITLE
New Grid Filter UX Text Automation.

### DIFF
--- a/src/org/labkey/test/components/react/MultiMenu.java
+++ b/src/org/labkey/test/components/react/MultiMenu.java
@@ -192,7 +192,9 @@ public class MultiMenu extends BootstrapMenu
 
     public String getButtonText()
     {
-        return getComponentElement().getText();
+        return Locator.tagWithClass("button", "current-page-dropdown")
+                .findElement(getComponentElement())
+                .getText();
     }
 
     public static abstract class Locators

--- a/src/org/labkey/test/components/react/MultiMenu.java
+++ b/src/org/labkey/test/components/react/MultiMenu.java
@@ -192,9 +192,7 @@ public class MultiMenu extends BootstrapMenu
 
     public String getButtonText()
     {
-        return Locator.tagWithClass("button", "current-page-dropdown")
-                .findElement(getComponentElement())
-                .getText();
+        return getComponentElement().getText();
     }
 
     public static abstract class Locators

--- a/src/org/labkey/test/components/react/Tabs.java
+++ b/src/org/labkey/test/components/react/Tabs.java
@@ -91,7 +91,6 @@ public class Tabs extends WebDriverComponent<Tabs.ElementCache>
         final List<WebElement> tabs = new ArrayList<>();
         private final Locator.XPathLocator tabLoc = Locator.tag("a").withAttribute("role", "tab");
         final WebElement tabContent = Locator.xpath("./div").withClass("tab-content").findWhenNeeded(this);
-        final Map<String, WebElement> tabPanels = new HashMap<>();
 
         public ElementCache()
         {
@@ -129,23 +128,21 @@ public class Tabs extends WebDriverComponent<Tabs.ElementCache>
             return tabMap.get(tabText);
         }
 
+        // Tab panels can be updated and changed when flipping between tabs. Don't persist the panel element find it each time.
         WebElement findTabPanel(String tabText)
         {
-            if (!tabPanels.containsKey(tabText))
+            String panelId = findTab(tabText).getAttribute("aria-controls");
+            WebElement panelEl;
+            try
             {
-                String panelId = findTab(tabText).getAttribute("aria-controls");
-                WebElement panelEl;
-                try
-                {
-                    panelEl = Locator.id(panelId).findElement(tabContent);
-                }
-                catch (NoSuchElementException ex)
-                {
-                    throw new NoSuchElementException("Panel not found for tab : " + tabText, ex);
-                }
-                tabPanels.put(tabText, panelEl);
+                panelEl = Locator.id(panelId).findElement(tabContent);
             }
-            return tabPanels.get(tabText);
+            catch (NoSuchElementException ex)
+            {
+                throw new NoSuchElementException("Panel not found for tab : " + tabText, ex);
+            }
+
+            return panelEl;
         }
     }
 

--- a/src/org/labkey/test/components/react/Tabs.java
+++ b/src/org/labkey/test/components/react/Tabs.java
@@ -60,18 +60,22 @@ public class Tabs extends WebDriverComponent<Tabs.ElementCache>
 
     public WebElement selectTab(String tabText)
     {
+        elementCache().findTab(tabText).click();
         WebElement panel = findPanelForTab(tabText);
-        if (!panel.isDisplayed())
-        {
-            elementCache().findTab(tabText).click();
-            getWrapper().shortWait().until(ExpectedConditions.visibilityOf(panel));
-        }
+        getWrapper().shortWait().until(ExpectedConditions.visibilityOf(panel));
         return panel;
     }
 
     public boolean isTabSelected(String tabText)
     {
         return Boolean.valueOf(elementCache().findTab(tabText).getAttribute("aria-selected"));
+    }
+
+    public List<String> getTabText()
+    {
+        List<WebElement> tabs = elementCache().findAllTabs();
+        return tabs
+                .stream().map(WebElement::getText).toList();
     }
 
     @Override

--- a/src/org/labkey/test/components/ui/Pager.java
+++ b/src/org/labkey/test/components/ui/Pager.java
@@ -81,6 +81,20 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
         return size;
     }
 
+    /**
+     * Helper to see if the paging menu is visible.
+     * Basically this is to check issue 45451.
+     *
+     * @return True if the dropdown page menu is visible, false otherwise.
+     */
+    public boolean isPagingMenuVisible()
+    {
+        Locator dropMenuLocator = Locator.tagWithClass("ul", "dropdown-menu");
+        WebElement gridPanel = Locator.tagWithClass("div", "grid-panel__body").findElement(getDriver());
+        WebElement dropDownMenu = dropMenuLocator.findWhenNeeded(gridPanel);
+        return dropDownMenu.isDisplayed();
+    }
+
     public boolean hasPaginationControls()
     {
         return Locator.tagWithClass("div", "pagination-button-group")

--- a/src/org/labkey/test/components/ui/Pager.java
+++ b/src/org/labkey/test/components/ui/Pager.java
@@ -5,11 +5,10 @@
 package org.labkey.test.components.ui;
 
 import org.labkey.test.Locator;
-import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.UpdatingComponent;
 import org.labkey.test.components.WebDriverComponent;
-import org.labkey.test.components.react.DropdownButtonGroup;
+import org.labkey.test.components.react.MultiMenu;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -45,7 +44,8 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
     public Pager jumpToPage(String jumpTo)      // only works on GridPanel
     {
         _pagedComponent.doAndWaitForUpdate(()->
-                elementCache().jumpToDropdown.clickSubMenu(jumpTo));
+                elementCache().jumpToDropdown.clickSubMenu(false, jumpTo));
+
         return this;
     }
 
@@ -59,7 +59,7 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
         int currentPageSize = getPageSize();
         if(currentPageSize != Integer.parseInt(pageSize))
         {
-            _pagedComponent.doAndWaitForUpdate(() -> elementCache().jumpToDropdown.clickSubMenu(pageSize));
+            _pagedComponent.doAndWaitForUpdate(() -> elementCache().jumpToDropdown.clickSubMenu(false, pageSize));
         }
         return this;
     }
@@ -67,6 +67,12 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
     public int getPageSize()                // only works on GridPanel
     {
         return Integer.parseInt(elementCache().jumpToDropdown.getButtonText());
+    }
+
+    public boolean hasPaginationControls()
+    {
+        return Locator.tagWithClass("div", "pagination-button-group")
+                .findWhenNeeded(getComponentElement()).isDisplayed();
     }
 
     public Pager clickPrevious()
@@ -176,7 +182,7 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
 
     protected class ElementCache extends Component<?>.ElementCache
     {
-        DropdownButtonGroup jumpToDropdown = new DropdownButtonGroup.DropdownButtonGroupFinder(getDriver())
+        MultiMenu jumpToDropdown = new MultiMenu.MultiMenuFinder(getDriver())
                 .withButtonClass("current-page-dropdown").findWhenNeeded(this);
 
         final Locator.XPathLocator pagingCountsSpan = Locator.tagWithClass("span", "pagination-info");

--- a/src/org/labkey/test/components/ui/Pager.java
+++ b/src/org/labkey/test/components/ui/Pager.java
@@ -66,8 +66,19 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
 
     public int getPageSize()                // only works on GridPanel
     {
-        // TODO Fix This.
-        return Integer.parseInt(elementCache().jumpToDropdown.getButtonText());
+        // Changing the jumpToDropdown button from the deprecated DropdownButtonGroup class to a MultiMenu type has changed
+        // the way that various text from the control is gathered. Getting the current page size now requires that the dropdown
+        // be expanded and the selected page size found in the list.
+
+        elementCache().jumpToDropdown.expand();
+
+        // Find the selected li element in the page size list (//div[@class='grid-panel__button-bar']//ul[contains(@aria-labelledby,'current-page-drop')]//li[@class='active'])
+        WebElement activeLi = Locator.tagWithAttributeContaining("ul", "aria-labelledby", "current-page-drop").childTag("li").withAttribute("class", "active").findElement(this);
+
+        int size = Integer.parseInt(activeLi.getText());
+        elementCache().jumpToDropdown.collapse();
+
+        return size;
     }
 
     public boolean hasPaginationControls()
@@ -183,6 +194,7 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
 
     protected class ElementCache extends Component<?>.ElementCache
     {
+        // Was previously a DropdownButtonGroup type, which is a deprecated class.
         MultiMenu jumpToDropdown = new MultiMenu.MultiMenuFinder(getDriver())
                 .withButtonClass("current-page-dropdown").findWhenNeeded(this);
 

--- a/src/org/labkey/test/components/ui/Pager.java
+++ b/src/org/labkey/test/components/ui/Pager.java
@@ -51,7 +51,7 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
 
     public int getCurrentPage()                 // only works on GridPanel
     {
-        return Integer.parseInt(elementCache().jumpToDropdown.getButtonText());
+        return Integer.parseInt(elementCache().currentPageButton.getText());
     }
 
     public Pager selectPageSize(String pageSize)    // only works on GridPanel
@@ -66,6 +66,7 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
 
     public int getPageSize()                // only works on GridPanel
     {
+        // TODO Fix This.
         return Integer.parseInt(elementCache().jumpToDropdown.getButtonText());
     }
 
@@ -184,6 +185,8 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
     {
         MultiMenu jumpToDropdown = new MultiMenu.MultiMenuFinder(getDriver())
                 .withButtonClass("current-page-dropdown").findWhenNeeded(this);
+
+        WebElement currentPageButton = Locator.tagWithClass("button", "current-page-dropdown").refindWhenNeeded(this);
 
         final Locator.XPathLocator pagingCountsSpan = Locator.tagWithClass("span", "pagination-info");
 

--- a/src/org/labkey/test/components/ui/grids/GridBar.java
+++ b/src/org/labkey/test/components/ui/grids/GridBar.java
@@ -416,6 +416,9 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
 
     public GridBar searchFor(String searchStr)
     {
+
+        clearSearch();
+
         _queryGrid.doAndWaitForUpdate(()->
         {
             elementCache().searchBox.set(searchStr);
@@ -442,7 +445,7 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
         return elementCache().searchBox.get();
     }
 
-    public GridFilterModal getFilterDialog()
+    public GridFilterModal openFilterDialog()
     {
         clickButton("Filters");
         return new GridFilterModal(getDriver(), _queryGrid);

--- a/src/org/labkey/test/components/ui/grids/GridBar.java
+++ b/src/org/labkey/test/components/ui/grids/GridBar.java
@@ -433,6 +433,12 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
         return elementCache().searchBox.get();
     }
 
+    public GridFilterModal getFilterDialog()
+    {
+        clickButton("Filters");
+        return new GridFilterModal(getDriver(), _queryGrid);
+    }
+
     @Override
     protected ElementCache newElementCache()
     {

--- a/src/org/labkey/test/components/ui/grids/GridBar.java
+++ b/src/org/labkey/test/components/ui/grids/GridBar.java
@@ -416,15 +416,24 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
 
     public GridBar searchFor(String searchStr)
     {
-        elementCache().searchBox.set(searchStr);
-        elementCache().searchBox.getComponentElement().sendKeys(Keys.ENTER);
+        _queryGrid.doAndWaitForUpdate(()->
+        {
+            elementCache().searchBox.set(searchStr);
+            elementCache().searchBox.getComponentElement().sendKeys(Keys.ENTER);
+        });
         return this;
     }
 
     public GridBar clearSearch()
     {
-        elementCache().searchBox.set("");
-        elementCache().searchBox.getComponentElement().sendKeys(Keys.ENTER);
+        if(!elementCache().searchBox.get().isEmpty())
+        {
+            _queryGrid.doAndWaitForUpdate(()->
+            {
+                elementCache().searchBox.set("");
+                elementCache().searchBox.getComponentElement().sendKeys(Keys.ENTER);
+            });
+        }
         return this;
     }
 

--- a/src/org/labkey/test/components/ui/grids/GridFilterModal.java
+++ b/src/org/labkey/test/components/ui/grids/GridFilterModal.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Wraps 'labkey-ui-component' defined in <code>public/QueryModel/GridFilterModal.tsx</code>
@@ -55,6 +56,15 @@ public class GridFilterModal extends ModalDialog
         return getWrapper().getTexts(elementCache().findFieldOptions());
     }
 
+    public List<String> getFilteredFields()
+    {
+        List<WebElement> filteredElements = Locator.byClass("list-group-item").withChild(
+                Locator.tagWithClass("span", "filter-modal__field_dot"))
+                .findElements(elementCache().fieldsSelectionPanel);
+
+        return filteredElements.stream().map(WebElement::getText).collect(Collectors.toList());
+    }
+
     /**
      * Select the filter expression tab for the current field.
      * @return panel for configuring the filter expression
@@ -62,7 +72,7 @@ public class GridFilterModal extends ModalDialog
     public FilterExpressionPanel selectExpressionTab()
     {
         elementCache().filterTabs.selectTab("Filter");
-        return elementCache().filterExpressionPanel;
+        return elementCache().filterExpressionPanel();
     }
 
     /**
@@ -72,7 +82,33 @@ public class GridFilterModal extends ModalDialog
     public FilterFacetedPanel selectFacetTab()
     {
         elementCache().filterTabs.selectTab("Choose values");
-        return elementCache().filterFacetedPanel;
+        return elementCache().filterFacetedPanel();
+    }
+
+    /**
+     * Get the text of the tabs that are shown.
+     *
+     * @return List of the tabs.
+     */
+    public List<String> getTabText()
+    {
+        return elementCache().filterTabs.getTabText();
+    }
+
+    public String getActiveTab()
+    {
+        String activeTab = "";
+
+        for(String tabText : getTabText())
+        {
+            if(elementCache().filterTabs.isTabSelected(tabText))
+            {
+                activeTab = tabText;
+                break;
+            }
+        }
+
+        return activeTab;
     }
 
     /**
@@ -144,11 +180,14 @@ public class GridFilterModal extends ModalDialog
         protected final WebElement filterPanel = Locator.byClass("filter-modal__col_filter_exp")
                 .findWhenNeeded(this);
         protected final Tabs filterTabs = new Tabs.TabsFinder(getDriver()).refindWhenNeeded(filterPanel);
-        protected final FilterExpressionPanel filterExpressionPanel =
-                new FilterExpressionPanel.FilterExpressionPanelFinder(getDriver()).refindWhenNeeded(filterPanel);
-        protected final FilterFacetedPanel filterFacetedPanel =
-                new FilterFacetedPanel.FilterFacetedPanelFinder(getDriver()).refindWhenNeeded(filterPanel);
-
+        protected final FilterExpressionPanel filterExpressionPanel()
+        {
+            return new FilterExpressionPanel.FilterExpressionPanelFinder(getDriver()).findWhenNeeded(filterPanel);
+        }
+        protected final FilterFacetedPanel filterFacetedPanel()
+        {
+            return new FilterFacetedPanel.FilterFacetedPanelFinder(getDriver()).findWhenNeeded(filterPanel);
+        }
         protected final WebElement submitButton = Locator.css(".modal-footer .btn-success").findWhenNeeded(this);
         protected final WebElement errorAlert = Locator.css(".modal-body .alert-danger").findWhenNeeded(this);
     }

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -214,6 +214,11 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         return this;
     }
 
+    public boolean hasSelectAllButton()
+    {
+        return elementCache().selectAllBtnLoc.findWhenNeeded(this).isDisplayed();
+    }
+
     /**
      *  Selects all rows in the target domain, including those on other pages, if there are any
      */

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -214,6 +214,17 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         return this;
     }
 
+    public boolean hasRemoveAllButton()
+    {
+        return elementCache().removeAllFilters.isDisplayed();
+    }
+
+    public QueryGrid clickRemoveAllButton()
+    {
+        doAndWaitForUpdate(()->elementCache().removeAllFilters.click());
+        return this;
+    }
+
     public boolean hasSelectAllButton()
     {
         return elementCache().selectAllBtnLoc.findWhenNeeded(this).isDisplayed();
@@ -340,6 +351,8 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
             return new FilterStatusValue.FilterStatusValueFinder(getDriver()).findAll(filterStatusPanel)
                     .stream().filter(FilterStatusValue::isFilter).toList();
         }
+
+        final WebElement removeAllFilters = Locator.tagWithClass("a", "remove-all-filters").refindWhenNeeded(this);
     }
 
     public static class QueryGridFinder extends WebDriverComponentFinder<QueryGrid, QueryGridFinder>

--- a/src/org/labkey/test/components/ui/search/FilterFacetedPanel.java
+++ b/src/org/labkey/test/components/ui/search/FilterFacetedPanel.java
@@ -47,7 +47,7 @@ public class FilterFacetedPanel extends WebDriverComponent<FilterFacetedPanel.El
     }
 
     /**
-     * Check all of the specified options. Should retain any existing selections.
+     * Check all the specified options. Should retain any existing selections.
      * @param values values to select
      */
     public void checkValues(String... values)
@@ -59,7 +59,7 @@ public class FilterFacetedPanel extends WebDriverComponent<FilterFacetedPanel.El
     }
 
     /**
-     * Unheck all of the specified options. Other existing selections should be unchanged.
+     * Uncheck all the specified options. Other existing selections should be unchanged.
      * @param values values to deselect
      */
     public void uncheckValues(String... values)
@@ -112,7 +112,7 @@ public class FilterFacetedPanel extends WebDriverComponent<FilterFacetedPanel.El
         }
 
         protected final WebElement selectedItemsSection =
-                Locator.byClass("filter-faceted__tags-value").findWhenNeeded(this);
+                Locator.byClass("filter-faceted__tags-div").findWhenNeeded(this);
 
         protected List<String> getSelectedValues()
         {

--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -378,20 +378,6 @@ public class GridPanelTest extends BaseWebDriverTest
     }
 
     /**
-     * Helper to see if the paging menu is visible.
-     * Basically this is to check issue 45451.
-     *
-     * @return True if the dropdown page menu is visible, false otherwise.
-     */
-    public boolean isPagingMenuVisible()
-    {
-        Locator dropMenuLocator = Locator.tagWithClass("ul", "dropdown-menu");
-        WebElement gridPanel = Locator.tagWithClass("div", "grid-panel__body").findElement(getDriver());
-        WebElement dropDownMenu = dropMenuLocator.findWhenNeeded(gridPanel);
-        return dropDownMenu.isDisplayed();
-    }
-
-    /**
      * Validate that using the 'First Page' and 'Last Page' navigation works as expected.
      */
     @Test
@@ -415,7 +401,7 @@ public class GridPanelTest extends BaseWebDriverTest
         checker()
                 .withScreenshot("Last_Page_Dropdown_Menu_Visible")
                 .verifyFalse("After selecting 'Last Page' the dropdown menu is still visible, it should not be.",
-                        isPagingMenuVisible());
+                        grid.getGridBar().pager().isPagingMenuVisible());
 
         int expectedNumOfPages = FILTER_SAMPLE_TYPE_SIZE / DEFAULT_PAGE_SIZE;
         checker().verifyEquals("Page number not as expected.",
@@ -434,7 +420,7 @@ public class GridPanelTest extends BaseWebDriverTest
         grid.getGridBar().jumpToPage("First Page");
 
         checker().verifyFalse("After selecting 'First Page' the dropdown menu is still visible, it should not be.",
-                isPagingMenuVisible());
+                grid.getGridBar().pager().isPagingMenuVisible());
 
         checker().verifyEquals("Page number not as expected.",
                 1, grid.getGridBar().getCurrentPage());
@@ -492,7 +478,7 @@ public class GridPanelTest extends BaseWebDriverTest
         checker()
                 .withScreenshot("Larger_Page_Size_Dropdown_Menu_Visible")
                 .verifyFalse("After selecting a page size the dropdown menu is still visible, it should not be.",
-                        isPagingMenuVisible());
+                        grid.getGridBar().pager().isPagingMenuVisible());
 
         checker().verifyTrue("After resize there are no paging control, there should be.",
                 grid.getGridBar().pager().hasPaginationControls());
@@ -522,7 +508,7 @@ public class GridPanelTest extends BaseWebDriverTest
         checker()
                 .withScreenshot("Smaller_page_Size_Dropdown_Menu_Visible")
                 .verifyFalse("After selecting a page size the dropdown menu is still visible, it should not be.",
-                        isPagingMenuVisible());
+                        grid.getGridBar().pager().isPagingMenuVisible());
 
         checker().verifyTrue("After resetting there are no paging control, there should be.",
                 grid.getGridBar().pager().hasPaginationControls());

--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -1,363 +1,689 @@
 package org.labkey.test.tests.component;
 
-import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.ui.grids.GridFilterModal;
 import org.labkey.test.components.ui.grids.QueryGrid;
+import org.labkey.test.components.ui.search.FilterExpressionPanel;
 import org.labkey.test.pages.test.CoreComponentsTestPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
+import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.TestDataGenerator;
 import org.labkey.test.util.exp.SampleTypeAPIHelper;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
 
 @Category({Daily.class})
 public class GridPanelTest extends BaseWebDriverTest
 {
 
+    private static final String TEST_SCHEMA = "samples";
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+
+    private static final String SMALL_SAMPLE_TYPE = "Small_SampleType";
+    private static final int SMALL_SAMPLE_TYPE_SIZE = 10;
+
+    private static final String FILTER_SAMPLE_TYPE = "Filter_SampleType";
+    private static final int FILTER_SAMPLE_TYPE_SIZE = 300;
+    private static final String FILTER_SAMPLE_PREFIX = "FST-";
+    private static final String FILTER_STRING_COL = "Str";
+    private static final String FILTER_INT_COL = "Int";
+    private static final String FILTER_EXTEND_CHAR_COL = "\u0106\u00D8\u0139";
+
+    // Various values used to populate Str filed for records. Also used in filtering/searching.
+    private static final String EXTEND_RECORD_STRING = "\u01C5 \u01FC";
+    private static final String EXTEND_RECORD_OTHER_STRING = "Not an extended value.";
+
+    private static final String ONE_RECORD_STRING = "This will return one row.";
+
+    private static final String FIVE_RECORD_STRING = "This will return five rows.";
+
+    private static final String ONE_PAGE_STRING = "This will return one page of data.";
+
+    private static final String MULTI_PAGE_STRING = "This will return more than one page of data.";
+    private static final int MULTI_PAGE_COUNT = 3;
+
+    private static final int NUMBER_FOR_STRING = 1234;
+    private static final String NUMBER_STRING = String.format("This string has numbers %d in it.", NUMBER_FOR_STRING);
+
+    private static final String STARTS_WITH = "This will";
+    private static final String ENDS_WITH = "page of data.";
+
+    // Number of entries that have the NUMBER_STRING value.
+    private static final int NUMBER_STRING_COUNT = 16;
+
+    // Number of entries that will be an empty string.
+    private static final int EMPTY_STRING_COUNT = 12;
+
+    // Number of records that will have extended characters.
+    private static final int EXTEND_RECORD_COUNT = 10;
+
+    // Upper value to put into the Int column.
+    private static final int INT_MAX = 15;
+
     @BeforeClass
-    public static void setupProject()
+    public static void setupProject() throws IOException, CommandException
     {
         GridPanelTest init = (GridPanelTest) getCurrentTest();
 
         init.doSetup();
     }
 
-    private void doSetup()
+    private void doSetup() throws IOException, CommandException
     {
         _containerHelper.createProject(getProjectName(), null);
+
+        // Add the 'Sample Types' web part. It is easier when debugging etc...
+        PortalHelper portalHelper = new PortalHelper(this);
+        portalHelper.enterAdminMode();
+        portalHelper.addWebPart("Sample Types");
+        portalHelper.exitAdminMode();
+
+        createSmallSampleType();
+
+        createFilterSampleType();
     }
 
-    TestDataGenerator sampleSetDataGenerator;
-
-    @Test
-    public void testJumpToLastPage() throws IOException, CommandException
+    // Create a small sample type that has one page of data by default (used in paging testing).
+    // Don't care about the data in the rows so use random data.
+    private void createSmallSampleType() throws IOException, CommandException
     {
-        // create a sampleType domain to use in this case
-        SampleTypeDefinition props = new SampleTypeDefinition("grid_paging_samples").setFields(standardTestSampleFields());
-        sampleSetDataGenerator = SampleTypeAPIHelper.createEmptySampleType(getProjectName(), props);
-        sampleSetDataGenerator.generateRows(200);
+        SampleTypeDefinition props = new SampleTypeDefinition(SMALL_SAMPLE_TYPE).setFields(standardTestSampleFields());
+        TestDataGenerator sampleSetDataGenerator = SampleTypeAPIHelper.createEmptySampleType(getProjectName(), props);
+        sampleSetDataGenerator.generateRows(SMALL_SAMPLE_TYPE_SIZE);
+        sampleSetDataGenerator.insertRows();
+    }
+
+    // Create a larger sample type that can be used for paging and filtering/searching tests.
+    private void createFilterSampleType() throws IOException, CommandException
+    {
+        List<FieldDefinition> fields = new ArrayList<>();
+        fields.add(new FieldDefinition(FILTER_STRING_COL, FieldDefinition.ColumnType.String));
+        fields.add(new FieldDefinition(FILTER_INT_COL, FieldDefinition.ColumnType.Integer));
+        fields.add(new FieldDefinition(FILTER_EXTEND_CHAR_COL, FieldDefinition.ColumnType.String));
+
+        SampleTypeDefinition sampleTypeDefinition = new SampleTypeDefinition(FILTER_SAMPLE_TYPE).setFields(fields);
+
+        TestDataGenerator sampleSetDataGenerator = SampleTypeAPIHelper.createEmptySampleType(getProjectName(), sampleTypeDefinition);
+
+        List<String> allPossibleValues = getCombinations("DCBA", 0);
+        // Remove the empty string option.
+        allPossibleValues.remove(0);
+
+        int fiveRecordCount = 0;
+        int onePageCount = 0;
+        int multiPageCount = 0;
+        int emptyCount = 0;
+        int extendedCharCount = 0;
+        int stringWithNumCount = 0;
+
+        int sampleId = 1;
+        int intValue = 1;
+        int allPossibleIndex = 0;
+
+        // Sprinkle the values to be searched/filtered for throughout the sample type.
+        // Records with the different values could be clumped together but this makes it a little more interesting and
+        // is a bit more useful when testing selections based on search/filter results.
+        while (sampleId <= FILTER_SAMPLE_TYPE_SIZE)
+        {
+
+            String filterColValue;
+            String extColValue = EXTEND_RECORD_OTHER_STRING;
+
+            if(sampleId == FILTER_SAMPLE_TYPE_SIZE / 2)
+            {
+                // Add the single unique row:
+                filterColValue = ONE_RECORD_STRING;
+            }
+            else if(sampleId % 5 == 0 && fiveRecordCount < 5)
+            {
+                // Add a five row strings.
+                filterColValue = FIVE_RECORD_STRING;
+                fiveRecordCount++;
+            }
+            else if(sampleId % 3 == 0 && onePageCount < DEFAULT_PAGE_SIZE)
+            {
+                // Add a page string.
+                filterColValue = ONE_PAGE_STRING;
+                onePageCount++;
+            }
+            else if(sampleId % 2 == 0 && multiPageCount < DEFAULT_PAGE_SIZE * MULTI_PAGE_COUNT)
+            {
+                // Add a multi-page string.
+                filterColValue = MULTI_PAGE_STRING;
+                multiPageCount++;
+            }
+            else if(sampleId % 4 == 0 && emptyCount < EMPTY_STRING_COUNT)
+            {
+                // Add an empty string record.
+                filterColValue = "";
+                emptyCount++;
+            }
+            else if(sampleId % 7 == 0 && stringWithNumCount < NUMBER_STRING_COUNT)
+            {
+                // Add a number string record.
+                filterColValue = NUMBER_STRING;
+                stringWithNumCount++;
+            }
+            else
+            {
+                if(allPossibleIndex == allPossibleValues.size())
+                    allPossibleIndex = 0;
+
+                filterColValue = allPossibleValues.get(allPossibleIndex++);
+                if(extendedCharCount < EXTEND_RECORD_COUNT)
+                {
+                    extColValue = EXTEND_RECORD_STRING;
+                    extendedCharCount++;
+                }
+
+            }
+
+            if(intValue > INT_MAX)
+                intValue = 1;
+
+            sampleSetDataGenerator.addCustomRow(
+                    Map.of("Name", String.format("%s%d", FILTER_SAMPLE_PREFIX, sampleId++),
+                            FILTER_INT_COL, intValue++,
+                            FILTER_STRING_COL, filterColValue,
+                            FILTER_EXTEND_CHAR_COL, extColValue));
+
+        }
+
         sampleSetDataGenerator.insertRows();
 
-        CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getGridPanel("samples", "grid_paging_samples");
+    }
 
-        assertEquals(1, grid.getGridBar().pager().start());
-        assertEquals(20, grid.getGridBar().pager().end());
+    // Generate a list of string that has different combinations from the string value passed in.
+    // For example if values = 'ABC' this will return a list ['A', 'B', 'C', 'AB', 'AC', 'ABC', 'BC'].
+    // It treats 'BC' and 'CB' as equivalent and only one would be added.
+    private static List<String> getCombinations(String values, int index)
+    {
+        List<String> allCombinations = new ArrayList<>();
+        if(index == values.length()) {
+            allCombinations.add("");
+            return allCombinations;
+        }
+
+        allCombinations = getCombinations(values, index + 1);
+        List<String> newCombinations = new ArrayList<>();
+
+        for (String allCombination : allCombinations)
+        {
+            newCombinations.add(allCombination + values.charAt(index));
+        }
+
+        allCombinations.addAll(newCombinations);
+
+        return allCombinations;
+    }
+
+    public QueryGrid beforeTest(String sampleType)
+    {
+        QueryGrid grid = CoreComponentsTestPage.beginAt(this, getProjectName())
+                .getGridPanel(TEST_SCHEMA, sampleType);
+
+        // Selections can persist, clear them.
+        grid.clearAllSelections();
+
+        // Searches and filter values shouldn't persist, but clear them just to be safe.
+        grid.clearFilters();
+        grid.clearSearch();
+
+        return grid;
+    }
+
+    public boolean isPagingMenuVisible()
+    {
+        Locator dropMenuLocator = Locator.tagWithClass("ul", "dropdown-menu");
+        WebElement gridPanel = Locator.tagWithClass("div", "grid-panel__body").findElement(getDriver());
+        WebElement dropDownMenu = dropMenuLocator.refindWhenNeeded(gridPanel);
+        return dropDownMenu.isDisplayed();
+    }
+
+    /**
+     * Validate that using the 'First Page' and 'Last Page' navigation works as expected.
+     */
+    @Test
+    public void testFirstAndLastPageNavigation()
+    {
+
+        QueryGrid grid = beforeTest(FILTER_SAMPLE_TYPE);
+
+        log("Check default paging values.");
+        checker().verifyEquals("Start row number on first page not as expected.",
+                1, grid.getGridBar().pager().start());
+
+        checker().verifyEquals("Last row number on first page size not as expected.",
+                DEFAULT_PAGE_SIZE, grid.getGridBar().pager().end());
+
+        checker().screenShotIfNewError("Defaults_First_Page_Error");
+
+        log("Go to the last page.");
         grid.getGridBar().jumpToPage("Last Page");
-        assertEquals(10, grid.getGridBar().getCurrentPage());
-        assertEquals(181, grid.getGridBar().pager().start());
-        assertEquals(200, grid.getGridBar().pager().end());
 
+        checker()
+                .withScreenshot("Dropdown_Menu_Visible")
+                .verifyFalse("After selecting 'Last Page' the dropdown menu is still visible, it should not be.",
+                        isPagingMenuVisible());
+
+        int expectedNumOfPages = FILTER_SAMPLE_TYPE_SIZE / DEFAULT_PAGE_SIZE;
+        checker().verifyEquals("Page number not as expected.",
+                expectedNumOfPages, grid.getGridBar().getCurrentPage());
+
+        int expectedStart = (FILTER_SAMPLE_TYPE_SIZE - DEFAULT_PAGE_SIZE) + 1;
+        checker().verifyEquals("First row number on last page not as expected.",
+                expectedStart, grid.getGridBar().pager().start());
+
+        checker().verifyEquals("Last row number on last page size not as expected.",
+                FILTER_SAMPLE_TYPE_SIZE, grid.getGridBar().pager().end());
+
+        checker().screenShotIfNewError("Defaults_Last_Page_Error");
+
+        log("Go back to the first page.");
         grid.getGridBar().jumpToPage("First Page");
-        assertEquals(1, grid.getGridBar().getCurrentPage());
-        assertEquals(1, grid.getGridBar().pager().start());
-        assertEquals(20, grid.getGridBar().pager().end());
 
-    }
+        checker().verifyFalse("After selecting 'First Page' the dropdown menu is still visible, it should not be.",
+                isPagingMenuVisible());
 
-    @Test
-    public void testSelectPageSize() throws IOException, CommandException
-    {
-        // create a sampleType domain to use in this case
-        SampleTypeDefinition props = new SampleTypeDefinition("grid_page_size_samples").setFields(standardTestSampleFields());
-        sampleSetDataGenerator = SampleTypeAPIHelper.createEmptySampleType(getProjectName(), props);
-        sampleSetDataGenerator.generateRows(200);
-        sampleSetDataGenerator.insertRows();
+        checker().verifyEquals("Page number not as expected.",
+                1, grid.getGridBar().getCurrentPage());
+        checker().verifyEquals("Start sample count on first page not as expected.",
+                1, grid.getGridBar().pager().start());
+        checker().verifyEquals("Last sample count on first page size not as expected.",
+                DEFAULT_PAGE_SIZE, grid.getGridBar().pager().end());
 
-        CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getGridPanel("samples", "grid_page_size_samples");
-
-        // assume default page size is 20
-        assertEquals(1, grid.getGridBar().getCurrentPage());
-        assertEquals(1, grid.getGridBar().pager().start());
-        assertEquals(20, grid.getGridBar().pager().end());
-        assertEquals(200, grid.getGridBar().pager().total());
-
-        // now set page size to equal 100
-        grid.getGridBar().selectPageSize("100");
-
-        // check to see that the pager thinks it's all true
-        assertEquals(1, grid.getGridBar().getCurrentPage());
-        assertEquals(1, grid.getGridBar().pager().start());
-        assertEquals(100, grid.getGridBar().pager().end());
-        assertEquals(200, grid.getGridBar().pager().total());
-        // but don't take the pager's word for it, count the visible rows in the grid
-        assertEquals(100, grid.getRows().size());
-
-        // restore defaults
-        grid.getGridBar().selectPageSize("20");
-        assertEquals(1, grid.getGridBar().getCurrentPage());
-        assertEquals(1, grid.getGridBar().pager().start());
-        assertEquals(20, grid.getGridBar().pager().end());
-        assertEquals(200, grid.getGridBar().pager().total());
+        checker().screenShotIfNewError("First_Page_Error");
 
     }
 
     /**
-     * regression coverage for issue 39011
+     * <p>
+     *     Test that changing page size works as expected.
+     * </p>
+     * <p>
+     *     This test will:
+     *     <ul>
+     *         <li>Validate default page size is as expected.</li>
+     *         <li>Change page size to 100 and validate rows in grid update and pagination controls update as expected.</li>
+     *         <li>Reset to defaults and make sure everything is right with the world.</li>
+     *     </ul>
+     * </p>
      */
     @Test
-    public void testFilterSelections() throws IOException, CommandException
+    public void testSelectPageSize()
     {
-        // create a sampleType domain to use in this case
-        SampleTypeDefinition props = new SampleTypeDefinition("filtered_grid_selection_samples").setFields(standardTestSampleFields());
-        sampleSetDataGenerator = SampleTypeAPIHelper.createEmptySampleType(getProjectName(), props);
-        sampleSetDataGenerator.generateRows(100);
-        for (int i=0; i < 16; i++)  // add some rows with a description we can filter on
-        {
-            sampleSetDataGenerator.addCustomRow(
-                    Map.of("Name", sampleSetDataGenerator.randomString(25),
-                            "descColumn", "used to test issue 39011",
-                            "intColumn", i,
-                            "stringColumn", "filtered_x" + sampleSetDataGenerator.randomString(20)));
-        }
-        sampleSetDataGenerator.insertRows();
 
-        CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getGridPanel("samples", "filtered_grid_selection_samples");
+        QueryGrid grid = beforeTest(FILTER_SAMPLE_TYPE);
 
-        // confirm that selectAll is limited to just the records in a filtered set
-        grid.filterColumn("Desc Column", Filter.Operator.EQUAL, "used to test issue 39011");
+        log("Validate paging with defaults.");
+
+        checker().verifyEquals("Start page not as expected.",
+                1, grid.getGridBar().getCurrentPage());
+
+        checker().verifyEquals("Start sample count on first page not as expected.",
+                1, grid.getGridBar().pager().start());
+
+        checker().verifyEquals("Last sample count on first page size not as expected.",
+                DEFAULT_PAGE_SIZE, grid.getGridBar().pager().end());
+
+        checker().verifyEquals("Total sample count on first page size not as expected.",
+                FILTER_SAMPLE_TYPE_SIZE, grid.getGridBar().pager().total());
+
+        checker().screenShotIfNewError("Defaults_Error");
+
+        int newPageSize = 100;
+        log(String.format("Now set page size to %d.", newPageSize));
+
+        grid.getGridBar().selectPageSize(Integer.toString(newPageSize));
+
+        log("Check to see that the pager thinks it's all true.");
+
+        checker()
+                .withScreenshot("Dropdown_Menu_Visible")
+                .verifyFalse("After selecting a page size the dropdown menu is still visible, it should not be.",
+                        isPagingMenuVisible());
+
+        checker().verifyTrue("After resize there are no paging control, there should be.",
+                grid.getGridBar().pager().hasPaginationControls());
+
+        checker().verifyEquals("Start page, after page resize, not as expected.",
+                1, grid.getGridBar().getCurrentPage());
+
+        checker().verifyEquals("Start sample count on first page, after page resize, not as expected.",
+                1, grid.getGridBar().pager().start());
+
+        checker().verifyEquals("Last sample count on first page, after page resize, not as expected.",
+                newPageSize, grid.getGridBar().pager().end());
+
+        checker().verifyEquals("Total sample count on first page, after page resize, not as expected.",
+                FILTER_SAMPLE_TYPE_SIZE, grid.getGridBar().pager().total());
+
+        log("But don't take the pager's word for it, count the visible rows in the grid.");
+
+        checker().verifyEquals("Total sample rows on page, after page resize, not as expected.",
+                newPageSize, grid.getRows().size());
+
+        checker().screenShotIfNewError("Resize_Error");
+
+        log(String.format("Set page size back to the default size %d.", DEFAULT_PAGE_SIZE));
+        grid.getGridBar().selectPageSize(Integer.toString(DEFAULT_PAGE_SIZE));
+
+        checker()
+                .withScreenshot("Dropdown_Menu_Visible")
+                .verifyFalse("After selecting a page size the dropdown menu is still visible, it should not be.",
+                        isPagingMenuVisible());
+
+        checker().verifyTrue("After resetting there are no paging control, there should be.",
+                grid.getGridBar().pager().hasPaginationControls());
+
+        checker().verifyEquals("After reset, current page not as expected.",
+                1, grid.getGridBar().getCurrentPage());
+
+        checker().verifyEquals("After reset, first sample index not as expected.",
+                1, grid.getGridBar().pager().start());
+
+        checker().verifyEquals("After reset, last index on page not as expected.",
+                DEFAULT_PAGE_SIZE, grid.getGridBar().pager().end());
+
+        checker().verifyEquals("After reset, number of rows in grid not as expected.",
+                FILTER_SAMPLE_TYPE_SIZE, grid.getGridBar().pager().total());
+
+        checker().screenShotIfNewError("Reset_Error");
+
+    }
+
+    /**
+     * <p>
+     *     Validate that a single page of unfiltered data works as expected.
+     * </p>
+     * <p>
+     *     This test will:
+     *     <ul>
+     *         <li>Load a small sample type with 20 records.</li>
+     *         <li>Validate counts and pagination is not present.</li>
+     *         <li>The 'Select All' button is not present.</li>
+     *     </ul>
+     * </p>
+     */
+    @Test
+    public void testSinglePageOfData()
+    {
+        QueryGrid grid = beforeTest(SMALL_SAMPLE_TYPE);
+
+        String expectedText = String.format("1 - %d", SMALL_SAMPLE_TYPE_SIZE);
+        String actualText = grid.getGridBar().pager().summary();
+        checker().verifyEquals("Sample count not as expected.", expectedText, actualText);
+
+        checker().verifyFalse("There should be no paging control for a single page of data.",
+                grid.getGridBar().pager().hasPaginationControls());
+
+        checker().verifyFalse("There should be no 'Select All' button for a single page of data.",
+                grid.hasSelectAllButton());
+
         grid.selectAllRows();
-        grid.removeColumnFilter("Desc Column");
-        assertEquals(16, grid.getSelectedRows().size());
 
+        expectedText = String.format("%1$d of %1$d selected", SMALL_SAMPLE_TYPE_SIZE);
+        actualText = grid.getSelectionStatusCount();
+
+        checker().verifyEquals("Selected text count not as expected.",
+                expectedText, actualText);
+
+    }
+
+    /**
+     * <p>
+     *     Validate the 'Select All' button with filtered grid.
+     * </p>
+     * <p>
+     *     This test will:
+     *     <ul>
+     *         <li>Filter the grid to a result set that has several pages.</li>
+     *         <li>Use the 'Select All' button to select all results.</li>
+     *         <li>Remove the filter and verify that the selections have not changed.</li>
+     *     </ul>
+     * </p>
+     */
+    @Test
+    public void testSelectAllButtonWithFilteredResults()
+    {
+        QueryGrid grid = beforeTest(FILTER_SAMPLE_TYPE);
+
+        log("Validate that the 'Select All' button works as expected.");
+        grid.filterColumn(FILTER_STRING_COL, Filter.Operator.EQUAL, MULTI_PAGE_STRING);
+
+        checker().fatal()
+                .verifyTrue("The 'Select All' button is not present.", grid.hasSelectAllButton());
+
+        grid.selectAllRows();
+        grid.removeColumnFilter(FILTER_STRING_COL);
+        checker().withScreenshot("Select_All_Button_Error")
+                .verifyEquals("Indicated number of selected rows not as expected after filter removed.",
+                        String.format("%d of %d selected", MULTI_PAGE_COUNT * DEFAULT_PAGE_SIZE, FILTER_SAMPLE_TYPE_SIZE), grid.getSelectionStatusCount());
+
+        log("Test is done. Clear the selection.");
         grid.clearAllSelections();
-        assertEquals(0, grid.getSelectedRows().size());
 
-        // confirm that search behaves the same way as a filter does
-        grid.search("filtered_x");
+    }
+
+    /**
+     * <p>
+     *     Verify that selecting all on a page with a result set works as expected.
+     * </p>
+     * <p>
+     *     This test will:
+     *     <ul>
+     *         <li>Filter the grid to a result with multiple pages.</li>
+     *         <li>Use the check box at the top of the grid to select all samples in the current page.</li>
+     *         <li>Remove filter and validate that selections persist.</li>
+     *     </ul>
+     * </p>
+     */
+    @Test
+    public void testSelectAllOnPageWithFilteredResults()
+    {
+        QueryGrid grid = beforeTest(FILTER_SAMPLE_TYPE);
+
+        log("Validate the select all check box at the top of the gird works as expected.");
+        grid.filterColumn(FILTER_STRING_COL, Filter.Operator.EQUAL, MULTI_PAGE_STRING);
         grid.selectAllOnPage(true);
-        grid.clearSearch();
-        assertEquals(16, grid.getSelectedRows().size());
+        grid.removeColumnFilter(FILTER_STRING_COL);
+        checker().withScreenshot("Select_All_On_Page_Error")
+                .verifyEquals("Using check box at top of grid did not select the expected samples.",
+                        String.format("%d of %d selected", DEFAULT_PAGE_SIZE, FILTER_SAMPLE_TYPE_SIZE), grid.getSelectionStatusCount());
+
+        log("Finished. Clear the selection.");
+        grid.clearAllSelections();
 
     }
 
     /**
-     * Tests select-all behavior for a sampletype that does not involve paging.
-     * The component does not show the same set of controls if paging isn't necessary; this ensures that
-     * the test-compontent wrapper handles that pathway appropriately
+     * <p>
+     *     Test the interaction between the select all on the page option and the 'Select All' button. This covers issues 39011, 41171.
+     * </p>
+     * <p>
+     *     This test will:
+     *     <ul>
+     *         <li>Filter the grid to multi-page results.</li>
+     *         <li>First use the select all on the page option to select some rows.</li>
+     *         <li>Then use the 'Select All' button to all the filtered results.</li>
+     *         <li>Remove the filter and validate the selected rows persisted.</li>
+     *     </ul>
+     * </p>
      */
     @Test
-    public void testSelectAllOnSinglePageSet() throws IOException, CommandException
+    public void testSelectOnPageAndSelectAllButton()
     {
-        // create a sampleType domain to use in this case
-        SampleTypeDefinition props = new SampleTypeDefinition("tiny_sampleset").setFields(standardTestSampleFields());
-        sampleSetDataGenerator = SampleTypeAPIHelper.createEmptySampleType(getProjectName(), props);
-        sampleSetDataGenerator.generateRows(5);
-        for (int i=0; i < 5; i++)  // add some rows with a description we can filter on
-        {
-            sampleSetDataGenerator.addCustomRow(
-                    Map.of("Name", sampleSetDataGenerator.randomString(25),
-                            "descColumn", "used to test single-page filter selection",
-                            "intColumn", i,
-                            "stringColumn", "filtered_x" + sampleSetDataGenerator.randomString(20)));
-        }
-        sampleSetDataGenerator.insertRows();
+        QueryGrid grid = beforeTest(FILTER_SAMPLE_TYPE);
 
-        CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getGridPanel("samples", "tiny_sampleset");
+        log("Filter grid to multiple pages.");
+        grid.filterColumn(FILTER_STRING_COL, Filter.Operator.EQUAL, MULTI_PAGE_STRING);
 
-        grid.filterColumn("Desc Column", Filter.Operator.EQUAL, "used to test single-page filter selection");
-        grid.selectAllRows();
+        log("Use the check box to select all on the page.");
+        grid.selectAllOnPage(true);
+        checker().withScreenshot("Select_All_On_Page_Error")
+                .verifyEquals("Using check box at top of grid did not select the expected samples.",
+                        String.format("%d of %d selected", DEFAULT_PAGE_SIZE, MULTI_PAGE_COUNT * DEFAULT_PAGE_SIZE), grid.getSelectionStatusCount());
 
-        assertEquals("5 of 5 selected", grid.getSelectionStatusCount());
-
-    }
-
-    @Test
-    public void testFilterInMultiPageSelectionSet() throws IOException, CommandException
-    {
-        // create a sampleType domain to use in this case
-        SampleTypeDefinition props = new SampleTypeDefinition("filtered_grid_multipageselection_samples").setFields(standardTestSampleFields());
-        sampleSetDataGenerator = SampleTypeAPIHelper.createEmptySampleType(getProjectName(), props);
-        sampleSetDataGenerator.generateRows(60);
-        for (int i=0; i < 64; i++)  // add some rows with a description we can filter on
-        {
-            sampleSetDataGenerator.addCustomRow(
-                    Map.of("Name", sampleSetDataGenerator.randomString(25),
-                            "descColumn", "used to test issue 39011",
-                            "intColumn", i,
-                            "stringColumn", "filtered_x" + sampleSetDataGenerator.randomString(20)));
-        }
-        sampleSetDataGenerator.insertRows();
-
-        CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getGridPanel("samples", "filtered_grid_multipageselection_samples");
-
-        // confirm that selectAll is limited to just the records in a filtered set
-        grid.filterColumn("Desc Column", Filter.Operator.EQUAL, "used to test issue 39011");
-        grid.selectAllRows();
-        grid.removeColumnFilter("Desc Column");
-        assertEquals("64 of 124 selected", grid.getSelectionStatusCount());
-
-        grid.clearAllSelections();
-        assertEquals(0, grid.getSelectedRows().size());
-
-        // confirm that search behaves the same way as a filter does
-        grid.search("filtered_x");
-        grid.selectAllRows();
-        grid.clearSearch();
-        assertEquals("64 of 124 selected", grid.getSelectionStatusCount());
-
-    }
-
-    @Test
-    public void testEmptyNotEmptyFilter() throws IOException, CommandException
-    {
-        // create a sampleType domain to use in this case
-        SampleTypeDefinition props = new SampleTypeDefinition("empty_filter_test_set").setFields(standardTestSampleFields());
-        sampleSetDataGenerator = SampleTypeAPIHelper.createEmptySampleType(getProjectName(), props);
-        sampleSetDataGenerator.addDataSupplier("descColumn", () -> null);
-        sampleSetDataGenerator.generateRows(30);
-        for (int i=0; i < 5; i++)  // add some rows with a descColumn we can filter on
-        {
-            sampleSetDataGenerator.addCustomRow(
-                    Map.of("Name", sampleSetDataGenerator.randomString(6),
-                            "descColumn", "used to filter non-empty",
-                            "stringColumn", "filtered_x" + sampleSetDataGenerator.randomString(20)));
-        }
-        sampleSetDataGenerator.insertRows();
-
-        CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getGridPanel("samples", "empty_filter_test_set");
-
-        grid.filterColumn("Desc Column", Filter.Operator.ISBLANK, null);
-        assertEquals("1 - 20 of 30", grid.getGridBar().pager().summary());
-        grid.removeColumnFilter("Desc Column");
-
-        grid.filterColumn("String Column", Filter.Operator.CONTAINS,  "filtered_x");
-        assertEquals("1 - 5", grid.getGridBar().pager().summary());
-        grid.removeColumnFilter("String Column");
-
-        grid.filterColumn("String Column", Filter.Operator.DOES_NOT_CONTAIN, "filtered_x");
-        assertEquals("1 - 20 of 30", grid.getGridBar().pager().summary());
-        grid.removeColumnFilter("String Column");
-
-        grid.filterColumn("Sample Date", Filter.Operator.NONBLANK, null);
-        assertEquals("1 - 20 of 30", grid.getGridBar().pager().summary());
-        grid.removeColumnFilter("Sample Date");
-
-        grid.filterColumn("Sample Date", Filter.Operator.ISBLANK, null);
-        assertEquals("1 - 5", grid.getGridBar().pager().summary());
-        grid.removeColumnFilter("Sample Date");
-
-    }
-
-    @Test
-    public void testDeselectOnePageWhenAllAreSelected() throws IOException, CommandException
-    {
-        // create a sampleType domain to use in this case
-        SampleTypeDefinition props = new SampleTypeDefinition("deselect_one_page_set").setFields(standardTestSampleFields());
-        sampleSetDataGenerator = SampleTypeAPIHelper.createEmptySampleType(getProjectName(), props);
-        sampleSetDataGenerator.generateRows(35);
-        sampleSetDataGenerator.insertRows();
-
-        CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getGridPanel("samples", "deselect_one_page_set");
+        log("Use the 'Select All' button to select all of the filtered rows.");
+        checker().fatal()
+                .verifyTrue("The 'Select All' button is not present.", grid.hasSelectAllButton());
 
         grid.selectAllRows();
-        assertEquals("1 - 20 of 35", grid.getGridBar().pager().summary());
-        assertEquals("unexpected selection tally after select or filter action" +
-                "likely https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41171",
-                "35 of 35 selected", grid.getSelectionStatusCount());
+        checker().withScreenshot("Select_All_Button_With_Some_Selected_Error")
+                .verifyEquals("Indicated number of selected rows not as expected after filter removed.",
+                        String.format("%1$d of %1$d selected", MULTI_PAGE_COUNT * DEFAULT_PAGE_SIZE), grid.getSelectionStatusCount());
 
-        grid.getGridBar().jumpToPage("Last Page");
-        grid.selectAllOnPage(false); // uncheck the checkbox
-        assertEquals("20 of 35 selected", grid.getSelectionStatusCount());
+        log("Remove the filter and validate that the selections persisted.");
+        grid.removeColumnFilter(FILTER_STRING_COL);
 
-        grid.getGridBar().jumpToPage("First Page");
-        assertEquals("20 of 35 selected", grid.getSelectionStatusCount());
+        checker().withScreenshot("Select_After_Filter_Removed_Error")
+                .verifyEquals("Indicated number of selected rows not as expected after filter removed.",
+                        String.format("%d of %d selected", MULTI_PAGE_COUNT * DEFAULT_PAGE_SIZE, FILTER_SAMPLE_TYPE_SIZE), grid.getSelectionStatusCount());
 
-    }
+        log("Apply the filter again...");
+        grid.filterColumn(FILTER_STRING_COL, Filter.Operator.EQUAL, MULTI_PAGE_STRING);
 
-    @Test
-    public void testRemoveFilterWithSelections() throws IOException, CommandException
-    {
-        // create a sampleType domain to use in this case
-        SampleTypeDefinition props = new SampleTypeDefinition("remove_filters_with_selections_set").setFields(standardTestSampleFields());
-        sampleSetDataGenerator = SampleTypeAPIHelper.createEmptySampleType(getProjectName(), props);
-        sampleSetDataGenerator.generateRows(30);
-        for (int i=0; i < 5; i++)  // add some rows with a description we can filter on
-        {
-            sampleSetDataGenerator.addCustomRow(
-                    Map.of("Name", sampleSetDataGenerator.randomString(6),
-                            "stringColumn", "filtered_y" + sampleSetDataGenerator.randomString(20)));
-        }
-        sampleSetDataGenerator.insertRows();
+        checker().withScreenshot("Select_Filter_Reapplied_Error")
+                .verifyEquals("Indicated number of selected rows not as expected after filter was reapplied.",
+                        String.format("%1$d of %1$d selected", MULTI_PAGE_COUNT * DEFAULT_PAGE_SIZE), grid.getSelectionStatusCount());
 
-        CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getGridPanel("samples", "remove_filters_with_selections_set");
-
-        grid.filterColumn("Int Column", Filter.Operator.NONBLANK);
-
-        grid.selectAllRows();
-        assertEquals("1 - 20 of 30", grid.getGridBar().pager().summary());
-        assertEquals("30 of 30 selected", grid.getSelectionStatusCount());
-
-        grid.getGridBar().jumpToPage("Last Page");
-        grid.selectAllOnPage(false); // uncheck the checkbox
-        assertEquals("20 of 30 selected", grid.getSelectionStatusCount());
-
-        grid.getGridBar().jumpToPage("First Page");
-        assertEquals("20 of 30 selected", grid.getSelectionStatusCount());
-
-        grid.removeColumnFilter("Int Column");
-        assertEquals("20 of 35 selected", grid.getSelectionStatusCount());
-
-    }
-
-    @Test
-    public void testDeselectRecordsWithFilter() throws IOException, CommandException
-    {
-        // create a sampleType domain to use in this case
-        SampleTypeDefinition props = new SampleTypeDefinition("deselect_with_filter").setFields(standardTestSampleFields());
-        sampleSetDataGenerator = SampleTypeAPIHelper.createEmptySampleType(getProjectName(), props);
-        sampleSetDataGenerator.generateRows(30);
-        for (int i=0; i < 5; i++)  // add some rows with a description we can filter on
-        {
-            sampleSetDataGenerator.addCustomRow(
-                    Map.of("Name", sampleSetDataGenerator.randomString(6),
-                            "stringColumn", "filtered_y" + sampleSetDataGenerator.randomString(20)));
-        }
-        sampleSetDataGenerator.insertRows();
-
-        CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
-        QueryGrid grid = testPage.getGridPanel("samples", "deselect_with_filter");
-
-        grid.selectAllRows();
-        grid.filterColumn("String Column", Filter.Operator.DOES_NOT_CONTAIN, "filtered_y");
-
-        assertEquals("1 - 20 of 30", grid.getGridBar().pager().summary());
-        assertEquals("30 of 30 selected", grid.getSelectionStatusCount());
-
+        log("Unselect all of the rows on the first page.");
         grid.selectAllOnPage(false);
-        assertEquals("1 - 20 of 30", grid.getGridBar().pager().summary());
-        assertEquals("10 of 30 selected", grid.getSelectionStatusCount());
 
-        grid.removeColumnFilter("String Column");
-        assertEquals("1 - 20 of 35", grid.getGridBar().pager().summary());
-        assertEquals("https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41171",
-                "15 of 35 selected", grid.getSelectionStatusCount());
+        checker().withScreenshot("Select_Clear_Page_Error")
+                .verifyEquals("Indicated number of selected rows not as expected after first page cleared.",
+                        String.format("%d of %d selected", (MULTI_PAGE_COUNT * DEFAULT_PAGE_SIZE) - DEFAULT_PAGE_SIZE, MULTI_PAGE_COUNT * DEFAULT_PAGE_SIZE), grid.getSelectionStatusCount());
+
+        log("Remove the filter, and validate selection count.");
+        grid.removeColumnFilter(FILTER_STRING_COL);
+
+        checker().withScreenshot("Select_Remove_Page_Error")
+                .verifyEquals("Indicated number of selected rows not as expected after first page cleared and filter removed.",
+                        String.format("%d of %d selected", (MULTI_PAGE_COUNT * DEFAULT_PAGE_SIZE) - DEFAULT_PAGE_SIZE, FILTER_SAMPLE_TYPE_SIZE), grid.getSelectionStatusCount());
+
+        log("Clean up.");
+        grid.clearAllSelections();
 
     }
 
-    @After
-    public void afterTest() throws IOException, CommandException
+    /**
+     * Validate that filtering on 'Is Blank' and 'Is Not Blank' return the expected results.
+     */
+    @Test
+    public void testIsBlankAndIsNotBlankFilter()
     {
-        sampleSetDataGenerator.getQueryHelper(createDefaultConnection()).deleteDomain();
+        QueryGrid grid = beforeTest(FILTER_SAMPLE_TYPE);
+
+        log("Filter grid to only rows with blank entries.");
+        grid.filterColumn(FILTER_STRING_COL, Filter.Operator.ISBLANK);
+
+        String expectedCount = String.format("1 - %d", EMPTY_STRING_COUNT);
+
+        checker().withScreenshot("Is_Blank_Error")
+                .verifyEquals("Filtering for 'Is Blank' did not return expected number of rows.",
+                        expectedCount, grid.getGridBar().pager().summary());
+
+        grid.filterColumn(FILTER_STRING_COL, Filter.Operator.NONBLANK);
+
+        int notBlankCount = FILTER_SAMPLE_TYPE_SIZE - EMPTY_STRING_COUNT;
+
+        expectedCount = String.format("1 - %d of %d", DEFAULT_PAGE_SIZE, notBlankCount);
+
+        checker().withScreenshot("Is_Not_Blank_Error")
+                .verifyEquals("Filtering for 'Is Not Blank' did not return expected number of rows.",
+                        expectedCount, grid.getGridBar().pager().summary());
+
+        grid.removeColumnFilter(FILTER_STRING_COL);
+    }
+
+    /**
+     * Apply two filters to the Int column. Filter for values between a low and a high value.
+     */
+    @Test
+    public void testMultipleFiltersOnOneColumn()
+    {
+
+        QueryGrid grid = beforeTest(FILTER_SAMPLE_TYPE);
+
+        int low = INT_MAX - 3;
+        int high = INT_MAX;
+
+        log(String.format("Filter the '%s' for values greater than %d and less than or equal to %d.", FILTER_INT_COL, low, high));
+
+        grid.filterColumn(FILTER_INT_COL, Filter.Operator.GT, low, Filter.Operator.LTE, high);
+
+        checker().withScreenshot("Multiple_Filters_One_Column_Error")
+                .verifyEquals("Number of records returned for filter not as expected.",
+                        60, grid.getRecordCount());
+
+        grid.clearFilters();
+    }
+
+    /**
+     * Validate that if required fields are not set for filter the dialog shows an error.
+     */
+    @Test
+    public void testExpectedTabAndFilterError()
+    {
+
+        QueryGrid grid = beforeTest(FILTER_SAMPLE_TYPE);
+
+        GridFilterModal filterDialog = grid.getGridBar().getFilterDialog();
+
+        log(String.format("Filter on the '%s' filed. This should only provide a 'Filter' tab.", FILTER_INT_COL));
+
+        filterDialog.selectField(FILTER_INT_COL);
+
+        try
+        {
+            filterDialog.selectFacetTab();
+
+            checker().error(String.format("There should be no 'Fields' tab for the '%s' field.", FILTER_INT_COL));
+        }
+        catch (NoSuchElementException expectedError)
+        {
+            log("Looks like there is no 'Fields' tab. This is as expected.");
+        }
+
+        log("Select the 'Filter' tab but only provide one condition when two are expected.");
+
+        FilterExpressionPanel panel = filterDialog.selectExpressionTab();
+        panel.setFilters(
+                new FilterExpressionPanel.Expression(Filter.Operator.GT, 1),
+                new FilterExpressionPanel.Expression(Filter.Operator.LT, "")
+        );
+
+        String errorMsg = filterDialog.confirmExpectingError();
+
+        checker().verifyEquals("Expected error message not present.",
+                String.format("Missing filter values for: %s.", FILTER_INT_COL), errorMsg);
+
+        checker().screenShotIfNewError("Filter_Dialog_Error");
+
+        log("Cancel the dialog and validate that no filters applied.");
+
+        filterDialog.cancel();
+
+        checker().withScreenshot("Unexpected_Filter_Error")
+                .verifyTrue("It looks like there are filters applied after canceling out of the dialog.",
+                        grid.getFilterStatusValues(true).isEmpty());
+
     }
 
     protected List<FieldDefinition> standardTestSampleFields()

--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -1157,7 +1157,7 @@ public class GridPanelTest extends BaseWebDriverTest
 
         // Need to change the focus. After removing the first filter the mouse is in the same position which causes the
         // next pill to get the 'x' icon. This causes the next call to getFilterStatusValues to not recognize the pill as a filter.
-        Locator.tagWithClass("div", "grid-panel__title").findElement(getDriver()).click();
+        Locator.tagWithClass("input", "grid-panel__search-input").findElement(getDriver()).click();
 
         FilterStatusValue filterPill = grid.getFilterStatusValues(false).get(0);
 

--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -79,6 +79,7 @@ public class GridPanelTest extends BaseWebDriverTest
     private static final String VIEW_DEFAULT = "Default";
     private static final String VIEW_EXTRA_COLUMNS = "Extra_Columns";
     private static final String VIEW_FEWER_COLUMNS = "Fewer_Columns";
+    private static final String VIEW_FILTERED_COLUMN = "Filtered_Column";
     private static final List<String> extraColumnsNames = Arrays.asList("IsAliquot", "GenId"); // Special case for adding the columns to the view and calling getRows api.
     private static final List<String> extraColumnsHeaders = Arrays.asList("Is Aliquot", "Gen Id"); // The column headers as they appear in the UI and exported file.
     private static final List<String> removedColumns = Arrays.asList(FILTER_BOOL_COL);
@@ -204,6 +205,11 @@ public class GridPanelTest extends BaseWebDriverTest
             cv.removeColumn(columnName);
         }
         cv.saveCustomView(VIEW_FEWER_COLUMNS);
+
+        log(String.format("Finally create a view named '%s' for '%s' that only has a filter.", VIEW_FILTERED_COLUMN, SMALL_SAMPLE_TYPE));
+        drtSamples.setFilter(FILTER_STRING_COL, "Contains One Of (example usage: a;b;c)", String.format("%1$s;%1$s%2$s", stringSetMembers.get(0), stringSetMembers.get(1)));
+        cv = drtSamples.openCustomizeGrid();
+        cv.saveCustomView(VIEW_FILTERED_COLUMN);
 
         goToProjectHome();
 
@@ -774,7 +780,7 @@ public class GridPanelTest extends BaseWebDriverTest
 
         QueryGrid grid = beforeTest(FILTER_SAMPLE_TYPE);
 
-        GridFilterModal filterDialog = grid.getGridBar().getFilterDialog();
+        GridFilterModal filterDialog = grid.getGridBar().openFilterDialog();
 
         log(String.format("Filter on the '%s' field. This should only provide a 'Filter' tab.", FILTER_INT_COL));
 
@@ -828,7 +834,7 @@ public class GridPanelTest extends BaseWebDriverTest
 
         QueryGrid grid = beforeTest(FILTER_SAMPLE_TYPE);
 
-        GridFilterModal filterDialog = grid.getGridBar().getFilterDialog();
+        GridFilterModal filterDialog = grid.getGridBar().openFilterDialog();
 
         log(String.format("Select '%s' and get the list of values for the field before filtering.", FILTER_STRING_COL));
 
@@ -864,7 +870,7 @@ public class GridPanelTest extends BaseWebDriverTest
         filterDialog.confirm();
 
         log(String.format("Open the dialog again and validate that the list of values to select from for '%s' is reduced.", FILTER_STRING_COL));
-        filterDialog = grid.getGridBar().getFilterDialog();
+        filterDialog = grid.getGridBar().openFilterDialog();
 
         filterDialog.selectField(FILTER_STRING_COL);
 
@@ -889,7 +895,7 @@ public class GridPanelTest extends BaseWebDriverTest
 
         log("Validate that applying a filter for a fields checks the values in the dialog.");
 
-        filterDialog = grid.getGridBar().getFilterDialog();
+        filterDialog = grid.getGridBar().openFilterDialog();
         filterDialog.selectField(FILTER_STRING_COL);
 
         String firstFilterValue = stringSets.get(0);
@@ -974,7 +980,7 @@ public class GridPanelTest extends BaseWebDriverTest
         int low = 4;
         int high = INT_MAX - 3;
 
-        GridFilterModal filterDialog = grid.getGridBar().getFilterDialog();
+        GridFilterModal filterDialog = grid.getGridBar().openFilterDialog();
 
         filterDialog.selectField(FILTER_INT_COL);
 
@@ -1067,7 +1073,7 @@ public class GridPanelTest extends BaseWebDriverTest
         int high = INT_MAX - 3;
         int low = 3;
 
-        GridFilterModal filterDialog = grid.getGridBar().getFilterDialog();
+        GridFilterModal filterDialog = grid.getGridBar().openFilterDialog();
 
         filterDialog.selectField(FILTER_INT_COL);
 
@@ -1245,7 +1251,7 @@ public class GridPanelTest extends BaseWebDriverTest
 
         grid.getGridBar().clearSearch();
 
-        GridFilterModal filterDialog = grid.getGridBar().getFilterDialog();
+        GridFilterModal filterDialog = grid.getGridBar().openFilterDialog();
 
         filterDialog.selectField(FILTER_STRING_COL);
 
@@ -1343,7 +1349,7 @@ public class GridPanelTest extends BaseWebDriverTest
 
         log(String.format("Filter the '%s' column for value '%s'.", FILTER_EXTEND_CHAR_COL, EXTEND_RECORD_STRING));
 
-        GridFilterModal filterDialog = grid.getGridBar().getFilterDialog();
+        GridFilterModal filterDialog = grid.getGridBar().openFilterDialog();
 
         filterDialog.selectField(FILTER_EXTEND_CHAR_COL);
 
@@ -1450,6 +1456,13 @@ public class GridPanelTest extends BaseWebDriverTest
      *                 <li>Verify that the removed field is not shown in the dialog.</li>
      *             </ul>
      *         </li>
+     *         <li>
+     *             Verify filter dialog with a custom view that is only a filter.
+     *             <ul>
+     *                 <li>Verify that the filed filtered by the view does not show as filtered in the dialog.</li>
+     *                 <li>Verify that the values to choose from are limited to the values filtered by the view.</li>
+     *             </ul>
+     *         </li>
      *     </ul>
      * </p>
      * @throws IOException Can be thrown by the call to getRows.
@@ -1465,7 +1478,7 @@ public class GridPanelTest extends BaseWebDriverTest
 
         grid.selectView(VIEW_EXTRA_COLUMNS);
 
-        GridFilterModal filterDialog = grid.getGridBar().getFilterDialog();
+        GridFilterModal filterDialog = grid.getGridBar().openFilterDialog();
 
         List<String> actualList = filterDialog.getAvailableFields();
 
@@ -1489,7 +1502,7 @@ public class GridPanelTest extends BaseWebDriverTest
         expectedList.removeAll(extraColumnsHeaders);
         expectedList.removeAll(removedColumns);
 
-        filterDialog = grid.getGridBar().getFilterDialog();
+        filterDialog = grid.getGridBar().openFilterDialog();
         actualList = filterDialog.getAvailableFields();
 
         checker().verifyTrue(String.format("The fields listed in the dialog are not as expected. Expected '%s'.", expectedList),
@@ -1524,7 +1537,7 @@ public class GridPanelTest extends BaseWebDriverTest
 
         log("Validate the removed, but filtered column, does not appear in the dialog.");
 
-        filterDialog = grid.getGridBar().getFilterDialog();
+        filterDialog = grid.getGridBar().openFilterDialog();
 
         actualList = filterDialog.getFilteredFields();
 
@@ -1594,7 +1607,7 @@ public class GridPanelTest extends BaseWebDriverTest
         expectedList.add(FILTER_BOOL_COL);
         expectedList.add(FILTER_DATE_COL);
 
-        filterDialog = grid.getGridBar().getFilterDialog();
+        filterDialog = grid.getGridBar().openFilterDialog();
 
         actualList = filterDialog.getAvailableFields();
 
@@ -1613,6 +1626,37 @@ public class GridPanelTest extends BaseWebDriverTest
         checker().screenShotIfNewError("View_Filter_With_Extra_Error");
 
         filterDialog.cancel();
+
+        log("One more check: Select the view that is only a filter.");
+        grid.clearFilters();
+        grid.selectView(VIEW_FILTERED_COLUMN);
+
+        log("Open the filter dialog.");
+        filterDialog = grid.getGridBar().openFilterDialog();
+
+        log("Make sure no fields are shown as filtered.");
+        actualList = filterDialog.getFilteredFields();
+
+        checker().verifyTrue(String.format("The fields '%s' are shown as being filtered. They should not be.", actualList),
+                actualList.isEmpty());
+
+        log("Make sure the values to filter for are as expected.");
+        filterDialog.selectField(FILTER_STRING_COL);
+        actualList = filterDialog.selectFacetTab().getAvailableValues();
+
+        // Going to hard code the expected values rather try and be clever and figure them out.
+        expectedList = new ArrayList<>(Arrays.asList(ALL_OPTION, "A", "AB", "ABC", "ABCD", "ABD", "AC", "ACD", "AD"));
+
+        Collections.sort(expectedList);
+        Collections.sort(actualList);
+
+        checker().verifyEquals("Values to choose from should only include those values filtered by the custom view.",
+                expectedList, actualList);
+
+        checker().screenShotIfNewError("View_With_Filter_Error");
+
+        filterDialog.cancel();
+
     }
 
     /**

--- a/src/org/labkey/test/util/DeferredErrorCollector.java
+++ b/src/org/labkey/test/util/DeferredErrorCollector.java
@@ -5,9 +5,11 @@ import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
+import org.labkey.junit.LabKeyAssert;
 import org.labkey.test.BaseWebDriverTest;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -228,6 +230,20 @@ public class DeferredErrorCollector
     public final boolean verifyNotEquals(String message, Object unexpected, Object actual)
     {
         return wrapAssertion(() -> Assert.assertNotEquals(message, unexpected, actual));
+    }
+
+    /**
+     * Sort the collections before checking to for equal. If not equal record an error message.
+     *
+     * @param message Message to show if check fails.
+     * @param expected The expected collection of objects.
+     * @param actual Actual collection of objects.
+     * @see LabKeyAssert#assertEqualsSorted(String, Collection, Collection)
+     * @return <code>true</code> if sorted collections are not equal
+     */
+    public final <T> boolean verifyEqualsSorted(String message, Collection<T> expected, Collection<T> actual)
+    {
+        return wrapAssertion(() -> LabKeyAssert.assertEqualsSorted(message, expected, actual));
     }
 
     /**


### PR DESCRIPTION
#### Rationale
This updates the test cases in GridPan

<img width="901" alt="Screen Shot 2022-05-23 at 9 14 27 PM" src="https://user-images.githubusercontent.com/12738200/169947617-f43ab7f6-6f95-45d2-bfbd-10c289ecb309.png">
elTest to test more functionality in the new grid filter dialog.

<img width="901" alt="Screen Shot 2022-05-23 at 9 14 40 PM" src="https://user-images.githubusercontent.com/12738200/169947627-bc42db59-77c8-4058-a65e-880699f8dd53.png">

The [New Grid Filter UX spec](https://docs.google.com/document/d/1PyPw34qpInoicg-hDx0Qzw19PmTrTi6A2s-c2FwMhAI/edit#) identified several test scenarios the needed to be covered. In addition several other tests were added as well to cover other gaps. As a result there are a lot of changes to the GridPanelTest, and it might be easier to view the file as if it were a new file and not as a diff. One of the biggest changes to the test was to use a shared sample type. Previously each test was creating its own sample type, populating and then deleting it at the end of the test. Several of the  older tests were consolidated into other tests.

For the most part only minor changes were made to the test components. Most of the changes involve how to access the filter dialog (e.g. clicking a filter 'pill' above the grid now returns the dialog). Other changes involved fixes to test components.

#### Related Pull Requests
* TBD

#### Changes
* Updated and consolidate tests in GridPanelTest.
* Removed calls to deprecated methods from GridPanelTest.
* Updated Pager component to use MultiMenu (removed references to deprecated DropDownButtonGroup)