### PR TITLE
Verify external schema events generate audit trail

### DIFF
--- a/src/org/labkey/test/pages/core/admin/ShowAuditLogPage.java
+++ b/src/org/labkey/test/pages/core/admin/ShowAuditLogPage.java
@@ -27,6 +27,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.Select;
 
 import java.io.File;
+import java.util.Map;
 
 public class ShowAuditLogPage extends LabKeyPage<ShowAuditLogPage.ElementCache>
 {
@@ -43,6 +44,12 @@ public class ShowAuditLogPage extends LabKeyPage<ShowAuditLogPage.ElementCache>
     public static ShowAuditLogPage beginAt(WebDriverWrapper driver, String containerPath)
     {
         driver.beginAt(WebTestHelper.buildURL("audit", containerPath, "showAuditLog"));
+        return new ShowAuditLogPage(driver.getDriver());
+    }
+
+    public static ShowAuditLogPage beginAt(WebDriverWrapper driver, String containerPath, String eventType)
+    {
+        driver.beginAt(WebTestHelper.buildURL("audit", containerPath, "showAuditLog", Map.of("view", eventType)));
         return new ShowAuditLogPage(driver.getDriver());
     }
 


### PR DESCRIPTION
#### Rationale
This provides test coverage to ensure that external schema create/update/delete events are audited, per[ issue 43317](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=43317)

#### Related Pull Requests
n/a

#### Changes
Allows the test to ensure that for a given container, there are audit events for the given external schema 