### PR TITLE
Fix SampleStatus Page Causing Failures in LKSM 

### DIFF
--- a/src/org/labkey/test/components/ManageSampleStatusesPanel.java
+++ b/src/org/labkey/test/components/ManageSampleStatusesPanel.java
@@ -164,7 +164,7 @@ public class ManageSampleStatusesPanel extends WebDriverComponent<ManageSampleSt
         elementCache().saveButton.click();
 
         WebDriverWrapper.waitFor(()->elementCache().deleteButton.isDisplayed(),
-                "Delete button did not become visible after adding a status.", 1_000);
+                "Delete button did not become visible after adding a status.", 5_000);
 
         return this;
     }

--- a/src/org/labkey/test/components/ManageSampleStatusesPanel.java
+++ b/src/org/labkey/test/components/ManageSampleStatusesPanel.java
@@ -162,6 +162,10 @@ public class ManageSampleStatusesPanel extends WebDriverComponent<ManageSampleSt
         setLabel(label).setDescription(description).setStatusType(statusType);
 
         elementCache().saveButton.click();
+
+        WebDriverWrapper.waitFor(()->elementCache().deleteButton.isDisplayed(),
+                "Delete button did not become visible after adding a status.", 1_000);
+
         return this;
     }
 
@@ -194,7 +198,7 @@ public class ManageSampleStatusesPanel extends WebDriverComponent<ManageSampleSt
         final WebElement descriptionField = Locator.textarea("description").findWhenNeeded(this);
         final ReactSelect statusTypeSelect = ReactSelect.finder(getDriver()).findWhenNeeded(this);
         final WebElement saveButton = Locator.tagWithText("button", "Save").findWhenNeeded(this);
-        final WebElement deleteButton = Locator.tagContainingText("button", "Delete").findWhenNeeded(this);
+        final WebElement deleteButton = Locator.tag("button").withChild(Locator.tagContainingText("span", "Delete")).refindWhenNeeded(this);
     }
 
     public static class ManageSampleStatusesPanelFinder extends WebDriverComponentFinder<ManageSampleStatusesPanel, ManageSampleStatusesPanelFinder>

--- a/src/org/labkey/test/components/ManageSampleStatusesPanel.java
+++ b/src/org/labkey/test/components/ManageSampleStatusesPanel.java
@@ -163,6 +163,7 @@ public class ManageSampleStatusesPanel extends WebDriverComponent<ManageSampleSt
 
         elementCache().saveButton.click();
 
+        // Don't know why but on MSSQL/Windows in TC this is taking a long time to complete.
         WebDriverWrapper.waitFor(()->elementCache().deleteButton.isDisplayed(),
                 "Delete button did not become visible after adding a status.", 5_000);
 


### PR DESCRIPTION
#### Rationale
For what ever reason adding a new sample status is taking longer to complete in MSSQL/Windows. This slow down exposed an issue with the ManageSampleStatusesPanel.addStatus method not waiting for the addition to complete this should fix that issue.

#### Related Pull Requests
* None

#### Changes
* Have the method wait until the "Delete" button is visible before returning from the addStatus method.
