### PR TITLE
Make `WebTestHelper.getDatabaseType` recognize 'jtds'

### DIFF
--- a/src/org/labkey/test/WebTestHelper.java
+++ b/src/org/labkey/test/WebTestHelper.java
@@ -303,7 +303,7 @@ public class WebTestHelper
     public enum DatabaseType
     {
         PostgreSQL("org.postgresql.Driver", "pg", "postgres"),
-        MicrosoftSQLServer("com.microsoft.sqlserver.jdbc.SQLServerDriver", "net.sourceforge.jtds.jdbc.Driver", "mssql", "sqlserver");
+        MicrosoftSQLServer("com.microsoft.sqlserver.jdbc.SQLServerDriver", "net.sourceforge.jtds.jdbc.Driver", "mssql", "sqlserver", "jtds");
 
         private static final Map<String, DatabaseType> DATABASE_TYPE_MAP;
 


### PR DESCRIPTION
#### Rationale
TeamCity uses the databaseType parameter to control which db config file to use (`pg.properties`, `mssql.properties`, or `jtds.properties`). The tests need to know how to interpret 'jtds' while we're still running it on TeamCity.

#### Related Pull Requests
* #1164 

#### Changes
* Make `WebTestHelper.getDatabaseType` recognize 'jtds'
