### PR TITLE
Fix failures cause by waiting for links to be clickable

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -101,7 +101,6 @@ import java.awt.datatransfer.StringSelection;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -3176,8 +3175,9 @@ public abstract class WebDriverWrapper implements WrapsDriver
      */
     public void waitAndClick(int waitFor, Locator l, int waitForPageToLoad)
     {
-        WebElement el = new WebDriverWait(getDriver(), Duration.ofMillis(waitFor))
-                .until(ExpectedConditions.elementToBeClickable(l));
+        WebElement el = l.waitForElement(getDriver(), waitFor);
+        new WebDriverWait(getDriver(), Duration.ofMillis(waitFor))
+                .until(ExpectedConditions.elementToBeClickable(el));
         try
         {
             clickAndWait(el, waitForPageToLoad);

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3175,9 +3175,8 @@ public abstract class WebDriverWrapper implements WrapsDriver
      */
     public void waitAndClick(int waitFor, Locator l, int waitForPageToLoad)
     {
-        WebElement el = l.waitForElement(getDriver(), waitFor);
-        new WebDriverWait(getDriver(), Duration.ofMillis(waitFor))
-                .until(ExpectedConditions.elementToBeClickable(el));
+        WebElement el = new WebDriverWait(getDriver(), Duration.ofMillis(waitFor))
+                .until(ExpectedConditions.elementToBeClickable(l));
         try
         {
             clickAndWait(el, waitForPageToLoad);

--- a/src/org/labkey/test/tests/MissingValueIndicatorsTest.java
+++ b/src/org/labkey/test/tests/MissingValueIndicatorsTest.java
@@ -26,7 +26,7 @@ import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.LogMethod;
 import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
@@ -122,7 +122,7 @@ public abstract class MissingValueIndicatorsTest extends BaseWebDriverTest
                 {
                     _extHelper.clickExtTab("Choose Filters");
                 }
-                catch (NoSuchElementException ignore) { }
+                catch (WebDriverException ignore) { }
                 WebElement comboArrow = Locator.css(".x-form-arrow-trigger")
                         .findElement( Locator.tagWithClass("div", "x-form-item").withPredicate(Locator.xpath("./label").withText("Filter Type:")).findElement(filterDialog));
                 comboArrow.click();

--- a/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
+++ b/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
@@ -598,7 +598,7 @@ public class ElispotAssayTest extends AbstractAssayTest
         for (String item : column)
             assertEquals("Background subtraction should be true for all runs.", "true", item);
 
-        DataRegionTable.DataRegion(getDriver()).find().clickRowDetails(0);
+        runTable.clickRowDetails(0);
         waitForElement(Locator.css(".plate-summary-grid"));
 
         DataRegionTable detailsTable = new CrosstabDataRegion("AntigenStats", this);

--- a/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
+++ b/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
@@ -199,13 +199,13 @@ public class ElispotAssayTest extends AbstractAssayTest
                 Arrays.asList(" ", " ", " ", " ", " ", " ", " ", " ", " ", " "),                           // intensity
                 Arrays.asList(" "," "," "," "," "," "," "," "," "," ")); //cytokines
         assertTextPresent("ptid 1 F2", "ptid 2 F2", "ptid 3 F2", "ptid 4 F2", "Antigen 5", "Antigen 6", "Cy3", "FITC");
-        clickAndWait(Locator.linkWithText("view runs"));  // clickAndWait to try and avoid a js error that shows up on TC.
-        waitAndClick(DataRegionTable.detailsLinkLocator());
+        clickAndWait(Locator.linkWithText("view runs"));
+        DataRegionTable.DataRegion(getDriver()).find().clickRowDetails(0);
         PlateSummary plateSummary = new PlateSummary(this, 3);
         assertEquals(Arrays.asList("244.0","544.0","210.0","449.0","333.0","429.0","393.0","689.0","400.0","159.0","130.0","94.0"), plateSummary.getRowValues(E));
         plateSummary.selectMeasurement(PlateSummary.Measurement.ACTIVITY);
         assertEquals(Arrays.asList("668.0","1610.0","1464.0","3945.0","3781.0","3703.0","8713.0","2222.0","2856.0","1208.0","880.0","1006.0"), plateSummary.getRowValues(G));
-        clickAndWait(Locator.linkWithText("view runs")); // clickAndWait to try and avoid a js error that shows up on TC.
+        clickAndWait(Locator.linkWithText("view runs"));
         waitAndClick(Locator.linkWithText("view results"));
         DataRegionTable results = new DataRegionTable("Data", this);
         results.ensureColumnsPresent("Wellgroup Name", "Antigen Wellgroup Name", "Antigen Name", "Cells per Well", "Wellgroup Location", "Spot Count", "Normalized Spot Count", "Spot Size", "Analyte", "Cytokine", "Activity", "Intensity", "Specimen ID", "Participant ID", "Visit ID", "Date", "Sample Description", "ProtocolName", "Plate Reader");
@@ -370,7 +370,7 @@ public class ElispotAssayTest extends AbstractAssayTest
         _customizeViewsHelper.revertUnsavedView();
 
         clickAndWait(Locator.linkWithText("view runs"));
-        clickAndWait(DataRegionTable.detailsLinkLocator());
+        DataRegionTable.DataRegion(getDriver()).find().clickRowDetails(0);
 
         assertTextPresent(
                 "Plate Summary Information",
@@ -598,7 +598,7 @@ public class ElispotAssayTest extends AbstractAssayTest
         for (String item : column)
             assertEquals("Background subtraction should be true for all runs.", "true", item);
 
-        clickAndWait(DataRegionTable.detailsLinkLocator());
+        DataRegionTable.DataRegion(getDriver()).find().clickRowDetails(0);
         waitForElement(Locator.css(".plate-summary-grid"));
 
         DataRegionTable detailsTable = new CrosstabDataRegion("AntigenStats", this);


### PR DESCRIPTION
#### Rationale
A couple of failures popped up after adding a wait for elements to be clickable.
1. Data region details links should be moused over to make them visible before clicking.
2. `MissingValueIndicatorsTest` needs to catch a different exception now

#### Related Pull Requests
* #1162

#### Changes
* Update how `ElispotAssayTest` clicks data region details links
* Update caught exception in `MissingValueIndicatorsTest`
