### PR TITLE
Select measure before changing axis side

### DIFF
--- a/src/org/labkey/test/components/ChartTypeDialog.java
+++ b/src/org/labkey/test/components/ChartTypeDialog.java
@@ -174,15 +174,14 @@ public class ChartTypeDialog extends ChartWizardDialog<ChartTypeDialog.ElementCa
         return this;
     }
 
-    public ChartTypeDialog clickYAxisMeasure(String columnName)
-    {
-        getWrapper().waitAndClick(elementCache().Y_FIELD_TEXT.withText(columnName));
-        return this;
-    }
-
     public ChartTypeDialog setYAxisSide(int measureIndex, YAxisSide side)
     {
-        getWrapper().mouseOver(elementCache().yAxis());
+        WebElement measureEl = elementCache().Y_FIELD_DISPLAY.index(measureIndex).findElement(this);
+        if (!measureEl.getAttribute("class").contains("selected"))
+        {
+            Locator.byClass("field-selection-text").findElement(measureEl).click();
+        }
+
         switch(side)
         {
             case Left:
@@ -529,8 +528,7 @@ public class ChartTypeDialog extends ChartWizardDialog<ChartTypeDialog.ElementCa
         public final String FIELD_DISPLAY = "//div[contains(@class, 'field-selection-display')]";
         public final String DROP_TEXT = "/following-sibling::div[contains(@class, 'field-area-drop-text ')]";
         public final String REMOVE_ICON = FIELD_DISPLAY + "//div[contains(@class, 'field-selection-remove')]";
-        public Locator Y_FIELD_TEXT = Locator.xpath(YAXIS_CONTAINER + FIELD_AREA + FIELD_DISPLAY + "//div[contains(@class, 'field-selection-text')]");
-
+        public Locator Y_FIELD_DISPLAY = Locator.xpath(YAXIS_CONTAINER + FIELD_AREA + FIELD_DISPLAY);
         public Locator Y_FIELD_SIDE_LEFT = Locator.xpath(YAXIS_CONTAINER + FIELD_AREA + FIELD_DISPLAY + "//i[contains(@class, 'fa-arrow-circle-left')]");
         public Locator Y_FIELD_SIDE_RIGHT = Locator.xpath(YAXIS_CONTAINER + FIELD_AREA + FIELD_DISPLAY + "//i[contains(@class, 'fa-arrow-circle-right')]");
         public WebElement typeTitle = new LazyWebElement(Locator.xpath("//div[contains(@class, 'type-title')]"), this);


### PR DESCRIPTION
#### Rationale
A test tries to switch which axis a measure is displayed on. Sometimes the button allowing this switch is not visible and the  measure needs to be clicked to show it.
```
org.openqa.selenium.ElementNotInteractableException: Element <i class="fa fa-arrow-circle-right unselected"> could not be scrolled into view
[...]
  at app//org.labkey.test.components.ChartTypeDialog.setYAxisSide(ChartTypeDialog.java:195)
  at app//org.labkey.test.tests.TimeChartDateBasedTest.multiAxisTimeChartTest(TimeChartDateBasedTest.java:646)
```
![image](https://user-images.githubusercontent.com/5263798/188023161-9c20c043-0bcc-402c-89e5-0df5da5e3ad9.png)

#### Changes
* Select measure before changing axis side
