### PR TITLE
Fix some test race conditions

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3153,7 +3153,8 @@ public abstract class WebDriverWrapper implements WrapsDriver
      */
     public void waitAndClick(int waitFor, Locator l, int waitForPageToLoad)
     {
-        WebElement el = l.waitForElement(getDriver(), waitFor);
+        WebElement el = new WebDriverWait(getDriver(), Duration.ofMillis(waitFor))
+                .until(ExpectedConditions.elementToBeClickable(l));
         try
         {
             clickAndWait(el, waitForPageToLoad);

--- a/src/org/labkey/test/pages/admin/PermissionsPage.java
+++ b/src/org/labkey/test/pages/admin/PermissionsPage.java
@@ -58,6 +58,12 @@ public class PermissionsPage extends LabKeyPage<PermissionsPage.ElementCache>
         return new PermissionsPage(driver.getDriver());
     }
 
+    @Override
+    protected void waitForPage()
+    {
+        waitForElement(Locator.tag("table").withAttributeContaining("id", "labkey-principalcombo-"));
+    }
+
     public void clickSaveAndFinish()
     {
         clickAndWait(elementCache().saveAndFinishButton);


### PR DESCRIPTION
#### Rationale
Fixing a couple of race conditions in tests.

`waitAndClick` might attempt to click before element is clickable:
```
org.openqa.selenium.ElementNotInteractableException: Element <a href="/labkey/StudyVerifyProject/My%20Study/specimen-showUploadSpecimens.view?"> could not be scrolled into view
  [...]
  at app//org.labkey.test.WebDriverWrapper.clickAndWait(WebDriverWrapper.java:2707)
  at app//org.labkey.test.WebDriverWrapper.waitAndClick(WebDriverWrapper.java:3159)
  at app//org.labkey.test.WebDriverWrapper.waitAndClickAndWait_aroundBody92(WebDriverWrapper.java:3148)
  at app//org.labkey.test.WebDriverWrapper.waitAndClickAndWait_aroundBody93$advice(WebDriverWrapper.java:40)
  at app//org.labkey.test.WebDriverWrapper.waitAndClickAndWait(WebDriverWrapper.java:1)
  at app//org.labkey.test.tests.SpecimenImportTest.goToImport(SpecimenImportTest.java:101)
  at app//org.labkey.test.tests.SpecimenImportTest.checkRequiredFields(SpecimenImportTest.java:106)
  at app//org.labkey.test.tests.SpecimenImportTest.doCreateSteps(SpecimenImportTest.java:79)
```

Main permissions page tab doesn't finish loading if the test switches tabs too quickly:
```
org.openqa.selenium.NoSuchElementException: Expected condition failed: waiting for xpath=//div[contains(@class, 'rolepanel')][.//h3[text()='Project Administrator']] (tried for 10 second(s) with 100 milliseconds interval)
[...]
  at app//org.labkey.test.pages.admin.PermissionsPage._selectPermission(PermissionsPage.java:174)
  at app//org.labkey.test.pages.admin.PermissionsPage._setPermissions(PermissionsPage.java:167)
  at app//org.labkey.test.pages.admin.PermissionsPage.setPermissions(PermissionsPage.java:121)
  at app//org.labkey.test.tests.MessagesLongTest.doSetup(MessagesLongTest.java:164)
  at app//org.labkey.test.tests.MessagesLongTest.setupProject(MessagesLongTest.java:155)
```

#### Changes
* Wait for element to be clickable in `waitAndClick`
* Add `PermissionsPage.waitForPage` 
