### PR TITLE
Make `ControllerActionId` work for absolute URLs

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -147,8 +147,7 @@ import static org.junit.Assert.fail;
 import static org.labkey.test.Locator.tag;
 import static org.labkey.test.TestProperties.isScriptCheckEnabled;
 import static org.labkey.test.TestProperties.isWebDriverLoggingEnabled;
-import static org.labkey.test.WebTestHelper.getBaseURL;
-import static org.labkey.test.WebTestHelper.stripContextPath;
+import static org.labkey.test.WebTestHelper.makeRelativeUrl;
 import static org.labkey.test.components.html.RadioButton.RadioButton;
 import static org.openqa.selenium.chrome.ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY;
 import static org.openqa.selenium.chrome.ChromeDriverService.CHROME_DRIVER_VERBOSE_LOG_PROPERTY;
@@ -1114,9 +1113,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
     public long beginAt(String relativeURL, int millis)
     {
-        if (relativeURL.startsWith(getBaseURL()))
-            relativeURL = relativeURL.substring(getBaseURL().length());
-        relativeURL = stripContextPath(relativeURL);
+        relativeURL = makeRelativeUrl(relativeURL);
         String logMessage = "";
 
         try

--- a/src/org/labkey/test/WebTestHelper.java
+++ b/src/org/labkey/test/WebTestHelper.java
@@ -282,23 +282,22 @@ public class WebTestHelper
         {
             if (url.startsWith(getBaseURL()))
             {
-                return url.substring(getBaseURL().length());
+                url = url.substring(getBaseURL().length());
             }
             else
             {
                 throw new IllegalArgumentException("URL does not appear to target server under test: " + url);
             }
         }
-
-        String contextPath = getContextPath() + "/";
-        if (url.startsWith(contextPath))
-        {
-            return url.substring(contextPath.length());
-        }
         else
         {
-            return StringUtils.stripStart(url, "/");
+            String contextPath = getContextPath();
+            if (url.startsWith(contextPath))
+            {
+                url = url.substring(contextPath.length());
+            }
         }
+        return StringUtils.stripStart(url, "/");
     }
 
     public enum DatabaseType

--- a/src/org/labkey/test/WebTestHelper.java
+++ b/src/org/labkey/test/WebTestHelper.java
@@ -272,22 +272,33 @@ public class WebTestHelper
     }
 
     /**
-     * Strip the context path off of the front of a relative URL. Will also remove leading slashes.
-     * @param url relative URL to the server under test
-     * @return Stripped URL
+     * Strip the base URL or context path off of the front of a URL. Will also remove leading slashes.
+     * @param url Absolute or relative URL to the server under test
+     * @return Relative URL
      */
-    public static String stripContextPath(String url)
+    public static String makeRelativeUrl(String url)
     {
+        if (url.startsWith("http://") || url.startsWith("https://"))
+        {
+            if (url.startsWith(getBaseURL()))
+            {
+                return url.substring(getBaseURL().length());
+            }
+            else
+            {
+                throw new IllegalArgumentException("URL does not appear to target server under test: " + url);
+            }
+        }
+
         String contextPath = getContextPath() + "/";
         if (url.startsWith(contextPath))
         {
-            url = url.substring(contextPath.length());
+            return url.substring(contextPath.length());
         }
         else
         {
-            url = StringUtils.stripStart(url, "/");
+            return StringUtils.stripStart(url, "/");
         }
-        return url;
     }
 
     public enum DatabaseType

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -79,8 +79,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.labkey.test.WebTestHelper.getBaseURL;
-import static org.labkey.test.WebTestHelper.stripContextPath;
+import static org.labkey.test.WebTestHelper.makeRelativeUrl;
 
 public class Crawler
 {
@@ -656,10 +655,9 @@ public class Crawler
             _action = action;
         }
 
-        public ControllerActionId(@NotNull String rootRelativeURL)
+        public ControllerActionId(@NotNull String url)
         {
-            rootRelativeURL = stripQueryParams(stripHash(rootRelativeURL));
-            rootRelativeURL = WebTestHelper.stripContextPath(rootRelativeURL);
+            String rootRelativeURL = WebTestHelper.makeRelativeUrl(stripQueryParams(stripHash(url)));
 
             if (rootRelativeURL.startsWith("_webdav/"))
             {
@@ -852,9 +850,7 @@ public class Crawler
                 .replace("]", "%5D")
                 .replace("{", "%7B")
                 .replace("}", "%7D");
-        if (relativeUrl.startsWith(getBaseURL()))
-            relativeUrl = relativeUrl.substring(getBaseURL().length());
-        relativeUrl = stripContextPath(relativeUrl);
+        relativeUrl = makeRelativeUrl(relativeUrl);
         String logMessage = "";
         Mutable<File[]> downloadedFiles = new MutableObject<>();
 


### PR DESCRIPTION
#### Rationale
A change to `WebTestHelper.stripContextPath` inadvertently made the `ControllerActionId` constructor not accept absolute URLs. It was not intended to accept them but there's no particular reason not to.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/commit/d897e8a7634ee84fb5367da9625187201424a27d#diff-44f784310be5a6e875a0087cbfb1b5875bed6db41bf1c1f8620be3b218937c6a

#### Changes
* Make `stripContextPath` work with absolute URLs
