### PR TITLE
Improve API test helpers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ project.dependencies {
     implementation "org.xerial:sqlite-jdbc:3.7.2" // declaring SQLite here to be used in targettedMS test
     api("junit:junit:${junitVersion}")
     api("org.seleniumhq.selenium:selenium-api:${seleniumVersion}")
+    api("org.assertj:assertj-core:${assertjVersion}")
     implementation("commons-io:commons-io:${commonsIoVersion}")
     implementation("com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}")
     implementation("org.bouncycastle:bcprov-jdk15on:${bouncycastleVersion}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 aspectjVersion=1.9.9.1
+assertjVersion=3.23.1
 commonsTextVersion=1.3
 reflectionsVersion=0.9.10
 hamcrestCoreVersion=1.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ jettyRepackagedVersion=9.4.12.v20180830
 seleniumVersion=4.1.4
 mockserverNettyVersion=5.5.1
 
-labkeySchemasTestVersion=22.3-SNAPSHOT
+labkeySchemasTestVersion=22.7-SNAPSHOT

--- a/src/org/labkey/junit/LabKeyAssert.java
+++ b/src/org/labkey/junit/LabKeyAssert.java
@@ -1,9 +1,10 @@
 package org.labkey.junit;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 
 import java.util.Collection;
-import java.util.stream.Collectors;
+import java.util.Collections;
 
 public class LabKeyAssert
 {
@@ -17,14 +18,15 @@ public class LabKeyAssert
      */
     public static <T> void assertEqualsSorted(String message, Collection<T> expected, Collection<T> actual)
     {
-        if (expected != null)
+        if (expected == null || actual == null)
         {
-            expected = expected.stream().sorted().collect(Collectors.toList());
+            Assert.assertEquals(message, expected, actual);
         }
-        if (actual != null)
+        else
         {
-            actual = actual.stream().sorted().collect(Collectors.toList());
+            // Can't call 'toArray' on a generic collection and retain type info. Convert to object collection.
+            Collection<Object> actualObjects = Collections.unmodifiableCollection(actual);
+            Assertions.assertThat(actualObjects).as(message).containsExactlyInAnyOrder(expected.toArray());
         }
-        Assert.assertEquals(message, expected, actual);
     }
 }

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -212,6 +212,16 @@ public abstract class TestProperties
         return "true".equals(System.getProperty("webtest.checker.fatal"));
     }
 
+    public static boolean isAssayProductFeatureAvailable()
+    {
+        return isProductFeatureAvailable("assay");
+    }
+
+    public static boolean isProductFeatureAvailable(String feature)
+    {
+        return "true".equals(System.getProperty("webtest.productFeature." + feature.toLowerCase(), "true"));
+    }
+
     /**
      * Parses system property 'webtest.server.startup.timeout' to determine maximum allowed server startup time.
      * If property is not defined or is not an integer, it defaults to 60 seconds.

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -97,7 +97,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
             if (ct.getLabel().equalsIgnoreCase(typeString))
                 return ct;
         }
-        return null;
+        throw new IllegalStateException("Unknown column type: " + typeString);
     }
 
     /**
@@ -423,9 +423,14 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         setType(FieldDefinition.ColumnType.Lookup);
         setFromFolder(lookupInfo.getFolder());
         setFromSchema(lookupInfo.getSchema());
-        if (lookupInfo.getTableType() == null)
-            throw new IllegalArgumentException("No lookup type specified for " + lookupInfo.getTable());
-        String tableType = lookupInfo.getTableType().name();
+        String tableType;
+        if (lookupInfo.getTableType() == FieldDefinition.ColumnType.Integer)
+            tableType = "Integer";
+        else if (lookupInfo.getTableType() == FieldDefinition.ColumnType.String)
+            tableType = "String";
+        else
+            throw new IllegalArgumentException("Invalid lookup type specified for " + lookupInfo.getTable() + ": " + lookupInfo.getTableType());
+
         setFromTargetTable(lookupInfo.getTable() + " (" + tableType + ")");
         return this;
     }

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -67,7 +67,7 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
 
     private DomainFormPanel editField(DomainFieldRow fieldRow, FieldDefinition fieldDefinition)
     {
-        if (fieldDefinition.getLookup() != null)
+        if (fieldDefinition.getLookup() != null && fieldDefinition.getType().getConceptURI() == null)
             fieldRow.setLookup(fieldDefinition.getLookup());
         else if (fieldDefinition.getType() != null)
             fieldRow.setType(fieldDefinition.getType());

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -50,6 +50,15 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
         return editField(fieldRow, fieldDefinition);
     }
 
+    public DomainFormPanel addFields(List<FieldDefinition> fieldDefinitions)
+    {
+        for (FieldDefinition fieldDefinition : fieldDefinitions)
+        {
+            addField(fieldDefinition);
+        }
+        return this;
+    }
+
     public DomainFormPanel setField(FieldDefinition fieldDefinition)
     {
         DomainFieldRow fieldRow = getField(fieldDefinition.getName());

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -67,10 +67,13 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
 
     private DomainFormPanel editField(DomainFieldRow fieldRow, FieldDefinition fieldDefinition)
     {
-        if (fieldDefinition.getLookup() != null && fieldDefinition.getType().getConceptURI() == null)
-            fieldRow.setLookup(fieldDefinition.getLookup());
-        else if (fieldDefinition.getType() != null)
-            fieldRow.setType(fieldDefinition.getType());
+        if (fieldDefinition.getType() != null)
+        {
+            if (fieldDefinition.getType().isLookup())
+                fieldRow.setLookup(fieldDefinition.getLookup());
+            else
+                fieldRow.setType(fieldDefinition.getType());
+        }
 
         if (fieldDefinition.getDescription() != null)
             fieldRow.setDescription(fieldDefinition.getDescription());

--- a/src/org/labkey/test/components/ui/grids/GridRow.java
+++ b/src/org/labkey/test/components/ui/grids/GridRow.java
@@ -15,7 +15,6 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -25,14 +24,12 @@ import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 public class GridRow extends WebDriverComponent<GridRow.ElementCache>
 {
     final WebElement _el;
-    final WebDriver _driver;
     final ResponsiveGrid<?> _grid;
     private Map<String, String> _rowMap = null;
 
-    protected GridRow(ResponsiveGrid<?> grid, WebElement element, WebDriver driver)
+    protected GridRow(ResponsiveGrid<?> grid, WebElement element)
     {
         _el = element;
-        _driver = driver;
         _grid = grid;
     }
 
@@ -63,7 +60,10 @@ public class GridRow extends WebDriverComponent<GridRow.ElementCache>
     {
         assertTrue("The row does not have a select box", hasSelectColumn());
         getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().selectCheckbox.getComponentElement()));
-        elementCache().selectCheckbox.set(checked);
+        if (elementCache().selectCheckbox.get() != checked)
+        {
+            _grid.doAndWaitForUpdate(()-> elementCache().selectCheckbox.set(checked));
+        }
         return this;
     }
 
@@ -184,7 +184,7 @@ public class GridRow extends WebDriverComponent<GridRow.ElementCache>
     @Override
     public WebDriver getDriver()
     {
-        return _driver;
+        return _grid.getDriver();
     }
 
     @Override
@@ -257,7 +257,7 @@ public class GridRow extends WebDriverComponent<GridRow.ElementCache>
         @Override
         protected GridRow construct(WebElement el, WebDriver driver)
         {
-            return new GridRow(_grid, el, driver);
+            return new GridRow(_grid, el);
         }
 
         @Override

--- a/src/org/labkey/test/components/ui/grids/LineageGrid.java
+++ b/src/org/labkey/test/components/ui/grids/LineageGrid.java
@@ -3,20 +3,14 @@ package org.labkey.test.components.ui.grids;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
-import org.labkey.test.components.UpdatingComponent;
 import org.labkey.test.components.WebDriverComponent;
-import org.labkey.test.components.html.Input;
 import org.labkey.test.components.ui.Pager;
-import org.labkey.test.pages.LabKeyPage;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import static org.labkey.test.components.html.Input.Input;
 
 /**
  * Wraps the component described in ui-components internal\components\lineage\grid\LineageGridDisplay.tsx
@@ -98,7 +92,7 @@ public class LineageGrid extends WebDriverComponent<LineageGrid.ElementCache>
     public List<LineageGridRow> getRows()
     {
         return new GridRow.GridRowFinder(elementCache().table)
-                .findAll().stream().map(a-> new LineageGridRow(elementCache().table, a.getComponentElement(), getDriver()))
+                .findAll().stream().map(a-> new LineageGridRow(elementCache().table, a.getComponentElement()))
                 .collect(Collectors.toList());
     }
 

--- a/src/org/labkey/test/components/ui/grids/LineageGridRow.java
+++ b/src/org/labkey/test/components/ui/grids/LineageGridRow.java
@@ -2,7 +2,6 @@ package org.labkey.test.components.ui.grids;
 
 
 import org.labkey.test.Locator;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 
@@ -16,21 +15,9 @@ public class LineageGridRow extends GridRow
     private static final Locator secondParentLoc = Locator.tagWithClass("span", "label-primary").withText("2nd parent");
     private String _lineageName;
 
-    protected LineageGridRow(ResponsiveGrid<?> grid, WebElement el, WebDriver driver)
+    protected LineageGridRow(ResponsiveGrid<?> grid, WebElement el)
     {
-        super(grid, el, driver);
-    }
-
-    @Override
-    public WebElement getComponentElement()
-    {
-        return _el;
-    }
-
-    @Override
-    public WebDriver getDriver()
-    {
-        return _driver;
+        super(grid, el);
     }
 
     public String getLineageName()

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -322,10 +322,11 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
     }
 
     public String getSelectionStatusCount()
-    {   // note: this element is only present when some number of rows in the set are selected
-        WebElement selectionStatus = Locator.tagWithClass("span", "selection-status__count")
-                .waitForElement(this, 4000);
-        return selectionStatus.getText();
+    {
+        // note: this element is only present when some number of rows in the set are selected
+        Optional<WebElement> selectionStatus = Locator.tagWithClass("span", "selection-status__count")
+                .findOptionalElement(this);
+        return selectionStatus.map(WebElement::getText).orElse(null);
     }
 
     public QueryGrid clearAllSelections()

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -592,6 +592,10 @@ public class FieldDefinition extends PropertyDescriptor
         private final String _table;
         private ColumnType _tableType;
 
+        /**
+         * @deprecated Use {@link IntLookup} or {@link StringLookup}
+         */
+        @Deprecated (since = "22.10")
         public LookupInfo(@Nullable String folder, String schema, String table)
         {
             if (folder == null || folder.isEmpty())
@@ -610,7 +614,7 @@ public class FieldDefinition extends PropertyDescriptor
 
             _schema = StringUtils.trimToNull(schema);
             _table = StringUtils.trimToNull(table);
-            setTableType(ColumnType.String);
+            _tableType = ColumnType.String;
         }
 
         public String getFolder()
@@ -659,13 +663,13 @@ public class FieldDefinition extends PropertyDescriptor
         }
 
         @Override
-        public java.lang.String getLabel()
+        public String getLabel()
         {
             return ColumnType.Lookup.getLabel();
         }
 
         @Override
-        public java.lang.String getRangeURI()
+        public String getRangeURI()
         {
             return _tableType.getRangeURI();
         }
@@ -674,6 +678,47 @@ public class FieldDefinition extends PropertyDescriptor
         public LookupInfo getLookupInfo()
         {
             return this;
+        }
+    }
+
+    private static abstract class Lookup extends LookupInfo
+    {
+        public Lookup(@Nullable String folder, String schema, String table, ColumnType lookupType)
+        {
+            super(folder, schema, table);
+            super.setTableType(lookupType);
+        }
+
+        @Override
+        public LookupInfo setTableType(ColumnType tableType)
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    public static class IntLookup extends Lookup
+    {
+        public IntLookup(@Nullable String folder, String schema, String table)
+        {
+            super(folder, schema, table, ColumnType.Integer);
+        }
+
+        public IntLookup(String schema, String table)
+        {
+            this(null, schema, table);
+        }
+    }
+
+    public static class StringLookup extends Lookup
+    {
+        public StringLookup(@Nullable String folder, String schema, String table)
+        {
+            super(folder, schema, table, ColumnType.String);
+        }
+
+        public StringLookup(String schema, String table)
+        {
+            this(null, schema, table);
         }
     }
 

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -454,6 +454,7 @@ public class FieldDefinition extends PropertyDescriptor
         Flag("Flag", "string", "http://www.labkey.org/exp/xml#flag", null),
         Attachment("Attachment", "attachment"),
         User("User", "int", null, new LookupInfo(null, "core", "users")),
+        @Deprecated(since = "22.10") // 'Lookup' isn't a type outside of the UI
         Lookup("Lookup", null),
         OntologyLookup("Ontology Lookup", "string", "http://www.labkey.org/types#conceptCode", null),
         VisitId("Visit ID","double","http://cpas.labkey.com/Study#VisitId",null),

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.params;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -39,7 +40,6 @@ public class FieldDefinition extends PropertyDescriptor
 
     // for UI helpers
     private ColumnType _type;
-    private LookupInfo _lookup;
     private String _principalConceptSearchSourceOntology;
     private String _principalConceptSearchExpression;
     private ExpSchema.DerivationDataScopeType _aliquotOption;
@@ -63,25 +63,12 @@ public class FieldDefinition extends PropertyDescriptor
 
     /**
      * Define a String field
-     * @deprecated Use {@link #FieldDefinition(String, ColumnType)} or {@link #FieldDefinition(String, LookupInfo)}
      * @param name field name
      */
-    @Deprecated
     public FieldDefinition(String name)
     {
         setName(name);
         super.setRangeURI(ColumnType.String.getRangeURI());
-    }
-
-    /**
-     * Define a lookup field
-     * @param name field name
-     * @param lookup info about the table targeted by the lookup
-     */
-    public FieldDefinition(String name, LookupInfo lookup)
-    {
-        setName(name);
-        setLookup(lookup);
     }
 
     @Override
@@ -103,13 +90,9 @@ public class FieldDefinition extends PropertyDescriptor
         {
             throw new IllegalStateException(String.format("'%s' already has the type '%s'.", getName(), _type.toString()));
         }
-        if (_lookup != null)
-        {
-            throw new IllegalStateException("This field is defined as a lookup. Use 'LookupInfo.setTableType' to set the rangeURI of the lookup.");
-        }
         if (type == ColumnType.Lookup)
         {
-            throw new IllegalArgumentException("Use 'setLookup' or construct with 'FieldDefinition(String, LookupInfo)' to create lookup fields");
+            throw new IllegalArgumentException("Construct with 'FieldDefinition(String, LookupInfo)' to create lookup fields");
         }
 
         _type = type;
@@ -177,25 +160,7 @@ public class FieldDefinition extends PropertyDescriptor
 
     public LookupInfo getLookup()
     {
-        return _lookup;
-    }
-
-    protected FieldDefinition setLookup(LookupInfo lookup)
-    {
-        if (_lookup != null)
-        {
-            throw new IllegalStateException(String.format("'%s' is already a lookup to '%s'.", getName(), _lookup.toString()));
-        }
-        if (_type != null)
-        {
-            throw new IllegalStateException(
-                    String.format("'%s' already has the type '%s'. Use 'new FieldDefinition(String, LookupInfo)' to define lookup fields",
-                            getName(), _type.toString()));
-        }
-        super.setLookup(lookup.getSchema(), lookup.getTable(), lookup.getFolder());
-        super.setRangeURI(lookup.getTableType().getRangeURI());
-        _lookup = lookup;
-        return this;
+        return _type.getLookupInfo();
     }
 
     @Override
@@ -440,64 +405,87 @@ public class FieldDefinition extends PropertyDescriptor
         }
     }
 
-    public enum ColumnType
+    public static class SampleColumnType implements ColumnType
     {
-        MultiLine("Multi-Line Text", "multiLine"),
-        Integer("Integer", "int"),
-        String("Text", "string"),
-        Subject("Subject/Participant", "string", "http://cpas.labkey.com/Study#ParticipantId", null),
-        DateAndTime("Date Time", "dateTime"),
-        Boolean("Boolean", "boolean"),
-        Double("Number (Double)", "float"),
-        Decimal("Decimal (floating point)", "double"),
-        File("File", "http://cpas.fhcrc.org/exp/xml#fileLink"),
-        Flag("Flag", "string", "http://www.labkey.org/exp/xml#flag", null),
-        Attachment("Attachment", "attachment"),
-        User("User", "int", null, new LookupInfo(null, "core", "users")),
-        @Deprecated(since = "22.10") // 'Lookup' isn't a type outside of the UI
-        Lookup("Lookup", null),
-        OntologyLookup("Ontology Lookup", "string", "http://www.labkey.org/types#conceptCode", null),
-        VisitId("Visit ID","double","http://cpas.labkey.com/Study#VisitId",null),
-        VisitDate("Visit Date","dateTime","http://cpas.labkey.com/Study#VisitId",null),
-        Sample("Sample", "int", "http://www.labkey.org/exp/xml#sample", new LookupInfo(null, "exp", "Materials")),
-        Barcode("Unique ID", "string", "http://www.labkey.org/types#storageUniqueId", null),
-        TextChoice("Text Choice", "string", "http://www.labkey.org/types#textChoice", null),
-        SMILES("SMILES", "string", "http://www.labkey.org/exp/xml#smiles", null),
-        ;
-
-        private final String _label; // the display value in the UI for this kind of field
-        private final String _rangeURI;     // the key used inside the API
-        private final String _conceptURI;
         private final LookupInfo _lookupInfo;
 
-        ColumnType(String label, String rangeURI, String conceptURI, LookupInfo lookupInfo)
+        public SampleColumnType(String sampleTypeName)
         {
-            _label = label;
-            _rangeURI = rangeURI;
-            _conceptURI = conceptURI;
-            _lookupInfo = lookupInfo;
+            _lookupInfo = new LookupInfo(null, "samples", sampleTypeName);
         }
 
-        ColumnType(String label, String rangeURI)
-        {
-            this(label, rangeURI, null, null);
-        }
-
+        @Override
         public String getLabel()
         {
-            return _label;
+            throw new IllegalStateException("UI helpers don't support this method of defining sample columns");
         }
 
-        public String getRangeURI() { return _rangeURI; }
-
-        protected String getConceptURI()
+        @Override
+        public String getRangeURI()
         {
-            return _conceptURI;
+            return ColumnType.Sample.getRangeURI();
         }
 
+        @Override
+        public String getConceptURI()
+        {
+            return ColumnType.Sample.getConceptURI();
+        }
+
+        @Override
         public LookupInfo getLookupInfo()
         {
             return _lookupInfo;
+        }
+
+    }
+
+    // Temporary, for 'ColumnType.values()'
+    private static final List<ColumnType> COLUMN_TYPES = List.of(
+            ColumnType.MultiLine, ColumnType.Integer, ColumnType.String, ColumnType.Subject, ColumnType.DateAndTime,
+            ColumnType.Boolean, ColumnType.Double, ColumnType.Decimal, ColumnType.File, ColumnType.Flag,
+            ColumnType.Attachment, ColumnType.User, ColumnType.Lookup, ColumnType.OntologyLookup, ColumnType.VisitId,
+            ColumnType.VisitDate, ColumnType.Sample, ColumnType.Barcode, ColumnType.TextChoice, ColumnType.SMILES
+    );
+    
+    public interface ColumnType
+    {
+        ColumnType MultiLine = new ColumnTypeImpl("Multi-Line Text", "multiLine");
+        ColumnType Integer = new ColumnTypeImpl("Integer", "int");
+        ColumnType String = new ColumnTypeImpl("Text", "string");
+        ColumnType Subject = new ColumnTypeImpl("Subject/Participant", "string", "http://cpas.labkey.com/Study#ParticipantId", null);
+        ColumnType DateAndTime = new ColumnTypeImpl("Date Time", "dateTime");
+        ColumnType Boolean = new ColumnTypeImpl("Boolean", "boolean");
+        ColumnType Double = new ColumnTypeImpl("Number (Double)", "float");
+        ColumnType Decimal = new ColumnTypeImpl("Decimal (floating point)", "double");
+        ColumnType File = new ColumnTypeImpl("File", "http://cpas.fhcrc.org/exp/xml#fileLink");
+        ColumnType Flag = new ColumnTypeImpl("Flag", "string", "http://www.labkey.org/exp/xml#flag", null);
+        ColumnType Attachment = new ColumnTypeImpl("Attachment", "attachment");
+        ColumnType User = new ColumnTypeImpl("User", "int", null, new LookupInfo(null, "core", "users"));
+        @Deprecated(since = "22.10") // 'Lookup' isn't a type outside of the UI
+        ColumnType Lookup = new ColumnTypeImpl("Lookup", null);
+        ColumnType OntologyLookup = new ColumnTypeImpl("Ontology Lookup", "string", "http://www.labkey.org/types#conceptCode", null);
+        ColumnType VisitId = new ColumnTypeImpl("Visit ID", "double", "http://cpas.labkey.com/Study#VisitId", null);
+        ColumnType VisitDate = new ColumnTypeImpl("Visit Date", "dateTime", "http://cpas.labkey.com/Study#VisitId", null);
+        ColumnType Sample = new ColumnTypeImpl("Sample", "int", "http://www.labkey.org/exp/xml#sample", new LookupInfo(null, "exp", "Materials"));
+        ColumnType Barcode = new ColumnTypeImpl("Unique ID", "string", "http://www.labkey.org/types#storageUniqueId", null);
+        ColumnType TextChoice = new ColumnTypeImpl("Text Choice", "string", "http://www.labkey.org/types#textChoice", null);
+        ColumnType SMILES = new ColumnTypeImpl("SMILES", "string", "http://www.labkey.org/exp/xml#smiles", null);
+
+        String getLabel();
+        String getRangeURI();
+        default String getConceptURI()
+        {
+            return null;
+        }
+        default FieldDefinition.LookupInfo getLookupInfo()
+        {
+            return null;
+        }
+
+        static List<ColumnType> values()
+        {
+            return COLUMN_TYPES;
         }
     }
 
@@ -597,7 +585,7 @@ public class FieldDefinition extends PropertyDescriptor
         }
     }
 
-    public static class LookupInfo
+    public static class LookupInfo implements ColumnType
     {
         private final String _folder;
         private final String _schema;
@@ -620,8 +608,8 @@ public class FieldDefinition extends PropertyDescriptor
                 _folder = folder;
             }
 
-            _schema = ("".equals(schema) ? null : schema);
-            _table = ("".equals(table) ? null : table);
+            _schema = StringUtils.trimToNull(schema);
+            _table = StringUtils.trimToNull(table);
             setTableType(ColumnType.String);
         }
 
@@ -668,6 +656,24 @@ public class FieldDefinition extends PropertyDescriptor
             sb.append(".");
             sb.append(getTable());
             return sb.toString();
+        }
+
+        @Override
+        public java.lang.String getLabel()
+        {
+            return ColumnType.Lookup.getLabel();
+        }
+
+        @Override
+        public java.lang.String getRangeURI()
+        {
+            return _tableType.getRangeURI();
+        }
+
+        @Override
+        public LookupInfo getLookupInfo()
+        {
+            return this;
         }
     }
 
@@ -911,4 +917,46 @@ public class FieldDefinition extends PropertyDescriptor
 
     }
 
+}
+
+class ColumnTypeImpl implements FieldDefinition.ColumnType
+{
+    private final String _label; // the display value in the UI for this kind of field
+    private final String _rangeURI;     // the key used inside the API
+    private final String _conceptURI;
+    private final FieldDefinition.LookupInfo _lookupInfo;
+
+    ColumnTypeImpl(String label, String rangeURI, String conceptURI, FieldDefinition.LookupInfo lookupInfo)
+    {
+        _label = label;
+        _rangeURI = rangeURI;
+        _conceptURI = conceptURI;
+        _lookupInfo = lookupInfo;
+    }
+
+    ColumnTypeImpl(String label, String rangeURI)
+    {
+        this(label, rangeURI, null, null);
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return _label;
+    }
+
+    @Override
+    public String getRangeURI() { return _rangeURI; }
+
+    @Override
+    public String getConceptURI()
+    {
+        return _conceptURI;
+    }
+
+    @Override
+    public FieldDefinition.LookupInfo getLookupInfo()
+    {
+        return _lookupInfo;
+    }
 }

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -421,6 +421,12 @@ public class FieldDefinition extends PropertyDescriptor
         }
 
         @Override
+        public boolean isLookup()
+        {
+            return false;
+        }
+
+        @Override
         public String getRangeURI()
         {
             return ColumnType.Sample.getRangeURI();
@@ -472,17 +478,47 @@ public class FieldDefinition extends PropertyDescriptor
         ColumnType TextChoice = new ColumnTypeImpl("Text Choice", "string", "http://www.labkey.org/types#textChoice", null);
         ColumnType SMILES = new ColumnTypeImpl("SMILES", "string", "http://www.labkey.org/exp/xml#smiles", null);
 
+        /**
+         * UI: The Option text for the column type.
+         * API: Unused
+         */
         String getLabel();
+
+        /**
+         * UI: Is this a plain lookup field. (Formerly 'ColumnType.Lookup'). Some column type have lookup info but are
+         * defined as lookups in the domain designer.
+         * API: Unused
+         */
+        boolean isLookup();
+
+        /**
+         * UI: Unused
+         * API: The value used by the server to determine the field's type
+         */
         String getRangeURI();
+
+        /**
+         * UI: Unused
+         * API: For definiting column types that add special functionality.
+         */
         default String getConceptURI()
         {
             return null;
         }
+
+        /**
+         * UI: Lookup info for plain lookup fields ({@link #isLookup()} == true)
+         * API: Lookup info for plain and special (e.g. 'Sample') lookup fields
+         */
         default FieldDefinition.LookupInfo getLookupInfo()
         {
             return null;
         }
 
+        /**
+         * @deprecated Bridge for converting away from enum
+         */
+        @Deprecated (since = "22.10")
         static List<ColumnType> values()
         {
             return COLUMN_TYPES;
@@ -678,6 +714,12 @@ public class FieldDefinition extends PropertyDescriptor
         public LookupInfo getLookupInfo()
         {
             return this;
+        }
+
+        @Override
+        public boolean isLookup()
+        {
+            return true;
         }
     }
 
@@ -988,6 +1030,12 @@ class ColumnTypeImpl implements FieldDefinition.ColumnType
     public String getLabel()
     {
         return _label;
+    }
+
+    @Override
+    public boolean isLookup()
+    {
+        return false;
     }
 
     @Override

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -67,8 +67,7 @@ public class FieldDefinition extends PropertyDescriptor
      */
     public FieldDefinition(String name)
     {
-        setName(name);
-        super.setRangeURI(ColumnType.String.getRangeURI());
+        this(name, ColumnType.String);
     }
 
     @Override
@@ -79,33 +78,25 @@ public class FieldDefinition extends PropertyDescriptor
 
     public ColumnType getType()
     {
-        return _type == null
-                ? ColumnType.String // null type indicates usage of the deprecated name-only constructor
-                : _type;
+        return _type;
     }
 
-    public FieldDefinition setType(ColumnType type)
+    private void setType(ColumnType type)
     {
-        if (_type != null)
-        {
-            throw new IllegalStateException(String.format("'%s' already has the type '%s'.", getName(), _type.toString()));
-        }
         if (type == ColumnType.Lookup)
         {
-            throw new IllegalArgumentException("Construct with 'FieldDefinition(String, LookupInfo)' to create lookup fields");
+            throw new IllegalArgumentException("Use IntLookup or StringLookup to create lookup fields");
         }
 
         _type = type;
         if (type.getLookupInfo() != null)
         {
-            // Special 'User' and 'Sample' lookups
             super.setLookup(type.getLookupInfo().getSchema(),
                     type.getLookupInfo().getTable(),
                     type.getLookupInfo().getFolder());
         }
         super.setRangeURI(type.getRangeURI());
         setFieldProperty("conceptURI", type.getConceptURI());
-        return this;
     }
 
     @Override
@@ -467,13 +458,13 @@ public class FieldDefinition extends PropertyDescriptor
         ColumnType File = new ColumnTypeImpl("File", "http://cpas.fhcrc.org/exp/xml#fileLink");
         ColumnType Flag = new ColumnTypeImpl("Flag", "string", "http://www.labkey.org/exp/xml#flag", null);
         ColumnType Attachment = new ColumnTypeImpl("Attachment", "attachment");
-        ColumnType User = new ColumnTypeImpl("User", "int", null, new LookupInfo(null, "core", "users"));
+        ColumnType User = new ColumnTypeImpl("User", "int", null, new IntLookup("core", "users"));
         @Deprecated(since = "22.10") // 'Lookup' isn't a type outside of the UI
         ColumnType Lookup = new ColumnTypeImpl("Lookup", null);
         ColumnType OntologyLookup = new ColumnTypeImpl("Ontology Lookup", "string", "http://www.labkey.org/types#conceptCode", null);
         ColumnType VisitId = new ColumnTypeImpl("Visit ID", "double", "http://cpas.labkey.com/Study#VisitId", null);
         ColumnType VisitDate = new ColumnTypeImpl("Visit Date", "dateTime", "http://cpas.labkey.com/Study#VisitId", null);
-        ColumnType Sample = new ColumnTypeImpl("Sample", "int", "http://www.labkey.org/exp/xml#sample", new LookupInfo(null, "exp", "Materials"));
+        ColumnType Sample = new ColumnTypeImpl("Sample", "int", "http://www.labkey.org/exp/xml#sample", new IntLookup( "exp", "Materials"));
         ColumnType Barcode = new ColumnTypeImpl("Unique ID", "string", "http://www.labkey.org/types#storageUniqueId", null);
         ColumnType TextChoice = new ColumnTypeImpl("Text Choice", "string", "http://www.labkey.org/types#textChoice", null);
         ColumnType SMILES = new ColumnTypeImpl("SMILES", "string", "http://www.labkey.org/exp/xml#smiles", null);
@@ -673,6 +664,10 @@ public class FieldDefinition extends PropertyDescriptor
             return _tableType;
         }
 
+        /**
+         * @deprecated Use {@link IntLookup} or {@link StringLookup}
+         */
+        @Deprecated (since = "22.10")
         public LookupInfo setTableType(ColumnType tableType)
         {
             _tableType = tableType;

--- a/src/org/labkey/test/params/assay/AssayDesign.java
+++ b/src/org/labkey/test/params/assay/AssayDesign.java
@@ -1,0 +1,117 @@
+package org.labkey.test.params.assay;
+
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.assay.GetProtocolCommand;
+import org.labkey.remoteapi.assay.Protocol;
+import org.labkey.remoteapi.assay.ProtocolResponse;
+import org.labkey.remoteapi.assay.SaveProtocolCommand;
+import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
+import org.labkey.remoteapi.domain.Domain;
+import org.labkey.remoteapi.domain.PropertyDescriptor;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public abstract class AssayDesign<T extends AssayDesign<T>>
+{
+    final String _providerName;
+    final List<Consumer<Protocol>> _transformers = new ArrayList<>();
+
+    protected AssayDesign(String providerName, String name)
+    {
+        _providerName = providerName;
+        _transformers.add(p -> p.setName(name));
+    }
+
+    public static AssayDesign<?> of(String providerName, String name)
+    {
+        return new AssayDesignImpl(name, providerName);
+    }
+
+    public T addProtocolTransformer(Consumer<Protocol> transformer)
+    {
+        _transformers.add(transformer);
+        return getThis();
+    }
+
+    public T addDomainTransformer(String domainName, Consumer<Domain> transformer)
+    {
+        _transformers.add(protocol -> {
+            Domain domain = extractDomain(domainName, protocol);
+            transformer.accept(domain);
+        });
+        return getThis();
+    }
+
+    public T setFields(String domainName, List<PropertyDescriptor> fields, boolean keepExisting)
+    {
+        return addDomainTransformer(domainName, domain -> {
+            List<PropertyDescriptor> pds = new ArrayList<>();
+            if (keepExisting)
+            {
+                pds.addAll(domain.getFields());
+            }
+            pds.addAll(fields);
+            domain.setFields(pds);
+        });
+    }
+
+    public Protocol createAssay(String containerPath, Connection connection) throws IOException, CommandException
+    {
+        GetProtocolCommand getProtocolCommand = new GetProtocolCommand(_providerName);
+        ProtocolResponse getProtocolResponse = getProtocolCommand.execute(connection, containerPath);
+
+        Protocol protocol = getProtocolResponse.getProtocol();
+
+        for (var transformer : _transformers)
+        {
+            transformer.accept(protocol);
+        }
+
+        SaveProtocolCommand saveProtocolCommand = new SaveProtocolCommand(protocol);
+        ProtocolResponse saveProtocolResponse = saveProtocolCommand.execute(connection, containerPath);
+        return saveProtocolResponse.getProtocol();
+    }
+
+    protected Domain extractDomain(String domainName, Protocol protocol)
+    {
+        Map<String, Domain> domains = new CaseInsensitiveHashMap<>();
+        for (Domain domain : protocol.getDomains())
+        {
+            domains.put(domain.getName(), domain);
+        }
+
+        Domain domain = domains.get(domainName);
+        if (domain == null)
+        {
+            domain = domains.get(domainName + " Fields");
+            if (domain == null)
+            {
+                throw new IllegalArgumentException(String.format(
+                        "Domain '%s' not found for assay provider '%s'. Found: %s",
+                        domainName, protocol.getProviderName(), domains.keySet()));
+            }
+        }
+        return domain;
+    }
+
+    protected abstract T getThis();
+}
+
+class AssayDesignImpl extends AssayDesign<AssayDesignImpl>
+{
+    public AssayDesignImpl(String name, String providerName)
+    {
+        super(providerName, name);
+    }
+
+    @Override
+    protected AssayDesignImpl getThis()
+    {
+        return this;
+    }
+}

--- a/src/org/labkey/test/params/assay/GeneralAssayDesign.java
+++ b/src/org/labkey/test/params/assay/GeneralAssayDesign.java
@@ -13,12 +13,12 @@ public class GeneralAssayDesign extends AssayDesign<GeneralAssayDesign>
 
     public GeneralAssayDesign setBatchFields(List<PropertyDescriptor> fields, boolean keepExisting)
     {
-        return setFields("Batch", fields, keepExisting);
+        return setFields("Batches", fields, keepExisting);
     }
 
     public GeneralAssayDesign setRunFields(List<PropertyDescriptor> fields, boolean keepExisting)
     {
-        return setFields("Run", fields, keepExisting);
+        return setFields("Runs", fields, keepExisting);
     }
 
     public GeneralAssayDesign setDataFields(List<PropertyDescriptor> fields, boolean keepExisting)

--- a/src/org/labkey/test/params/assay/GeneralAssayDesign.java
+++ b/src/org/labkey/test/params/assay/GeneralAssayDesign.java
@@ -1,0 +1,34 @@
+package org.labkey.test.params.assay;
+
+import org.labkey.remoteapi.domain.PropertyDescriptor;
+
+import java.util.List;
+
+public class GeneralAssayDesign extends AssayDesign<GeneralAssayDesign>
+{
+    public GeneralAssayDesign(String name)
+    {
+        super("General", name);
+    }
+
+    public GeneralAssayDesign setBatchFields(List<PropertyDescriptor> fields, boolean keepExisting)
+    {
+        return setFields("Batch", fields, keepExisting);
+    }
+
+    public GeneralAssayDesign setRunFields(List<PropertyDescriptor> fields, boolean keepExisting)
+    {
+        return setFields("Run", fields, keepExisting);
+    }
+
+    public GeneralAssayDesign setDataFields(List<PropertyDescriptor> fields, boolean keepExisting)
+    {
+        return setFields("Data", fields, keepExisting);
+    }
+
+    @Override
+    protected GeneralAssayDesign getThis()
+    {
+        return this;
+    }
+}

--- a/src/org/labkey/test/params/assay/GeneralAssayDesign.java
+++ b/src/org/labkey/test/params/assay/GeneralAssayDesign.java
@@ -13,12 +13,12 @@ public class GeneralAssayDesign extends AssayDesign<GeneralAssayDesign>
 
     public GeneralAssayDesign setBatchFields(List<PropertyDescriptor> fields, boolean keepExisting)
     {
-        return setFields("Batches", fields, keepExisting);
+        return setFields("Batch", fields, keepExisting);
     }
 
     public GeneralAssayDesign setRunFields(List<PropertyDescriptor> fields, boolean keepExisting)
     {
-        return setFields("Runs", fields, keepExisting);
+        return setFields("Run", fields, keepExisting);
     }
 
     public GeneralAssayDesign setDataFields(List<PropertyDescriptor> fields, boolean keepExisting)

--- a/src/org/labkey/test/params/property/DomainProps.java
+++ b/src/org/labkey/test/params/property/DomainProps.java
@@ -39,7 +39,7 @@ public abstract class DomainProps
 
     public final TestDataGenerator create(Connection connection, String containerPath) throws IOException, CommandException
     {
-        TestLogger.info(String.format("Creating domain '%s.%s' in '%s'", getSchemaName(), getQueryName(), containerPath));
+        TestLogger.info(String.format("Creating %s domain '%s.%s' in '%s'", getKind(), getSchemaName(), getQueryName(), containerPath));
         getCreateCommand().execute(connection, containerPath);
         return getTestDataGenerator(containerPath);
     }

--- a/src/org/labkey/test/tests/DataClassFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/DataClassFolderExportImportTest.java
@@ -1,7 +1,7 @@
 package org.labkey.test.tests;
 
-import org.junit.BeforeClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
@@ -26,9 +26,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 @Category({Daily.class})
 public class DataClassFolderExportImportTest extends BaseWebDriverTest
@@ -196,12 +197,10 @@ public class DataClassFolderExportImportTest extends BaseWebDriverTest
 
         // put a dataclass in the export subfolder and add test data to it
         List<FieldDefinition> testFields = new ArrayList<>();
-        testFields.add(new FieldDefinition("requiredField")
-                .setType(FieldDefinition.ColumnType.String)
+        testFields.add(new FieldDefinition("requiredField", FieldDefinition.ColumnType.String)
                 .setMvEnabled(false)
                 .setRequired(true));
-        testFields.add(new FieldDefinition("missingValueField")
-                .setType(FieldDefinition.ColumnType.String)
+        testFields.add(new FieldDefinition("missingValueField", FieldDefinition.ColumnType.String)
                 .setMvEnabled(true)
                 .setRequired(false));
 

--- a/src/org/labkey/test/tests/FolderExportTest.java
+++ b/src/org/labkey/test/tests/FolderExportTest.java
@@ -229,7 +229,8 @@ public class FolderExportTest extends BaseWebDriverTest
         _containerHelper.createSubfolder(importProjects[5], "Inherited Imported Subfolder");
         importFolder("Inherited Imported Subfolder", inheritedPermsZip);
         clickFolder("Inherited Imported Subfolder");
-        _permissionsHelper.assertPermissionsInherited();
+        assertTrue("Permissions not inherited for folder: " + getCurrentContainerPath(),
+                _permissionsHelper.isPermissionsInherited());
     }
 
     private void importFolder(String folderName, String zipFileName)

--- a/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
@@ -60,11 +60,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -287,12 +284,10 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         log("Create the sample type named '" + SAMPLE_TYPE_NAME + "' and add the fields.");
         SampleTypeHelper sampleHelper = new SampleTypeHelper(this);
         List<FieldDefinition> fields = new ArrayList<>();
-        fields.add(new FieldDefinition(REQUIRED_FIELD_NAME)
-                .setType(FieldDefinition.ColumnType.String)
+        fields.add(new FieldDefinition(REQUIRED_FIELD_NAME, FieldDefinition.ColumnType.String)
                 .setMvEnabled(false)
                 .setRequired(true));
-        fields.add(new FieldDefinition(MISSING_FIELD_NAME)
-                .setType(FieldDefinition.ColumnType.String)
+        fields.add(new FieldDefinition(MISSING_FIELD_NAME, FieldDefinition.ColumnType.String)
                 .setMvEnabled(true)
                 .setRequired(false));
         SampleTypeDefinition definition = new SampleTypeDefinition(SAMPLE_TYPE_NAME).setFields(fields);

--- a/src/org/labkey/test/tests/SampleTypeLimitsTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLimitsTest.java
@@ -185,7 +185,7 @@ public class SampleTypeLimitsTest extends BaseWebDriverTest
         String sampleTypeName = "SampleTypeWithLookup";
         SampleTypeHelper sampleHelper = new SampleTypeHelper(this);
         SampleTypeDefinition definition = new SampleTypeDefinition(sampleTypeName);
-        definition.addField(new FieldDefinition("label"));
+        definition.addField(new FieldDefinition("label", FieldDefinition.ColumnType.String));
         definition.addField(new FieldDefinition("lookUpField",
                 new FieldDefinition.LookupInfo(null, "exp.materials", "10000Samples")
                     .setTableType(FieldDefinition.ColumnType.Integer))

--- a/src/org/labkey/test/tests/SampleTypeParentColumnTest.java
+++ b/src/org/labkey/test/tests/SampleTypeParentColumnTest.java
@@ -134,8 +134,7 @@ public class SampleTypeParentColumnTest extends BaseWebDriverTest
             switch(key)
             {
                 case COL_NAME_CAPTION:
-                    fields.add(new FieldDefinition(_mapCaptionToName.get(key))
-                            .setType(FieldDefinition.ColumnType.String));
+                    fields.add(new FieldDefinition(_mapCaptionToName.get(key), FieldDefinition.ColumnType.String));
                     break;
                 default:
                     // These fields are automatically created when the domain is created. Do nothing for them.
@@ -675,8 +674,7 @@ public class SampleTypeParentColumnTest extends BaseWebDriverTest
 
         List<FieldDefinition> fields = new ArrayList<>();
 
-        fields.add(new FieldDefinition(ALIAS_NAME_CONFLICT)
-                .setType(FieldDefinition.ColumnType.String));
+        fields.add(new FieldDefinition(ALIAS_NAME_CONFLICT, FieldDefinition.ColumnType.String));
 
         log("Create Sample Type - Add a parent alias column to the sample type that conflicts with a given column name.");
         CreateSampleTypePage createPage = sampleHelper.goToCreateNewSampleType()

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -18,7 +18,6 @@ package org.labkey.test.tests;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.poi.ss.usermodel.Sheet;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -39,12 +38,10 @@ import org.labkey.test.components.domain.BaseDomainDesigner;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.components.html.OptionSelect;
-import org.labkey.test.components.ui.domainproperties.samples.SampleTypeDesigner;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.experiment.CreateSampleTypePage;
 import org.labkey.test.pages.experiment.UpdateSampleTypePage;
-import org.labkey.test.pages.query.UpdateQueryRowPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.params.FieldDefinition.LookupInfo;
@@ -78,7 +75,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.DataRegionTable.DataRegion;
 
@@ -222,7 +218,7 @@ public class SampleTypeTest extends BaseWebDriverTest
     {
         String sampleTypeName = "SimpleCreateWithExp";
         List<String> fieldNames = Arrays.asList("StringValue", "FloatValue");
-        List<FieldDefinition> fields = Arrays.asList(new FieldDefinition(fieldNames.get(0)), new FieldDefinition(fieldNames.get(1), ColumnType.Decimal));
+        List<FieldDefinition> fields = Arrays.asList(new FieldDefinition(fieldNames.get(0), ColumnType.String), new FieldDefinition(fieldNames.get(1), ColumnType.Decimal));
         SampleTypeHelper sampleTypeHelper = new SampleTypeHelper(this);
         log("Create a new sample type with a name and name expression");
         projectMenu().navigateToFolder(PROJECT_NAME, FOLDER_NAME);
@@ -1002,12 +998,10 @@ public class SampleTypeTest extends BaseWebDriverTest
 
         SampleTypeHelper sampleHelper = new SampleTypeHelper(this);
         List<FieldDefinition> fields = new ArrayList<>();
-        fields.add(new FieldDefinition(REQUIRED_FIELD_NAME)
-                .setType(ColumnType.String)
+        fields.add(new FieldDefinition(REQUIRED_FIELD_NAME, ColumnType.String)
                 .setMvEnabled(false)
                 .setRequired(true));
-        fields.add(new FieldDefinition(MISSING_FIELD_NAME)
-                .setType(ColumnType.String)
+        fields.add(new FieldDefinition(MISSING_FIELD_NAME, ColumnType.String)
                 .setMvEnabled(true)
                 .setRequired(false));
         SampleTypeDefinition def = new SampleTypeDefinition(SAMPLE_TYPE_NAME).setFields(fields);

--- a/src/org/labkey/test/tests/SpecimenCustomizeTest.java
+++ b/src/org/labkey/test/tests/SpecimenCustomizeTest.java
@@ -87,43 +87,43 @@ public class SpecimenCustomizeTest extends SpecimenBaseTest
         clickAndWait(Locator.linkContainingText("Edit Specimen Event fields"));
 
         DomainDesignerPage designerPage = new DomainDesignerPage(getDriver());
-        designerPage.fieldsPanel().addField(new FieldDefinition("Tally").setType(ColumnType.Integer));
+        designerPage.fieldsPanel().addField(new FieldDefinition("Tally", ColumnType.Integer));
         // Set a couple import aliases to test them below: Issue 39672
-        designerPage.fieldsPanel().addField(new FieldDefinition("Note").setType(ColumnType.String).setImportAliases("Comment,Notables"));
-        designerPage.fieldsPanel().addField(new FieldDefinition("Minutes").setType(ColumnType.Decimal));
-        designerPage.fieldsPanel().addField(new FieldDefinition("Flag").setType(ColumnType.Boolean));
+        designerPage.fieldsPanel().addField(new FieldDefinition("Note", ColumnType.String).setImportAliases("Comment,Notables"));
+        designerPage.fieldsPanel().addField(new FieldDefinition("Minutes", ColumnType.Decimal));
+        designerPage.fieldsPanel().addField(new FieldDefinition("Flag", ColumnType.Boolean));
         designerPage.clickFinish();
 
         clickAndWait(Locator.linkContainingText("Edit Vial fields"));
         designerPage = new DomainDesignerPage(getDriver());
-        designerPage.fieldsPanel().addField(new FieldDefinition("Tally").setType(ColumnType.Integer));
-        designerPage.fieldsPanel().addField(new FieldDefinition("FirstTally").setType(ColumnType.Integer));
-        designerPage.fieldsPanel().addField(new FieldDefinition("LatestTally").setType(ColumnType.Integer));
-        designerPage.fieldsPanel().addField(new FieldDefinition("LatestNonBlankTally").setType(ColumnType.Integer));
-        designerPage.fieldsPanel().addField(new FieldDefinition("CombineTally").setType(ColumnType.Integer));
-        designerPage.fieldsPanel().addField(new FieldDefinition("FirstNote").setType(ColumnType.String));
-        designerPage.fieldsPanel().addField(new FieldDefinition("LatestNote").setType(ColumnType.String));
-        designerPage.fieldsPanel().addField(new FieldDefinition("LatestNonBlankNote").setType(ColumnType.String));
-        designerPage.fieldsPanel().addField(new FieldDefinition("CombineNote").setType(ColumnType.String));
-        designerPage.fieldsPanel().addField(new FieldDefinition("FirstMinutes").setType(ColumnType.Decimal));
-        designerPage.fieldsPanel().addField(new FieldDefinition("LatestMinutes").setType(ColumnType.Decimal));
-        designerPage.fieldsPanel().addField(new FieldDefinition("LatestNonBlankMinutes").setType(ColumnType.Decimal));
-        designerPage.fieldsPanel().addField(new FieldDefinition("CombineMinutes").setType(ColumnType.Decimal).setFormat("0.####"));
-        designerPage.fieldsPanel().addField(new FieldDefinition("FirstFlag").setType(ColumnType.Boolean));
-        designerPage.fieldsPanel().addField(new FieldDefinition("LatestFlag").setType(ColumnType.Boolean));
-        designerPage.fieldsPanel().addField(new FieldDefinition("LatestNonBlankFlag").setType(ColumnType.Boolean));
-        designerPage.fieldsPanel().addField(new FieldDefinition("LatestDrawTimestamp").setType(ColumnType.DateAndTime));
-        designerPage.fieldsPanel().addField(new FieldDefinition("FirstDrawTimestamp").setType(ColumnType.DateAndTime));
+        designerPage.fieldsPanel().addField(new FieldDefinition("Tally", ColumnType.Integer));
+        designerPage.fieldsPanel().addField(new FieldDefinition("FirstTally", ColumnType.Integer));
+        designerPage.fieldsPanel().addField(new FieldDefinition("LatestTally", ColumnType.Integer));
+        designerPage.fieldsPanel().addField(new FieldDefinition("LatestNonBlankTally", ColumnType.Integer));
+        designerPage.fieldsPanel().addField(new FieldDefinition("CombineTally", ColumnType.Integer));
+        designerPage.fieldsPanel().addField(new FieldDefinition("FirstNote", ColumnType.String));
+        designerPage.fieldsPanel().addField(new FieldDefinition("LatestNote", ColumnType.String));
+        designerPage.fieldsPanel().addField(new FieldDefinition("LatestNonBlankNote", ColumnType.String));
+        designerPage.fieldsPanel().addField(new FieldDefinition("CombineNote", ColumnType.String));
+        designerPage.fieldsPanel().addField(new FieldDefinition("FirstMinutes", ColumnType.Decimal));
+        designerPage.fieldsPanel().addField(new FieldDefinition("LatestMinutes", ColumnType.Decimal));
+        designerPage.fieldsPanel().addField(new FieldDefinition("LatestNonBlankMinutes", ColumnType.Decimal));
+        designerPage.fieldsPanel().addField(new FieldDefinition("CombineMinutes", ColumnType.Decimal).setFormat("0.####"));
+        designerPage.fieldsPanel().addField(new FieldDefinition("FirstFlag", ColumnType.Boolean));
+        designerPage.fieldsPanel().addField(new FieldDefinition("LatestFlag", ColumnType.Boolean));
+        designerPage.fieldsPanel().addField(new FieldDefinition("LatestNonBlankFlag", ColumnType.Boolean));
+        designerPage.fieldsPanel().addField(new FieldDefinition("LatestDrawTimestamp", ColumnType.DateAndTime));
+        designerPage.fieldsPanel().addField(new FieldDefinition("FirstDrawTimestamp", ColumnType.DateAndTime));
         designerPage.clickFinish();
 
         clickAndWait(Locator.linkContainingText("Edit Specimen fields"));
         designerPage = new DomainDesignerPage(getDriver());
-        designerPage.fieldsPanel().addField(new FieldDefinition("TotalLatestNonBlankTally").setType(ColumnType.Integer));
-        designerPage.fieldsPanel().addField(new FieldDefinition("SumOfLatestNonBlankMinutes").setType(ColumnType.Decimal).setFormat("0.####"));
-        designerPage.fieldsPanel().addField(new FieldDefinition("SumOfCombineMinutes").setType(ColumnType.Decimal).setFormat("0.####"));
-        designerPage.fieldsPanel().addField(new FieldDefinition("CountLatestNonBlankFlag").setType(ColumnType.Integer));
-        designerPage.fieldsPanel().addField(new FieldDefinition("MaxAvailabilityReason").setType(ColumnType.String));
-        designerPage.fieldsPanel().addField(new FieldDefinition("MinAvailabilityReason").setType(ColumnType.String));
+        designerPage.fieldsPanel().addField(new FieldDefinition("TotalLatestNonBlankTally", ColumnType.Integer));
+        designerPage.fieldsPanel().addField(new FieldDefinition("SumOfLatestNonBlankMinutes", ColumnType.Decimal).setFormat("0.####"));
+        designerPage.fieldsPanel().addField(new FieldDefinition("SumOfCombineMinutes", ColumnType.Decimal).setFormat("0.####"));
+        designerPage.fieldsPanel().addField(new FieldDefinition("CountLatestNonBlankFlag", ColumnType.Integer));
+        designerPage.fieldsPanel().addField(new FieldDefinition("MaxAvailabilityReason", ColumnType.String));
+        designerPage.fieldsPanel().addField(new FieldDefinition("MinAvailabilityReason", ColumnType.String));
         designerPage.clickFinish();
     }
 

--- a/src/org/labkey/test/tests/issues/IssueDomainSharingTest.java
+++ b/src/org/labkey/test/tests/issues/IssueDomainSharingTest.java
@@ -24,12 +24,12 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Issues;
-import org.labkey.test.components.issues.IssueListDefDataRegion;
 import org.labkey.test.components.ext4.Window;
-import org.labkey.test.pages.issues.IssuesAdminPage;
+import org.labkey.test.components.issues.IssueListDefDataRegion;
 import org.labkey.test.pages.issues.DetailsPage;
 import org.labkey.test.pages.issues.InsertIssueDefPage;
 import org.labkey.test.pages.issues.InsertPage;
+import org.labkey.test.pages.issues.IssuesAdminPage;
 import org.labkey.test.pages.issues.ListPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
@@ -103,7 +103,7 @@ public class IssueDomainSharingTest extends BaseWebDriverTest
 
         IssuesAdminPage adminPage = IssuesAdminPage.beginAt(this, getProjectName(), listDef);
         String inheritedField = "inheritedfield";
-        adminPage.getFieldsPanel().addField(new FieldDefinition(inheritedField).setLabel(inheritedField).setType(ColumnType.String));
+        adminPage.getFieldsPanel().addField(new FieldDefinition(inheritedField, ColumnType.String).setLabel(inheritedField));
         adminPage.clickSave();
 
         ListPage issueList = ListPage.beginAt(this, FOLDER_PATH, listDef);
@@ -145,7 +145,7 @@ public class IssueDomainSharingTest extends BaseWebDriverTest
 
         adminPage = IssuesAdminPage.beginAt(this, "Shared", listDef);
         // Append ":" to field name: Issue 32057: Issues forms can't handle complex field names
-        adminPage.getFieldsPanel().addField(new FieldDefinition(inheritedField + ":").setLabel(inheritedField).setType(ColumnType.String));
+        adminPage.getFieldsPanel().addField(new FieldDefinition(inheritedField + ":", ColumnType.String).setLabel(inheritedField));
         adminPage.clickSave();
 
         ListPage issueList = ListPage.beginAt(this, getProjectName(), listDef);
@@ -186,7 +186,7 @@ public class IssueDomainSharingTest extends BaseWebDriverTest
 
         IssuesAdminPage adminPage = IssuesAdminPage.beginAt(this, PROJECT2, listDef);
         String inheritedField = "uninheritedfield";
-        adminPage.getFieldsPanel().addField(new FieldDefinition(inheritedField).setLabel(inheritedField).setType(ColumnType.String));
+        adminPage.getFieldsPanel().addField(new FieldDefinition(inheritedField, ColumnType.String).setLabel(inheritedField));
         adminPage.clickSave();
 
         ListPage issueList = ListPage.beginAt(this, getProjectName(), listDef);
@@ -213,7 +213,7 @@ public class IssueDomainSharingTest extends BaseWebDriverTest
 
         IssuesAdminPage adminPage = confirmationWindow.clickYes();
         String inheritedField = "uninheritedfield";
-        adminPage.getFieldsPanel().addField(new FieldDefinition(inheritedField).setLabel(inheritedField).setType(ColumnType.String));
+        adminPage.getFieldsPanel().addField(new FieldDefinition(inheritedField, ColumnType.String).setLabel(inheritedField));
         adminPage.clickSave();
 
         ListPage issueList = ListPage.beginAt(this, FOLDER_PATH, listDef);

--- a/src/org/labkey/test/tests/viability/ViabilityTest.java
+++ b/src/org/labkey/test/tests/viability/ViabilityTest.java
@@ -301,7 +301,7 @@ public class ViabilityTest extends AbstractViabilityTest
 
         // remove TargetStudy field from the Batch domain and add it to the Result domain.
         assayDesignerPage.expandFieldsPanel("Batch").removeField("TargetStudy", true);
-        assayDesignerPage.expandFieldsPanel("Result").addField(new FieldDefinition("TargetStudy").setLabel("Target Study").setType(FieldDefinition.ColumnType.String));
+        assayDesignerPage.expandFieldsPanel("Result").addField(new FieldDefinition("TargetStudy", FieldDefinition.ColumnType.String).setLabel("Target Study"));
         assayDesignerPage.clickFinish();
 
         navigateToFolder(getProjectName(), getFolderName());

--- a/src/org/labkey/test/util/APIAssayHelper.java
+++ b/src/org/labkey/test/util/APIAssayHelper.java
@@ -39,6 +39,7 @@ import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.pages.ReactAssayDesignerPage;
+import org.labkey.test.params.assay.AssayDesign;
 
 import java.io.File;
 import java.io.IOException;
@@ -279,15 +280,8 @@ public class APIAssayHelper extends AbstractAssayHelper
 
     public Protocol createAssayDesignWithDefaults(String containerPath, String providerName, String assayName) throws IOException, CommandException
     {
-        Connection connection = _test.createDefaultConnection();
-        GetProtocolCommand getProtocolCommand = new GetProtocolCommand(providerName);
-        ProtocolResponse getProtocolResponse = getProtocolCommand.execute(connection, containerPath);
-
-        Protocol newAssayProtocol = getProtocolResponse.getProtocol();
-        newAssayProtocol.setName(assayName);
-        SaveProtocolCommand saveProtocolCommand = new SaveProtocolCommand(newAssayProtocol);
-        ProtocolResponse saveProtocolResponse = saveProtocolCommand.execute(connection, containerPath);
-        return saveProtocolResponse.getProtocol();
+        return AssayDesign.of(providerName, assayName)
+                .createAssay(containerPath, _test.createDefaultConnection());
     }
 
     /**

--- a/src/org/labkey/test/util/ApiPermissionsHelper.java
+++ b/src/org/labkey/test/util/ApiPermissionsHelper.java
@@ -27,6 +27,7 @@ import org.labkey.remoteapi.security.BulkUpdateGroupCommand;
 import org.labkey.remoteapi.security.CreateGroupCommand;
 import org.labkey.remoteapi.security.DeleteGroupCommand;
 import org.labkey.remoteapi.security.DeletePolicyCommand;
+import org.labkey.remoteapi.security.GetContainersCommand;
 import org.labkey.remoteapi.security.GetGroupPermsCommand;
 import org.labkey.remoteapi.security.GetGroupPermsResponse;
 import org.labkey.remoteapi.security.RemoveAssignmentCommand;
@@ -45,23 +46,54 @@ import java.util.function.Supplier;
 
 public class ApiPermissionsHelper extends PermissionsHelper
 {
-    private final Supplier<Connection> connectionFactory;
+    private final Supplier<Connection> _connectionSupplier;
+    private final Supplier<String> _containerPathSupplier;
 
-    public ApiPermissionsHelper(WebDriverWrapper driver, Supplier<Connection> connectionFactory)
+    private ApiPermissionsHelper(Supplier<Connection> connectionSupplier, Supplier<String> containerPathSupplier)
     {
-        super(driver);
-        this.connectionFactory = connectionFactory;
+        _connectionSupplier = connectionSupplier;
+        _containerPathSupplier = containerPathSupplier;
+    }
+
+    public ApiPermissionsHelper(WebDriverWrapper driver, Supplier<Connection> connectionSupplier)
+    {
+        this(connectionSupplier, driver::getCurrentContainerPath);
     }
 
     public ApiPermissionsHelper(WebDriverWrapper test)
     {
-        this(test, () -> WebTestHelper.getRemoteApiConnection());
+        this(test, WebTestHelper::getRemoteApiConnection);
+    }
+
+    /**
+     * For API-only operations against a specific container.
+     */
+    public ApiPermissionsHelper(String containerPath)
+    {
+        this(WebTestHelper::getRemoteApiConnection, () -> containerPath);
+    }
+
+    @Override
+    protected Connection getConnection()
+    {
+        return _connectionSupplier.get();
+    }
+
+    private String getContainerPath()
+    {
+        return _containerPathSupplier.get();
+    }
+
+    private String getProject()
+    {
+        String project = StringUtils.stripStart(getContainerPath(), "/").split("/", 2)[0];
+        return project.isBlank() ? "/" : project;
     }
 
     @Override
     public void assertNoPermission(String userOrGroupName, String permissionSetting)
     {
-        String container = _driver.getCurrentContainerPath();
+        String container = getContainerPath();
         List<String> roles = new ArrayList<>();
         if (userOrGroupName.contains("@"))
             roles.addAll(getUserRoles(container, userOrGroupName));
@@ -75,7 +107,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
     @Override
     public void assertPermissionSetting(String userOrGroupName, String permissionSetting)
     {
-        String container = _driver.getCurrentContainerPath();
+        String container = getContainerPath();
         String expectedRole = toRole(permissionSetting);
         List<String> roles = new ArrayList<>();
         if (userOrGroupName.contains("@"))
@@ -176,15 +208,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
         if (project.isEmpty() || project.equals("/"))
             return groups;
 
-        Iterator<Map<String, Object>> iter = groups.iterator();
-        while (iter.hasNext())
-        {
-            Map<String, Object> group = iter.next();
-            if (!(Boolean)group.get("isProjectGroup"))
-            {
-                iter.remove();
-            }
-        }
+        groups.removeIf(group -> !(Boolean) group.get("isProjectGroup"));
         return groups;
     }
 
@@ -224,7 +248,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
     {
         Integer id = getSiteGroupId(groupName);
         if (id == null)
-            id = getProjectGroupId(groupName, _driver.getCurrentProject());
+            id = getProjectGroupId(groupName, getProject());
         return id;
     }
 
@@ -255,8 +279,8 @@ public class ApiPermissionsHelper extends PermissionsHelper
         }
 
         Connection connection = getConnection();
-        Command command = new Command("security", "getGroupMembers");
-        command.setParameters(new HashMap<String, Object>(Maps.of("groupId", groupId)));
+        Command<?> command = new Command<>("security", "getGroupMembers");
+        command.setParameters(new HashMap<>(Maps.of("groupId", groupId)));
 
         CommandResponse response;
         try
@@ -273,14 +297,14 @@ public class ApiPermissionsHelper extends PermissionsHelper
 
     private List<Map<String, Object>> getUserGroups(String container, String user) throws CommandException
     {
-        return (List)getUserPerms(container, user).getProperty("container.groups");
+        return getUserPerms(container, user).getProperty("container.groups");
     }
 
     private List<String> getUserRoles(String container, String user)
     {
         try
         {
-            return (List<String>)getUserPerms(container, user).getProperty("container.roles");
+            return getUserPerms(container, user).getProperty("container.roles");
         }
         catch (CommandException e)
         {
@@ -291,8 +315,8 @@ public class ApiPermissionsHelper extends PermissionsHelper
     private CommandResponse getUserPerms(String container, String user) throws CommandException
     {
         Connection connection = getConnection();
-        Command command = new Command("security", "getUserPerms");
-        command.setParameters(new HashMap<String, Object>(Maps.of("userEmail", user)));
+        Command<?> command = new Command<>("security", "getUserPerms");
+        command.setParameters(new HashMap<>(Maps.of("userEmail", user)));
 
         CommandResponse response;
         try
@@ -310,23 +334,27 @@ public class ApiPermissionsHelper extends PermissionsHelper
     @Override
     public void uncheckInheritedPermissions()
     {
-        new UIPermissionsHelper((BaseWebDriverTest) _driver).uncheckInheritedPermissions();
+        new UIPermissionsHelper(BaseWebDriverTest.getCurrentTest()).uncheckInheritedPermissions();
     }
 
     @Override
     public void checkInheritedPermissions()
     {
-        inheritPermissions(_driver.getContainerId());
+        inheritPermissions(getContainerPath());
     }
 
-    public void inheritPermissions(String containerId)
+    public void inheritPermissions(String containerPath)
     {
-        DeletePolicyCommand  command = new DeletePolicyCommand(containerId);
-        Connection connection = getConnection();
-
         try
         {
-            command.execute(connection, "/");
+            Connection connection = getConnection();
+
+            String containerId = new GetContainersCommand()
+                    .execute(connection, containerPath)
+                    .getContainerId();
+
+            new DeletePolicyCommand(containerId)
+                    .execute(connection, "/");
         }
         catch (IOException | CommandException e)
         {
@@ -337,7 +365,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
     @Override
     public boolean isPermissionsInherited()
     {
-        return isPermissionsInherited(_driver.getCurrentContainerPath());
+        return isPermissionsInherited(getContainerPath());
     }
 
     public boolean isPermissionsInherited(String container)
@@ -360,7 +388,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
     @Override
     protected void removeRoleAssignment(String userOrGroupName, String permissionString, MemberType memberType)
     {
-        String container = _driver.getCurrentContainerPath();
+        String container = getContainerPath();
         if (memberType == MemberType.user)
             removeUserRoleAssignment(userOrGroupName, permissionString, container);
         else
@@ -416,7 +444,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
     @Override
     public void addMemberToRole(String userOrGroupName, String permissionString, MemberType memberType)
     {
-        addMemberToRole(userOrGroupName, permissionString, memberType, _driver.getCurrentContainerPath());
+        addMemberToRole(userOrGroupName, permissionString, memberType, getContainerPath());
     }
 
     public void addMemberToRole(String userOrGroupName, String permissionString, MemberType memberType, String container)
@@ -454,7 +482,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
             case siteGroup:
                 return getSiteGroupId(userOrGroupName);
             default:
-                throw new IllegalArgumentException("Unknown principal type: " + principalType.toString());
+                throw new IllegalArgumentException("Unknown principal type: " + principalType);
         }
     }
 
@@ -538,11 +566,6 @@ public class ApiPermissionsHelper extends PermissionsHelper
         }
     }
 
-    private Connection getConnection()
-    {
-        return connectionFactory.get();
-    }
-
     @Override
     public Integer createGlobalPermissionsGroup(String groupName, String... users)
     {
@@ -552,13 +575,13 @@ public class ApiPermissionsHelper extends PermissionsHelper
     @Override
     public Integer createPermissionsGroup(String groupName)
     {
-        return  createProjectGroup(groupName, _driver.getCurrentProject());
+        return  createProjectGroup(groupName, getProject());
     }
 
     @Override
     public Integer createPermissionsGroup(String groupName, String... users)
     {
-        return _createPermissionsGroup(groupName, _driver.getCurrentProject(), users);
+        return _createPermissionsGroup(groupName, getProject(), users);
     }
 
     private void addMembersToGroup(String project, Integer groupId, String... members)

--- a/src/org/labkey/test/util/ListHelper.java
+++ b/src/org/labkey/test/util/ListHelper.java
@@ -16,6 +16,7 @@
 
 package org.labkey.test.util;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.LabKeySiteWrapper;
 import org.labkey.test.Locator;
@@ -383,24 +384,26 @@ public class ListHelper extends LabKeySiteWrapper
     @Deprecated
     public enum ListColumnType
     {
-        MultiLine("Multi-Line Text"),
-        Integer("Integer"),
-        String("Text (String)"),
-        Subject("Subject/Participant (String)"),
-        DateAndTime("Date Time"),
-        Boolean("Boolean"),
-        Decimal("Decimal"),
-        File("File"),
-        AutoInteger("Auto-Increment Integer"),
-        Flag("Flag (String)"),
-        Attachment("Attachment"),
-        User("User");
+        MultiLine("Multi-Line Text", ColumnType.MultiLine),
+        Integer("Integer", ColumnType.Integer),
+        String("Text (String)", ColumnType.String),
+        Subject("Subject/Participant (String)", ColumnType.Subject),
+        DateAndTime("Date Time", ColumnType.DateAndTime),
+        Boolean("Boolean", ColumnType.Boolean),
+        Decimal("Decimal", ColumnType.Decimal),
+        File("File", ColumnType.File),
+        AutoInteger("Auto-Increment Integer", null),
+        Flag("Flag (String)", ColumnType.Flag),
+        Attachment("Attachment", ColumnType.Attachment),
+        User("User", ColumnType.User);
 
         private final String _description;
+        private final ColumnType _newType;
 
-        ListColumnType(String description)
+        ListColumnType(String description, ColumnType newType)
         {
             _description = description;
+            _newType = newType;
         }
 
         public String toString()
@@ -410,19 +413,18 @@ public class ListHelper extends LabKeySiteWrapper
 
         public ColumnType toNew()
         {
-            for (ColumnType thisType : ColumnType.values())
+            if (_newType == null)
             {
-                if (name().equals(thisType.name()))
-                    return thisType;
+                throw new IllegalArgumentException("Not a valid column type: " + name());
             }
-            throw new IllegalArgumentException("Type mismatch: " + this);
+            return _newType;
         }
 
-        public static ListColumnType fromNew(ColumnType newType)
+        public static ListColumnType fromNew(@NotNull ColumnType newType)
         {
             for (ListColumnType thisType : values())
             {
-                if (newType.name().equals(thisType.name()))
+                if (newType == thisType.toNew())
                     return thisType;
             }
             throw new IllegalArgumentException("Type mismatch: " + newType);
@@ -437,20 +439,14 @@ public class ListHelper extends LabKeySiteWrapper
     {
         public ListColumn(String name, String label, ListColumnType type, String description)
         {
-            super(name);
+            super(name, type.toNew());
             setLabel(label);
             setDescription(description);
-            setType(type.toNew());
         }
 
         public ListColumn(String name, String label, ListColumnType type)
         {
             this(name, label, type, null);
-        }
-
-        public ListColumn(String name, ListColumnType type)
-        {
-            this(name, null, type);
         }
     }
 }

--- a/src/org/labkey/test/util/PermissionsHelper.java
+++ b/src/org/labkey/test/util/PermissionsHelper.java
@@ -20,14 +20,12 @@ import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.security.GetRolesCommand;
 import org.labkey.remoteapi.security.GetRolesResponse;
-import org.labkey.test.WebDriverWrapper;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -36,13 +34,6 @@ import static org.junit.Assert.fail;
 public abstract class PermissionsHelper
 {
     private static final String permissionClassPkg = "org.labkey.api.security.roles.";
-    protected WebDriverWrapper _driver;
-
-    public PermissionsHelper(WebDriverWrapper driver)
-    {
-        _driver = driver;
-    }
-
     public String toRole(final String perm)
     {
         if (perm.contains("."))
@@ -67,7 +58,7 @@ public abstract class PermissionsHelper
         {
             _roles = new HashMap<>();
             GetRolesCommand command = new GetRolesCommand();
-            Connection connection = _driver.createDefaultConnection();
+            Connection connection = getConnection();
 
             try
             {
@@ -96,11 +87,7 @@ public abstract class PermissionsHelper
     public abstract void checkInheritedPermissions();
     public abstract void uncheckInheritedPermissions();
     public abstract boolean isPermissionsInherited();
-
-    public void assertPermissionsInherited()
-    {
-        assertTrue("Permissions not inherited for folder: " + _driver.getCurrentContainerPath(), isPermissionsInherited());
-    }
+    protected abstract Connection getConnection();
 
     public enum MemberType
     {user, group, siteGroup}
@@ -168,14 +155,14 @@ public abstract class PermissionsHelper
 
     public void assertGroupExists(String groupName, String projectName)
     {
-        _driver.log("asserting that group " + groupName + " exists in project " + projectName + "...");
+        TestLogger.log("asserting that group " + groupName + " exists in project " + projectName + "...");
         if (!doesGroupExist(groupName, projectName))
             fail("group " + groupName + " does not exist in project " + projectName);
     }
 
     public void assertGroupDoesNotExist(String groupName, String projectName)
     {
-        _driver.log("asserting that group " + groupName + " does not exist in project " + projectName + "...");
+        TestLogger.log("asserting that group " + groupName + " does not exist in project " + projectName + "...");
         if (doesGroupExist(groupName, projectName))
             fail("group " + groupName + " exists in project " + projectName);
     }
@@ -184,14 +171,14 @@ public abstract class PermissionsHelper
 
     public void assertUserInGroup(String member, String groupName, String projectName, PrincipalType principalType)
     {
-        _driver.log("asserting that member " + member + " is in group " + projectName + "/" + groupName + "...");
+        TestLogger.log("asserting that member " + member + " is in group " + projectName + "/" + groupName + "...");
         if (!isUserInGroup(member, groupName, projectName, principalType))
             fail("member " + member + " was not in group " + projectName + "/" + groupName);
     }
 
     public void assertUserNotInGroup(String member, String groupName, String projectName, PrincipalType principalType)
     {
-        _driver.log("asserting that member " + member + " is not in group " + projectName + "/" + groupName + "...");
+        TestLogger.log("asserting that member " + member + " is not in group " + projectName + "/" + groupName + "...");
         if (isUserInGroup(member, groupName, projectName, principalType))
             fail("member " + member + " was found in group " + projectName + "/" + groupName);
     }

--- a/src/org/labkey/test/util/UIPermissionsHelper.java
+++ b/src/org/labkey/test/util/UIPermissionsHelper.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.util;
 
+import org.labkey.remoteapi.Connection;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.WebTestHelper;
@@ -31,12 +32,17 @@ import static org.junit.Assert.assertFalse;
 
 public class UIPermissionsHelper extends PermissionsHelper
 {
-    protected BaseWebDriverTest _test;
+    private final BaseWebDriverTest _driver;
 
     public UIPermissionsHelper(BaseWebDriverTest test)
     {
-        super(test);
-        _test = test;
+        _driver = test;
+    }
+
+    @Override
+    protected Connection getConnection()
+    {
+        return _driver.createDefaultConnection();
     }
 
     @Override
@@ -48,7 +54,7 @@ public class UIPermissionsHelper extends PermissionsHelper
     @LogMethod
     public void startCreateGlobalPermissionsGroup(@LoggedParam String groupName, boolean failIfAlreadyExists)
     {
-        _test.goToHome();
+        _driver.goToHome();
         _driver.goToSiteGroups();
         if (_driver.isElementPresent(Locator.tagWithText("div", groupName)))
         {
@@ -215,7 +221,7 @@ public class UIPermissionsHelper extends PermissionsHelper
     @Override
     public void addUserToSiteGroup(String userName, String groupName)
     {
-        _test.ensureAdminMode();
+        _driver.ensureAdminMode();
         switch (groupName)
         {
             case "Administrators":
@@ -252,7 +258,7 @@ public class UIPermissionsHelper extends PermissionsHelper
     {
         if (!_driver.getCurrentContainerPath().startsWith("/" + projectName))
         {
-            _test.goToProjectHome(projectName);
+            _driver.goToProjectHome(projectName);
         }
         enterPermissionsUI();
         clickManageGroup(groupName);
@@ -262,7 +268,7 @@ public class UIPermissionsHelper extends PermissionsHelper
     @Deprecated
     public void enterPermissionsUI()
     {
-        PermissionsEditor.enterPermissionsUI(_test);
+        PermissionsEditor.enterPermissionsUI(_driver);
     }
 
     public void exitPermissionsUI()
@@ -340,8 +346,8 @@ public class UIPermissionsHelper extends PermissionsHelper
     @Override
     public boolean doesGroupExist(String groupName, String projectName)
     {
-        _test.ensureAdminMode();
-        _test.clickProject(projectName);
+        _driver.ensureAdminMode();
+        _driver.clickProject(projectName);
         enterPermissionsUI();
         _driver._ext4Helper.clickTabContainingText("Project Groups");
         _driver.waitForText("Member Groups");
@@ -355,8 +361,8 @@ public class UIPermissionsHelper extends PermissionsHelper
     @Override
     public boolean isUserInGroup(String user, String groupName, String projectName, PrincipalType principalType)
     {
-        _test.ensureAdminMode();
-        _test.clickProject(projectName);
+        _driver.ensureAdminMode();
+        _driver.clickProject(projectName);
         enterPermissionsUI();
         _driver._ext4Helper.clickTabContainingText("Project Groups");
         _driver.waitForElement(Locator.css(".groupPicker"), BaseWebDriverTest.WAIT_FOR_JAVASCRIPT);


### PR DESCRIPTION
#### Rationale
Some refactors and improvements to help test sample grids. Adding some API helpers to assist in this testing. This led to numerous refactors and improvements to `FieldDefinition` and related beans and helpers.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/issues/1102
* https://github.com/LabKey/sampleManagement/pull/1188
* https://github.com/LabKey/inventory/pull/529

#### Changes
* Make `ApiPermissionsHelper` not require direct WebDriver access
* Add [`assertJ` assertion library](https://assertj.github.io/doc)
* Add support for test properties that specify whether product features are available
* Refactor `FieldDefinition.ColumnType` to be an interface instead of an enum
  * Allows creation of type-specific 'Sample' columns (`SampleColumnType`) without using raw `PropertyDescriptor`s
  * Allows `LookupInfo` to just be another column type
* Create `IntLookup` and `StringLookup` in favor of permitting invalid lookup types via `LookupInfo.setTableType`
* Add new methods to inspect `MultiMenu` contents
* Simplify `GridRow`/`LineageGridRow` constructor
* Add `AssayDesign` bean for creating more complex assays via API
* Remove inappropriate usages of `FieldDefinition.setType`
