### PR TITLE
Wait for mask to disappear after setting default script engine

### DIFF
--- a/src/org/labkey/test/pages/ConfigureReportsAndScriptsPage.java
+++ b/src/org/labkey/test/pages/ConfigureReportsAndScriptsPage.java
@@ -88,6 +88,7 @@ public class ConfigureReportsAndScriptsPage extends LabKeyPage
         editEngineWindow.clickButton("Submit", 0);
         acceptAlert();
         editEngineWindow.waitForClose();
+        _ext4Helper.waitForMaskToDisappear();
     }
 
     @LogMethod


### PR DESCRIPTION
#### Rationale
Fix test failure introduced by changes to the `ConfigureReportsAndScriptsPage`.

```
org.openqa.selenium.ElementClickInterceptedException: Element <td id="ext4-ext-gen1075" class="x4-grid-cell x4-grid-td x4-grid-cell-gridcolumn-1011 x4-grid-cell-first x4-unselectable "> is not clickable at point (186,487) because another element <div id="ext4-ext-gen1066" class="x4-mask"> obscures it
[...]
	at app//org.labkey.test.selenium.ReclickingWebElement.clickRowInFirefox(ReclickingWebElement.java:185)
	at app//org.labkey.test.selenium.ReclickingWebElement.click(ReclickingWebElement.java:91)
	at app//org.labkey.test.pages.ConfigureReportsAndScriptsPage.selectEngineNamed(ConfigureReportsAndScriptsPage.java:260)
	at app//org.labkey.test.pages.ConfigureReportsAndScriptsPage.editEngine(ConfigureReportsAndScriptsPage.java:222)
	at app//org.labkey.test.tests.RConfigTest.testSwitchDefaultEngine(RConfigTest.java:170)
```

#### Related Pull Requests
* #1168 

#### Changes
* Wait for mask to disappear after setting default script engine
