### PR TITLE
Refind the BaseBoostrapMenu

### DIFF
--- a/src/org/labkey/test/components/react/BaseBootstrapMenu.java
+++ b/src/org/labkey/test/components/react/BaseBootstrapMenu.java
@@ -87,7 +87,7 @@ public abstract class BaseBootstrapMenu extends WebDriverComponent<BaseBootstrap
 
     protected class ElementCache extends Component<?>.ElementCache
     {
-        public final WebElement toggleAnchor = getToggleLocator().findWhenNeeded(getComponentElement());
+        public final WebElement toggleAnchor = getToggleLocator().refindWhenNeeded(getComponentElement());
 
         public WebElement findOpenMenu()
         {


### PR DESCRIPTION
#### Rationale
There have been some test failures where the BaseBootstrapMenu has been stale (or no longer attached to the dom) when trying to expand. Screen shots show the menu button has been clicked but the dropdown menu has yet to show. The expand method has some retry logic but it doesn't catch the element going stale, maybe this will help.

#### Related Pull Requests
* None

#### Changes
* Changed finder for toggleAnchor element to be refindWhenNeeded.
