### PR TITLE
Try to fix intermittent SchemaBrowserTest failure

### DIFF
--- a/src/org/labkey/test/util/Ext4Helper.java
+++ b/src/org/labkey/test/util/Ext4Helper.java
@@ -27,6 +27,7 @@ import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -767,7 +768,11 @@ public class Ext4Helper
     public void closeExtTab(String tabName)
     {
         _test.log("Closing Ext tab " + tabName);
-        _test.click(Locator.xpath("//a[contains(@class, 'x4-tab')]//span[contains(@class, 'x4-tab-inner') and text()='" + tabName + "']/../../../span[contains(@class, 'x4-tab-close-btn')]"));
+        WebElement closeButton = _test.shortWait().until(ExpectedConditions
+                .elementToBeClickable(Locator.xpath("//a[contains(@class, 'x4-tab')]//span[contains(@class, 'x4-tab-inner') and text()='" + tabName + "']/../../../span[contains(@class, 'x4-tab-close-btn')]")));
+        _test.mouseOver(closeButton);
+        closeButton.click();
+        _test.shortWait().until(ExpectedConditions.stalenessOf(closeButton));
     }
 
     public static class Locators


### PR DESCRIPTION
#### Rationale
`SchemaBrowserTest` fails intermittently because it fails to close a schema browser tab.

```
java.lang.AssertionError: Text 'This is a test description on publishers' was present: pan></span></td><td>[This is a test description on publishers]</td></tr><tr><td></
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.labkey.test.WebDriverWrapper.assertTextNotPresent(WebDriverWrapper.java:1765)
	at org.labkey.test.WebDriverWrapper.assertTextNotPresent(WebDriverWrapper.java:1773)
	at org.labkey.test.tests.SchemaBrowserTest.testSteps(SchemaBrowserTest.java:95)
```

#### Related Pull Requests
* N/A

#### Changes
* Make `Ext4Helper.closeExtTab` more reliable
