### PR TITLE
Add Method 'getTabsWithCounts' to TabbedGridPanel

### DIFF
--- a/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
+++ b/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
@@ -9,7 +9,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -60,7 +60,7 @@ public class TabbedGridPanel extends WebDriverComponent<TabbedGridPanel.ElementC
 
     public Map<String, Integer> getTabsWithCounts()
     {
-        Map<String, Integer> counts = new HashMap<>();
+        Map<String, Integer> counts = new LinkedHashMap<>();
 
         List<String> tabs = getTabs();
 

--- a/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
+++ b/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
@@ -9,7 +9,9 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -55,6 +57,25 @@ public class TabbedGridPanel extends WebDriverComponent<TabbedGridPanel.ElementC
                 .map(tab -> tab.replaceFirst(" \\([0-9]+\\)$", ""))
                 .collect(Collectors.toList());
     }
+
+    public Map<String, Integer> getTabsWithCounts()
+    {
+        Map<String, Integer> counts = new HashMap<>();
+
+        List<String> tabs = getTabs();
+
+        for(String tabText : tabs)
+        {
+            String sampleTypeName = tabText.substring(0, tabText.lastIndexOf(" ("));
+            int count = Integer.parseInt(tabText.substring(tabText.lastIndexOf(" ("))
+                    .replace("(", "")
+                    .replace(")", "").trim());
+            counts.put(sampleTypeName, count);
+        }
+
+        return counts;
+    }
+
 
     private boolean isSelected(String tabText)
     {


### PR DESCRIPTION
#### Rationale
Added method getTabsWithCounts to TabbedGridPanel. This will return a map with the tab name as the key and the count as the value. Used int tests that validate sample counts are filtered in the tabs.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/550
* https://github.com/LabKey/biologics/pull/1618

#### Changes
* Added method getTabsWithCounts to TabbedGridPanel.
