### PR TITLE
Make `AttachmentCard.getFileName` work properly on Windows

### DIFF
--- a/src/org/labkey/test/components/ui/files/AttachmentCard.java
+++ b/src/org/labkey/test/components/ui/files/AttachmentCard.java
@@ -43,7 +43,7 @@ public class AttachmentCard extends WebDriverComponent<AttachmentCard.ElementCac
     public String getFileName()
     {
         String title = getComponentElement().getAttribute("title");
-        String[] filePath = title.split("/");
+        String[] filePath = title.split("[/\\\\]"); // '\' for Windows. '/' for MacOS and Linux
         return filePath[filePath.length - 1];
     }
 


### PR DESCRIPTION
#### Rationale
'title' attribute might include relative file path (e.g. "assaydata/help.jpg") which varies based on OS (e.g. "assaydata\help.jpg" on Windows). `AttachmentCard.getFileName` should handle both slashes.

#### Related Pull Requests
* #1112 

#### Changes
* Split file path on slashes and backslashes
