### PR TITLE
Fix failure in `ChartTypeDialog.setYAxisSide`

### DIFF
--- a/src/org/labkey/test/components/ChartTypeDialog.java
+++ b/src/org/labkey/test/components/ChartTypeDialog.java
@@ -177,24 +177,15 @@ public class ChartTypeDialog extends ChartWizardDialog<ChartTypeDialog.ElementCa
     public ChartTypeDialog setYAxisSide(int measureIndex, YAxisSide side)
     {
         WebElement measureEl = elementCache().Y_FIELD_DISPLAY.index(measureIndex).findElement(this);
-        if (!measureEl.getAttribute("class").contains("selected"))
+        WebElement arrow = Locator.tagWithClass("i", "fa-arrow-circle-" + side.name().toLowerCase()).waitForElement(measureEl, 5_000);
+        if (!arrow.isDisplayed())
         {
             Locator.byClass("field-selection-text").findElement(measureEl).click();
+            getWrapper().shortWait().until(ExpectedConditions.visibilityOf(arrow));
         }
+        arrow.click();
+        getWrapper().shortWait().until(ExpectedConditions.stalenessOf(arrow));
 
-        switch(side)
-        {
-            case Left:
-                final WebElement leftArrow = elementCache().Y_FIELD_SIDE_LEFT.index(measureIndex).findElement(this);
-                leftArrow.click();
-                getWrapper().shortWait().until(ExpectedConditions.stalenessOf(leftArrow));
-                break;
-            case Right:
-                final WebElement rightArrow = elementCache().Y_FIELD_SIDE_RIGHT.index(measureIndex).findElement(this);
-                rightArrow.click();
-                getWrapper().shortWait().until(ExpectedConditions.stalenessOf(rightArrow));
-                break;
-        }
         return this;
     }
 
@@ -529,8 +520,6 @@ public class ChartTypeDialog extends ChartWizardDialog<ChartTypeDialog.ElementCa
         public final String DROP_TEXT = "/following-sibling::div[contains(@class, 'field-area-drop-text ')]";
         public final String REMOVE_ICON = FIELD_DISPLAY + "//div[contains(@class, 'field-selection-remove')]";
         public Locator Y_FIELD_DISPLAY = Locator.xpath(YAXIS_CONTAINER + FIELD_AREA + FIELD_DISPLAY);
-        public Locator Y_FIELD_SIDE_LEFT = Locator.xpath(YAXIS_CONTAINER + FIELD_AREA + FIELD_DISPLAY + "//i[contains(@class, 'fa-arrow-circle-left')]");
-        public Locator Y_FIELD_SIDE_RIGHT = Locator.xpath(YAXIS_CONTAINER + FIELD_AREA + FIELD_DISPLAY + "//i[contains(@class, 'fa-arrow-circle-right')]");
         public WebElement typeTitle = new LazyWebElement(Locator.xpath("//div[contains(@class, 'type-title')]"), this);
 
         public final String SERIES_CONTAINER = "//div[contains(@class, 'field-title')][contains(text(), 'Series')]";

--- a/src/org/labkey/test/components/ChartWizardDialog.java
+++ b/src/org/labkey/test/components/ChartWizardDialog.java
@@ -40,7 +40,7 @@ public abstract class ChartWizardDialog<EC extends ChartWizardDialog.ElementCach
         clickButton("Cancel", true);
     }
 
-    class ElementCache extends Window.ElementCache
+    class ElementCache extends Window<?>.ElementCache
     {
         public ElementCache()
         {


### PR DESCRIPTION
#### Rationale
Previous fix didn't do the trick.
```
org.openqa.selenium.ElementNotInteractableException: Element <i class="fa fa-arrow-circle-right unselected"> could not be scrolled into view
[...]
  at app//org.labkey.test.components.ChartTypeDialog.setYAxisSide(ChartTypeDialog.java:194)
  at app//org.labkey.test.tests.TimeChartDateBasedTest.multiAxisTimeChartTest(TimeChartDateBasedTest.java:646)
  at app//org.labkey.test.tests.TimeChartDateBasedTest.doVerifySteps(TimeChartDateBasedTest.java:114)
  at app//org.labkey.test.tests.StudyBaseTest.runUITests(StudyBaseTest.java:138)
  at app//org.labkey.test.tests.StudyBaseTest.testSteps(StudyBaseTest.java:348)
```
This attempt checks the arrow button visibility directly instead of checking the 'class' attribute of the row.

#### Related Pull Requests
* Previous attempt: #1228

#### Changes
* Wait for button to be visible
* Fix some IDE warnings in 'Window' and wait for visibility
