### PR TITLE
Locator for field selected dot in filter dialog has changed.

### DIFF
--- a/src/org/labkey/test/components/ui/grids/GridFilterModal.java
+++ b/src/org/labkey/test/components/ui/grids/GridFilterModal.java
@@ -59,7 +59,7 @@ public class GridFilterModal extends ModalDialog
     public List<String> getFilteredFields()
     {
         List<WebElement> filteredElements = Locator.byClass("list-group-item").withChild(
-                Locator.tagWithClass("span", "filter-modal__field_dot"))
+                Locator.tagWithClass("span", "field-modal__field_dot"))
                 .findElements(elementCache().fieldsSelectionPanel);
 
         return filteredElements.stream().map(WebElement::getText).collect(Collectors.toList());


### PR DESCRIPTION
#### Rationale
Css class for the selector dot has changed. Need to update locator in the test component.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3437 (I don't think this is the PR that changed the field, but it is the PR that updated component version in platform/core).

#### Changes
* Update locator for field selected dot from 'filter-modal__field_dot' to 'field-modal__field_dot'
