### PR TITLE
Fix 'rowid' key in Category bean

### DIFF
--- a/src/org/labkey/remoteapi/reports/Category.java
+++ b/src/org/labkey/remoteapi/reports/Category.java
@@ -41,7 +41,7 @@ public class Category extends ResponseObject
     Category(Map<String, Object> map)
     {
         super(map);
-        _rowId = (Integer) map.get("rowId");
+        _rowId = (Integer) map.get("rowid");
         _label = (String) map.get("label");
         _displayOrder = (Integer) map.get("displayOrder");
         _parent = (Integer) map.get("parent");
@@ -56,7 +56,7 @@ public class Category extends ResponseObject
     {
         JSONObject json = new JSONObject();
         json.put("label", _label);
-        json.put("rowId", _rowId);
+        json.put("rowid", _rowId);
         json.put("displayOrder", _displayOrder);
         json.put("parent", _parent);
 


### PR DESCRIPTION
#### Rationale
I inadvertently changed the casing of `rowid` in the previous refactor.

#### Related Pull Requests
* #1248 

#### Changes
* Use correct key: "rowid", not "rowId"
