### PR TITLE
Automation test

### DIFF
--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -841,11 +841,11 @@ public class LinkedSchemaTest extends BaseWebDriverTest
 
         goToSchemaBrowser();
         table = viewQueryData(linkedSchemaName, "ListAuditEvent");
-        assertEquals("Incorrect number of rows in ListAuditEvent", 6, table.getDataRowCount());
+        assertEquals("Incorrect number of rows in ListAuditEvent", 5, table.getDataRowCount());
 
         goToSchemaBrowser();
         table = viewQueryData(linkedSchemaName, "DomainAuditEvent");
-        assertEquals("Incorrect number of rows in DomainAuditEvent", 40, table.getDataRowCount());
+        assertEquals("Incorrect number of rows in DomainAuditEvent", 38, table.getDataRowCount());
     }
 
     protected void goToSchemaBrowserTable(String schemaName, String tableName)

--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -821,6 +821,9 @@ public class LinkedSchemaTest extends BaseWebDriverTest
         assertEquals("Dave", table.getDataAsText(1, "Crazy " + D_PEOPLE_METADATA_TITLE));
     }
 
+    /*
+        Test coverage : Issue 45347: Audit table data not available in linked schema
+     */
     @Test
     public void testAuditTableLinkedSchema()
     {

--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -834,11 +834,11 @@ public class LinkedSchemaTest extends BaseWebDriverTest
         log("Verify the content is visible via schema");
         goToSchemaBrowser();
         DataRegionTable table = viewQueryData(linkedSchemaName, "ContainerAuditEvent");
-        assertEquals("Incorrect number of rows in ContainerAuditEvent", 1 , table.getDataRowCount());
+        assertEquals("Incorrect number of rows in ContainerAuditEvent", 1, table.getDataRowCount());
 
         goToSchemaBrowser();
-        table =   viewQueryData(linkedSchemaName, "ListAuditEvent");
-        assertEquals("Incorrect number of rows in ListAuditEvent", 6 , table.getDataRowCount());
+        table = viewQueryData(linkedSchemaName, "ListAuditEvent");
+        assertEquals("Incorrect number of rows in ListAuditEvent", 6, table.getDataRowCount());
     }
 
     protected void goToSchemaBrowserTable(String schemaName, String tableName)

--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -828,13 +828,13 @@ public class LinkedSchemaTest extends BaseWebDriverTest
     public void testAuditTableLinkedSchema()
     {
         String linkedSchemaName = "auditTableLinkedSchema";
-        String sourceContainerPath = "/" + getProjectName() + "/" + SOURCE_FOLDER;
+        String sourceContainerPath = "/" + getProjectName() + "/" + STUDY_FOLDER;
         String targetContainerPath = "/" + getProjectName() + "/" + TARGET_FOLDER;
 
         log("Create the linked schema on auditlog");
         _schemaHelper.createLinkedSchema(targetContainerPath, linkedSchemaName, sourceContainerPath, null, "auditLog", null, null);
 
-        log("Verify the content is visible via schema");
+        log("Verify the content is visible via linked schema");
         goToSchemaBrowser();
         DataRegionTable table = viewQueryData(linkedSchemaName, "ContainerAuditEvent");
         assertEquals("Incorrect number of rows in ContainerAuditEvent", 1, table.getDataRowCount());
@@ -842,6 +842,10 @@ public class LinkedSchemaTest extends BaseWebDriverTest
         goToSchemaBrowser();
         table = viewQueryData(linkedSchemaName, "ListAuditEvent");
         assertEquals("Incorrect number of rows in ListAuditEvent", 6, table.getDataRowCount());
+
+        goToSchemaBrowser();
+        table = viewQueryData(linkedSchemaName, "DomainAuditEvent");
+        assertEquals("Incorrect number of rows in DomainAuditEvent", 40, table.getDataRowCount());
     }
 
     protected void goToSchemaBrowserTable(String schemaName, String tableName)

--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -821,6 +821,26 @@ public class LinkedSchemaTest extends BaseWebDriverTest
         assertEquals("Dave", table.getDataAsText(1, "Crazy " + D_PEOPLE_METADATA_TITLE));
     }
 
+    @Test
+    public void testAuditTableLinkedSchema()
+    {
+        String linkedSchemaName = "auditTableLinkedSchema";
+        String sourceContainerPath = "/" + getProjectName() + "/" + SOURCE_FOLDER;
+        String targetContainerPath = "/" + getProjectName() + "/" + TARGET_FOLDER;
+
+        log("Create the linked schema on auditlog");
+        _schemaHelper.createLinkedSchema(targetContainerPath, linkedSchemaName, sourceContainerPath, null, "auditLog", null, null);
+
+        log("Verify the content is visible via schema");
+        goToSchemaBrowser();
+        DataRegionTable table = viewQueryData(linkedSchemaName, "ContainerAuditEvent");
+        assertEquals("Incorrect number of rows in ContainerAuditEvent", 1 , table.getDataRowCount());
+
+        goToSchemaBrowser();
+        table =   viewQueryData(linkedSchemaName, "ListAuditEvent");
+        assertEquals("Incorrect number of rows in ListAuditEvent", 6 , table.getDataRowCount());
+    }
+
     protected void goToSchemaBrowserTable(String schemaName, String tableName)
     {
         goToSchemaBrowser();

--- a/src/org/labkey/test/util/SchemaHelper.java
+++ b/src/org/labkey/test/util/SchemaHelper.java
@@ -126,6 +126,11 @@ public class SchemaHelper
             _test.shortWait().until(LabKeyExpectedConditions.elementIsEnabled(Locator.xpath("//input[@name='sourceSchemaName']")));
 
             // There are multiple Ext form elements on this row, so the label for the actual combo box is empty
+             if(! _test._ext4Helper.getComboBoxOptions("").contains(sourceSchemaName))
+             {
+                 _test._ext4Helper.checkCheckbox(Locator.ehrCheckboxWithLabel("Show System Schemas"));
+             }
+
             _test._ext4Helper.selectComboBoxItem("", sourceSchemaName);
 
             if(_queryLoadTimeOut > 0)

--- a/src/org/labkey/test/util/SchemaHelper.java
+++ b/src/org/labkey/test/util/SchemaHelper.java
@@ -126,10 +126,10 @@ public class SchemaHelper
             _test.shortWait().until(LabKeyExpectedConditions.elementIsEnabled(Locator.xpath("//input[@name='sourceSchemaName']")));
 
             // There are multiple Ext form elements on this row, so the label for the actual combo box is empty
-             if(! _test._ext4Helper.getComboBoxOptions("").contains(sourceSchemaName))
-             {
-                 _test._ext4Helper.checkCheckbox(Locator.ehrCheckboxWithLabel("Show System Schemas"));
-             }
+            if (!_test._ext4Helper.getComboBoxOptions("").contains(sourceSchemaName))
+            {
+                _test._ext4Helper.checkCheckbox(Locator.ehrCheckboxWithLabel("Show System Schemas"));
+            }
 
             _test._ext4Helper.selectComboBoxItem("", sourceSchemaName);
 


### PR DESCRIPTION
#### Rationale
Issue 45347: Audit table data not available in linked schema - Automation test coverage 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
New test case testAuditTableLinkedSchema in src/org/labkey/test/tests/LinkedSchemaTest.java test
