### PR TITLE
Revert change to deleteSelectedRows on ExperimentRunTable

### DIFF
--- a/src/org/labkey/test/util/ExperimentRunTable.java
+++ b/src/org/labkey/test/util/ExperimentRunTable.java
@@ -54,8 +54,8 @@ public class ExperimentRunTable extends DataRegionTable
     {
         doAndWaitForUpdate(() ->
         {
-            clickHeaderButton("Delete");
-            getWrapper().clickAndWait(Locator.linkWithText("Yes, Delete"));
+            clickHeaderButtonAndWait("Delete");
+            getWrapper().clickAndWait(Locator.lkButton("Confirm Delete"));
         });
     }
 


### PR DESCRIPTION
#### Rationale
We're reverting the assay run deletion confirmation changes, so test interaction needs to be reverted too.

#### Related Pull Requests
* #1200 

#### Changes
* Revert change in `deleteSelectedRows`
