### PR TITLE
Roll back Selenium upgrade

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ hamcrestCoreVersion=1.3
 
 lookfirstSardineVersion=5.7
 jettyRepackagedVersion=9.4.12.v20180830
-seleniumVersion=4.3.0
+seleniumVersion=4.1.4
 mockserverNettyVersion=5.5.1
 
 labkeySchemasTestVersion=22.3-SNAPSHOT


### PR DESCRIPTION
#### Rationale
Tests are currently unable to run on Windows with Selenium 4.3. Downgrading temporarily until this can be fixed.

```
org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Possible causes are invalid address of the remote server or browser start-up failure.
         at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:587)
         at org.openqa.selenium.remote.RemoteWebDriver.startSession(RemoteWebDriver.java:264)
         at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:179)
         at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:110)
         at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:106)
         at org.labkey.test.WebDriverWrapper.createNewWebDriver(WebDriverWrapper.java:377)
         ... 46 more
       Caused by: org.openqa.selenium.WebDriverException: Driver server process died prematurely.
       Build info: version: '4.3.0', revision: 'a4995e2c09*'
       System info: host: 'EC2AMAZ-CKOB5PR', ip: '172.32.1.32', os.name: 'Windows Server 2019', os.arch: 'amd64', os.version: '10.0', java.version: '17'
       Driver info: driver.version: BaseWebDriverTest$SingletonWebDriver
         at org.openqa.selenium.remote.service.DriverService.start(DriverService.java:226)
         at org.openqa.selenium.remote.service.DriverCommandExecutor.execute(DriverCommandExecutor.java:98)
         at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:569)
         ... 51 more
```

#### Related Pull Requests
* #1122 

#### Changes
* Downgrade Selenium to 4.1.4
