### PR TITLE
Clear page load listeners before test postamble

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1063,6 +1063,8 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     {
         disablePageUnloadEvents();
 
+        clearPageLoadListeners();
+
         ensureSignedInAsPrimaryTestUser();
 
         checkQueries();

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1990,6 +1990,11 @@ public abstract class WebDriverWrapper implements WrapsDriver
         _pageLoadListeners.get(getDriver()).add(listener);
     }
 
+    protected void clearPageLoadListeners()
+    {
+        _pageLoadListeners.get(getDriver()).clear();
+    }
+
     /**
      * Interface for classes that want to be notified of page loads (e.g. to clear a cache)
      * Not guarianteed to work flawlessly. It depends on tests using {@linkplain #doAndWaitForPageToLoad(Runnable)}

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1982,7 +1982,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
         return actionWarnings.asMap();
     }
 
-    private static final WeakHashMap<Class<? extends WebDriverWrapper>, Set<PageLoadListener>> _pageLoadListeners = new WeakHashMap<>();
+    private static final WeakHashMap<WebDriver, Set<PageLoadListener>> _pageLoadListeners = new WeakHashMap<>();
 
     public void addPageLoadListener(PageLoadListener listener)
     {
@@ -1996,8 +1996,8 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
     private Set<PageLoadListener> getPageLoadListeners()
     {
-        _pageLoadListeners.putIfAbsent(this.getClass(), Collections.newSetFromMap(new WeakHashMap<>()));
-        return _pageLoadListeners.get(this.getClass());
+        _pageLoadListeners.putIfAbsent(getDriver(), Collections.newSetFromMap(new WeakHashMap<>()));
+        return _pageLoadListeners.get(getDriver());
     }
 
     /**

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1996,8 +1996,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
     private Set<PageLoadListener> getPageLoadListeners()
     {
-        _pageLoadListeners.putIfAbsent(getDriver(), Collections.newSetFromMap(new WeakHashMap<>()));
-        return _pageLoadListeners.get(getDriver());
+        return _pageLoadListeners.computeIfAbsent(getDriver(), k -> Collections.newSetFromMap(new WeakHashMap<>()));
     }
 
     /**

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1917,7 +1917,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
         if (msWait > 0)
         {
-            _pageLoadListeners.getOrDefault(getDriver(), Collections.emptySet()).forEach((listener) -> {
+            getPageLoadListeners().forEach((listener) -> {
                 if (null != listener)
                 {
                     TestLogger.log().trace("beforePageLoad - " + listener.getClass().getSimpleName());
@@ -1934,7 +1934,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
         {
             waitForPageToLoad(toBeStale, loadTimer);
             getDriver().manage().timeouts().pageLoadTimeout(Duration.ofMillis(defaultWaitForPage));
-            _pageLoadListeners.getOrDefault(getDriver(), Collections.emptySet()).forEach((listener) -> {
+            getPageLoadListeners().forEach((listener) -> {
                 if (null != listener)
                 {
                     TestLogger.log().trace("afterPageLoad - " + listener.getClass().getSimpleName());
@@ -1982,17 +1982,22 @@ public abstract class WebDriverWrapper implements WrapsDriver
         return actionWarnings.asMap();
     }
 
-    private static final WeakHashMap<WebDriver, Set<PageLoadListener>> _pageLoadListeners = new WeakHashMap<>();
+    private static final WeakHashMap<Class<? extends WebDriverWrapper>, Set<PageLoadListener>> _pageLoadListeners = new WeakHashMap<>();
 
     public void addPageLoadListener(PageLoadListener listener)
     {
-        _pageLoadListeners.putIfAbsent(getDriver(), Collections.newSetFromMap(new WeakHashMap<>()));
-        _pageLoadListeners.get(getDriver()).add(listener);
+        getPageLoadListeners().add(listener);
     }
 
     protected void clearPageLoadListeners()
     {
-        _pageLoadListeners.get(getDriver()).clear();
+        getPageLoadListeners().clear();
+    }
+
+    private Set<PageLoadListener> getPageLoadListeners()
+    {
+        _pageLoadListeners.putIfAbsent(this.getClass(), Collections.newSetFromMap(new WeakHashMap<>()));
+        return _pageLoadListeners.get(this.getClass());
     }
 
     /**


### PR DESCRIPTION
#### Rationale
There is a page load listener that collects all visited URLs. This list of URLs is used to start off the crawler.
This combination can put crawled injection URLs in the initial set of URLs for subsequent tests; this can bypass the crawler's special handling of injection URLs.

#### Related Pull Requests
* N/A

#### Changes
* Clear page load listeners before test postamble
