### PR TITLE
Update expected id for Base Server URL field.

### DIFF
--- a/src/org/labkey/test/pages/core/admin/CustomizeSitePage.java
+++ b/src/org/labkey/test/pages/core/admin/CustomizeSitePage.java
@@ -210,7 +210,7 @@ public class CustomizeSitePage extends LabKeyPage<CustomizeSitePage.ElementCache
 
         // Site URLs
         protected final Input defaultDomain = Input(Locator.id("defaultDomain"), getDriver()).findWhenNeeded(this);
-        protected final Input baseServerUrl = Input(Locator.id("baseServerUrl"), getDriver()).findWhenNeeded(this);
+        protected final Input baseServerUrl = Input(Locator.id("baseServerURL"), getDriver()).findWhenNeeded(this);
         protected final Checkbox containerRelativeUrl = Checkbox(Locator.id("useContainerRelativeURL")).findWhenNeeded(this);
 
         // Usage Reporting


### PR DESCRIPTION
#### Rationale
The id for the Base Server URL field on the customize page has changed to "baseServerURL". Simple test update.

#### Related Pull Requests
* None

#### Changes
* Update expected id of control to "baseServerURL"
