### PR TITLE
Fix Java transform build.gradle dependencies

### DIFF
--- a/data/qc/build.gradle
+++ b/data/qc/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'java'
 
 dependencies {
   BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getRemoteApiProjectPath(gradle), depVersion: project.labkeyClientApiVersion)
+  implementation "commons-logging:commons-logging:${project.commonsLoggingVersion}"
 }
 
 sourceSets {


### PR DESCRIPTION
#### Rationale
Need an explicit dependency on commons logging, as of labkey-client-api v3.0.0