### PR TITLE
Extract CreateProjectCommand and prepare to move to remote api

### DIFF
--- a/src/org/labkey/remoteapi/admin/CreateProjectCommand.java
+++ b/src/org/labkey/remoteapi/admin/CreateProjectCommand.java
@@ -1,4 +1,4 @@
-package org.labkey.test.tests;
+package org.labkey.remoteapi.admin;
 
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;

--- a/src/org/labkey/test/tests/CreateProjectCommand.java
+++ b/src/org/labkey/test/tests/CreateProjectCommand.java
@@ -10,33 +10,74 @@ import org.labkey.remoteapi.PostCommand;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 public class CreateProjectCommand extends PostCommand<CommandResponse>
 {
-    private final Map<String, Object> _params;
+    private String _name;
+    private String _folderType;
+    private boolean _assignProjectAdmin = false;
+    private String _templateSourceId;
+    private boolean _templateIncludeSubfolders = false;
+    private List<String> _templateWriterTypes = List.of();
 
-    public CreateProjectCommand(Map<String, Object> params)
+    public CreateProjectCommand()
     {
         super("admin", "createProject");
-        _params = params;
+    }
+
+    public CreateProjectCommand setName(String name)
+    {
+        _name = name;
+        return this;
+    }
+
+    public CreateProjectCommand setFolderType(String folderType)
+    {
+        _folderType = folderType;
+        return this;
+    }
+
+    public CreateProjectCommand setAssignProjectAdmin(boolean assignProjectAdmin)
+    {
+        _assignProjectAdmin = assignProjectAdmin;
+        return this;
+    }
+
+    public CreateProjectCommand setTemplateSourceId(String templateSourceId)
+    {
+        _templateSourceId = templateSourceId;
+        return this;
+    }
+
+    public CreateProjectCommand setTemplateIncludeSubfolders(boolean templateIncludeSubfolders)
+    {
+        _templateIncludeSubfolders = templateIncludeSubfolders;
+        return this;
+    }
+
+    public CreateProjectCommand setTemplateWriterTypes(String... templateWriterTypes)
+    {
+        _templateWriterTypes = List.of(templateWriterTypes);
+        return this;
     }
 
     @Override
     protected HttpUriRequest createRequest(URI uri)
     {
-        // CreateProjectAction is not a real API action, so we POST form data not JSON
-        List<BasicNameValuePair> postData = new ArrayList<>();
+        // CreateProjectAction is not a real API action, so we POST form data instead of JSON
 
-        _params.forEach((k, v) -> {
-            // Expand any collections into multiple individual params
-            if (v instanceof Collection<?> col)
-                col.forEach(val -> postData.add(new BasicNameValuePair(k, String.valueOf(val))));
-            else
-                postData.add(new BasicNameValuePair(k, String.valueOf(v)));
-        });
+        List<BasicNameValuePair> postData = new ArrayList<>();
+        postData.add(new BasicNameValuePair("name", _name));
+        postData.add(new BasicNameValuePair("folderType", _folderType));
+        postData.add(new BasicNameValuePair("assignProjectAdmin", Boolean.toString(_assignProjectAdmin)));
+
+        if ("Template".equals(_folderType))
+        {
+            postData.add(new BasicNameValuePair("templateSourceId", _templateSourceId));
+            postData.add(new BasicNameValuePair("templateIncludeSubfolders", Boolean.toString(_templateIncludeSubfolders)));
+            _templateWriterTypes.forEach(type -> postData.add(new BasicNameValuePair("templateWriterTypes", type)));
+        }
 
         try
         {

--- a/src/org/labkey/test/tests/CreateProjectCommand.java
+++ b/src/org/labkey/test/tests/CreateProjectCommand.java
@@ -1,0 +1,52 @@
+package org.labkey.test.tests;
+
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.message.BasicNameValuePair;
+import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.PostCommand;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class CreateProjectCommand extends PostCommand<CommandResponse>
+{
+    private final Map<String, Object> _params;
+
+    public CreateProjectCommand(Map<String, Object> params)
+    {
+        super("admin", "createProject");
+        _params = params;
+    }
+
+    @Override
+    protected HttpUriRequest createRequest(URI uri)
+    {
+        // CreateProjectAction is not a real API action, so we POST form data not JSON
+        List<BasicNameValuePair> postData = new ArrayList<>();
+
+        _params.forEach((k, v) -> {
+            // Expand any collections into multiple individual params
+            if (v instanceof Collection<?> col)
+                col.forEach(val -> postData.add(new BasicNameValuePair(k, String.valueOf(val))));
+            else
+                postData.add(new BasicNameValuePair(k, String.valueOf(v)));
+        });
+
+        try
+        {
+            HttpPost request = new HttpPost(uri);
+            request.setEntity(new UrlEncodedFormEntity(postData));
+            return request;
+        }
+        catch (UnsupportedEncodingException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/org/labkey/test/tests/ProjectCreatorUserTest.java
+++ b/src/org/labkey/test/tests/ProjectCreatorUserTest.java
@@ -1,17 +1,11 @@
 package org.labkey.test.tests;
 
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.message.BasicNameValuePair;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
-import org.labkey.remoteapi.CommandResponse;
-import org.labkey.remoteapi.PostCommand;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
@@ -24,11 +18,7 @@ import org.labkey.test.util.PermissionsHelper;
 import org.openqa.selenium.WebElement;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -201,34 +191,7 @@ public class ProjectCreatorUserTest extends BaseWebDriverTest
 
     private String createProject(Map<String, Object> params) throws IOException
     {
-        // CreateProjectAction is not a real API action, so we POST form data not JSON
-        PostCommand<CommandResponse> command = new PostCommand<>("admin", "createProject")
-        {
-            @Override
-            protected HttpUriRequest createRequest(URI uri)
-            {
-                List<BasicNameValuePair> postData = new ArrayList<>();
-
-                params.forEach((k, v) -> {
-                    // Expand any collections into multiple individual params
-                    if (v instanceof Collection<?> col)
-                        col.forEach(val -> postData.add(new BasicNameValuePair(k, String.valueOf(val))));
-                    else
-                        postData.add(new BasicNameValuePair(k, String.valueOf(v)));
-                });
-
-                try
-                {
-                    HttpPost request = new HttpPost(uri);
-                    request.setEntity(new UrlEncodedFormEntity(postData));
-                    return request;
-                }
-                catch (UnsupportedEncodingException e)
-                {
-                    throw new RuntimeException(e);
-                }
-            }
-        };
+        CreateProjectCommand command = new CreateProjectCommand(params);
 
         try
         {

--- a/src/org/labkey/test/tests/ProjectCreatorUserTest.java
+++ b/src/org/labkey/test/tests/ProjectCreatorUserTest.java
@@ -19,9 +19,7 @@ import org.openqa.selenium.WebElement;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -91,11 +89,11 @@ public class ProjectCreatorUserTest extends BaseWebDriverTest
         log("Project Creator creating the project with admin permission");
         goToHome();
         impersonate(PROJECT_CREATOR_USER);
-        Map<String, Object> params = new HashMap<>();
-        params.put("name", PROJECT_NAME_PC);
-        params.put("assignProjectAdmin", "true");
-        params.put("folderType", "Collaboration");
-        createProject(params);
+        CreateProjectCommand command = new CreateProjectCommand()
+            .setName(PROJECT_NAME_PC)
+            .setAssignProjectAdmin(true)
+            .setFolderType("Collaboration");
+        createProject(command);
         stopImpersonating();
 
         log("Verifying the permissions");
@@ -109,11 +107,11 @@ public class ProjectCreatorUserTest extends BaseWebDriverTest
         log("Project Creator creating the project without admin permission");
         goToHome();
         impersonate(PROJECT_CREATOR_USER);
-        params = new HashMap<>();
-        params.put("name", PROJECT_NAME_PC);
-        params.put("assignProjectAdmin", "false");
-        params.put("folderType", "Collaboration");
-        createProject(params);
+        command = new CreateProjectCommand()
+            .setName(PROJECT_NAME_PC)
+            .setAssignProjectAdmin(false)
+            .setFolderType("Collaboration");
+        createProject(command);
         stopImpersonating();
 
         log("Verifying the permissions");
@@ -127,11 +125,11 @@ public class ProjectCreatorUserTest extends BaseWebDriverTest
         log("Verifying Reader creating the project fails");
         goToHome();
         impersonate(READER);
-        Map<String, Object> params = new HashMap<>();
-        params.put("name", PROJECT_NAME_PC);
-        params.put("assignProjectAdmin", "false");
-        params.put("folderType", "Collaboration");
-        String response = createProject(params);
+        CreateProjectCommand command = new CreateProjectCommand()
+            .setName(PROJECT_NAME_PC)
+            .setAssignProjectAdmin(false)
+            .setFolderType("Collaboration");
+        String response = createProject(command);
         stopImpersonating();
 
         assertEquals("Should not be able to create the project", "403 : Forbidden", response);
@@ -144,13 +142,14 @@ public class ProjectCreatorUserTest extends BaseWebDriverTest
         String containerId = ((APIContainerHelper) _containerHelper).getContainerId(TEMPLATE_PROJECT);
         goToHome();
         impersonate(PROJECT_CREATOR_USER);
-        Map<String, Object> params = new HashMap<>();
-        params.put("name", PROJECT_NAME_PC);
-        params.put("assignProjectAdmin", "true");
-        params.put("folderType", "Template");
-        params.put("templateSourceId", containerId);
-        params.put("templateWriterTypes", "Lists");
-        createProject(params);
+        CreateProjectCommand command = new CreateProjectCommand()
+            .setName(PROJECT_NAME_PC)
+            .setAssignProjectAdmin(true)
+            .setFolderType("Template")
+            .setTemplateSourceId(containerId)
+            .setTemplateIncludeSubfolders(true)
+            .setTemplateWriterTypes("Lists");
+        createProject(command);
         stopImpersonating();
 
         goToProjectHome(PROJECT_NAME_PC);
@@ -172,14 +171,14 @@ public class ProjectCreatorUserTest extends BaseWebDriverTest
 
         goToHome();
         impersonate(PROJECT_CREATOR_USER);
-        Map<String, Object> params = new HashMap<>();
-        params.put("name", PROJECT_NAME_PC);
-        params.put("assignProjectAdmin", "true");
-        params.put("folderType", "Template");
-        params.put("templateSourceId", containerId);
-        params.put("templateIncludeSubfolders", "true");
-        params.put("templateWriterTypes", List.of("Role assignments for users and groups", "Project-level groups and members"));
-        createProject(params);
+        CreateProjectCommand command = new CreateProjectCommand()
+            .setName(PROJECT_NAME_PC)
+            .setAssignProjectAdmin(true)
+            .setFolderType("Template")
+            .setTemplateSourceId(containerId)
+            .setTemplateIncludeSubfolders(true)
+            .setTemplateWriterTypes("Role assignments for users and groups", "Project-level groups and members");
+        createProject(command);
         stopImpersonating();
 
         assertTrue(projectMenu().projectLinkExists(PROJECT_NAME_PC));
@@ -189,10 +188,8 @@ public class ProjectCreatorUserTest extends BaseWebDriverTest
         goToFolderPermissions().isUserInGroup(PROJECT_CREATOR_USER, TEMPLATE_FOLDER_PERMISSION, PermissionsHelper.PrincipalType.USER);
     }
 
-    private String createProject(Map<String, Object> params) throws IOException
+    private String createProject(CreateProjectCommand command) throws IOException
     {
-        CreateProjectCommand command = new CreateProjectCommand(params);
-
         try
         {
             command.execute(getRemoteApiConnection(), "/");

--- a/src/org/labkey/test/tests/ProjectCreatorUserTest.java
+++ b/src/org/labkey/test/tests/ProjectCreatorUserTest.java
@@ -6,6 +6,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.admin.CreateProjectCommand;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;


### PR DESCRIPTION
#### Rationale
Improve the usability of this command. We'll move it into labkey-client-api once the library supports Java 17.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/31

#### Changes
* Extract a named class and use setters instead of String-based maps, like a real API
