### PR TITLE
Improve Lineage node test components

### DIFF
--- a/src/org/labkey/test/components/ui/lineage/NodeDetail.java
+++ b/src/org/labkey/test/components/ui/lineage/NodeDetail.java
@@ -1,6 +1,7 @@
 package org.labkey.test.components.ui.lineage;
 
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
 import org.openqa.selenium.WebDriver;
@@ -11,6 +12,10 @@ import org.openqa.selenium.WebElement;
  */
 public class NodeDetail extends WebDriverComponent<NodeDetail.ElementCache>
 {
+    private static final Locator.XPathLocator NAME_LOC = Locator.XPathLocator.union(
+            Locator.tagWithClass("a", "lineage-link"),
+            Locator.tagWithClass("span", "lineage-sm-name"));
+
     final WebElement _el;
     final WebDriver _driver;
 
@@ -25,15 +30,11 @@ public class NodeDetail extends WebDriverComponent<NodeDetail.ElementCache>
        return elementCache().nameElement.getText();
     }
 
-    private boolean isNameLinked()
-    {
-        return elementCache().nameSpan.existsIn(this);
-    }
-
     public void clickOverViewLink(boolean wait)
     {
         getWrapper().mouseOver(getComponentElement());
-        getWrapper().waitFor(()-> elementCache().overviewLink.isEnabled(), 1000);
+        WebDriverWrapper.waitFor(()-> elementCache().overviewLink.isEnabled(),
+                () -> "Overview link not enabled for " + getName(), 1000);
         if (wait)
             getWrapper().clickAndWait(elementCache().overviewLink);
         else
@@ -43,7 +44,8 @@ public class NodeDetail extends WebDriverComponent<NodeDetail.ElementCache>
     public void clickLineageGraphLink(boolean wait)
     {
         getWrapper().mouseOver(getComponentElement());
-        getWrapper().waitFor(()-> elementCache().lineageGraphLink.isEnabled(), 1000);
+        WebDriverWrapper.waitFor(()-> elementCache().lineageGraphLink.isEnabled(),
+                () -> "Lineage graph link not enabled for " + getName(), 1000);
         if (wait)
             getWrapper().clickAndWait(elementCache().lineageGraphLink);
         else
@@ -83,15 +85,13 @@ public class NodeDetail extends WebDriverComponent<NodeDetail.ElementCache>
                 .withText("Overview").findWhenNeeded(this).withTimeout(2000);
         final WebElement lineageGraphLink = Locator.tagWithClass("a", "lineage-data-link--text")
                 .withText("Lineage").findWhenNeeded(this).withTimeout(2000);
-        final Locator.XPathLocator nameLink = Locator.tagWithClass("a", "lineage-link");
-        final Locator.XPathLocator nameSpan = Locator.tag("span");
-        final WebElement nameElement = Locator.XPathLocator.union(nameLink, nameSpan).findElement(this);
+        final WebElement nameElement = NAME_LOC.findElement(this);
     }
 
     public static class NodeDetailItemFinder extends WebDriverComponentFinder<NodeDetail, NodeDetailItemFinder>
     {
-        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "lineage-item-test");
-        private String _title = null;
+        private final Locator.XPathLocator _baseLocator = Locator.tag("li").child(Locator.tagWithClass("div", "lineage-name"));
+        private Locator _locator = _baseLocator;
 
         public NodeDetailItemFinder(WebDriver driver)
         {
@@ -100,7 +100,13 @@ public class NodeDetail extends WebDriverComponent<NodeDetail.ElementCache>
 
         public NodeDetailItemFinder withTitle(String title)
         {
-            _title = title;
+            _locator = _baseLocator.withAttribute("title", title);
+            return this;
+        }
+
+        public NodeDetailItemFinder withName(String name)
+        {
+            _locator = _baseLocator.withChild(NAME_LOC.withText(name));
             return this;
         }
 
@@ -114,10 +120,7 @@ public class NodeDetail extends WebDriverComponent<NodeDetail.ElementCache>
         @Override
         protected Locator locator()
         {
-           if (_title != null)
-                return _baseLocator.withAttribute("title", _title);
-            else
-                return _baseLocator;
+           return _locator;
         }
     }
 }

--- a/src/org/labkey/test/components/ui/lineage/NodeDetailGroup.java
+++ b/src/org/labkey/test/components/ui/lineage/NodeDetailGroup.java
@@ -5,6 +5,7 @@ import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -30,25 +31,41 @@ public class NodeDetailGroup extends WebDriverComponent<NodeDetailGroup.ElementC
             return elementCache().summary.getText();
     }
 
+    private void showAllItems()
+    {
+        Locator.tag("li").child(Locator.tagWithClass("a", "lineage-link"))
+                .findOptionalElement(this)
+                .ifPresent(moreLink ->
+                {
+                    if (moreLink.getText().contains("more"))
+                    {
+                        moreLink.click();
+                        getWrapper().shortWait().until(ExpectedConditions.textToBePresentInElement(moreLink, "less"));
+                    }
+                });
+    }
+
     public NodeDetail getItem(String itemName)
     {
-        return  elementCache().items().stream().filter(a-> a.getName().equals(itemName))
-                .findFirst().orElseThrow();
+        showAllItems();
+        return elementCache().itemNamed(itemName);
     }
 
     public NodeDetail getItemByTitle(String title)
     {
-        return elementCache().item(title);
+        showAllItems();
+        return elementCache().itemWithTitle(title);
     }
 
     public List<NodeDetail> getItems()
     {
+        showAllItems();
         return elementCache().items();
     }
 
     public List<String> getItemNames()
     {
-        return elementCache().items().stream().map(NodeDetail::getName).collect(Collectors.toList());
+        return getItems().stream().map(NodeDetail::getName).collect(Collectors.toList());
     }
 
     @Override
@@ -80,7 +97,12 @@ public class NodeDetailGroup extends WebDriverComponent<NodeDetailGroup.ElementC
             return new NodeDetail.NodeDetailItemFinder(getDriver()).findAll(this);
         }
 
-        NodeDetail item(String title)
+        NodeDetail itemNamed(String name)
+        {
+            return new NodeDetail.NodeDetailItemFinder(getDriver()).withName(name).find(this);
+        }
+
+        NodeDetail itemWithTitle(String title)
         {
             return new NodeDetail.NodeDetailItemFinder(getDriver()).withTitle(title).find(this);
         }


### PR DESCRIPTION
#### Rationale
Various tests fail occasionally because they search for a node that is hidden behind a "Show x more..." link.
This change clicks the link before fetching the node details.

#### Related Pull Requests
* N/A

#### Changes
* Show hidden lineage items
* Add finder method to find node details by name
* Some minor cleanup to `ExpTest`
