### PR TITLE
refactor changes for group management tests and components in apps

### DIFF
--- a/src/org/labkey/test/components/react/ReactSelect.java
+++ b/src/org/labkey/test/components/react/ReactSelect.java
@@ -31,6 +31,11 @@ public class ReactSelect extends BaseReactSelect<ReactSelect>
         super(element, driver);
     }
 
+    public ReactSelect(ReactSelect wrapped)
+    {
+        this(wrapped.getComponentElement(), wrapped.getDriver());
+    }
+
     public static ReactSelectFinder finder(WebDriver driver)
     {
         return new ReactSelectFinder(driver);

--- a/src/org/labkey/test/components/ui/permissions/GroupDetailsPanel.java
+++ b/src/org/labkey/test/components/ui/permissions/GroupDetailsPanel.java
@@ -1,0 +1,69 @@
+package org.labkey.test.components.ui.permissions;
+
+import org.labkey.test.BootstrapLocators;
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class GroupDetailsPanel extends WebDriverComponent<GroupDetailsPanel.ElementCache>
+{
+    protected static final Locator LOC = BootstrapLocators.panel("Group Details");
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected GroupDetailsPanel(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    public String getGroupName()
+    {
+        return elementCache().title.getText();
+    }
+
+    public String getUserCount()
+    {
+        return elementCache().detailValueEl("User Count").getText();
+    }
+
+    public String getGroupCount()
+    {
+        return elementCache().detailValueEl("Group Count").getText();
+    }
+
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        final WebElement title = Locator.tagWithClass("p", "principal-title-primary").findWhenNeeded(this);
+
+        WebElement detailValueEl(String label)
+        {
+            return Locator.tagWithClass("div", "principal-detail-label").startsWith(label)
+                    .followingSibling("div").findElement(this);
+        }
+    }
+
+
+}

--- a/src/org/labkey/test/components/ui/permissions/GroupRow.java
+++ b/src/org/labkey/test/components/ui/permissions/GroupRow.java
@@ -1,7 +1,6 @@
 package org.labkey.test.components.ui.permissions;
 
 import org.labkey.test.Locator;
-import org.labkey.test.components.react.ReactSelect;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -55,14 +54,6 @@ public class GroupRow extends PermissionsRowBase<GroupRow>
     {
         final WebElement actionContainer = Locator.tagWithClass("div", "expandable-container__action-container")
                 .findWhenNeeded(this);
-
-        public ElementCache()
-        {
-            super(
-                    g -> ReactSelect.Locators.option.withText("Group: " + g), // group options start with "Group: "
-                    null // user options show just their emails
-            );
-        }
 
         final WebElement deleteEmptyGroupBtn()
         {

--- a/src/org/labkey/test/components/ui/permissions/GroupRow.java
+++ b/src/org/labkey/test/components/ui/permissions/GroupRow.java
@@ -1,122 +1,31 @@
 package org.labkey.test.components.ui.permissions;
 
 import org.labkey.test.Locator;
-import org.labkey.test.WebDriverWrapper;
-import org.labkey.test.components.WebDriverComponent;
-import org.labkey.test.components.react.ReactSelect;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-public class GroupRow extends WebDriverComponent<GroupRow.ElementCache>
+public class GroupRow extends PermissionsRowBase<GroupRow>
 {
-    private final WebElement _el;
-    private final WebDriver _driver;
-
     protected GroupRow(WebElement el, WebDriver driver)
     {
-        _el = el;
-        _driver = driver;
+        super(el, driver);
     }
 
     @Override
-    public WebElement getComponentElement()
+    protected WebElement getAssignmentContainer()
     {
-        return _el;
+        return Locator.tagWithClass("div", "expandable-container__member-buttons")
+                .waitForElement(getComponentElement(), 2000);
     }
 
     @Override
-    public WebDriver getDriver()
+    protected GroupRow getThis()
     {
-        return _driver;
-    }
-
-    private void expand()
-    {
-        if (!isExpanded())
-        {
-            elementCache().rowContainer.click();
-        }
-    }
-
-    private boolean isExpanded()
-    {
-        return elementCache().rowContainer.getAttribute("class").contains("container-expandable-child__inactive");
-    }
-
-    public String getTitle()
-    {
-        return Locator.byClass("permissions-title").findElement(this).getText();
-    }
-
-    public GroupRow addUser(String email)
-    {
-        expand();
-        elementCache().memberSelect.select(email);
-        WebDriverWrapper.waitFor(()-> getMemberEmails().contains(email),
-                "user was not added in time", 2000);
         return this;
     }
 
-    public GroupRow removeUser(String email)
-    {
-        expand();
-        elementCache().findUser(email).remove();
-        return this;
-    }
-
-    public GroupRow addGroup(String groupName)
-    {
-        expand();
-        elementCache().memberSelect.select(groupName);
-        WebDriverWrapper.waitFor(()-> getGroups().contains(groupName),
-                "group was not added in time", 2000);
-        return this;
-    }
-
-    public GroupRow removeGroup(String groupName)
-    {
-        expand();
-        elementCache().findGroup(groupName).remove();
-        return this;
-    }
-
-    public List<String> getMemberEmails()
-    {
-        expand();
-        return elementCache().findUsers().stream()
-                .map(PermissionsMember::getName)
-                .collect(Collectors.toList());
-    }
-
-    public List<String> getGroups()
-    {
-        expand();
-        return elementCache().findGroups().stream()
-                .map(PermissionsMember::getName)
-                .collect(Collectors.toList());
-    }
-
-    public GroupRow selectUser(String email)
-    {
-        expand();
-        elementCache().findUser(email).select();
-        return this;
-    }
-
-    public GroupRow selectGroup(String name)
-    {
-        expand();
-        elementCache().findGroup(name).select();
-        return this;
-    }
-
-
-
-    public boolean isDeleteEmptyButtonDisabled()
+    protected boolean isDeleteEmptyButtonDisabled()
     {
         return elementCache().deleteEmptyGroupBtn().getAttribute("class")
                 .contains("disabled-button-with-tooltip");
@@ -139,42 +48,13 @@ public class GroupRow extends WebDriverComponent<GroupRow.ElementCache>
     @Override
     protected ElementCache elementCache()
     {
-        return super.elementCache();
+        return (ElementCache) super.elementCache();
     }
 
-    protected class ElementCache extends WebDriverComponent<RoleRow.ElementCache>.ElementCache
+    protected class ElementCache extends PermissionsRowBase.ElementCache
     {
-        final WebElement rowContainer = Locator.byClass("container-expandable-grey").findWhenNeeded(this);
-        final WebElement memberBtnsRow = Locator.tagWithClass("div", "expandable-container__member-buttons")
-                .findWhenNeeded(this);
-        final WebElement usersList = Locator.tagWithText("div","Users:").followingSibling("ul")
-                .findWhenNeeded(memberBtnsRow).withTimeout(2000);
-        final WebElement groupsList = Locator.tagWithText("div","Groups:").followingSibling("ul")
-                .findWhenNeeded(memberBtnsRow).withTimeout(2000);
         final WebElement actionContainer = Locator.tagWithClass("div", "expandable-container__action-container")
                 .findWhenNeeded(this);
-        final ReactSelect memberSelect = ReactSelect.finder(getDriver()).timeout(2000).findWhenNeeded(actionContainer)
-                .setOptionLocator(ReactSelect.Locators.option::startsWith);
-
-        List<PermissionsMember> findUsers()
-        {
-            return new PermissionsMember.PermissionsMemberFinder(getDriver()).findAll(usersList);
-        }
-
-        PermissionsMember findUser(String email)
-        {
-            return new PermissionsMember.PermissionsMemberFinder(getDriver()).withTitle(email).waitFor(usersList);
-        }
-
-        List<PermissionsMember> findGroups()
-        {
-            return new PermissionsMember.PermissionsMemberFinder(getDriver()).findAll(groupsList);
-        }
-
-        PermissionsMember findGroup(String name)
-        {
-            return new PermissionsMember.PermissionsMemberFinder(getDriver()).withTitle(name).waitFor(groupsList);
-        }
 
         final WebElement deleteEmptyGroupBtn()
         {

--- a/src/org/labkey/test/components/ui/permissions/GroupRow.java
+++ b/src/org/labkey/test/components/ui/permissions/GroupRow.java
@@ -1,0 +1,219 @@
+package org.labkey.test.components.ui.permissions;
+
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.react.ReactSelect;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class GroupRow extends WebDriverComponent<GroupRow.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected GroupRow(WebElement el, WebDriver driver)
+    {
+        _el = el;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    private void expand()
+    {
+        if (!isExpanded())
+        {
+            elementCache().rowContainer.click();
+        }
+    }
+
+    private boolean isExpanded()
+    {
+        return elementCache().rowContainer.getAttribute("class").contains("container-expandable-child__inactive");
+    }
+
+    public String getTitle()
+    {
+        return Locator.byClass("permissions-title").findElement(this).getText();
+    }
+
+    public GroupRow addUser(String email)
+    {
+        expand();
+        elementCache().memberSelect.select(email);
+        WebDriverWrapper.waitFor(()-> getMemberEmails().contains(email),
+                "user was not added in time", 2000);
+        return this;
+    }
+
+    public GroupRow removeUser(String email)
+    {
+        expand();
+        elementCache().findUser(email).remove();
+        return this;
+    }
+
+    public GroupRow addGroup(String groupName)
+    {
+        expand();
+        elementCache().memberSelect.select(groupName);
+        WebDriverWrapper.waitFor(()-> getGroups().contains(groupName),
+                "group was not added in time", 2000);
+        return this;
+    }
+
+    public GroupRow removeGroup(String groupName)
+    {
+        expand();
+        elementCache().findGroup(groupName).remove();
+        return this;
+    }
+
+    public List<String> getMemberEmails()
+    {
+        expand();
+        return elementCache().findUsers().stream()
+                .map(PermissionsMember::getName)
+                .collect(Collectors.toList());
+    }
+
+    public List<String> getGroups()
+    {
+        expand();
+        return elementCache().findGroups().stream()
+                .map(PermissionsMember::getName)
+                .collect(Collectors.toList());
+    }
+
+    public GroupRow selectUser(String email)
+    {
+        expand();
+        elementCache().findUser(email).select();
+        return this;
+    }
+
+    public GroupRow selectGroup(String name)
+    {
+        expand();
+        elementCache().findGroup(name).select();
+        return this;
+    }
+
+
+
+    public boolean isDeleteEmptyButtonDisabled()
+    {
+        return elementCache().deleteEmptyGroupBtn().getAttribute("class")
+                .contains("disabled-button-with-tooltip");
+    }
+
+    public void clickDeleteEmptyGroup()
+    {
+        expand();
+        var btn = elementCache().deleteEmptyGroupBtn();
+        btn.click();
+        getWrapper().shortWait().until(ExpectedConditions.stalenessOf(btn));
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return super.elementCache();
+    }
+
+    protected class ElementCache extends WebDriverComponent<RoleRow.ElementCache>.ElementCache
+    {
+        final WebElement rowContainer = Locator.byClass("container-expandable-grey").findWhenNeeded(this);
+        final WebElement memberBtnsRow = Locator.tagWithClass("div", "expandable-container__member-buttons")
+                .findWhenNeeded(this);
+        final WebElement usersList = Locator.tagWithText("div","Users:").followingSibling("ul")
+                .findWhenNeeded(memberBtnsRow).withTimeout(2000);
+        final WebElement groupsList = Locator.tagWithText("div","Groups:").followingSibling("ul")
+                .findWhenNeeded(memberBtnsRow).withTimeout(2000);
+        final WebElement actionContainer = Locator.tagWithClass("div", "expandable-container__action-container")
+                .findWhenNeeded(this);
+        final ReactSelect memberSelect = ReactSelect.finder(getDriver()).timeout(2000).findWhenNeeded(actionContainer)
+                .setOptionLocator(ReactSelect.Locators.option::startsWith);
+
+        List<PermissionsMember> findUsers()
+        {
+            return new PermissionsMember.PermissionsMemberFinder(getDriver()).findAll(usersList);
+        }
+
+        PermissionsMember findUser(String email)
+        {
+            return new PermissionsMember.PermissionsMemberFinder(getDriver()).withTitle(email).waitFor(usersList);
+        }
+
+        List<PermissionsMember> findGroups()
+        {
+            return new PermissionsMember.PermissionsMemberFinder(getDriver()).findAll(groupsList);
+        }
+
+        PermissionsMember findGroup(String name)
+        {
+            return new PermissionsMember.PermissionsMemberFinder(getDriver()).withTitle(name).waitFor(groupsList);
+        }
+
+        final WebElement deleteEmptyGroupBtn()
+        {
+            return Locator.tagWithText("button", "Delete Empty Group")
+                    .findElement(actionContainer);
+        }
+    }
+
+    public static class GroupRowFinder extends WebDriverComponentFinder<GroupRow, GroupRow.GroupRowFinder>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "container-expandable")
+                .withChild(Locator.tagWithClass("div", "container-expandable-grey"));
+        private String _groupName = null;
+
+        public GroupRowFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        public GroupRowFinder forGroup(String groupName)
+        {
+            _groupName = groupName;
+            return this;
+        }
+
+        @Override
+        protected GroupRow construct(WebElement el, WebDriver driver)
+        {
+            return new GroupRow(el, driver);
+        }
+
+        @Override
+        protected Locator locator()
+        {
+            if (_groupName != null)
+                return _baseLocator.withDescendant(Locator.byClass("permissions-title").withText(_groupName));
+            else
+                return _baseLocator;
+        }
+    }
+
+}

--- a/src/org/labkey/test/components/ui/permissions/GroupRow.java
+++ b/src/org/labkey/test/components/ui/permissions/GroupRow.java
@@ -62,7 +62,7 @@ public class GroupRow extends PermissionsRowBase<GroupRow>
         }
     }
 
-    public static class GroupRowFinder extends PermissionsRowFinder<GroupRow>
+    public static class GroupRowFinder extends PermissionsRowFinder<GroupRow, GroupRowFinder>
     {
         public GroupRowFinder(WebDriver driver)
         {

--- a/src/org/labkey/test/components/ui/permissions/GroupRow.java
+++ b/src/org/labkey/test/components/ui/permissions/GroupRow.java
@@ -27,8 +27,7 @@ public class GroupRow extends PermissionsRowBase<GroupRow>
 
     protected boolean isDeleteEmptyButtonDisabled()
     {
-        return elementCache().deleteEmptyGroupBtn().getAttribute("class")
-                .contains("disabled-button-with-tooltip");
+        return !elementCache().deleteEmptyGroupBtn().isEnabled();
     }
 
     public void clickDeleteEmptyGroup()
@@ -63,12 +62,8 @@ public class GroupRow extends PermissionsRowBase<GroupRow>
         }
     }
 
-    public static class GroupRowFinder extends WebDriverComponentFinder<GroupRow, GroupRow.GroupRowFinder>
+    public static class GroupRowFinder extends PermissionsRowFinder<GroupRow>
     {
-        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "container-expandable")
-                .withChild(Locator.tagWithClass("div", "container-expandable-grey"));
-        private String _groupName = null;
-
         public GroupRowFinder(WebDriver driver)
         {
             super(driver);
@@ -76,7 +71,7 @@ public class GroupRow extends PermissionsRowBase<GroupRow>
 
         public GroupRowFinder forGroup(String groupName)
         {
-            _groupName = groupName;
+            super.withTitle(groupName);
             return this;
         }
 
@@ -86,14 +81,6 @@ public class GroupRow extends PermissionsRowBase<GroupRow>
             return new GroupRow(el, driver);
         }
 
-        @Override
-        protected Locator locator()
-        {
-            if (_groupName != null)
-                return _baseLocator.withDescendant(Locator.byClass("permissions-title").withText(_groupName));
-            else
-                return _baseLocator;
-        }
     }
 
 }

--- a/src/org/labkey/test/components/ui/permissions/GroupRow.java
+++ b/src/org/labkey/test/components/ui/permissions/GroupRow.java
@@ -51,7 +51,7 @@ public class GroupRow extends PermissionsRowBase<GroupRow>
         return (ElementCache) super.elementCache();
     }
 
-    protected class ElementCache extends PermissionsRowBase.ElementCache
+    protected class ElementCache extends PermissionsRowBase<GroupRow>.ElementCache
     {
         final WebElement actionContainer = Locator.tagWithClass("div", "expandable-container__action-container")
                 .findWhenNeeded(this);

--- a/src/org/labkey/test/components/ui/permissions/GroupRow.java
+++ b/src/org/labkey/test/components/ui/permissions/GroupRow.java
@@ -1,6 +1,7 @@
 package org.labkey.test.components.ui.permissions;
 
 import org.labkey.test.Locator;
+import org.labkey.test.components.react.ReactSelect;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -54,6 +55,14 @@ public class GroupRow extends PermissionsRowBase<GroupRow>
     {
         final WebElement actionContainer = Locator.tagWithClass("div", "expandable-container__action-container")
                 .findWhenNeeded(this);
+
+        public ElementCache()
+        {
+            super(
+                    g -> ReactSelect.Locators.option.withText("Group: " + g), // group options start with "Group: "
+                    null // user options show just their emails
+            );
+        }
 
         final WebElement deleteEmptyGroupBtn()
         {

--- a/src/org/labkey/test/components/ui/permissions/PermissionsMember.java
+++ b/src/org/labkey/test/components/ui/permissions/PermissionsMember.java
@@ -1,0 +1,96 @@
+package org.labkey.test.components.ui.permissions;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+public class PermissionsMember extends WebDriverComponent<PermissionsMember.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected PermissionsMember(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    public void remove()
+    {
+        elementCache()._removeButton.click();
+        getWrapper().shortWait().until(ExpectedConditions.stalenessOf(_el));
+    }
+
+    public void select()
+    {
+        elementCache()._nameButton.click();
+        getWrapper().shortWait().until(ExpectedConditions.attributeContains(elementCache()._nameButton, "class", "primary"));
+    }
+
+    public String getName()
+    {
+        return elementCache()._nameButton.getText();
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        private final WebElement _removeButton = Locator.byClass("btn")
+                .withChild(Locator.byClass("fa-remove")).findWhenNeeded(this);
+        private final WebElement _nameButton = Locator.byClass("permissions-button-display")
+                .findWhenNeeded(this).withTimeout(1000);
+    }
+
+    public static class PermissionsMemberFinder extends WebDriverComponentFinder<PermissionsMember, PermissionsMemberFinder>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("li","permissions-groups-member-li");
+        private String _title = null;
+
+        public PermissionsMemberFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        public PermissionsMemberFinder withTitle(String title)
+        {
+            _title = title;
+            return this;
+        }
+
+        @Override
+        protected PermissionsMember construct(WebElement el, WebDriver driver)
+        {
+            return new PermissionsMember(el, driver);
+        }
+
+        @Override
+        protected Locator locator()
+        {
+            if (_title != null)
+                return _baseLocator.withDescendant(
+                        Locator.tagWithClass("button", "permissions-button-display").startsWith(_title));
+            else
+                return _baseLocator;
+        }
+    }
+}

--- a/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
+++ b/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
@@ -163,7 +163,8 @@ public abstract class PermissionsRowBase<T extends PermissionsRowBase<T>> extend
                 .setOptionLocator(ReactSelect.Locators.option::endsWith);
     }
 
-    protected static abstract class PermissionsRowFinder<T extends PermissionsRowBase<T>> extends WebDriverComponentFinder<T, PermissionsRowBase.PermissionsRowFinder<T>>
+    protected static abstract class PermissionsRowFinder<C extends PermissionsRowBase<C>, F extends PermissionsRowBase.PermissionsRowFinder<C, F>>
+            extends WebDriverComponentFinder<C, F>
     {
         private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "container-expandable")
                 .withChild(Locator.tagWithClass("div", "container-expandable-grey"));
@@ -181,7 +182,7 @@ public abstract class PermissionsRowBase<T extends PermissionsRowBase<T>> extend
         }
 
         @Override
-        protected abstract T construct(WebElement el, WebDriver driver);
+        protected abstract C construct(WebElement el, WebDriver driver);
 
         @Override
         protected Locator locator()

--- a/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
+++ b/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
@@ -3,12 +3,12 @@ package org.labkey.test.components.ui.permissions;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.react.BaseReactSelect;
 import org.labkey.test.components.react.ReactSelect;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 
@@ -160,21 +160,15 @@ public abstract class PermissionsRowBase<T extends PermissionsRowBase<T>> extend
         private final ReactSelect groupMemberSelect;
         private final ReactSelect userMemberSelect;
 
-        protected ElementCache(Function<String, Locator> groupOptionLocator, Function<String, Locator> userOptionLocator)
+        protected ElementCache()
         {
             // Use same WebElement for both selects but with different option locators.
             ReactSelect rawMemberSelect = ReactSelect.finder(getDriver()).findWhenNeeded(this);
 
             groupMemberSelect = new ReactSelect(rawMemberSelect);
-            if (groupOptionLocator != null)
-            {
-                groupMemberSelect.setOptionLocator(groupOptionLocator);
-            }
-            userMemberSelect = new ReactSelect(rawMemberSelect);
-            if (userOptionLocator != null)
-            {
-                userMemberSelect.setOptionLocator(userOptionLocator);
-            }
+            // it's possible that user select items will have a suffix of the user's display name, so match on startsWith
+            userMemberSelect = new ReactSelect(rawMemberSelect)
+                    .setOptionLocator(BaseReactSelect.Locators.option :: startsWith);
         }
     }
 

--- a/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
+++ b/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
@@ -1,0 +1,171 @@
+package org.labkey.test.components.ui.permissions;
+
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.react.ReactSelect;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+public abstract class PermissionsRowBase<T extends PermissionsRowBase<T>> extends WebDriverComponent<PermissionsRowBase<?>.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected PermissionsRowBase(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    protected abstract WebElement getAssignmentContainer();
+    protected abstract T getThis();
+
+    protected WebElement userListContainer()
+    {
+        return Locator.tagWithText("div","Users:").followingSibling("ul")
+                .findElement(getAssignmentContainer());
+    }
+
+    protected WebElement groupListContainer()
+    {
+        return Locator.tagWithText("div","Groups:").followingSibling("ul")
+                .findElement(getAssignmentContainer());
+    }
+
+    protected void expand()
+    {
+        if (!isExpanded())
+        {
+            elementCache().rowContainer.click();
+        }
+    }
+    private boolean isExpanded()
+    {
+        return elementCache().rowContainer.getAttribute("class").contains("container-expandable-child__inactive");
+    }
+
+    public String getTitle()
+    {
+        return Locator.byClass("permissions-title").findElement(this).getText();
+    }
+
+    public List<String> getMemberEmails()
+    {
+        expand();
+        return findUsers().stream()
+                .map(PermissionsMember::getName)
+                .collect(Collectors.toList());
+    }
+
+    public T selectMember(String email)
+    {
+        expand();
+        findUser(email).select();
+        return getThis();
+    }
+
+    public T addMember(String email)
+    {
+        expand();
+        elementCache().memberSelect.select(email);
+        WebDriverWrapper.waitFor(()-> getMemberEmails().contains(email),
+                "member was not added in time", 2000);
+        return getThis();
+    }
+
+    public T removeMember(String email)
+    {
+        expand();
+        findUser(email).remove();
+        return getThis();
+    }
+
+    public List<String> getGroups()
+    {
+        expand();
+        return findGroups().stream()
+                .map(PermissionsMember::getName)
+                .collect(Collectors.toList());
+    }
+
+    public T selectGroup(String name)
+    {
+        expand();
+        findGroup(name).select();
+        return getThis();
+    }
+
+    public T addGroup(String name)
+    {
+        expand();
+        elementCache().memberSelect.select(name);
+        WebDriverWrapper.waitFor(()-> getGroups().contains(name),
+                "group was not added in time", 2000);
+        return getThis();
+    }
+
+    public T removeGroup(String name)
+    {
+        expand();
+        findGroup(name).remove();
+        return getThis();
+    }
+
+    protected List<PermissionsMember> findUsers()
+    {
+        return new PermissionsMember.PermissionsMemberFinder(getDriver()).findAll(userListContainer());
+    }
+
+    protected PermissionsMember findUser(String email)
+    {
+        return new PermissionsMember.PermissionsMemberFinder(getDriver()).withTitle(email).waitFor(userListContainer());
+    }
+
+    protected List<PermissionsMember> findGroups()
+    {
+        return new PermissionsMember.PermissionsMemberFinder(getDriver()).findAll(groupListContainer());
+    }
+
+    protected PermissionsMember findGroup(String name)
+    {
+        return new PermissionsMember.PermissionsMemberFinder(getDriver()).withTitle(name).waitFor(groupListContainer());
+    }
+
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends WebDriverComponent<?>.ElementCache
+    {
+        final WebElement rowContainer = Locator.byClass("container-expandable-grey").findWhenNeeded(this);
+
+        final ReactSelect memberSelect = ReactSelect.finder(getDriver()).findWhenNeeded(this)
+                .setOptionLocator(ReactSelect.Locators.option::startsWith);
+    }
+}

--- a/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
+++ b/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
@@ -159,7 +159,6 @@ public abstract class PermissionsRowBase<T extends PermissionsRowBase<T>> extend
     {
         final WebElement rowContainer = Locator.byClass("container-expandable-grey").findWhenNeeded(this);
 
-        final ReactSelect memberSelect = ReactSelect.finder(getDriver()).findWhenNeeded(this)
-                .setOptionLocator(ReactSelect.Locators.option::startsWith);
+        final ReactSelect memberSelect = ReactSelect.finder(getDriver()).findWhenNeeded(this);
     }
 }

--- a/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
+++ b/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
@@ -159,6 +159,7 @@ public abstract class PermissionsRowBase<T extends PermissionsRowBase<T>> extend
     {
         final WebElement rowContainer = Locator.byClass("container-expandable-grey").findWhenNeeded(this);
 
-        final ReactSelect memberSelect = ReactSelect.finder(getDriver()).findWhenNeeded(this);
+        final ReactSelect memberSelect = ReactSelect.finder(getDriver()).findWhenNeeded(this)
+                .setOptionLocator(ReactSelect.Locators.option::endsWith);
     }
 }

--- a/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
+++ b/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
@@ -155,12 +155,6 @@ public abstract class PermissionsRowBase<T extends PermissionsRowBase<T>> extend
         return new ElementCache();
     }
 
-    @Override
-    protected ElementCache elementCache()
-    {
-        return new ElementCache();
-    }
-
     protected class ElementCache extends WebDriverComponent<?>.ElementCache
     {
         final WebElement rowContainer = Locator.byClass("container-expandable-grey").findWhenNeeded(this);

--- a/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
+++ b/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
@@ -162,4 +162,34 @@ public abstract class PermissionsRowBase<T extends PermissionsRowBase<T>> extend
         final ReactSelect memberSelect = ReactSelect.finder(getDriver()).findWhenNeeded(this)
                 .setOptionLocator(ReactSelect.Locators.option::endsWith);
     }
+
+    protected static abstract class PermissionsRowFinder<T extends PermissionsRowBase<T>> extends WebDriverComponentFinder<T, PermissionsRowBase.PermissionsRowFinder<T>>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "container-expandable")
+                .withChild(Locator.tagWithClass("div", "container-expandable-grey"));
+        private String _title = null;
+
+        protected PermissionsRowFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        // Call from group/role row finder
+        protected void withTitle(String title)
+        {
+            _title = title;
+        }
+
+        @Override
+        protected abstract T construct(WebElement el, WebDriver driver);
+
+        @Override
+        protected Locator locator()
+        {
+            if (_title != null)
+                return _baseLocator.withDescendant(Locator.byClass("permissions-title").withText(_title));
+            else
+                return _baseLocator;
+        }
+    }
 }

--- a/src/org/labkey/test/components/ui/permissions/RoleRow.java
+++ b/src/org/labkey/test/components/ui/permissions/RoleRow.java
@@ -33,20 +33,17 @@ public class RoleRow extends PermissionsRowBase<RoleRow>
     {
     }
 
-    public static class RoleRowFinder extends WebDriverComponentFinder<RoleRow, RoleRow.RoleRowFinder>
+    public static class RoleRowFinder extends PermissionsRowFinder<RoleRow>
     {
-        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "container-expandable")
-                .withChild(Locator.tagWithClass("div", "container-expandable-grey"));
-        private String _roleTitle = null;
 
         public RoleRowFinder(WebDriver driver)
         {
             super(driver);
         }
 
-        public RoleRow.RoleRowFinder forRole(String roleTitle)
+        public RoleRowFinder forRole(String roleTitle)
         {
-            _roleTitle = roleTitle;
+            super.withTitle(roleTitle);
             return this;
         }
 
@@ -54,15 +51,6 @@ public class RoleRow extends PermissionsRowBase<RoleRow>
         protected RoleRow construct(WebElement el, WebDriver driver)
         {
             return new RoleRow(el, driver);
-        }
-
-        @Override
-        protected Locator locator()
-        {
-            if (_roleTitle != null)
-                return _baseLocator.withDescendant(Locator.byClass("permissions-title").withText(_roleTitle));
-            else
-                return _baseLocator;
         }
     }
 }

--- a/src/org/labkey/test/components/ui/permissions/RoleRow.java
+++ b/src/org/labkey/test/components/ui/permissions/RoleRow.java
@@ -1,113 +1,26 @@
 package org.labkey.test.components.ui.permissions;
 
 import org.labkey.test.Locator;
-import org.labkey.test.components.WebDriverComponent;
-import org.labkey.test.components.react.ReactSelect;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-public class RoleRow extends WebDriverComponent<RoleRow.ElementCache>
+public class RoleRow extends PermissionsRowBase<RoleRow>
 {
-    private static final Locator.XPathLocator MEMBER_LOC = Locator.byClass("permissions-groups-member-li");
-
-    private final WebElement _el;
-    private final WebDriver _driver;
-
     protected RoleRow(WebElement element, WebDriver driver)
     {
-        _el = element;
-        _driver = driver;
-    }
-
-    private void expand()
-    {
-        if (!isExpanded())
-        {
-            elementCache().rowContainer.click();
-        }
-    }
-
-    private boolean isExpanded()
-    {
-        return elementCache().rowContainer.getAttribute("class").contains("container-expandable-child__inactive");
-    }
-
-    public String getTitle()
-    {
-        return Locator.byClass("permissions-title").findElement(this).getText();
-    }
-
-    public List<String> getMemberEmails()
-    {
-        expand();
-        return elementCache().findUsers().stream()
-                .map(PermissionsMember::getName)
-                .collect(Collectors.toList());
-    }
-
-    public RoleRow selectMember(String email)
-    {
-        expand();
-        elementCache().findUser(email).select();
-        return this;
-    }
-
-    public RoleRow removeMember(String email)
-    {
-        expand();
-        elementCache().findUser(email).remove();
-        return this;
-    }
-
-    public RoleRow addMember(String email)
-    {
-        expand();
-        elementCache().memberSelect.select(email);
-        return this;
-    }
-
-    public List<String> getMemberGroups()
-    {
-        expand();
-        return elementCache().findGroups().stream()
-                .map(PermissionsMember::getName)
-                .collect(Collectors.toList());
-    }
-
-    public RoleRow selectMemberGroups(String name)
-    {
-        expand();
-        elementCache().findGroup(name).select();
-        return this;
-    }
-
-    public RoleRow removeMemberGroup(String name)
-    {
-        expand();
-        elementCache().findGroup(name).remove();
-        return this;
-    }
-
-    public RoleRow addMemberGroup(String name)
-    {
-        expand();
-        elementCache().memberSelect.select(name);
-        return this;
+        super(element, driver);
     }
 
     @Override
-    public WebElement getComponentElement()
+    protected WebElement getAssignmentContainer()
     {
-        return _el;
+        return Locator.byClass("permissions-assignments-row").waitForElement(getComponentElement(), 2000);
     }
 
     @Override
-    public WebDriver getDriver()
+    protected RoleRow getThis()
     {
-        return _driver;
+        return this;
     }
 
     @Override
@@ -116,37 +29,8 @@ public class RoleRow extends WebDriverComponent<RoleRow.ElementCache>
         return new ElementCache();
     }
 
-    protected class ElementCache extends WebDriverComponent<RoleRow.ElementCache>.ElementCache
+    protected class ElementCache extends PermissionsRowBase.ElementCache
     {
-        final WebElement rowContainer = Locator.byClass("container-expandable-grey").findWhenNeeded(this);
-        final WebElement assignmentsRow = Locator.byClass("permissions-assignments-row").findWhenNeeded(this);
-        final WebElement usersList = Locator.tagWithText("div","Users:").followingSibling("ul")
-                .findElement(assignmentsRow);
-        final WebElement groupsList = Locator.tagWithText("div","Groups:").followingSibling("ul")
-                .findElement(assignmentsRow);
-
-        final ReactSelect memberSelect = ReactSelect.finder(getDriver()).findWhenNeeded(this)
-                .setOptionLocator(ReactSelect.Locators.option::startsWith);
-
-        List<PermissionsMember> findUsers()
-        {
-            return new PermissionsMember.PermissionsMemberFinder(getDriver()).findAll(usersList);
-        }
-
-        PermissionsMember findUser(String email)
-        {
-            return new PermissionsMember.PermissionsMemberFinder(getDriver()).withTitle(email).waitFor(usersList);
-        }
-
-        List<PermissionsMember> findGroups()
-        {
-            return new PermissionsMember.PermissionsMemberFinder(getDriver()).findAll(groupsList);
-        }
-
-        PermissionsMember findGroup(String name)
-        {
-            return new PermissionsMember.PermissionsMemberFinder(getDriver()).withTitle(name).waitFor(groupsList);
-        }
     }
 
     public static class RoleRowFinder extends WebDriverComponentFinder<RoleRow, RoleRow.RoleRowFinder>

--- a/src/org/labkey/test/components/ui/permissions/RoleRow.java
+++ b/src/org/labkey/test/components/ui/permissions/RoleRow.java
@@ -1,6 +1,7 @@
 package org.labkey.test.components.ui.permissions;
 
 import org.labkey.test.Locator;
+import org.labkey.test.components.react.ReactSelect;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -31,6 +32,12 @@ public class RoleRow extends PermissionsRowBase<RoleRow>
 
     protected class ElementCache extends PermissionsRowBase<RoleRow>.ElementCache
     {
+        public ElementCache()
+        {
+            super(null, // group options show the raw group name
+                    ReactSelect.Locators.option::startsWith // users options may end with display name
+            );
+        }
     }
 
     public static class RoleRowFinder extends PermissionsRowFinder<RoleRow>

--- a/src/org/labkey/test/components/ui/permissions/RoleRow.java
+++ b/src/org/labkey/test/components/ui/permissions/RoleRow.java
@@ -33,7 +33,7 @@ public class RoleRow extends PermissionsRowBase<RoleRow>
     {
     }
 
-    public static class RoleRowFinder extends PermissionsRowFinder<RoleRow>
+    public static class RoleRowFinder extends PermissionsRowFinder<RoleRow, RoleRowFinder>
     {
 
         public RoleRowFinder(WebDriver driver)

--- a/src/org/labkey/test/components/ui/permissions/RoleRow.java
+++ b/src/org/labkey/test/components/ui/permissions/RoleRow.java
@@ -29,7 +29,7 @@ public class RoleRow extends PermissionsRowBase<RoleRow>
         return new ElementCache();
     }
 
-    protected class ElementCache extends PermissionsRowBase.ElementCache
+    protected class ElementCache extends PermissionsRowBase<RoleRow>.ElementCache
     {
     }
 

--- a/src/org/labkey/test/components/ui/permissions/RoleRow.java
+++ b/src/org/labkey/test/components/ui/permissions/RoleRow.java
@@ -1,7 +1,6 @@
 package org.labkey.test.components.ui.permissions;
 
 import org.labkey.test.Locator;
-import org.labkey.test.components.react.ReactSelect;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -32,12 +31,6 @@ public class RoleRow extends PermissionsRowBase<RoleRow>
 
     protected class ElementCache extends PermissionsRowBase<RoleRow>.ElementCache
     {
-        public ElementCache()
-        {
-            super(null, // group options show the raw group name
-                    ReactSelect.Locators.option::startsWith // users options may end with display name
-            );
-        }
     }
 
     public static class RoleRowFinder extends PermissionsRowFinder<RoleRow, RoleRowFinder>

--- a/src/org/labkey/test/components/ui/permissions/UserDetailsPanel.java
+++ b/src/org/labkey/test/components/ui/permissions/UserDetailsPanel.java
@@ -8,7 +8,6 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class UserDetailsPanel extends WebDriverComponent<Component<?>.ElementCache>
 {
@@ -40,6 +39,13 @@ public class UserDetailsPanel extends WebDriverComponent<Component<?>.ElementCac
         return Locator.byClass("principal-title-primary")
                 .findOptionalElement(this)
                 .map(WebElement::getText).orElse(null);
+    }
+
+    public List<String> getMemberships()
+    {
+        var membersList = Locator.tagWithClass("div", "principal-detail-label").withText("Member of:")
+                .followingSibling("ul").findElement(this);
+        return getWrapper().getTexts(Locator.tag("li").findElements(membersList));
     }
 
 }


### PR DESCRIPTION
#### Rationale
Adding in-app administration for groups in addition to roles calls for components to support their very-similar but slightly different implementation- this is an attempt to update our components to be able to interact with roles and groups separately but distinctly

#### Related Pull Requests
test changes + new tests in biologics - https://github.com/LabKey/biologics/pull/1634
Update in SM - https://github.com/LabKey/sampleManagement/pull/1275

#### Changes
modified RoleRow to work with the UI changes that went into adding the notion of groups- now users and groups can be represented as being in a role 
![image](https://user-images.githubusercontent.com/16809856/193112771-0f2c477a-f9bc-4cae-b378-ff527d924743.png)

created GroupRow to support groups, which can have users and groups as members
![image](https://user-images.githubusercontent.com/16809856/193112527-5ae818c0-b0c9-4e2f-8767-2796acb4a08c.png)

extracted PermissionsMember (was internal to RoleRow) so RoleRow and GroupRow can both use it
Added GroupDetailsPanel, similar to UserDetailsPanel
Expanded the info UserDetailsPanel can get from the dom- in particular, groups the user is a member of
