### PR TITLE
`clickSave` should expect success by default

### DIFF
--- a/src/org/labkey/test/components/QueryMetadataEditorPage.java
+++ b/src/org/labkey/test/components/QueryMetadataEditorPage.java
@@ -46,12 +46,6 @@ public class QueryMetadataEditorPage extends DomainDesigner<QueryMetadataEditorP
     public QueryMetadataEditorPage clickSave()
     {
         elementCache().saveButton.click();
-        return this;
-    }
-
-    public QueryMetadataEditorPage clickSaveAndWaitForSuccess()
-    {
-        clickSave();
         WebDriverWrapper.waitFor(()->  Locator.tagWithClass("div", "alert-success")
                         .containingIgnoreCase("Save Successful").existsIn(this),
                 "Expected success message did not appear in time", WAIT_FOR_JAVASCRIPT);

--- a/src/org/labkey/test/tests/ExpTest.java
+++ b/src/org/labkey/test/tests/ExpTest.java
@@ -173,7 +173,7 @@ public class ExpTest extends BaseWebDriverTest
         domainRow.setType(FieldDefinition.ColumnType.Lookup).setFromSchema("exp").setFromTargetTable("dataCustomQuery" + " (Integer)");
 
         // Save it
-        designerPage.clickSaveAndWaitForSuccess();
+        designerPage.clickSave();
         designerPage.viewData();
 
         // Customize the view to add the newly joined column


### PR DESCRIPTION
#### Rationale
Not waiting for success can cause subsequent operations to fail. `clickSave` should wait for success. `clickSaveExpectingErrors` is to be used otherwise.

#### Changes
* Remove `clickSaveAndWaitForSuccess` from `QueryMetadataEditorPage`
