### PR TITLE
Fix Updating Grid View Names

### DIFF
--- a/src/org/labkey/test/components/ui/grids/ManageViewsDialog.java
+++ b/src/org/labkey/test/components/ui/grids/ManageViewsDialog.java
@@ -71,11 +71,14 @@ public class ManageViewsDialog extends ModalDialog
         WebDriverWrapper.waitFor(()->elementCache().viewNameInput.isDisplayed(),
                 String.format("View name input for view '%s' did not show up in time.", currentName), 500);
 
+        // Clear the current name.
+        elementCache().viewNameInput.clear();
+
+        // Make sure focus is on the control (is this needed?)
+        elementCache().viewNameInput.click();
+
         Actions replaceCurrentText = new Actions(getDriver());
-        replaceCurrentText.sendKeys(Keys.END)
-                .keyDown(Keys.SHIFT)
-                .sendKeys(Keys.HOME)
-                .keyUp(Keys.SHIFT)
+        replaceCurrentText
                 .sendKeys(newName)
                 .sendKeys(Keys.TAB)
                 .perform();

--- a/src/org/labkey/test/components/ui/grids/ManageViewsDialog.java
+++ b/src/org/labkey/test/components/ui/grids/ManageViewsDialog.java
@@ -72,10 +72,7 @@ public class ManageViewsDialog extends ModalDialog
                 String.format("View name input for view '%s' did not show up in time.", currentName), 500);
 
         // Clear the current name.
-        elementCache().viewNameInput.clear();
-
-        // Make sure focus is on the control (is this needed?)
-        elementCache().viewNameInput.click();
+        getWrapper().actionClear(elementCache().viewNameInput);
 
         Actions replaceCurrentText = new Actions(getDriver());
         replaceCurrentText


### PR DESCRIPTION
#### Rationale
Addressing this [test failure in TC](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyCPostgres/1969622?buildTab=tests&name=GridPanelViewTest.testManageViews). The screenshot shows that the view name was not updated. 

#### Related Pull Requests
* None

#### Changes
* Change ManageViewsDialog.changeViewName to use  getWrapper().actionClear to clear the text box before setting it.
