### PR TITLE
Issue 45553 - Fix selectors for ResponsiveGrid

### DIFF
--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -261,7 +261,10 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
         getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(toggle));
         toggle.click();
 
-        WebElement menuItem = Locator.css("li > a").containing(menuText).findWhenNeeded(headerCell);
+        // Use getDriver() because the grid menus are rendered in a "react portal" at the end of the HTML body, so they
+        // are totally detached from the rest of the grid.
+        WebElement menu = Locator.css("ul.grid-header-cell__dropdown-menu.open").findWhenNeeded(getDriver());
+        WebElement menuItem = Locator.css("li > a").containing(menuText).findWhenNeeded(menu);
         waitFor(menuItem::isDisplayed, 1000);
         if (waitForUpdate)
             doAndWaitForUpdate(menuItem::click);
@@ -723,7 +726,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
         {
             if (!headerCells.containsKey(headerText))
             {
-                WebElement headerCell = Locator.tagWithClass("th", "grid-header-cell")
+                WebElement headerCell = Locator.tagWithClass("div", "grid-header-cell__body")
                         .withChild(Locator.tag("span").startsWith(headerText)).findElement(this);
                 headerCells.put(headerText, headerCell);
             }

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -656,8 +656,9 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
      */
     public boolean getColumnPHIProtected(String columnText)
     {
-        return elementCache().getColumnHeaderCell(columnText)
-                .getAttribute("class").contains("phi-protected");
+        WebElement columnHeader = Locator.tagWithClass("th", "grid-header-cell")
+                .withDescendant(Locators.headerCellBody(columnText)).findElement(this);
+        return columnHeader.getAttribute("class").contains("phi-protected");
     }
 
     /**
@@ -726,8 +727,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
         {
             if (!headerCells.containsKey(headerText))
             {
-                WebElement headerCell = Locator.tagWithClass("div", "grid-header-cell__body")
-                        .withChild(Locator.tag("span").startsWith(headerText)).findElement(this);
+                WebElement headerCell = Locators.headerCellBody(headerText).findElement(this);
                 headerCells.put(headerText, headerCell);
             }
             return headerCells.get(headerText);
@@ -857,7 +857,11 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
         static final Locator emptyGrid = Locator.css("tbody tr.grid-empty");
         static final Locator spinner = Locator.css("span i.fa-spinner");
         static final Locator headerCells = Locator.tagWithClass("th", "grid-header-cell");
-
+        static public Locator.XPathLocator headerCellBody(String headerText)
+        {
+            return Locator.tagWithClass("div", "grid-header-cell__body")
+                    .withChild(Locator.tag("span").startsWith(headerText));
+        }
     }
 
     public static class ResponsiveGridFinder extends WebDriverComponentFinder<ResponsiveGrid, ResponsiveGridFinder>


### PR DESCRIPTION
#### Rationale
This PR updates the ResponsiveGrid class to use selectors compatible with the fix for Issue 45553

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/997
* https://github.com/LabKey/biologics/pull/1682
* https://github.com/LabKey/sampleManagement/pull/1327
* https://github.com/LabKey/labbook/pull/303
* https://github.com/LabKey/inventory/pull/576
* https://github.com/LabKey/testAutomation/pull/1283

#### Changes
* Update selectors for ResponsiveGrid
