### PR TITLE
Include server-side JUnit tests in sharded suites

### DIFF
--- a/src/org/labkey/test/SuiteBuilder.java
+++ b/src/org/labkey/test/SuiteBuilder.java
@@ -251,6 +251,7 @@ public class SuiteBuilder
         boolean optional = suiteInfo.isOptional();
         int subset = suiteInfo.getSubset();
         int subsetCount = suiteInfo.getSubsetCount();
+        suiteName = suiteInfo.getName();
 
         Set<Class<?>> tests = _suites.getOrDefault(suiteName, optional ? Collections.emptySet() : null);
 

--- a/src/org/labkey/test/tests/JUnitTest.java
+++ b/src/org/labkey/test/tests/JUnitTest.java
@@ -43,6 +43,7 @@ import org.labkey.remoteapi.PostCommand;
 import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Runner;
+import org.labkey.test.SuiteBuilder;
 import org.labkey.test.TestProperties;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
@@ -155,6 +156,7 @@ public class JUnitTest extends TestSuite
         if (categories.isEmpty())
             return new TestSuite();
 
+        final List<SuiteBuilder.SuiteInfo> suiteInfos = categories.stream().map(SuiteBuilder.SuiteInfo::new).toList();
         try
         {
             return _suite(testProps -> {
@@ -164,9 +166,10 @@ public class JUnitTest extends TestSuite
                     if (testCategories.contains(excludedCategory))
                         return false;
                 }
-                for (String suite : categories)
+                for (SuiteBuilder.SuiteInfo suiteInfo : suiteInfos)
                 {
-                    if (testCategories.contains(suite))
+                    if (testCategories.contains(suiteInfo.getName()) &&
+                            suiteInfo.getSubset() == suiteInfo.getSubsetCount()) // Only run in last shard for sharded suite
                         return true;
                 }
                 return testCategories.contains("smoke"); // Always run smoke tests


### PR DESCRIPTION
#### Rationale
When running a test suite for a module (e.g. `-Psuite=biologics`), the test runner will run the server-side tests for that module as well. This doesn't currently work for sharded suites (e.g. `-Psuite=biologics[1/3]`). This change includes the server-side tests for the last shard (e.g. `-Psuite=biologics[3/3]`).

#### Changes
* Include server-side JUnit tests in sharded suites
