### PR TITLE
Make tests understand "jtds" database type

### DIFF
--- a/src/org/labkey/test/Runner.java
+++ b/src/org/labkey/test/Runner.java
@@ -423,24 +423,21 @@ public class Runner extends TestSuite
             if (test == null)
             {
                 List<Class<?>> interfaces = ClassUtils.getAllInterfaces(testClass);
-                String databaseType = System.getProperty("databaseType");
-                String databaseVersion = System.getProperty("databaseVersion");
+                WebTestHelper.DatabaseType databaseType = WebTestHelper.getDatabaseType();
+                String databaseVersion = WebTestHelper.getDatabaseVersion();
                 String osName = System.getProperty("os.name", "<unknown>");
-                if (!StringUtils.isEmpty(databaseType)) // Prefer to run illegal tests vs missing coverage when databaseType isn't set
+                if (interfaces.contains(PostgresOnlyTest.class) && databaseType != WebTestHelper.DatabaseType.PostgreSQL)
                 {
-                    if (interfaces.contains(PostgresOnlyTest.class) && !("postgres".equals(databaseType) || "pg".equals(databaseType)))
-                    {
-                        LOG.warn("** Skipping " + testClass.getSimpleName() + " test for unsupported database: " + databaseType + " " + databaseVersion);
-                        continue;
-                    }
-                    else if (interfaces.contains(SqlserverOnlyTest.class) && !("sqlserver".equals(databaseType) || "mssql".equals(databaseType) || "SQLEXPRESS".equals(databaseType)))
-                    {
-                        LOG.warn("** Skipping " + testClass.getSimpleName() + " test for unsupported database: " + databaseType + " " + databaseVersion);
-                        continue;
-                    }
+                    LOG.warn("** Skipping " + testClass.getSimpleName() + " test for unsupported database: " + databaseType + " " + databaseVersion);
+                    continue;
+                }
+                else if (interfaces.contains(SqlserverOnlyTest.class) && databaseType != WebTestHelper.DatabaseType.MicrosoftSQLServer)
+                {
+                    LOG.warn("** Skipping " + testClass.getSimpleName() + " test for unsupported database: " + databaseType + " " + databaseVersion);
+                    continue;
                 }
 
-                if(interfaces.contains(DevModeOnlyTest.class) && !"true".equals(System.getProperty("devMode")))
+                if(interfaces.contains(DevModeOnlyTest.class) && !TestProperties.isDevModeEnabled())
                 {
                     LOG.warn("** Skipping " + testClass.getSimpleName() + ": server must be in dev mode");
                     continue;
@@ -919,7 +916,6 @@ public class Runner extends TestSuite
         boolean skipLeakCheck = "false".equals(System.getProperty("memCheck"));
         boolean disableAssertions = "true".equals(System.getProperty("disableAssertions"));
         boolean cleanOnly = "true".equals(System.getProperty("cleanOnly"));
-        boolean skipClean = "false".equals(System.getProperty("clean"));
         boolean shuffleTests = "true".equals(System.getProperty("shuffleTests"));
         boolean testRecentlyFailed = "true".equals(System.getProperty("testRecentlyFailed"));
         boolean testNewAndModified = "true".equals(System.getProperty("testNewAndModified"));
@@ -931,11 +927,6 @@ public class Runner extends TestSuite
         if (StringUtils.trimToEmpty(removeFromSuite).contains("."))
         {
             throw new IllegalArgumentException("It looks like you are trying to prevent an individual test method from executing. That is not currently supported. removeFromSuite=" + removeFromSuite);
-        }
-
-        if (cleanOnly && skipClean)
-        {
-            throw new IllegalArgumentException("Invalid parameters: cannot specify both 'cleanOnly=true' and 'clean=false'.");
         }
 
         if (!skipLeakCheck && disableAssertions)

--- a/src/org/labkey/test/WebTestHelper.java
+++ b/src/org/labkey/test/WebTestHelper.java
@@ -79,6 +79,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
+import java.util.Set;
 
 /**
  * Static methods for getting properties of and communicating with a running LabKey server
@@ -282,7 +283,18 @@ public class WebTestHelper
         return url;
     }
 
-    public enum DatabaseType {PostgreSQL, MicrosoftSQLServer}
+    public enum DatabaseType
+    {
+        PostgreSQL("postgres", "pg"),
+        MicrosoftSQLServer("sqlserver", "mssql", "jtds");
+
+        private final Set<String> typeNames;
+
+        DatabaseType(String... typeNames)
+        {
+            this.typeNames = Set.of(typeNames);
+        }
+    }
 
     public static DatabaseType getDatabaseType()
     {
@@ -291,10 +303,10 @@ public class WebTestHelper
         if (null == databaseType)
             throw new IllegalStateException("Can't determine database type: databaseType property is not set");
 
-        if ("postgres".equals(databaseType) || "pg".equals(databaseType))
+        if (DatabaseType.PostgreSQL.typeNames.contains(databaseType))
             return DatabaseType.PostgreSQL;
 
-        if ("sqlserver".equals(databaseType) || "mssql".equals(databaseType))
+        if (DatabaseType.MicrosoftSQLServer.typeNames.contains(databaseType))
             return DatabaseType.MicrosoftSQLServer;
 
         throw new IllegalStateException("Unknown database type: " + databaseType);


### PR DESCRIPTION
#### Rationale
Test harness needs to know how to interpret the "jtds" database type.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/264

#### Changes
* Update `TestProperties.getDatabaseType` to map "jtds" to SQL Server
* Update test Runner to use `TestProperties` instead of parsing properties itself
