### PR TITLE
Refactor deprecated ReactInput

### DIFF
--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -37,6 +37,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.support.ui.Quotes;
 
 import java.text.DecimalFormat;
 import java.time.Duration;
@@ -481,7 +482,12 @@ public abstract class Locator extends By
 
     public WebElement waitForElement(final SearchContext context, final int msTimeout)
     {
-        FluentWait<SearchContext> wait = new FluentWait<>(context).withTimeout(Duration.ofMillis(msTimeout));
+        return waitForElement(context, Duration.ofMillis(msTimeout));
+    }
+
+    public WebElement waitForElement(final SearchContext context, final Duration timeout)
+    {
+        FluentWait<SearchContext> wait = new FluentWait<>(context).withTimeout(timeout);
 
         return waitForElement(wait);
     }
@@ -945,35 +951,7 @@ public abstract class Locator extends By
      */
     public static String xq(String value)
     {
-        if (!value.contains("'")) {
-            return "'" + value + "'";
-        } else if (!value.contains("\"")) {
-            return '"' + value + '"';
-        } else {
-            StringBuilder result = new StringBuilder("concat(");
-            while (true) {
-                int apos = value.indexOf("'");
-                int quot = value.indexOf('"');
-                if (apos < 0) {
-                    result.append("'").append(value).append("'");
-                    break;
-                } else if (quot < 0) {
-                    result.append('"').append(value).append('"');
-                    break;
-                } else if (quot < apos) {
-                    String part = value.substring(0, apos);
-                    result.append("'").append(part).append("'");
-                    value = value.substring(part.length());
-                } else {
-                    String part = value.substring(0, quot);
-                    result.append('"').append(part).append('"');
-                    value = value.substring(part.length());
-                }
-                result.append(',');
-            }
-            result.append(')');
-            return result.toString();
-        }
+        return Quotes.escape(value);
     }
 
     public static String cq(String value)

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3292,6 +3292,9 @@ public abstract class WebDriverWrapper implements WrapsDriver
         try
         {
             fireEvent(input, SeleniumEvent.change);
+            String elementClass = input.getAttribute("class");
+            if (elementClass.contains("gwt-TextBox") || elementClass.contains("gwt-TextArea") || elementClass.contains("x-form-text"))
+                fireEvent(input, SeleniumEvent.blur); // Make GWT and ExtJS form elements behave better
         }
         catch(StaleElementReferenceException stale)
         {
@@ -3510,9 +3513,6 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
     public void setDropZone(WebElement dropZone, List<File> files)
     {
-        // Remove class so that WebDriver can interact with concealed form element
-        executeScript("arguments[0].setAttribute('class', '');arguments[0].setAttribute('style', '');", dropZone);
-        shortWait().until(ExpectedConditions.elementToBeClickable(dropZone)); // Takes a moment for DOM to update
         setInput(dropZone, files);
     }
 

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3249,10 +3249,12 @@ public abstract class WebDriverWrapper implements WrapsDriver
         {
             TestLogger.warn("Please use a File object to set file input");
             setFormElement(el, new File(text));
-            return;
         }
-
-        if (isHtml5InputTypeSupported(inputType))
+        else if (el.getTagName().equals("select"))
+        {
+            selectOptionImproperly(el, text);
+        }
+        else if (isHtml5InputTypeSupported(inputType))
         {
             setHtml5Input(el, inputType, text);
         }
@@ -3268,7 +3270,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
         {
             actionClear(input);
         }
-        else if (!input.getTagName().equals("select") && text.length() < 1000 && !text.contains("\n") && !text.contains("\t"))
+        else if (text.length() < 1000 && !text.contains("\n") && !text.contains("\t"))
         {
             actionClear(input); // Some inputs swallow standard 'WebElement.clear' in certain cases
             if (!waitFor(()-> getFormElement(input).length() == 0, 500))
@@ -3466,22 +3468,27 @@ public abstract class WebDriverWrapper implements WrapsDriver
     {
         if ("select".equals(el.getTagName()))
         {
-            try
-            {
-                selectOptionByText(el,text);
-                log("WARNING: Use selectOptionByText(..) instead of setFormElement(..) for select inputs");
-            }
-            catch (NoSuchElementException x)
-            {
-                selectOptionByValue(el,text);
-                log("WARNING: Use selectOptionByValue(..) instead of setFormElement(..) for select inputs");
-            }
+            selectOptionImproperly(el, text);
         }
         else
         {
             executeScript("arguments[0].value = arguments[1]", el, text);
         }
         fireEvent(el, SeleniumEvent.change);
+    }
+
+    private void selectOptionImproperly(WebElement el, String text)
+    {
+        try
+        {
+            selectOptionByText(el, text);
+            log("WARNING: Use selectOptionByText(..) instead of setFormElement(..) for select elements");
+        }
+        catch (NoSuchElementException x)
+        {
+            selectOptionByValue(el, text);
+            log("WARNING: Use selectOptionByValue(..) instead of setFormElement(..) for select elements");
+        }
     }
 
     public void setInput(Locator loc, List<File> files)

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3268,11 +3268,11 @@ public abstract class WebDriverWrapper implements WrapsDriver
     {
         if (StringUtils.isEmpty(text))
         {
-            actionClear(input);
+            input.clear();
         }
         else if (text.length() < 1000 && !text.contains("\n") && !text.contains("\t"))
         {
-            actionClear(input); // Some inputs swallow standard 'WebElement.clear' in certain cases
+            input.clear();
             if (!waitFor(()-> getFormElement(input).length() == 0, 500))
             {
                 TestLogger.warn("Failed to clear input: " + input);
@@ -3285,13 +3285,11 @@ public abstract class WebDriverWrapper implements WrapsDriver
         }
         else
         {
-            actionClear(input);
-            actionPaste(input, text);
+            setFormElementJS(input, text);
         }
 
         try
         {
-            fireEvent(input, SeleniumEvent.change);
             String elementClass = input.getAttribute("class");
             if (elementClass.contains("gwt-TextBox") || elementClass.contains("gwt-TextArea") || elementClass.contains("x-form-text"))
                 fireEvent(input, SeleniumEvent.blur); // Make GWT and ExtJS form elements behave better

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3238,7 +3238,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
         if ("file".equals(inputType))
         {
-            log("WARNING: Please use File object to set file input");
+            TestLogger.warn("Please use a File object to set file input");
             setFormElement(el, new File(text));
             return;
         }
@@ -3257,11 +3257,11 @@ public abstract class WebDriverWrapper implements WrapsDriver
     {
         if (StringUtils.isEmpty(text))
         {
-            input.clear();
+            actionClear(input);
         }
         else if (!input.getTagName().equals("select") && text.length() < 1000 && !text.contains("\n") && !text.contains("\t"))
         {
-            input.clear();
+            actionClear(input); // Some inputs swallow standard 'WebElement.clear' in certain cases
             if (!waitFor(()-> input.getDomProperty("value").length() == 0, 500))
             {
                 TestLogger.warn("Failed to clear input: " + input);
@@ -3374,7 +3374,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
                 setHtml5NumberInput(input, value);
                 break;
             default:
-                log(String.format("WARNING: No special handling defined for HTML5 input type = '%s'.", inputType));
+                TestLogger.warn(String.format("No special handling defined for HTML5 input type = '%s'.", inputType));
                 setInput(input, value);
         }
     }

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3250,17 +3250,28 @@ public abstract class WebDriverWrapper implements WrapsDriver
             TestLogger.warn("Please use a File object to set file input");
             setFormElement(el, new File(text));
         }
-        else if (el.getTagName().equals("select"))
-        {
-            selectOptionImproperly(el, text);
-        }
-        else if (isHtml5InputTypeSupported(inputType))
-        {
-            setHtml5Input(el, inputType, text);
-        }
         else
         {
-            setInput(el, text);
+            String tagName = el.getTagName();
+            if (tagName.equals("select"))
+            {
+                selectOptionImproperly(el, text);
+            }
+            else if (tagName.equals("input") || tagName.equals("textarea"))
+            {
+                if (isHtml5InputTypeSupported(inputType))
+                {
+                    setHtml5Input(el, inputType, text);
+                }
+                else
+                {
+                    setInput(el, text);
+                }
+            }
+            else
+            {
+                throw new IllegalArgumentException("Invalid element: " + el);
+            }
         }
     }
 

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3262,19 +3262,20 @@ public abstract class WebDriverWrapper implements WrapsDriver
         else if (!input.getTagName().equals("select") && text.length() < 1000 && !text.contains("\n") && !text.contains("\t"))
         {
             actionClear(input); // Some inputs swallow standard 'WebElement.clear' in certain cases
-            if (!waitFor(()-> input.getDomProperty("value").length() == 0, 500))
+            if (!waitFor(()-> getFormElement(input).length() == 0, 500))
             {
                 TestLogger.warn("Failed to clear input: " + input);
             }
             input.sendKeys(text);
-            if (!waitFor(()-> input.getDomProperty("value").equals(text), 500))
+            if (!waitFor(()-> getFormElement(input).equals(text), 500))
             {
                 TestLogger.warn("Failed to set input: " + input);
             }
         }
         else
         {
-            setFormElementJS(input, text);
+            actionClear(input);
+            actionPaste(input, text);
         }
 
         try
@@ -3298,6 +3299,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
     {
         String osName = System.getProperty("os.name");
         Keys cmdKey = osName.toLowerCase().contains("mac") ? Keys.COMMAND : Keys.CONTROL;
+        scrollIntoView(input);
         new Actions(getDriver())
             .keyDown(cmdKey)
             .sendKeys(input, "a")                        // select all
@@ -3331,6 +3333,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
         }
         else
         {
+            scrollIntoView(input);
             new Actions(getDriver())
                     .keyDown(cmdKey)
                     .sendKeys(input, "v")       // paste the contents of the clipboard into the input

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3255,7 +3255,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
             String tagName = el.getTagName();
             if (tagName.equals("select"))
             {
-                selectOptionImproperly(el, text);
+                selectOption(el, text);
             }
             else if (tagName.equals("input") || tagName.equals("textarea"))
             {
@@ -3480,27 +3480,13 @@ public abstract class WebDriverWrapper implements WrapsDriver
     {
         if ("select".equals(el.getTagName()))
         {
-            selectOptionImproperly(el, text);
+            selectOption(el, text);
         }
         else
         {
             executeScript("arguments[0].value = arguments[1]", el, text);
         }
         fireEvent(el, SeleniumEvent.change);
-    }
-
-    private void selectOptionImproperly(WebElement el, String text)
-    {
-        try
-        {
-            selectOptionByText(el, text);
-            log("WARNING: Use selectOptionByText(..) instead of setFormElement(..) for select elements");
-        }
-        catch (NoSuchElementException x)
-        {
-            selectOptionByValue(el, text);
-            log("WARNING: Use selectOptionByValue(..) instead of setFormElement(..) for select elements");
-        }
     }
 
     public void setInput(Locator loc, List<File> files)
@@ -3517,13 +3503,8 @@ public abstract class WebDriverWrapper implements WrapsDriver
         executeScript("arguments[0].value = '';", el);
         List<String> filePaths = files.stream().map(File::getAbsolutePath).collect(Collectors.toList());
         String fileNames = String.join("\n", filePaths);
-        log(fileNames);
+        TestLogger.debug(fileNames);
         el.sendKeys(fileNames);
-    }
-
-    public void setDropZone(WebElement dropZone, List<File> files)
-    {
-        setInput(dropZone, files);
     }
 
     /**
@@ -3711,9 +3692,28 @@ public abstract class WebDriverWrapper implements WrapsDriver
         return checkBoxLocator.findElement(getDriver()).isSelected();
     }
 
-    public boolean isChecked(WebElement checkBoxLocator)
+    /**
+     * @deprecated Use {@link WebElement#isSelected()}
+     */
+    @Deprecated (since = "22.9")
+    public boolean isChecked(WebElement checkBox)
     {
-        return null != checkBoxLocator.getAttribute("checked");
+        return checkBox.isSelected();
+    }
+
+    /**
+     * Try to select option by text or value.
+     */
+    private void selectOption(WebElement el, String text)
+    {
+        try
+        {
+            selectOptionByText(el, text);
+        }
+        catch (NoSuchElementException x)
+        {
+            selectOptionByValue(el, text);
+        }
     }
 
     public void selectOptionByValue(Locator locator, String value)

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3292,7 +3292,6 @@ public abstract class WebDriverWrapper implements WrapsDriver
         try
         {
             fireEvent(input, SeleniumEvent.change);
-            fireEvent(input, SeleniumEvent.blur);
         }
         catch(StaleElementReferenceException stale)
         {

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3297,6 +3297,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
         else
         {
             setFormElementJS(input, text);
+            input.sendKeys(" ", Keys.BACK_SPACE); // 'change' event isn't always sufficient
         }
 
         try

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3280,9 +3280,8 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
         try
         {
-            String elementClass = input.getAttribute("class");
-            if (elementClass.contains("gwt-TextBox") || elementClass.contains("gwt-TextArea") || elementClass.contains("x-form-text"))
-                fireEvent(input, SeleniumEvent.blur); // Make GWT and ExtJS form elements behave better
+            fireEvent(input, SeleniumEvent.change);
+            fireEvent(input, SeleniumEvent.blur);
         }
         catch(StaleElementReferenceException stale)
         {

--- a/src/org/labkey/test/components/html/FileInput.java
+++ b/src/org/labkey/test/components/html/FileInput.java
@@ -38,6 +38,6 @@ public class FileInput extends Input
     {
         super.assertElementType(el);
         String type = el.getAttribute("type");
-        Assert.assertEquals("Not a file input: " + el.toString(), "file", type);
+        Assert.assertEquals("Not a file input: " + el, "file", type);
     }
 }

--- a/src/org/labkey/test/components/html/Input.java
+++ b/src/org/labkey/test/components/html/Input.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.components.html;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
@@ -24,6 +25,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
 
 public class Input extends WebDriverComponent<Component<?>.ElementCache> implements FormItem<String>
 {
@@ -88,12 +91,59 @@ public class Input extends WebDriverComponent<Component<?>.ElementCache> impleme
     @Override
     public void set(String value)
     {
+        set(value, true);
+    }
+
+    public void set(String value, boolean validateValue)
+    {
+        WebDriverWrapper.waitFor(()-> getComponentElement().isEnabled(), "Input is not enabled.", WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
+
         getWrapper().setFormElement(getComponentElement(), value);
+//        int tryCount = retry ? 0 : 4;
+//        while (!strip(value).equals(strip(get())) && tryCount < 5)
+//        {
+//            getComponentElement().clear();
+//            getWrapper().fireEvent(getComponentElement(), WebDriverWrapper.SeleniumEvent.blur);
+//
+//            if (!value.contains("\n") && !value.contains("\t"))
+//            {
+//                getComponentElement().sendKeys(value);
+//                getWrapper().waitFor(() -> strip(get()).equals(strip(value)), 1000);
+//            }
+//            else // sendKeys times out with very long values; work around follows
+//            {
+//                getWrapper().fireEvent(getComponentElement(), WebDriverWrapper.SeleniumEvent.focus);
+//                getWrapper().setFormElementJS(getComponentElement(), value);
+//                getWrapper().fireEvent(getComponentElement(), WebDriverWrapper.SeleniumEvent.change);
+//            }
+//            new FluentWait<>(this).withTimeout(Duration.ofMillis(tryCount * 250)); // pause progressively as trycount goes up
+//            tryCount++;
+//            getWrapper().fireEvent(getComponentElement(), WebDriverWrapper.SeleniumEvent.blur);
+//        }
+        if (validateValue)
+            assertEquals("Set failed", StringUtils.trim(value), StringUtils.trim(get())); // Fail fast when react select gets out of sync somehow
+    }
+
+    public void setWithPaste(String value)
+    {
+        getWrapper().actionClear(getComponentElement());
+        getWrapper().actionPaste(getComponentElement(), value);
+        getWrapper().fireEvent(getComponentElement(), WebDriverWrapper.SeleniumEvent.change);
     }
 
     public void blur()
     {
         getWrapper().fireEvent(getComponentElement(), WebDriverWrapper.SeleniumEvent.blur);
+    }
+
+    /**
+     * removes newlines, tabs, other non-space, non-comma, other chars
+     * @param value
+     * @return
+     */
+    private String strip(String value)
+    {
+        return value.replace("\n", "").replaceAll("[^a-zA-Z0-9.,\\s+]", "");
     }
 
     protected void assertElementType(WebElement el)

--- a/src/org/labkey/test/components/html/Input.java
+++ b/src/org/labkey/test/components/html/Input.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.test.components.html;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
@@ -25,8 +24,6 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.util.Arrays;
-
-import static org.junit.Assert.assertEquals;
 
 public class Input extends WebDriverComponent<Component<?>.ElementCache> implements FormItem<String>
 {
@@ -91,37 +88,7 @@ public class Input extends WebDriverComponent<Component<?>.ElementCache> impleme
     @Override
     public void set(String value)
     {
-        set(value, true);
-    }
-
-    public void set(String value, boolean validateValue)
-    {
-        WebDriverWrapper.waitFor(()-> getComponentElement().isEnabled(), "Input is not enabled.", WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
-
         getWrapper().setFormElement(getComponentElement(), value);
-//        int tryCount = retry ? 0 : 4;
-//        while (!strip(value).equals(strip(get())) && tryCount < 5)
-//        {
-//            getComponentElement().clear();
-//            getWrapper().fireEvent(getComponentElement(), WebDriverWrapper.SeleniumEvent.blur);
-//
-//            if (!value.contains("\n") && !value.contains("\t"))
-//            {
-//                getComponentElement().sendKeys(value);
-//                getWrapper().waitFor(() -> strip(get()).equals(strip(value)), 1000);
-//            }
-//            else // sendKeys times out with very long values; work around follows
-//            {
-//                getWrapper().fireEvent(getComponentElement(), WebDriverWrapper.SeleniumEvent.focus);
-//                getWrapper().setFormElementJS(getComponentElement(), value);
-//                getWrapper().fireEvent(getComponentElement(), WebDriverWrapper.SeleniumEvent.change);
-//            }
-//            new FluentWait<>(this).withTimeout(Duration.ofMillis(tryCount * 250)); // pause progressively as trycount goes up
-//            tryCount++;
-//            getWrapper().fireEvent(getComponentElement(), WebDriverWrapper.SeleniumEvent.blur);
-//        }
-        if (validateValue)
-            assertEquals("Set failed", StringUtils.trim(value), StringUtils.trim(get())); // Fail fast when react select gets out of sync somehow
     }
 
     public void setWithPaste(String value)
@@ -134,16 +101,6 @@ public class Input extends WebDriverComponent<Component<?>.ElementCache> impleme
     public void blur()
     {
         getWrapper().fireEvent(getComponentElement(), WebDriverWrapper.SeleniumEvent.blur);
-    }
-
-    /**
-     * removes newlines, tabs, other non-space, non-comma, other chars
-     * @param value
-     * @return
-     */
-    private String strip(String value)
-    {
-        return value.replace("\n", "").replaceAll("[^a-zA-Z0-9.,\\s+]", "");
     }
 
     protected void assertElementType(WebElement el)

--- a/src/org/labkey/test/components/html/Input.java
+++ b/src/org/labkey/test/components/html/Input.java
@@ -82,7 +82,7 @@ public class Input extends WebDriverComponent<Component<?>.ElementCache> impleme
     @Override
     public String get()
     {
-        return getWrapper().getFormElement(getComponentElement());
+        return getComponentElement().getDomProperty("value");
     }
 
     @Override

--- a/src/org/labkey/test/components/html/ValidatingInput.java
+++ b/src/org/labkey/test/components/html/ValidatingInput.java
@@ -29,8 +29,11 @@ public class ValidatingInput extends Input
 
         super.set(value);
 
-        if (validateValue)
+        if (validateValue && !strip(value).equals(strip(get())))
+        {
+            super.set(value); // Retry once
             assertEquals("Set failed", strip(value), strip(get())); // Fail fast when react select gets out of sync somehow
+        }
     }
 
     private String strip(String value) // removes newlines, tabs, other non-space, non-comma, other chars

--- a/src/org/labkey/test/components/html/ValidatingInput.java
+++ b/src/org/labkey/test/components/html/ValidatingInput.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016-2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
+ * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
+ */
+package org.labkey.test.components.html;
+
+import org.apache.commons.lang3.StringUtils;
+import org.labkey.test.WebDriverWrapper;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertEquals;
+
+public class ValidatingInput extends Input
+{
+    public ValidatingInput(WebElement el, WebDriver driver)
+    {
+        super(el, driver);
+    }
+
+    @Override
+    public void set(String value)
+    {
+        set(value, true);
+    }
+
+    public void set(String value, boolean validateValue)
+    {
+        WebDriverWrapper.waitFor(()-> getComponentElement().isEnabled(), "Input is not enabled.", WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
+
+        super.set(value);
+
+        if (validateValue)
+            assertEquals("Set failed", StringUtils.trim(value), StringUtils.trim(get())); // Fail fast when react select gets out of sync somehow
+    }
+
+}

--- a/src/org/labkey/test/components/html/ValidatingInput.java
+++ b/src/org/labkey/test/components/html/ValidatingInput.java
@@ -28,10 +28,12 @@ public class ValidatingInput extends Input
         WebDriverWrapper.waitFor(()-> getComponentElement().isEnabled(), "Input is not enabled.", WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
 
         super.set(value);
+        blur();
 
         if (validateValue && !strip(value).equals(strip(get())))
         {
             super.set(value); // Retry once
+            blur();
             assertEquals("Set failed", strip(value), strip(get())); // Fail fast when react select gets out of sync somehow
         }
     }

--- a/src/org/labkey/test/components/html/ValidatingInput.java
+++ b/src/org/labkey/test/components/html/ValidatingInput.java
@@ -4,7 +4,6 @@
  */
 package org.labkey.test.components.html;
 
-import org.apache.commons.lang3.StringUtils;
 import org.labkey.test.WebDriverWrapper;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -31,7 +30,11 @@ public class ValidatingInput extends Input
         super.set(value);
 
         if (validateValue)
-            assertEquals("Set failed", StringUtils.trim(value), StringUtils.trim(get())); // Fail fast when react select gets out of sync somehow
+            assertEquals("Set failed", strip(value), strip(get())); // Fail fast when react select gets out of sync somehow
     }
 
+    private String strip(String value) // removes newlines, tabs, other non-space, non-comma, other chars
+    {
+        return value.replace("\n", "").replaceAll("[^a-zA-Z0-9.,\\s+]", "");
+    }
 }

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -6,6 +6,7 @@ package org.labkey.test.components.react;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.WebDriverComponent;
@@ -255,16 +256,27 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
 
         scrollIntoView();
 
-        WebElement removeBtn = Locators.removeMultiSelectValueButton(value).findWhenNeeded(getComponentElement());
-        removeBtn.click();
-
-        getWrapper().shortWait().until(ExpectedConditions.stalenessOf(removeBtn));
+        attemptRemove(value);
 
         // Validate that the selected item really was removed.
         WebDriverWrapper.sleep(500);
-        waitFor(()->!getSelections().contains(value), String.format("Failed to remove selection '%s'.", value), WAIT_FOR_JAVASCRIPT);
+        if (getSelections().contains(value))
+        {
+            String msg = String.format("Failed to remove selection '%s'.", value);
+            TestLogger.warn(msg + ": retrying");
+            attemptRemove(value);
+            Assert.assertFalse(msg, getSelections().contains(value));
+        }
 
         return getThis();
+    }
+
+    private void attemptRemove(String value)
+    {
+        WebElement removeBtn = Locators.removeMultiSelectValueButton(value).findElement(getComponentElement());
+        removeBtn.click();
+
+        getWrapper().shortWait().until(ExpectedConditions.stalenessOf(removeBtn));
     }
 
     public boolean hasSelection()

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -147,19 +147,19 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
     {
         scrollIntoView();
         open();
-        getWrapper().setFormElement(elementCache().input, value);
-        WebElement foundElement;
+        elementCache().input.clear();
+        elementCache().input.sendKeys(value);
         try
         {
             var optionElement = ReactSelect.Locators.options.containing(value);
-            foundElement = optionElement.waitForElement(elementCache().selectMenu, 4000);
+            optionElement.waitForElement(elementCache().selectMenu, 4000);
             elementCache().input.clear();
+            return true;
         }
         catch (NoSuchElementException nse)
         {
             return false;
         }
-        return foundElement != null;
     }
 
     /* waits until the currently selected 'value' equals or contains the specified string */

--- a/src/org/labkey/test/components/react/ToggleButton.java
+++ b/src/org/labkey/test/components/react/ToggleButton.java
@@ -6,7 +6,7 @@ import org.labkey.test.components.WebDriverComponent;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
-public class ToggleButton extends WebDriverComponent<ToggleButton.ElementCache>
+public class ToggleButton extends WebDriverComponent<WebDriverComponent<?>.ElementCache>
 {
     final WebElement _el;
     final WebDriver _driver;
@@ -44,21 +44,11 @@ public class ToggleButton extends WebDriverComponent<ToggleButton.ElementCache>
         return !getComponentElement().getAttribute("class").contains("off");
     }
 
-    @Override
-    protected ElementCache newElementCache()
-    {
-        return new ElementCache();
-    }
-
-    protected class ElementCache extends WebDriverComponent.ElementCache
-    {
-    }
-
-
     public static class ToggleButtonFinder extends WebDriverComponentFinder<ToggleButton, ToggleButtonFinder>
     {
-        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "toggle");
+        private static final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "toggle");
         private String _state = null;
+        private String _containerClass = null;
 
         public ToggleButtonFinder(WebDriver driver)
         {
@@ -71,6 +61,12 @@ public class ToggleButton extends WebDriverComponent<ToggleButton.ElementCache>
             return this;
         }
 
+        public ToggleButtonFinder withContainerClass(String containerClass)
+        {
+            _containerClass = containerClass;
+            return  this;
+        }
+
         @Override
         protected ToggleButton construct(WebElement el, WebDriver driver)
         {
@@ -80,10 +76,17 @@ public class ToggleButton extends WebDriverComponent<ToggleButton.ElementCache>
         @Override
         protected Locator locator()
         {
+            Locator.XPathLocator locator = _baseLocator;
+            if (_containerClass != null)
+            {
+                locator = Locator.tagWithClassContaining("div", _containerClass).descendant(locator);
+            }
             if (_state != null)
-                return _baseLocator.withDescendant(Locator.tagWithText("span", _state));
-            else
-                return _baseLocator;
+            {
+                locator = locator.withDescendant(Locator.tagWithText("span", _state));
+            }
+
+            return locator;
         }
     }
 }

--- a/src/org/labkey/test/components/ui/edit/EditInlineField.java
+++ b/src/org/labkey/test/components/ui/edit/EditInlineField.java
@@ -37,7 +37,7 @@ public class EditInlineField extends WebDriverComponent<EditInlineField.ElementC
         open();
         WebElement input = elementCache().input;
         // 'setFormElement' calls 'WebElement.clear()' which can close the edit-in-place input
-        getWrapper().setFormElementJS(input, "");
+        getWrapper().actionClear(input);
         input.sendKeys(value, Keys.ENTER);
         getWrapper().shortWait().until(ExpectedConditions.stalenessOf(input));
     }

--- a/src/org/labkey/test/components/ui/files/FileUploadPanel.java
+++ b/src/org/labkey/test/components/ui/files/FileUploadPanel.java
@@ -4,6 +4,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.FileInput;
 import org.labkey.test.components.html.Input;
 import org.openqa.selenium.ElementNotInteractableException;
 import org.openqa.selenium.WebDriver;
@@ -12,8 +13,6 @@ import org.openqa.selenium.WebElement;
 import java.io.File;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static org.labkey.test.components.html.Input.Input;
 
 public class FileUploadPanel extends WebDriverComponent<FileUploadPanel.ElementCache>
 {
@@ -42,11 +41,11 @@ public class FileUploadPanel extends WebDriverComponent<FileUploadPanel.ElementC
     {
         try
         {
-            elementCache().input().set(file.getAbsolutePath());
+            elementCache().fileUploadInput().set(file);
         }catch(ElementNotInteractableException nie)
         {
             WebDriverWrapper.sleep(1000);
-            elementCache().input().set(file.getAbsolutePath());   // retry
+            elementCache().fileUploadInput().set(file);   // retry
         }
         WebDriverWrapper.waitFor(()-> hasFile(file.getName()),
                 "the file ["+ file.getName() +"] was not added", 2000);
@@ -87,9 +86,9 @@ public class FileUploadPanel extends WebDriverComponent<FileUploadPanel.ElementC
 
     protected class ElementCache extends Component<?>.ElementCache
     {
-        Input input()
+        FileInput fileUploadInput()
         {
-            return Input(Locator.id("fileUpload"), getDriver()).waitFor(this);
+            return Input.FileInput(Locator.id("fileUpload"), getDriver()).waitFor(this);
         }
 
         Locator.XPathLocator attachedFileContainer = Locator.tagWithClass("div", "attached-file--container")


### PR DESCRIPTION
#### Rationale
The deprecated biologics `ReactInput` has lingered for too long and is resulting in some unnecessary cross-module test dependencies. This change renames the component to `ValidatingInput` and moves it to `testAutomation`. It also tries to extend the functionality of `Input` more clearly and cleanly. I was unable to merge them entirely because they have different expectations of whether the input will lose focus after setting.
We should standardize the functionality of these components and `WebDriverWrapper.setFormElement` but my experimentation made it clear that doing so would be a sizable project.

The deprecated biologics `Toggle` component was interchangeable with `ToggleButton` without much modification. Just had to pull in a different Locator from `ToggleFinder`

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1201
* https://github.com/LabKey/labbook/pull/252
* https://github.com/LabKey/biologics/pull/1506
* https://github.com/LabKey/accounts/pull/154

#### Changes
* Move deprecated `ReactInput` from biologics and rename to `ValidatingInput`
* Clean up `WebDriverWrapper.setFormElement` a bit
* Integrate deprecated `ToggleFinder` into `ToggleButtonFinder`
