### PR TITLE
Delete lists confirmation page automation

### DIFF
--- a/src/org/labkey/test/components/list/ManageListsGrid.java
+++ b/src/org/labkey/test/components/list/ManageListsGrid.java
@@ -17,6 +17,7 @@ package org.labkey.test.components.list;
 
 import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.pages.list.BeginPage;
+import org.labkey.test.pages.list.ConfirmDeletePage;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.pages.list.ImportListArchivePage;
 import org.labkey.test.util.DataRegionTable;
@@ -52,8 +53,9 @@ public class ManageListsGrid extends DataRegionTable
 
     public BeginPage deleteSelectedLists()
     {
-        deleteSelectedRows();
-        return new BeginPage(getDriver());
+        clickHeaderButtonAndWait("Delete");
+        ConfirmDeletePage confirmPage = new ConfirmDeletePage(getDriver());
+        return confirmPage.confirmDelete();
     }
 
     public List<String> getListNames()

--- a/src/org/labkey/test/pages/list/ConfirmDeletePage.java
+++ b/src/org/labkey/test/pages/list/ConfirmDeletePage.java
@@ -1,0 +1,32 @@
+package org.labkey.test.pages.list;
+
+import org.labkey.test.Locator;
+import org.labkey.test.pages.LabKeyPage;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+
+public class ConfirmDeletePage extends LabKeyPage<ConfirmDeletePage.ElementCache>
+{
+    public ConfirmDeletePage(WebDriver driver)
+    {
+        super(driver);
+    }
+
+    public BeginPage confirmDelete()
+    {
+        elementCache().deleteButton.click();
+        return new BeginPage(getDriver());
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends LabKeyPage.ElementCache
+    {
+        WebElement deleteButton = Locator.lkButton("Confirm Delete").findWhenNeeded(this);
+    }
+}

--- a/src/org/labkey/test/tests/api/CustomizeGridPermissionsTest.java
+++ b/src/org/labkey/test/tests/api/CustomizeGridPermissionsTest.java
@@ -89,18 +89,20 @@ public class CustomizeGridPermissionsTest extends BaseWebDriverTest
         recreateList();
     }
 
-    private void recreateList() throws Exception
+    private void recreateList()
     {
         final ManageListsGrid manageListsGrid = BeginPage.beginAt(this, getProjectName()).getGrid();
+        manageListsGrid.setContainerFilter(DataRegionTable.ContainerFilterType.CURRENT_FOLDER);
+
         if (manageListsGrid.getDataRowCount() > 0)
         {
-            manageListsGrid.checkAll();
+            manageListsGrid.checkAllOnPage();
             manageListsGrid.deleteSelectedLists();
         }
-        manageListsGrid.
-                clickImportArchive().
-                setZipFile(LIST_ARCHIVE).
-                clickImport();
+
+        manageListsGrid.clickImportArchive()
+                .setZipFile(LIST_ARCHIVE)
+                .clickImport();
     }
 
     private DataRegionTable goToList()
@@ -219,7 +221,7 @@ public class CustomizeGridPermissionsTest extends BaseWebDriverTest
     }
 
     @Test
-    public void testViewEditorNamedCustomGrid() throws Exception
+    public void testViewEditorNamedCustomGrid()
     {
         impersonate(VIEW_EDITOR);
         {


### PR DESCRIPTION
#### Rationale
This adjusts automation to account for the confirmation page when deleting lists from the list management page.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3762

#### Changes
* Add list specific `ConfirmDeletePage`.
* Use in automation of deletion of multiple lists.
