### PR TITLE
Fix flaky editable grid tests in SM

### DIFF
--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -780,7 +780,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
         public ReactSelect lookupSelect()
         {
-            return ReactSelect.finder(getDriver()).find(getComponentElement());
+            return ReactSelect.finder(getDriver()).timeout(10000).find(getComponentElement());
         }
 
         public ReactDatePicker datePicker()


### PR DESCRIPTION
#### Rationale
Looks like this related PR is causing a couple flaky tests in SM.

#### Related Pull Requests
https://github.com/LabKey/labkey-ui-components/pull/968
https://github.com/LabKey/sampleManagement/pull/1242

#### Changes
* Increase lookup cell timeout
