### PR TITLE
Address the Stale Element Error When Renaming a Grid View

### DIFF
--- a/src/org/labkey/test/components/ui/grids/ManageViewsDialog.java
+++ b/src/org/labkey/test/components/ui/grids/ManageViewsDialog.java
@@ -5,6 +5,8 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.bootstrap.ModalDialog;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
@@ -80,7 +82,16 @@ public class ManageViewsDialog extends ModalDialog
                 .sendKeys(Keys.TAB)
                 .perform();
 
-        WebDriverWrapper.waitFor(()->!elementCache().viewNameInput.isDisplayed() && getViewNames().contains(newName),
+        WebDriverWrapper.waitFor(()->{
+            try {
+                return !elementCache().viewNameInput.isDisplayed() && getViewNames().contains(newName);
+            }
+            catch (StaleElementReferenceException | NoSuchElementException exp)
+            {
+                // Sometimes there is a race condition with the elementCache().viewRows refreshing after a view has been renamed.
+                return false;
+            }
+        },
                 String.format("New view name '%s' was not added to the list of views.", newName), 1_500);
 
         return this;


### PR DESCRIPTION
#### Rationale
The GridPanelTest is still occasionally failing with a stale element error when renaming a grid view. I think is race condition in the dialog with the elements getting re-rendered after a view is renamed.

#### Related Pull Requests
* None

#### Changes
* Add a try/catch in the waitFor call in the rename method.
