### PR TITLE
Skip injection check when redirected to an external site

### DIFF
--- a/src/org/labkey/test/WebTestHelper.java
+++ b/src/org/labkey/test/WebTestHelper.java
@@ -278,9 +278,9 @@ public class WebTestHelper
      */
     public static String makeRelativeUrl(String url)
     {
-        if (url.startsWith("http://") || url.startsWith("https://"))
+        if (isAbsoluteUrl(url))
         {
-            if (url.startsWith(getBaseURL()))
+            if (isTestServerUrl(url))
             {
                 url = url.substring(getBaseURL().length());
             }
@@ -298,6 +298,16 @@ public class WebTestHelper
             }
         }
         return StringUtils.stripStart(url, "/");
+    }
+
+    public static boolean isAbsoluteUrl(String url)
+    {
+        return url.startsWith("http://") || url.startsWith("https://");
+    }
+
+    public static boolean isTestServerUrl(String url)
+    {
+        return url.startsWith(getBaseURL()) || !isAbsoluteUrl(url);
     }
 
     public enum DatabaseType

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -1112,7 +1112,7 @@ public class Crawler
             throw new RuntimeException(e);
         }
 
-        if (urlToCheck.isInjectableURL() && _injectionCheckEnabled)
+        if (urlToCheck.isInjectableURL() && _injectionCheckEnabled && WebTestHelper.isTestServerUrl(actualUrl.toString()))
         {
             TestLogger.increaseIndent();
             try


### PR DESCRIPTION
#### Rationale
Previous fix made the crawler skip _some_ checks when redirected but it still attempted script injection.
```
java.lang.IllegalArgumentException: URL does not appear to target server under test: https://www.labkey.org/home/project-begin.view
  at org.labkey.test.WebTestHelper.makeRelativeUrl(WebTestHelper.java:289)
  at org.labkey.test.util.Crawler$ControllerActionId.<init>(Crawler.java:665)
  at org.labkey.test.util.Crawler.testInjection(Crawler.java:1340)
  at org.labkey.test.util.Crawler.crawlLink(Crawler.java:1120)
```

#### Related Pull Requests
* #1234

#### Changes
* Skip injection check when redirected to an external site
