### PR TITLE
StudySecurityTest fix for masked WebElement with locked table column header

### DIFF
--- a/src/org/labkey/test/pages/study/StudySecurityPage.java
+++ b/src/org/labkey/test/pages/study/StudySecurityPage.java
@@ -285,7 +285,9 @@ public class StudySecurityPage extends LabKeyPage<StudySecurityPage.ElementCache
     public StudySecurityPage setDatasetPermissions(String groupName, String datasetName, String role)
     {
         int position = getGroupColumnIndex(groupName);
-        selectOptionByText(elementCache().datasetPermissionSelect(datasetName, position), role);
+        WebElement selectElement = elementCache().datasetPermissionSelect(datasetName, position);
+        scrollToMiddle(selectElement);
+        selectOptionByText(selectElement, role);
         return this;
     }
 


### PR DESCRIPTION
#### Rationale
Test failure after locked column headers added to study dataset security page because of the header locking masking a select input after the page is scrolled.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3541

#### Changes
* Scroll dataset security select input to middle of page before selecting from it
