### PR TITLE
Share default view to make name consistent

### DIFF
--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -334,7 +334,7 @@ public class GridPanelTest extends BaseWebDriverTest
 
         CustomizeView cv = drtSamples.openCustomizeGrid();
         cv.removeColumn(REMOVED_FLAG_COLUMN);
-        cv.saveDefaultView();
+        cv.saveCustomView("", true);
 
     }
 


### PR DESCRIPTION
#### Rationale
The display name for the default view is shows as "My Default" when a user has a non-shared default view. Need to share to be able to select the "Default" view

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/877

#### Changes
* Share when saving default view
