### PR TITLE
also scroll header cells horizontally to bring them into view

### DIFF
--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -32,6 +32,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.BaseWebDriverTest.WAIT_FOR_JAVASCRIPT;
+import static org.labkey.test.WebDriverWrapper.sleep;
 import static org.labkey.test.WebDriverWrapper.waitFor;
 
 public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent<ResponsiveGrid<T>.ElementCache> implements UpdatingComponent
@@ -182,7 +183,11 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
 
         // scroll the header cell as much to the center of the viewport as possible; if it is at the bottom the menu
         // fly-up can be problematic to automate, if to the top sometimes that puts it behind the navbar
-        getWrapper().scrollIntoView(headerCell);    // for cells to the right or left of the viewport, scroll X to visible if visible
+        if (!headerCell.isDisplayed())
+        {
+            getWrapper().scrollIntoView(headerCell);    // for cells to the right or left of the viewport, scroll X to visible if visible
+            sleep(750);     // give script a chance to complete before executing another
+        }
         getWrapper().scrollToMiddle(headerCell);    // scroll Y to middle of the viewport to prevent burying behind navbar
 
         WebElement toggle = Locator.tagWithClass("span", "fa-chevron-circle-down")

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -182,10 +182,8 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
     {
         WebElement headerCell = elementCache().getColumnHeaderCell(columnLabel);
 
-        // scrollIntoView handles horizontal scrolling for cases where the header is non-interactable
-        getWrapper().scrollIntoView(headerCell);    // for cells to the right or left of the viewport, scrollIntoView handles horizontal scroll
-        sleep(500);  // todo: find a way to test for whether or not x-scroll is needed, and only x-scroll if necessary
-                         //  sleep here to give scrollToMiddle call below a better chance of firing
+        // make sure grid headers are in the middle of the page
+        getWrapper().scrollToMiddle(getComponentElement());
 
         WebElement toggle = Locator.tagWithClass("span", "fa-chevron-circle-down")
                 .findElement(headerCell);

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -182,7 +182,8 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
 
         // scroll the header cell as much to the center of the viewport as possible; if it is at the bottom the menu
         // fly-up can be problematic to automate, if to the top sometimes that puts it behind the navbar
-        getWrapper().scrollToMiddle(headerCell);
+        getWrapper().scrollIntoView(headerCell);    // for cells to the right or left of the viewport, scroll X to visible if visible
+        getWrapper().scrollToMiddle(headerCell);    // scroll Y to middle of the viewport to prevent burying behind navbar
 
         WebElement toggle = Locator.tagWithClass("span", "fa-chevron-circle-down")
                 .findElement(headerCell);

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -181,9 +181,9 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
     protected void clickColumnMenuItem(String columnLabel, String menuText, boolean waitForUpdate)
     {
         WebElement headerCell = elementCache().getColumnHeaderCell(columnLabel);
-
-        // make sure grid headers are in the middle of the page
-        getWrapper().scrollToMiddle(getComponentElement());
+        getWrapper().scrollIntoView(headerCell);    // for cells to the right or left of the viewport, scrollIntoView handles horizontal scroll
+        sleep(500);  //it would be nice to find a way to test for whether or not x-scroll is needed, and only x-scroll if necessary
+                         //  sleep here to give scrollToMiddle call below a better chance of firing
 
         WebElement toggle = Locator.tagWithClass("span", "fa-chevron-circle-down")
                 .findElement(headerCell);
@@ -198,13 +198,6 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
         else
             menuItem.click();
         waitFor(()-> !menuItem.isDisplayed(), 1000);
-    }
-
-    private boolean isElementWithinComponentRectangle(WebElement element)
-    {
-        var containerRect = getComponentElement().getRect();
-        var elementRect = element.getRect();
-        return elementRect.getX() > containerRect.getX();
     }
 
 


### PR DESCRIPTION
#### Rationale
merge https://github.com/LabKey/testAutomation/pull/1131 addressed one problem (that header cells weren't being reliably scrolled into an interactable position on the y axis), but inadvertently broke tests that relied on scrollIntoView to horizontally scroll column headers when they're off to the right or left of the viewport.
This fix worked locally, hopefully it also does on TC  (but we've all seen cases where the second script-execution doesn't work, so maybe we will have to update scrollToMiddle such that it also scrolls by x)

#### Related Pull Requests


#### Changes
call scrollIntoView first if the target isn't displayed, which handles any necessary x-scrolling
     if scrolling into view first, wait 750msec before centering the target
call scrollToMiddle, which approximately centers the target vertically in the viewport
