### PR TITLE
Don't assume that ETLs run instantly

### DIFF
--- a/src/org/labkey/test/util/di/DataIntegrationHelper.java
+++ b/src/org/labkey/test/util/di/DataIntegrationHelper.java
@@ -103,6 +103,12 @@ public class DataIntegrationHelper
         return response;
     }
 
+    /** Queues and waits up to one minute for the job to finish */
+    public RunTransformResponse runTransformAndWait(@LoggedParam String transformId) throws CommandException, IOException
+    {
+        return runTransformAndWait(transformId, 60_000);
+    }
+
     @LogMethod
     public RunTransformResponse runTransformAndWait(@LoggedParam String transformId, int msTimeout) throws CommandException, IOException
     {


### PR DESCRIPTION
#### Rationale
ETL tests sometimes fail because the data they expect isn't there yet. They're not waiting for the ETL to complete before checking the results.

https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_LabkeyPremiumTrunk_GitModules_DataIntegrationSqlserver/1901150?buildTab=overview&hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true#%2FETLListTest.tar.gz

#### Changes
* Make it ever so slightly easier to wait for completion