### PR TITLE
Ignore pre-test server errors when running tests locally

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -590,6 +590,11 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         // step in the test, there's no reason to bother doing it again at the beginning of the next test
         if (!_checkedLeaksAndErrors && !"DRT".equals(System.getProperty("suite")))
         {
+            if (!TestProperties.isTestRunningOnTeamCity())
+            {
+                // Running locally, pre-test errors are unlikely to be interesting. Clear them out.
+                resetErrors();
+            }
             checker().addRecordableErrorType(WebDriverException.class);
             checker().withScreenshot("startupErrors").wrapAssertion(this::checkErrors);
             checker().withScreenshot("startupLeaks").wrapAssertion(() -> checkLeaks(null));


### PR DESCRIPTION
#### Rationale
When running outside of CI, pre-test server errors are very likely to just be noise.

#### Changes
* Skip pre-test check for server-side errors when not running on TeamCity
