### PR TITLE
Eliminate need for database properties in config.properties

### DIFF
--- a/src/org/labkey/test/Runner.java
+++ b/src/org/labkey/test/Runner.java
@@ -424,16 +424,15 @@ public class Runner extends TestSuite
             {
                 List<Class<?>> interfaces = ClassUtils.getAllInterfaces(testClass);
                 WebTestHelper.DatabaseType databaseType = WebTestHelper.getDatabaseType();
-                String databaseVersion = WebTestHelper.getDatabaseVersion();
                 String osName = System.getProperty("os.name", "<unknown>");
                 if (interfaces.contains(PostgresOnlyTest.class) && databaseType != WebTestHelper.DatabaseType.PostgreSQL)
                 {
-                    LOG.warn("** Skipping " + testClass.getSimpleName() + " test for unsupported database: " + databaseType + " " + databaseVersion);
+                    LOG.warn("** Skipping " + testClass.getSimpleName() + " test for unsupported database: " + databaseType);
                     continue;
                 }
                 else if (interfaces.contains(SqlserverOnlyTest.class) && databaseType != WebTestHelper.DatabaseType.MicrosoftSQLServer)
                 {
-                    LOG.warn("** Skipping " + testClass.getSimpleName() + " test for unsupported database: " + databaseType + " " + databaseVersion);
+                    LOG.warn("** Skipping " + testClass.getSimpleName() + " test for unsupported database: " + databaseType);
                     continue;
                 }
 


### PR DESCRIPTION
#### Rationale
These properties aren't needed. `databaseVersion` is rarely changed and fairly useless when it is changed. `databaseType` is unnecessary since it can be inferred from `jdbcDriverClassName`.

#### Changes
* Stop using these properties, except for remote server's use of `databaseType`
