### PR TITLE
Scroll grid into view

### DIFF
--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -14,7 +14,6 @@ import org.labkey.test.components.UpdatingComponent;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.react.ReactCheckBox;
 import org.labkey.test.components.ui.search.FilterExpressionPanel;
-import org.openqa.selenium.ElementNotInteractableException;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.WebDriver;
@@ -33,7 +32,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.BaseWebDriverTest.WAIT_FOR_JAVASCRIPT;
-import static org.labkey.test.WebDriverWrapper.sleep;
 import static org.labkey.test.WebDriverWrapper.waitFor;
 
 public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent<ResponsiveGrid<T>.ElementCache> implements UpdatingComponent
@@ -181,14 +179,12 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
     protected void clickColumnMenuItem(String columnLabel, String menuText, boolean waitForUpdate)
     {
         WebElement headerCell = elementCache().getColumnHeaderCell(columnLabel);
-        getWrapper().scrollIntoView(headerCell);    // for cells to the right or left of the viewport, scrollIntoView handles horizontal scroll
-        sleep(500);  //it would be nice to find a way to test for whether or not x-scroll is needed, and only x-scroll if necessary
-                         //  sleep here to give scrollToMiddle call below a better chance of firing
+        // Workaround for 45553: App Grid: Grid column menu does not scroll when page is scrolled.
+        getWrapper().scrollIntoView(getComponentElement(), true);
 
         WebElement toggle = Locator.tagWithClass("span", "fa-chevron-circle-down")
                 .findElement(headerCell);
         getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(toggle));
-        getWrapper().scrollToMiddle(toggle);        // scroll the target vertically to the middle of the page
         toggle.click();
 
         WebElement menuItem = Locator.css("li > a").containing(menuText).findElement(headerCell);

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -181,6 +181,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
         WebElement headerCell = elementCache().getColumnHeaderCell(columnLabel);
         // Workaround for 45553: App Grid: Grid column menu does not scroll when page is scrolled.
         getWrapper().scrollIntoView(getComponentElement(), true);
+        getWrapper().scrollIntoView(headerCell, true);
 
         WebElement toggle = Locator.tagWithClass("span", "fa-chevron-circle-down")
                 .findElement(headerCell);


### PR DESCRIPTION
#### Rationale
Need to make sure the grid header is in view before clicking. Not sure why `scrollToMiddle` is ineffective.
[Issue 45553: App Grid: Grid column menu does not scroll when page is scrolled.](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45553)

#### Changes
* Scroll grid instead of header cell before opening menu
