### PR TITLE
Enable deep reflection for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,11 @@ def initPropertiesTask = project.tasks.register("initProperties", Task) {
         })
 }
 
+tasks.withType(Test).configureEach {
+    jvmArgs(["--add-opens=java.base/java.lang=ALL-UNNAMED",
+             "--add-opens=java.base/java.util=ALL-UNNAMED"])
+}
+
 project.tasks.uiTests.dependsOn(initPropertiesTask)
 project.parent.parent.tasks.ijConfigure.dependsOn(initPropertiesTask)
 


### PR DESCRIPTION
#### Rationale
The Sardine WebDav client uses reflection techniques that are no longer enabled by default as of Gradle 7.5.
https://docs.gradle.org/7.5/userguide/upgrading_version_7.html#removes_implicit_add_opens_for_test_workers

#### Related Pull Requests
* https://github.com/LabKey/server/pull/285

#### Changes
* Add `--add-opens` flags to test JVM args
