### PR TITLE
Update interaction when delete data class objects

### DIFF
--- a/src/org/labkey/test/tests/TriggerScriptTest.java
+++ b/src/org/labkey/test/tests/TriggerScriptTest.java
@@ -691,7 +691,7 @@ public class TriggerScriptTest extends BaseWebDriverTest
         DataRegionTable drt = new DataRegionTable(tableName, this);
         int rowId = drt.getRowIndex(columnName, columnValue);
         drt.checkCheckbox(rowId);
-        doAndMaybeWaitForPageToLoad(1000, () ->
+        doAndMaybeWaitForPageToLoad(defaultWaitForPage, () ->
         {
             drt.clickHeaderButton("Delete");
             Alert alert = getAlertIfPresent();

--- a/src/org/labkey/test/tests/TriggerScriptTest.java
+++ b/src/org/labkey/test/tests/TriggerScriptTest.java
@@ -697,10 +697,8 @@ public class TriggerScriptTest extends BaseWebDriverTest
             Alert alert = getAlertIfPresent();
             if (alert != null)
                 alert.accept();
-            else if (expectPageLoad)
-                clickButton(deleteButtonText);
             else
-                click(Locator.linkWithText(deleteButtonText));
+                clickButton(deleteButtonText, expectPageLoad ? defaultWaitForPage : 0);
             return expectPageLoad;
         });
     }

--- a/src/org/labkey/test/tests/TriggerScriptTest.java
+++ b/src/org/labkey/test/tests/TriggerScriptTest.java
@@ -684,7 +684,7 @@ public class TriggerScriptTest extends BaseWebDriverTest
      * @param columnValue      value to look for
      * @param tableName        DataRegionTable name
      * @param deleteButtonText text that appears in delete confirmation when not in an alert.
-     * @param expectPageLoad
+     * @param expectPageLoad indicates whether confirming deletion will result in a page load or not
      */
     private void deleteSingleRowViaUI(String columnName, String columnValue, String tableName, String deleteButtonText, boolean expectPageLoad)
     {

--- a/src/org/labkey/test/tests/TriggerScriptTest.java
+++ b/src/org/labkey/test/tests/TriggerScriptTest.java
@@ -231,7 +231,7 @@ public class TriggerScriptTest extends BaseWebDriverTest
         //Check BeforeDelete Event
         step = "BeforeDelete";
         log("** " + testName + " " + step + " Event");
-        deleteSingleRowViaUI("Company", "Inserting Single", "query");
+        deleteSingleRowViaUI("Company", "Inserting Single", "query", "Confirm Delete", true);
         assertTextPresent(BEFORE_DELETE_ERROR);
         clickButton("Back");
 
@@ -253,7 +253,7 @@ public class TriggerScriptTest extends BaseWebDriverTest
         //Check AfterDelete Event
         step = "AfterDelete";
         log("** " + testName + " " + step + " Event");
-        deleteSingleRowViaUI("Company", BEFORE_UPDATE_COMPANY, "query");
+        deleteSingleRowViaUI("Company", BEFORE_UPDATE_COMPANY, "query", "Confirm Delete", true);
         assertTextPresent(AFTER_DELETE_ERROR);
         clickButton("Back");
         //Verify validation error prevented delete
@@ -381,7 +381,7 @@ public class TriggerScriptTest extends BaseWebDriverTest
     {
         GoToDataUI goToDataset = () -> goToDataset(DATASET_NAME);
 
-        doIndividualTriggerTest("Dataset", goToDataset, "ParticipantId", true);
+        doIndividualTriggerTest("Dataset", goToDataset, "ParticipantId", true, "Confirm Delete", true);
 
         //For some reason these only get logged for datasets...
         checkExpectedErrors(6);
@@ -446,7 +446,7 @@ public class TriggerScriptTest extends BaseWebDriverTest
         GoToDataUI goToDataClass = () -> goToDataClass(DATA_CLASSES_NAME);
 
         setupDataClass();
-        doIndividualTriggerTest("query", goToDataClass, "Name", false);
+        doIndividualTriggerTest("query", goToDataClass, "Name", false, "Yes, Delete", false);
     }
 
 
@@ -558,7 +558,7 @@ public class TriggerScriptTest extends BaseWebDriverTest
     /**
      * Execute a set of tests against a datatype and preset trigger script
      */
-    private void doIndividualTriggerTest(String dataRegionName, GoToDataUI goToData, String keyColumnName, boolean requiresDate)
+    private void doIndividualTriggerTest(String dataRegionName, GoToDataUI goToData, String keyColumnName, boolean requiresDate, String deleteButtonText, boolean expectPageLoad)
     {
         String flagField = COMMENTS_FIELD; //Field to watch in trigger script
         String updateField = COUNTRY_FIELD; //Field updated by trigger script
@@ -604,7 +604,7 @@ public class TriggerScriptTest extends BaseWebDriverTest
         //Check previous step prepared row for delete
         pushLocation();
         assertElementPresent(Locator.tagWithText("td", "BeforeDelete"));
-        deleteSingleRowViaUI(flagField, step, dataRegionName);
+        deleteSingleRowViaUI(flagField, step, dataRegionName, deleteButtonText, expectPageLoad);
         assertTextPresent(BEFORE_DELETE_ERROR);
         popLocation();
         //Verify validation error prevented delete
@@ -630,7 +630,7 @@ public class TriggerScriptTest extends BaseWebDriverTest
         step = "AfterDelete";
         log("** " + testName + " " + step + " Event");
         pushLocation();
-        deleteSingleRowViaUI(updateField, BEFORE_UPDATE_COMPANY, dataRegionName);
+        deleteSingleRowViaUI(updateField, BEFORE_UPDATE_COMPANY, dataRegionName, deleteButtonText, expectPageLoad);
         assertTextPresent(AFTER_DELETE_ERROR);
         popLocation();
         //Verify validation error prevented delete
@@ -679,23 +679,29 @@ public class TriggerScriptTest extends BaseWebDriverTest
 
     /**
      * delete single record via the table UI
-     * @param columnName Column to look at
-     * @param columnValue value to look for
-     * @param tableName DataRegionTable name
+     *
+     * @param columnName       Column to look at
+     * @param columnValue      value to look for
+     * @param tableName        DataRegionTable name
+     * @param deleteButtonText text that appears in delete confirmation when not in an alert.
+     * @param expectPageLoad
      */
-    private void deleteSingleRowViaUI(String columnName, String columnValue, String tableName)
+    private void deleteSingleRowViaUI(String columnName, String columnValue, String tableName, String deleteButtonText, boolean expectPageLoad)
     {
         DataRegionTable drt = new DataRegionTable(tableName, this);
         int rowId = drt.getRowIndex(columnName, columnValue);
         drt.checkCheckbox(rowId);
-        doAndWaitForPageToLoad(() ->
+        doAndMaybeWaitForPageToLoad(1000, () ->
         {
             drt.clickHeaderButton("Delete");
             Alert alert = getAlertIfPresent();
             if (alert != null)
                 alert.accept();
+            else if (expectPageLoad)
+                clickButton(deleteButtonText);
             else
-                clickButton("Confirm Delete");
+                click(Locator.linkWithText(deleteButtonText));
+            return expectPageLoad;
         });
     }
 


### PR DESCRIPTION
#### Rationale
Deletion of data class objects now uses the confirmDelete.js script, which displays an Ext4.Msg panel instead of loading a new page. For these tests for error processing, the button text has been updated and we don't expect a page load when there are errors that prevent deletion from happening.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3623

#### Changes
* Add more parameters to internal method to account for different delete interactions
