### PR TITLE
EditInlineField: stop looking for pencil icon, it is optional.

### DIFF
--- a/src/org/labkey/test/Locators.java
+++ b/src/org/labkey/test/Locators.java
@@ -40,7 +40,7 @@ public abstract class Locators
 
     public static Locator.XPathLocator appFloatingHeader()
     {
-        return Locator.tag("div").withClasses("app-header-wrapper", "scrolled");
+        return Locator.tag("div").withClass("app-navigation");
     }
 
     public static Locator.XPathLocator bodyPanel()

--- a/src/org/labkey/test/components/react/Tabs.java
+++ b/src/org/labkey/test/components/react/Tabs.java
@@ -60,7 +60,9 @@ public class Tabs extends WebDriverComponent<Tabs.ElementCache>
 
     public WebElement selectTab(String tabText)
     {
-        elementCache().findTab(tabText).click();
+        WebElement tab = elementCache().findTab(tabText);
+        getWrapper().scrollIntoView(tab);
+        tab.click();
         WebElement panel = findPanelForTab(tabText);
         getWrapper().shortWait().until(ExpectedConditions.visibilityOf(panel));
         return panel;

--- a/src/org/labkey/test/components/ui/edit/EditInlineField.java
+++ b/src/org/labkey/test/components/ui/edit/EditInlineField.java
@@ -4,6 +4,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
+import org.openqa.selenium.ElementNotInteractableException;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -64,7 +65,17 @@ public class EditInlineField extends WebDriverComponent<EditInlineField.ElementC
         {
             WebElement toggle = elementCache().toggle();
             getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(toggle));
-            toggle.click();
+
+            try {
+                toggle.click();
+            }
+            catch (ElementNotInteractableException e)
+            {
+                // If the EditInlineField has showToggle set to true then we need to click the pencil icon, not the
+                // toggle element.
+                elementCache().pencil().click();
+            }
+
             WebDriverWrapper.waitFor(this::isOpen,
                     "the edit inline field did not open", 2000);
         }
@@ -81,6 +92,7 @@ public class EditInlineField extends WebDriverComponent<EditInlineField.ElementC
         final WebElement label = Locator.tagWithClass("span", "edit-inline-field__label")
                 .refindWhenNeeded(this);
         final Locator toggleLoc = Locator.tagWithClass("span", "edit-inline-field__toggle");
+        final Locator pencilLoc = Locator.tagWithClass("span", "fa-pencil");
         final WebElement input = Locator.css("input.form-control, textarea.form-control").refindWhenNeeded(this);
 
         WebElement placeholderElement()
@@ -92,6 +104,11 @@ public class EditInlineField extends WebDriverComponent<EditInlineField.ElementC
         WebElement toggle()
         {
             return toggleLoc.waitForElement(this, 1_000);
+        }
+
+        WebElement pencil()
+        {
+            return pencilLoc.waitForElement(this, 1_000);
         }
     }
 

--- a/src/org/labkey/test/components/ui/edit/EditInlineField.java
+++ b/src/org/labkey/test/components/ui/edit/EditInlineField.java
@@ -80,8 +80,7 @@ public class EditInlineField extends WebDriverComponent<EditInlineField.ElementC
     {
         final WebElement label = Locator.tagWithClass("span", "edit-inline-field__label")
                 .refindWhenNeeded(this);
-        final Locator toggleLoc = Locator.tagWithClass("span", "edit-inline-field__toggle")
-                .withChild(Locator.tagWithClass("i", "fa-pencil"));
+        final Locator toggleLoc = Locator.tagWithClass("span", "edit-inline-field__toggle");
         final WebElement input = Locator.css("input.form-control, textarea.form-control").refindWhenNeeded(this);
 
         WebElement placeholderElement()

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -32,7 +32,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.BaseWebDriverTest.WAIT_FOR_JAVASCRIPT;
-import static org.labkey.test.WebDriverWrapper.sleep;
 import static org.labkey.test.WebDriverWrapper.waitFor;
 
 public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent<ResponsiveGrid<T>.ElementCache> implements UpdatingComponent
@@ -254,14 +253,12 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
         }
 
         WebElement headerCell = elementCache().getColumnHeaderCell(columnLabel);
-        getWrapper().scrollIntoView(headerCell);    // for cells to the right or left of the viewport, scrollIntoView handles horizontal scroll
-        sleep(500);  //it would be nice to find a way to test for whether or not x-scroll is needed, and only x-scroll if necessary
-                         //  sleep here to give scrollToMiddle call below a better chance of firing
+        // Scroll to middle in order to make room for the dropdown menu
+        getWrapper().scrollToMiddle(headerCell);
 
         WebElement toggle = Locator.tagWithClass("span", "fa-chevron-circle-down")
                 .findElement(headerCell);
         getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(toggle));
-        getWrapper().scrollToMiddle(toggle);        // scroll the target vertically to the middle of the page
         toggle.click();
 
         WebElement menuItem = Locator.css("li > a").containing(menuText).findWhenNeeded(headerCell);


### PR DESCRIPTION
#### Rationale
This PR updates the EditInlineField to stop requiring the pencil icon be present, since it is now optional to render the pencil.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/972
* https://github.com/LabKey/labbook/pull/292
* https://github.com/LabKey/biologics/pull/1633
* https://github.com/LabKey/sampleManagement/pull/1253

#### Changes
* EditInlineField: Remove withChild that looks for fa-pencil
