### PR TITLE
Issue 45368: Attachment fields containing field names with spaces doesn't show attachment

### DIFF
--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -1210,6 +1210,30 @@ public class ListTest extends BaseWebDriverTest
     }
 
     @Test
+    public void testAttachmentFieldWithSpace()
+    {
+        final String listName = "Attachment Field with Space List";
+        final String attachmentFileName = "searchData.tsv";
+        final String path = TestFileUtils.getSampleData("lists/" + attachmentFileName).getAbsolutePath();
+        final String attachmentCol = "Attachment Field With Space";
+
+        Map<String, String> row = new HashMap<>();
+        row.put(attachmentCol, path);
+
+        goToProjectHome();
+
+        log("create list with an attachment column '" + attachmentCol + "'");
+        _listHelper.createList(getProjectName(), listName, ListColumnType.AutoInteger, "id",
+                col(attachmentCol, ColumnType.Attachment));
+
+        log("Insert data, upload attachment for col '" + attachmentCol + "'");
+        goToProjectHome();
+        clickAndWait(Locator.linkWithText(listName));
+        _listHelper.insertNewRow(row, false);
+        assertTextPresent(attachmentFileName);
+    }
+
+    @Test
     public void testAttachmentSearch()
     {
         final String listName = "Attachment Search List";


### PR DESCRIPTION
#### Rationale
Auto test coverage for 'Issue [45368](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45368): Attachment fields containing field names with spaces doesn't show attachment'

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3684

#### Changes
* Add auto test for a List containing attachment column with spaces
