### PR TITLE
Update deleteSelectedRows in ExperimentRunTable for new interaction

### DIFF
--- a/src/org/labkey/test/util/ExperimentRunTable.java
+++ b/src/org/labkey/test/util/ExperimentRunTable.java
@@ -54,8 +54,8 @@ public class ExperimentRunTable extends DataRegionTable
     {
         doAndWaitForUpdate(() ->
         {
-            clickHeaderButtonAndWait("Delete");
-            getWrapper().clickAndWait(Locator.lkButton("Confirm Delete"));
+            clickHeaderButton("Delete");
+            getWrapper().clickAndWait(Locator.linkWithText("Yes, Delete"));
         });
     }
 


### PR DESCRIPTION
#### Rationale
We have changed the interaction for deleting assay runs to use a modal confirmation instead of a separate page.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3589

#### Changes
* Update `dleeteSelectedRows` in ExperimentRunTable 
