### PR TITLE
Attempt to resolve header menu interaction issues by scrolling to middle

### DIFF
--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -180,10 +180,9 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
     {
         WebElement headerCell = elementCache().getColumnHeaderCell(columnLabel);
 
-        // scroll the header cell into view plus some extra vertical scroll to make sure the menu is visible
-        getWrapper().scrollIntoView(headerCell);
-        getWrapper().scrollBy(0, 1); // First scroll fails sometimes
-        getWrapper().scrollBy(0, 250);
+        // scroll the header cell as much to the center of the viewport as possible; if it is at the bottom the menu
+        // fly-up can be problematic to automate, if to the top sometimes that puts it behind the navbar
+        getWrapper().scrollToMiddle(headerCell);
 
         WebElement toggle = Locator.tagWithClass("span", "fa-chevron-circle-down")
                 .findElement(headerCell);


### PR DESCRIPTION
#### Rationale
Recently some tests (like [this one](https://teamcity.labkey.org/viewLog.html?buildId=1851564&buildTypeId=LabKey_Trunk_LabkeyPremiumTrunk_GitModules_BiologicsPostgres95&fromExperimentalUI=true#testNameId6310373606914595483)) have been failing when they need to scroll-then-scroll-some in order to interact with grid header menus.  It turns out that if we use the scrollIntoView method and tell it to scroll to the top, sometimes that puts the header cell behind the navBar, causing failures.  If we just scrollIntoView when the target cell is at the bottom or below the viewport, the component's menu fly-up behavior seems to evade the automation.

This attempts to find a middle path (literally) between these two cases, by scrolling the target cell vertically (on the y-axis) only.

#### Related Pull Requests
n/a

#### Changes
adds a new 'scrollToMiddle' method to WebDriverWrapper
updates ResponsiveGrid to use it for clicking columnMenus
