### PR TITLE
Adjust test for new Dataset Properties navtrail

### DIFF
--- a/src/org/labkey/test/tests/visualization/ScatterPlotTest.java
+++ b/src/org/labkey/test/tests/visualization/ScatterPlotTest.java
@@ -275,7 +275,7 @@ public class ScatterPlotTest extends GenericChartsTest
         pulseField.setDimension(true);
         datasetDesignerPage.clickSave();
 
-        waitForText("APX-1: Abbreviated Physical Exam Dataset Properties");
+        waitForText("APX-1: Abbreviated Physical Exam", "Dataset Properties");
 
         navigateToFolder(getProjectName(), getFolderName());
         ChartTypeDialog chartTypeDialog = clickAddChart("study", QUERY_APX_1);


### PR DESCRIPTION
#### Rationale
Related PR corrected the Dataset Properties page navtrail to avoid displaying an inaccessible page to non-admins. Need to adjust the test to accommodate this change.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3588