### PR TITLE
Fixing SampleFinder and Notification Test Failures.

### DIFF
--- a/src/org/labkey/test/components/ui/notifications/ServerNotificationItem.java
+++ b/src/org/labkey/test/components/ui/notifications/ServerNotificationItem.java
@@ -166,7 +166,7 @@ public class ServerNotificationItem extends WebDriverComponent<ServerNotificatio
      */
     public void clickViewLink()
     {
-        String currentUrl = getDriver().getCurrentUrl().toLowerCase();
+        String currentUrl = getDriver().getCurrentUrl().toLowerCase().replace("app.view?#/", "app.view#/");
         String targetUrl = elementCache().link.getAttribute("href").toLowerCase();
 
         elementCache().link.click();

--- a/src/org/labkey/test/components/ui/search/SampleFinder.java
+++ b/src/org/labkey/test/components/ui/search/SampleFinder.java
@@ -142,7 +142,7 @@ public class SampleFinder extends WebDriverComponent<SampleFinder.ElementCache>
      */
     protected WebDriverWait loadingWait()
     {
-        return getWrapper().shortWait();
+        return getWrapper().longWait();
     }
 
     public boolean isEmptySearch()


### PR DESCRIPTION
#### Rationale
Sample finder is taking longer to load in TeamCity. Updated page component to use long wait for page load. 
Also updated expected URL in notification navigation page.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/1167

#### Changes
* Use longWait for SampleFinder page load.
* Update expected url when validating notification navigation.
