### PR TITLE
Issue 45030: Admin > Permissions Groups click target should be the whole row

### DIFF
--- a/src/org/labkey/test/components/ui/permissions/RoleRow.java
+++ b/src/org/labkey/test/components/ui/permissions/RoleRow.java
@@ -28,7 +28,7 @@ public class RoleRow extends WebDriverComponent<RoleRow.ElementCache>
     {
         if (!isExpanded())
         {
-            elementCache().rowToggle.click();
+            elementCache().rowContainer.click();
         }
     }
 
@@ -92,7 +92,6 @@ public class RoleRow extends WebDriverComponent<RoleRow.ElementCache>
     protected class ElementCache extends WebDriverComponent<RoleRow.ElementCache>.ElementCache
     {
         final WebElement rowContainer = Locator.byClass("container-expandable-grey").findWhenNeeded(this);
-        final WebElement rowToggle = Locator.byClass("container-expandable-child__chevron").findWhenNeeded(this);
         final WebElement assignmentsRow = Locator.byClass("permissions-assignments-row").findWhenNeeded(this);
         final ReactSelect memberSelect = ReactSelect.finder(getDriver()).findWhenNeeded(this)
                 .setOptionLocator(ReactSelect.Locators.option::startsWith);

--- a/src/org/labkey/test/components/ui/permissions/RoleRow.java
+++ b/src/org/labkey/test/components/ui/permissions/RoleRow.java
@@ -91,7 +91,7 @@ public class RoleRow extends WebDriverComponent<RoleRow.ElementCache>
 
     protected class ElementCache extends WebDriverComponent<RoleRow.ElementCache>.ElementCache
     {
-        final WebElement rowContainer = Locator.byClass("container-expandable").findWhenNeeded(this);
+        final WebElement rowContainer = Locator.byClass("container-expandable-grey").findWhenNeeded(this);
         final WebElement rowToggle = Locator.byClass("container-expandable-child__chevron").findWhenNeeded(this);
         final WebElement assignmentsRow = Locator.byClass("permissions-assignments-row").findWhenNeeded(this);
         final ReactSelect memberSelect = ReactSelect.finder(getDriver()).findWhenNeeded(this)

--- a/src/org/labkey/test/components/ui/permissions/RoleRow.java
+++ b/src/org/labkey/test/components/ui/permissions/RoleRow.java
@@ -91,7 +91,7 @@ public class RoleRow extends WebDriverComponent<RoleRow.ElementCache>
 
     protected class ElementCache extends WebDriverComponent<RoleRow.ElementCache>.ElementCache
     {
-        final WebElement rowContainer = Locator.byClass("container-expandable-icononly").findWhenNeeded(this);
+        final WebElement rowContainer = Locator.byClass("container-expandable").findWhenNeeded(this);
         final WebElement rowToggle = Locator.byClass("container-expandable-child__chevron").findWhenNeeded(this);
         final WebElement assignmentsRow = Locator.byClass("permissions-assignments-row").findWhenNeeded(this);
         final ReactSelect memberSelect = ReactSelect.finder(getDriver()).findWhenNeeded(this)


### PR DESCRIPTION
#### Rationale
Currently, in the Admin > Permissions page, only clicking the chevron opens the group. However, clicking anywhere on the panel should open the group.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/859
* https://github.com/LabKey/sampleManagement/pull/995
* https://github.com/LabKey/biologics/pull/1369
* https://github.com/LabKey/testAutomation/pull/1134

#### Changes
* Change selector
