### PR TITLE
give LdapTestPage elementcache elements time to appear

### DIFF
--- a/src/org/labkey/test/pages/ldap/LdapTestPage.java
+++ b/src/org/labkey/test/pages/ldap/LdapTestPage.java
@@ -59,10 +59,10 @@ public class LdapTestPage extends LabKeyPage<LdapTestPage.ElementCache>
 
     protected class ElementCache extends LabKeyPage.ElementCache
     {
-        WebElement serverInput = Locator.id("server").refindWhenNeeded(this);
-        WebElement principalInput = Locator.id("principal").refindWhenNeeded(this);
-        WebElement passwordInput = Locator.id("password").refindWhenNeeded(this);
+        WebElement serverInput = Locator.id("server").refindWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+        WebElement principalInput = Locator.id("principal").refindWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+        WebElement passwordInput = Locator.id("password").refindWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
 
-        WebElement testBtn = Locator.lkButton("Test").refindWhenNeeded(this);
+        WebElement testBtn = Locator.lkButton("Test").refindWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
     }
 }


### PR DESCRIPTION
#### Rationale
Recently, LDAPTest [failed](https://teamcity.labkey.org/viewLog.html?buildId=1828311&tab=buildResultsDiv&buildTypeId=LabKey_223Release_Premium_ModulesSuites_LdapPostgres#testNameId7734585319997564733) with complaints that the server ID input could not be found, with it clearly present in the screengrab/artifacts.
The elementcache finder in the test page does not wait for it to be present, assumes it will be immediately there
This just makes the finders for page elements wait for the elements.

#### Related Pull Requests
n/a

#### Changes

