### PR TITLE
Stop crawling deeper if redirected to an external site

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -460,6 +460,10 @@ public class Crawler
 
         public UrlToCheck(URL origin, String urlText, int depth)
         {
+            if (depth < 0)
+            {
+                throw new IllegalArgumentException("Invalid crawl depth: " + depth);
+            }
             _origin = origin;
             _urlText = urlText;
             _depth = depth;
@@ -528,9 +532,10 @@ public class Crawler
             return _isFromForm;
         }
 
-        public void setFromForm(boolean fromForm)
+        public UrlToCheck setFromForm(boolean fromForm)
         {
             _isFromForm = fromForm;
+            return this;
         }
 
         public URL getOrigin()
@@ -1020,9 +1025,7 @@ public class Crawler
                     if (code == 200 && _test.getDriver().getTitle().isEmpty())
                         _warnings.add("Action does not specify title: " + actionId);
 
-                    if (depth >= 0 && // Negative depth indicates a one-off check
-                            actualUrl.toString().startsWith(WebTestHelper.getBaseURL()) && // Stop if redirected to an external site
-                            !_terminalActions.contains(actionId))
+                    if (actualUrl.toString().startsWith(WebTestHelper.getBaseURL())) // Stop if redirected to an external site
                     {
                         List<Pair<String, Map<String, String>>> linksWithAttributes = _test.getLinkAddresses();
                         for (Pair<String, Map<String, String>> linkWithAttributes : linksWithAttributes)
@@ -1041,26 +1044,33 @@ public class Crawler
                                 }
                             }
                         }
-                        List<String> linkAddresses = linksWithAttributes.stream().map(Pair::getLeft).collect(Collectors.toList());
-                        List<String> formAddresses = _test.getFormAddresses();
-                        linkAddresses.addAll(formAddresses);
 
-                        for (String url : linkAddresses)
+                        if (!_terminalActions.contains(actionId))
                         {
-                            try
+                            int nextDepth = depth + 1;
+
+                            for (Pair<String, ?> p : linksWithAttributes)
                             {
-                                UrlToCheck candidateUrl = new UrlToCheck(actualUrl, url, depth + 1);
-                                if (candidateUrl.isVisitableURL())
+                                String url = p.getLeft();
+                                try
                                 {
-                                    candidateUrl.setFromForm(formAddresses.contains(url));
-                                    newUrlsToCheck.add(candidateUrl);
+                                    newUrlsToCheck.add(new UrlToCheck(actualUrl, url, nextDepth));
+                                }
+                                catch (IllegalArgumentException badUrl)
+                                {
+                                    throw new IllegalArgumentException("Unable to parse link: \"" + url + "\". " + originMessage, badUrl);
                                 }
                             }
-                            catch (IllegalArgumentException badUrl)
+
+                            for (String url : _test.getFormAddresses())
                             {
-                                if (!formAddresses.contains(url)) // forms might have strange target action (e.g. '../formulations')
+                                try
                                 {
-                                    throw new AssertionError("Unable to parse link: \"" + url + "\". " + originMessage, badUrl);
+                                    newUrlsToCheck.add(new UrlToCheck(actualUrl, url, nextDepth).setFromForm(true));
+                                }
+                                catch (IllegalArgumentException ignore)
+                                {
+                                    // forms might have strange target action (e.g. '../formulations')
                                 }
                             }
                         }
@@ -1118,7 +1128,7 @@ public class Crawler
             }
         }
 
-        return newUrlsToCheck;
+        return newUrlsToCheck.stream().filter(UrlToCheck::isVisitableURL).toList();
     }
 
     private static final ControllerActionId spiderAction = new ControllerActionId("admin", "spider");

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -1045,33 +1045,30 @@ public class Crawler
                             }
                         }
 
-                        if (!_terminalActions.contains(actionId))
+                        int nextDepth = depth + 1;
+
+                        for (Pair<String, ?> p : linksWithAttributes)
                         {
-                            int nextDepth = depth + 1;
-
-                            for (Pair<String, ?> p : linksWithAttributes)
+                            String url = p.getLeft();
+                            try
                             {
-                                String url = p.getLeft();
-                                try
-                                {
-                                    newUrlsToCheck.add(new UrlToCheck(actualUrl, url, nextDepth));
-                                }
-                                catch (IllegalArgumentException badUrl)
-                                {
-                                    throw new IllegalArgumentException("Unable to parse link: \"" + url + "\". " + originMessage, badUrl);
-                                }
+                                newUrlsToCheck.add(new UrlToCheck(actualUrl, url, nextDepth));
                             }
-
-                            for (String url : _test.getFormAddresses())
+                            catch (IllegalArgumentException badUrl)
                             {
-                                try
-                                {
-                                    newUrlsToCheck.add(new UrlToCheck(actualUrl, url, nextDepth).setFromForm(true));
-                                }
-                                catch (IllegalArgumentException ignore)
-                                {
-                                    // forms might have strange target action (e.g. '../formulations')
-                                }
+                                throw new IllegalArgumentException("Unable to parse link: \"" + url + "\". " + originMessage, badUrl);
+                            }
+                        }
+
+                        for (String url : _test.getFormAddresses())
+                        {
+                            try
+                            {
+                                newUrlsToCheck.add(new UrlToCheck(actualUrl, url, nextDepth).setFromForm(true));
+                            }
+                            catch (IllegalArgumentException ignore)
+                            {
+                                // forms might have strange target action (e.g. '../formulations')
                             }
                         }
                     }
@@ -1128,7 +1125,9 @@ public class Crawler
             }
         }
 
-        return newUrlsToCheck.stream().filter(UrlToCheck::isVisitableURL).toList();
+        return _terminalActions.contains(actionId)
+                ? Collections.emptyList()
+                : newUrlsToCheck.stream().filter(UrlToCheck::isVisitableURL).toList();
     }
 
     private static final ControllerActionId spiderAction = new ControllerActionId("admin", "spider");

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -1020,7 +1020,9 @@ public class Crawler
                     if (code == 200 && _test.getDriver().getTitle().isEmpty())
                         _warnings.add("Action does not specify title: " + actionId);
 
-                    if (depth >= 0 && !_terminalActions.contains(actionId)) // Negative depth indicates a one-off check
+                    if (depth >= 0 && // Negative depth indicates a one-off check
+                            actualUrl.toString().startsWith(WebTestHelper.getBaseURL()) && // Stop if redirected to an external site
+                            !_terminalActions.contains(actionId))
                     {
                         List<Pair<String, Map<String, String>>> linksWithAttributes = _test.getLinkAddresses();
                         for (Pair<String, Map<String, String>> linkWithAttributes : linksWithAttributes)


### PR DESCRIPTION
#### Rationale
Some tests create "link" reports pointing at labkey.org; this causes the crawler to get redirected to a page that it would normally not crawl. The crawler shouldn't further inspect such pages.
```
java.lang.AssertionError: Bad 'rel' attribute for link to https://www.labkey.org/wiki/Documentation/page.view?name=default. On Page: https://www.labkey.org/home/project-begin.view
Expected: (a collection containing "noopener" and a collection containing "noreferrer")
     but: a collection containing "noopener" was ""
  at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
  at org.labkey.test.util.Crawler.crawlLink(Crawler.java:1037)
  at org.labkey.test.util.Crawler.crawl(Crawler.java:824)
  at org.labkey.test.util.Crawler.crawlAllLinks(Crawler.java:787)
```

I also noticed that the crawler is skipping the [`rel` attribute validation](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=40708) for some actions.

#### Related Pull Requests
* #1160 

#### Changes
* Stop crawling deeper if redirected to an external site.
* Defer filtering of `crawlLink` results until all checks have been performed
