### PR TITLE
FolderTreeEncodingTest fix to just check for existing links

### DIFF
--- a/src/org/labkey/test/tests/FolderTreeEncodingTest.java
+++ b/src/org/labkey/test/tests/FolderTreeEncodingTest.java
@@ -21,6 +21,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.admin.PermissionsPage;
 import org.labkey.test.pages.core.admin.ConfigureFileSystemAccessPage;
@@ -68,8 +69,8 @@ public class FolderTreeEncodingTest extends BaseWebDriverTest
     {
         // Issue 45079: Double encoding at the root of the permissions page folder tree
         PermissionsPage page = goToFolderPermissions();
-        page = page.selectFolder(CHILD_CONTAINER);
-        page.selectFolder(getProjectName());
+        isElementPresent(Locator.linkWithText(CHILD_CONTAINER).withClass("x4-tree-node-text"));
+        isElementPresent(Locator.linkWithText(getProjectName()).withClass("x4-tree-node-text"));
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/project.html?projectId=LabkeyTrunk_DailySuites&testNameId=-8316117493851147454&tab=testDetails

org.openqa.selenium.ElementNotInteractableException: Element <a class="x4-tree-node-text " href="/labkey/FolderTreeEncodingTest%20%26nbsp/ChildContainer%20%26nbsp/security-permissions.view?"> could not be scrolled into view

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1150

#### Changes
* Switch test to verify that link exists instead of "selectFolder" in tree
