### PR TITLE
Fix FileContentUploadTest.testFileBrowser

### DIFF
--- a/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
@@ -178,7 +178,6 @@ public class FileContentUploadTest extends BaseWebDriverTest
         _searchHelper.enqueueSearchItem(newFileName, folderName, Locator.linkContainingText(newFileName));
         _searchHelper.enqueueSearchItem(FILE_DESCRIPTION, folderName, Locator.linkContainingText(newFileName));
         _searchHelper.enqueueSearchItem(CUSTOM_PROPERTY_VALUE, folderName, Locator.linkContainingText(newFileName));
-        _searchHelper.enqueueSearchItem(folderDescription, folderName, Locator.linkWithText(folderName));
 
         _searchHelper.verifySearchResults(getProjectName(), "searchAfterRename");
 


### PR DESCRIPTION
#### Rationale
Directories are not indexed so the test needs to be updated to not expect that.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
