### PR TITLE
Test ETLs for cross-container ETLs

### DIFF
--- a/modules/ETLtest/resources/ETLs/SProcRunFilter.xml
+++ b/modules/ETLtest/resources/ETLs/SProcRunFilter.xml
@@ -9,5 +9,6 @@
             </procedure>
         </transform>
     </transforms>
-    <incrementalFilter className="RunFilterStrategy" runTableSchema="etltest" runTable="Transfer" pkColumnName="Rowid" />
+    <incrementalFilter className="RunFilterStrategy" runTableSchema="etltest" runTable="Transfer" pkColumnName="Rowid"
+                       runTableContainerPath="/ETLTestProject"/>
 </etl>

--- a/modules/ETLtest/resources/ETLs/crossContainer.xml
+++ b/modules/ETLtest/resources/ETLs/crossContainer.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>Cross Container Test</name>
+    <description>Perform ETL across containers</description>
+    <transforms>
+        <transform id="step1" type="org.labkey.di.pipeline.TransformTask">
+            <description>Copy to target</description>
+            <source containerPath="/ETLTestProject/ETL1" schemaName="lists" queryName="ListA">
+                <sourceColumns>
+                    <column>xKey</column>
+                    <column>Field1</column>
+                    <column>EntityId</column>
+                </sourceColumns>
+            </source>
+            <destination schemaName="lists" queryName="ListB" targetOption="merge"/>
+        </transform>
+    </transforms>
+    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified">
+        <deletedRowsSource containerPath="/ETLTestProject/ETL1" schemaName="auditLog" queryName="listDeletedRows"
+                           deletedSourceKeyColumnName="ListItemEntityId" timestampColumnName="created" targetKeyColumnName="EntityId"/>
+    </incrementalFilter>
+</etl>

--- a/modules/ETLtest/resources/ETLs/crossContainer.xml
+++ b/modules/ETLtest/resources/ETLs/crossContainer.xml
@@ -5,7 +5,7 @@
     <transforms>
         <transform id="step1" type="org.labkey.di.pipeline.TransformTask">
             <description>Copy to target</description>
-            <source containerPath="/ETLTestProject/ETL1" schemaName="lists" queryName="ListA">
+            <source sourceContainerPath="/ETLTestProject/ETL1" schemaName="lists" queryName="ListA">
                 <sourceColumns>
                     <column>xKey</column>
                     <column>Field1</column>
@@ -16,7 +16,7 @@
         </transform>
     </transforms>
     <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified">
-        <deletedRowsSource containerPath="/ETLTestProject/ETL1" schemaName="auditLog" queryName="listDeletedRows"
+        <deletedRowsSource sourceContainerPath="/ETLTestProject/ETL1" schemaName="auditLog" queryName="listDeletedRows"
                            deletedSourceKeyColumnName="ListItemEntityId" timestampColumnName="created" targetKeyColumnName="EntityId"/>
     </incrementalFilter>
 </etl>


### PR DESCRIPTION
#### Rationale
Cross-container ETL functionality added to ETLs. This creates a new crossContainer ETL and updates an existing run filter ETL to be cross-container.

#### Related Pull Requests
* https://github.com/LabKey/dataintegration/pull/174

#### Changes
* Add cross-container ETL testing source, modified-since and deleted rows source containerPaths
* Update run filter ETL to be cross-container
