### PR TITLE
Reset active user limit after tests

### DIFF
--- a/src/org/labkey/test/pages/core/login/DatabaseAuthConfigureDialog.java
+++ b/src/org/labkey/test/pages/core/login/DatabaseAuthConfigureDialog.java
@@ -20,6 +20,8 @@ public class DatabaseAuthConfigureDialog extends AuthDialogBase<DatabaseAuthConf
     public DatabaseAuthConfigureDialog(LoginConfigRow row)
     {
         super(getFinder("Configure Database Authentication", row.getDriver()));
+        oldExpiration = getPasswordExpiration();
+        oldStrength = getPasswordStrength();
     }
 
     private static ModalDialogFinder getFinder(String title, WebDriver driver)
@@ -37,7 +39,6 @@ public class DatabaseAuthConfigureDialog extends AuthDialogBase<DatabaseAuthConf
 
     public DatabaseAuthConfigureDialog setPasswordStrength(PasswordStrength newStrength)
     {
-        currentStrength = newStrength;
         if (getPasswordStrength().equals(newStrength))
             return this;
 
@@ -54,7 +55,6 @@ public class DatabaseAuthConfigureDialog extends AuthDialogBase<DatabaseAuthConf
     public DatabaseAuthConfigureDialog setPasswordExpiration(PasswordExpiration expiration)
     {
         elementCache().passwordExpirationSelect.selectOption(expiration);
-        currentExpiration = expiration;
         return this;
     }
 
@@ -66,11 +66,6 @@ public class DatabaseAuthConfigureDialog extends AuthDialogBase<DatabaseAuthConf
     @Override
     public LoginConfigRow clickApply()
     {
-        if (oldExpiration == null)
-            oldExpiration = currentExpiration;
-        if (oldStrength == null)
-            oldStrength = currentStrength;
-
         Locator.findAnyElement("Finish or Apply button", this,
                 Locators.dismissButton("Finish"), Locators.dismissButton("Apply")).click();
         waitForClose(4);
@@ -99,6 +94,8 @@ public class DatabaseAuthConfigureDialog extends AuthDialogBase<DatabaseAuthConf
             try
             {
                 postCommand.execute(connection, "/");
+                oldStrength = null;
+                oldExpiration = null;
             }
             catch (IOException | CommandException e)
             {
@@ -120,9 +117,7 @@ public class DatabaseAuthConfigureDialog extends AuthDialogBase<DatabaseAuthConf
     }
 
     private static PasswordStrength oldStrength = null;
-    private PasswordStrength currentStrength = null;
     private static PasswordExpiration oldExpiration = null;
-    private PasswordExpiration currentExpiration = null;
 
     @Override
     protected DatabaseAuthConfigureDialog getThis()
@@ -144,7 +139,7 @@ public class DatabaseAuthConfigureDialog extends AuthDialogBase<DatabaseAuthConf
 
     protected class ElementCache extends AuthDialogBase.ElementCache
     {
-        OptionSelect passwordExpirationSelect = new OptionSelect(Locator.tagWithName("select", "expiration")
+        OptionSelect<PasswordExpiration> passwordExpirationSelect = new OptionSelect<>(Locator.tagWithName("select", "expiration")
                 .findWhenNeeded(this).withTimeout(2000));
 
         WebElement strongButton = Locator.button("Strong").refindWhenNeeded(this).withTimeout(4000);

--- a/src/org/labkey/test/tests/ActiveUserLimitationTest.java
+++ b/src/org/labkey/test/tests/ActiveUserLimitationTest.java
@@ -1,6 +1,7 @@
 package org.labkey.test.tests;
 
 import org.jetbrains.annotations.Nullable;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -8,11 +9,9 @@ import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.security.CreateUserResponse;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
-import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.core.admin.LimitActiveUserPage;
 import org.labkey.test.pages.user.ShowUsersPage;
-import org.labkey.test.util.TestLogger;
 
 import java.util.List;
 
@@ -53,18 +52,22 @@ public class ActiveUserLimitationTest extends BaseWebDriverTest
     }
 
     @Override
-    protected void doCleanup(boolean afterTest) throws TestTimeoutException
+    protected void doCleanup(boolean afterTest)
     {
         _containerHelper.deleteProject(getProjectName(), afterTest);
         _userHelper.deleteUsers(false, USER1, USER2, USER3);
-        resetLimits();
     }
 
     @Before
-    public void deleteUsers()
+    public void deleteUsers() throws Exception
     {
         _userHelper.deleteUsers(false, USER1, USER2, USER3);
-        resetLimits();
+    }
+
+    @After
+    public void resetUserLimits() throws Exception
+    {
+        LimitActiveUserPage.resetUserLimits(createDefaultConnection());
     }
 
     @Test
@@ -72,21 +75,20 @@ public class ActiveUserLimitationTest extends BaseWebDriverTest
     {
         log("Validating User limit < warning limit");
         LimitActiveUserPage limitActiveUserPage = LimitActiveUserPage.beginAt(this);
-        limitActiveUserPage.userWarning(true).limitActiveUsers(true)
+        String error = limitActiveUserPage.enableUserWarning(true).enableUserLimit(true)
                 .setUserLimitLevel("99")
                 .setUserWarningLevel("100")
-                .saveExpectingErrors();
+                .saveExpectingError();
 
-        assertEquals("Invalid error message", "User limit level must be greater than or equal to user warning level.", limitActiveUserPage.getErrorMessage());
+        assertEquals("Invalid error message", "User limit level must be greater than or equal to user warning level.", error);
 
         log("Validating user limit and warning limit is integer");
-        limitActiveUserPage = LimitActiveUserPage.beginAt(this);
-        limitActiveUserPage.limitActiveUsers(true).userWarning(true)
+        error = limitActiveUserPage.enableUserLimit(true).enableUserWarning(true)
                 .setUserLimitLevel("99FA")
                 .setUserWarningLevel("GH90")
-                .saveExpectingErrors();
+                .saveExpectingError();
         assertEquals("Invalid error message", "userLimitLevel: Please enter a valid integer value\n" +
-                "userWarningLevel: Please enter a valid integer value", limitActiveUserPage.getErrorMessage());
+                "userWarningLevel: Please enter a valid integer value", error);
     }
 
     @Test
@@ -94,8 +96,8 @@ public class ActiveUserLimitationTest extends BaseWebDriverTest
     {
         String warningLevel = String.valueOf(getActiveUsers() + 2);
         LimitActiveUserPage limitActiveUserPage = LimitActiveUserPage.beginAt(this);
-        limitActiveUserPage.userWarning(true).
-                limitActiveUsers(false).
+        limitActiveUserPage.enableUserWarning(true).
+                enableUserLimit(false).
                 setUserWarningLevel(warningLevel).
                 setUserLimitLevel("100").
                 setUserWarningMessage("You have been warned..! ${WarningLevel} is the limit and currently server has ${ActiveUsers} users. ");
@@ -119,8 +121,8 @@ public class ActiveUserLimitationTest extends BaseWebDriverTest
     {
         String limitLevel = String.valueOf(getActiveUsers() + 1);
         LimitActiveUserPage limitActiveUserPage = LimitActiveUserPage.beginAt(this);
-        limitActiveUserPage.limitActiveUsers(true).
-                userWarning(false).
+        limitActiveUserPage.enableUserLimit(true).
+                enableUserWarning(false).
                 setUserLimitLevel(limitLevel).
                 setUserLimitMessage("You cannot do this..! ${LimitLevel} is the limit and currently server has ${ActiveUsers} users " +
                         "You can add or reactivate ${RemainingUsers} more users.");
@@ -152,8 +154,8 @@ public class ActiveUserLimitationTest extends BaseWebDriverTest
         log("Setting the limit same as current active user");
         String limitLevel = String.valueOf(getActiveUsers());
         LimitActiveUserPage limitActiveUserPage = LimitActiveUserPage.beginAt(this);
-        limitActiveUserPage.limitActiveUsers(true).
-                userWarning(false).
+        limitActiveUserPage.enableUserLimit(true).
+                enableUserWarning(false).
                 setUserLimitLevel(limitLevel).
                 setUserLimitMessage("You cannot do this..! ${LimitLevel} is the limit and currently server has ${ActiveUsers} users");
         limitActiveUserPage.save();
@@ -189,8 +191,8 @@ public class ActiveUserLimitationTest extends BaseWebDriverTest
         log("Setting the limit same as current active user");
         String limitLevel = String.valueOf(getActiveUsers());
         LimitActiveUserPage limitActiveUserPage = LimitActiveUserPage.beginAt(this);
-        limitActiveUserPage.limitActiveUsers(true).
-                userWarning(false).
+        limitActiveUserPage.enableUserLimit(true).
+                enableUserWarning(false).
                 setUserLimitLevel(limitLevel).
                 setUserLimitMessage("You cannot do this..! ${LimitLevel} is the limit and currently server has ${ActiveUsers} users");
         limitActiveUserPage.save();
@@ -218,7 +220,7 @@ public class ActiveUserLimitationTest extends BaseWebDriverTest
         usersPage.getUsersTable().clickHeaderButton("Reactivate");
         waitForElement(Locator.tagWithText("span", "Reactivate"));
         clickButton("Reactivate");
-        assertTrue("Missing error message", isTextPresent("Failed to activate user2: User limit has been reached so no more users can be reactivated on this deployment."));
+        assertTrue("Missing error message", isTextPresent("Failed to activate " + _userHelper.getDisplayNameForEmail(USER2) + ": User limit has been reached so no more users can be reactivated on this deployment."));
 
         goToSiteUsers();
         assertTrue(USER1 + " should have been reactivated", isTextPresent(USER1));
@@ -230,8 +232,8 @@ public class ActiveUserLimitationTest extends BaseWebDriverTest
         log("Setting both user limit and warning limit");
         String limitLevel = String.valueOf(getActiveUsers() + 1);
         LimitActiveUserPage limitActiveUserPage = LimitActiveUserPage.beginAt(this);
-        limitActiveUserPage.limitActiveUsers(true).
-                userWarning(true).
+        limitActiveUserPage.enableUserLimit(true).
+                enableUserWarning(true).
                 setUserLimitLevel(limitLevel).
                 setUserWarningLevel(limitLevel).
                 setUserLimitMessage("You cannot do this..!").
@@ -258,14 +260,6 @@ public class ActiveUserLimitationTest extends BaseWebDriverTest
             return getText(Locator.tagWithClassContaining("div", "lk-dismissable-warn"));
         else
             return "";
-    }
-
-    private void resetLimits()
-    {
-        LimitActiveUserPage limitActiveUserPage = LimitActiveUserPage.beginAt(this);
-        limitActiveUserPage.limitActiveUsers(false).
-                userWarning(false);
-        limitActiveUserPage.save();
     }
 
     private boolean isBannerPresent()


### PR DESCRIPTION
#### Rationale
Leaving the active user limit enabled can cause subsequent, unrelated tests to fail when attempting to create a new user.

#### Related Pull Requests
* #1128 

#### Changes
* Add a method for stashing and resetting user limits
* Make `DatabaseAuthConfigureDialog.resetDbLoginConfig` work as intended
