### PR TITLE
Add test coverage for list improvements

### DIFF
--- a/src/org/labkey/test/tests/list/CrossFolderListTest.java
+++ b/src/org/labkey/test/tests/list/CrossFolderListTest.java
@@ -4,6 +4,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Data;
 import org.labkey.test.categories.Hosting;
@@ -13,6 +14,8 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.list.IntListDefinition;
 import org.labkey.test.params.list.ListDefinition;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.DomainUtils;
+import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.query.QueryApiHelper;
 
 import java.util.Arrays;
@@ -21,21 +24,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @Category({Daily.class, Data.class, Hosting.class})
 public class CrossFolderListTest extends BaseWebDriverTest
 {
+    private static final String PROJECT_NAME = "CrossFolderListTest Project";
     private static final String SUBFOLDER_A = "subA";
-    private static String SUBFOLDER_A_PATH;
+    private static final String SUBFOLDER_A_PATH = PROJECT_NAME + "/" + SUBFOLDER_A;
+
+    private static final String SHARED_LIST = "shared_list_for_crossfolder_test";
 
     @Override
     protected void doCleanup(boolean afterTest)
     {
         _containerHelper.deleteProject(getProjectName(), afterTest);
+        DomainUtils.ensureDeleted("/Shared", "lists", SHARED_LIST);
     }
 
     @BeforeClass
@@ -49,7 +55,94 @@ public class CrossFolderListTest extends BaseWebDriverTest
     {
         _containerHelper.createProject(getProjectName(), null);
         _containerHelper.createSubfolder(getProjectName(), SUBFOLDER_A);
-        SUBFOLDER_A_PATH = getProjectName() + "/" + SUBFOLDER_A;
+    }
+
+    @Test
+    public void testCannotAddSameNameListToSubfolder() throws Exception
+    {
+        // begin by creating a list in the project level
+        String listName = "name_collision_test_list";
+        ListDefinition listDef = createListDef(listName, testFields());
+        listDef.create(createDefaultConnection(), getProjectName());
+
+        // use the UI to attempt to create a list by the same name in the subfolder
+        // expect the UI to refuse
+        var listEditPage = new ListHelper(getDriver()).beginCreateList(SUBFOLDER_A_PATH, listName);
+        listEditPage.addField(new FieldDefinition("field", FieldDefinition.ColumnType.String));
+        var errors = listEditPage.clickSaveExpectingErrors();
+
+        assertThat(errors).as("error should explain that our list name is already in use")
+                .containsOnly("The name 'name_collision_test_list' is already in use.");
+    }
+
+    @Test
+    public void testListViewShowsContainerByDefault()
+    {
+        goToProjectHome(getProjectName());
+        var listsPage = goToManageLists();
+
+        // ensure 'folder' is represented in the default view here
+        assertThat(listsPage.getGrid().getColumnNames()).as("expect default view to contain 'Container'")
+                .contains("Container");
+
+        // expect default folder filter to be "current folder, project, and shared project"
+        assertThat(listsPage.getGrid().getContainerFilter()).as("expect current, project, shared")
+                .isEqualTo("Current folder, project, and Shared project");
+    }
+
+    @Test
+    public void testCanDeleteTestInSeparateFolder() throws Exception
+    {
+        // create a list in a subfolder
+        String listName = "suba_folder_delete_test";
+        ListDefinition listDef = createListDef(listName, testFields());
+        listDef.create(createDefaultConnection(), SUBFOLDER_A_PATH);
+
+        // also a list in '/Shared'
+        ListDefinition sharedListDef = createListDef(SHARED_LIST, testFields());
+        sharedListDef.create(createDefaultConnection(), "/Shared");
+
+        goToProjectHome();
+        var helper = new ListHelper(getDriver());
+        helper.beginAtList(getProjectName(), SHARED_LIST);
+
+        // insert a record into the shared list, in the current folder
+        DataRegionTable.DataRegion(getDriver()).find().clickInsertNewRow()
+                .update(Map.of("intColumn", 1, "decimalColumn", "2.2", "stringColumn", "stringy"));
+
+        // navigate to the shared list but view it in the project
+        helper.beginAtList(getProjectName(), SHARED_LIST);
+
+        // click the 'stringy' link in the record we put into the shared list
+        clickAndWait(Locator.linkWithText("stringy"));  // the presence of this link confirms data in this view
+        assertThat(getURL().toString()).as("expect data url to be in project, is not in /Shared")
+                .contains("CrossFolderListTest")
+                .doesNotContain("Shared");
+        // now click on the list link, expecting that to navigate us to where it is defined, in ths /Shared folder
+        clickAndWait(Locator.linkWithText(SHARED_LIST));
+        assertThat(getURL().toString()).as("expect link to shared list to navigate to shared folder")
+                .doesNotContain("CrossFolderListTest")
+                .contains("Shared");
+
+        // navigate to lists in the subfolderA
+        navigateToFolder(getProjectName(), SUBFOLDER_A);
+        var listsPage = goToManageLists();
+        // ensure the created lists are visible in this view (assumes folder filter is set to Current folder, project, and Shared)
+        var listNames = listsPage.getGrid().getColumnDataAsText("Name");
+        assertThat(listNames).as("expect shared and other list to be present")
+                .contains(listName, SHARED_LIST);
+
+        // delete these lists via the UI
+        var testListIndex = listsPage.getGrid().getRowIndex("Name", listName);
+        var sharedListIndex = listsPage.getGrid().getRowIndex("Name", SHARED_LIST);
+        listsPage.getGrid().checkCheckbox(testListIndex);
+        listsPage.getGrid().checkCheckbox(sharedListIndex);
+        listsPage.getGrid().deleteSelectedLists();
+
+        // verify they are no longer present
+        var afterListNames = listsPage.getGrid().getColumnDataAsText("Name");
+        assertThat(afterListNames).as("expect shared and other list to be absent niw")
+                .doesNotContain(listName, SHARED_LIST);
     }
 
     @Test
@@ -78,8 +171,8 @@ public class CrossFolderListTest extends BaseWebDriverTest
         var displayedData = subFolderListPage.getGrid().getTableData();
         assertEquals("expect only subfolder data to be shown here by default",
                 rowsToInsert.size(), displayedData.size());
-        assertThat("expect only the data inserted here to be shown",
-                subFolderListPage.getGrid().getColumnDataAsText("String Column"), hasItems("stringy", "chewy"));
+        assertThat(subFolderListPage.getGrid().getColumnDataAsText("String Column"))
+                .as("expect only the data inserted here to be shown").contains("stringy", "chewy");
     }
 
     @Test
@@ -113,8 +206,8 @@ public class CrossFolderListTest extends BaseWebDriverTest
         var displayedData = subFolderListPage.getGrid().getTableData();
         assertEquals("expect only 1 record to be visible here",
                 1, displayedData.size());
-        assertThat("expect to be shown folder and key columns",
-                subFolderListPage.getGrid().getColumnNames(), hasItems("container", "Key"));
+        assertThat(subFolderListPage.getGrid().getColumnNames())
+                .as("expect to be shown folder and key columns").contains("container", "Key");
 
         var displayedRecord = displayedData.get(0);
         assertEquals("expect subfolder name metadata to be available here",
@@ -195,7 +288,7 @@ public class CrossFolderListTest extends BaseWebDriverTest
     @Override
     protected String getProjectName()
     {
-        return "CrossFolderListTest Project";
+        return PROJECT_NAME;
     }
 
     @Override

--- a/src/org/labkey/test/tests/list/CrossFolderListTest.java
+++ b/src/org/labkey/test/tests/list/CrossFolderListTest.java
@@ -69,6 +69,7 @@ public class CrossFolderListTest extends BaseWebDriverTest
         // expect the UI to refuse
         var listEditPage = new ListHelper(getDriver()).beginCreateList(SUBFOLDER_A_PATH, listName);
         listEditPage.addField(new FieldDefinition("field", FieldDefinition.ColumnType.String));
+        listEditPage.selectAutoIntegerKeyField();
         var errors = listEditPage.clickSaveExpectingErrors();
 
         assertThat(errors).as("error should explain that our list name is already in use")
@@ -87,7 +88,7 @@ public class CrossFolderListTest extends BaseWebDriverTest
 
         // expect default folder filter to be "current folder, project, and shared project"
         assertThat(listsPage.getGrid().getContainerFilter()).as("expect current, project, shared")
-                .isEqualTo("Current folder, project, and Shared project");
+                .isEqualTo(DataRegionTable.ContainerFilterType.CURRENT_PLUS_PROJECT_AND_SHARED);
     }
 
     @Test
@@ -115,14 +116,12 @@ public class CrossFolderListTest extends BaseWebDriverTest
 
         // click the 'stringy' link in the record we put into the shared list
         clickAndWait(Locator.linkWithText("stringy"));  // the presence of this link confirms data in this view
-        assertThat(getURL().toString()).as("expect data url to be in project, is not in /Shared")
-                .contains("CrossFolderListTest")
-                .doesNotContain("Shared");
-        // now click on the list link, expecting that to navigate us to where it is defined, in ths /Shared folder
+        assertThat(getCurrentContainerPath()).as("expect data url to be in project, is not in /Shared")
+                . isEqualTo("/" + getProjectName());
+        // now click on the list link, expecting that to navigate us to where it is defined, in the /Shared folder
         clickAndWait(Locator.linkWithText(SHARED_LIST));
-        assertThat(getURL().toString()).as("expect link to shared list to navigate to shared folder")
-                .doesNotContain("CrossFolderListTest")
-                .contains("Shared");
+        assertThat(getCurrentContainerPath()).as("expect link to shared list to navigate to shared folder")
+                .isEqualTo("/Shared");
 
         // navigate to lists in the subfolderA
         navigateToFolder(getProjectName(), SUBFOLDER_A);

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -1306,7 +1306,7 @@ public class DataRegionTable extends DataRegion
         getViewsMenu().clickSubMenu(true, "Folder Filter", filterType.getLabel());
     }
 
-    public String getContainerFilter()
+    public ContainerFilterType getContainerFilter()
     {
         getViewsMenu().openMenuTo("Folder Filter", "Folder Filter");
         var visibleFilterMenuItemOptions = getViewsMenu().findVisibleMenuItems();
@@ -1314,7 +1314,7 @@ public class DataRegionTable extends DataRegion
         {
             if (Locator.tagWithClass("i", "fa-check-square-o").existsIn(el))
             {
-                return el.getText();   // would be nice if enum.valueOf() allowed us to get the enum constant from its text but oh java you crazy
+                return ContainerFilterType.fromLabel(el.getText());
             }
         }
         return null;
@@ -1692,6 +1692,12 @@ public class DataRegionTable extends DataRegion
         ContainerFilterType(String label)
         {
             _label = label;
+        }
+
+        public static ContainerFilterType fromLabel(String label)
+        {
+            return Arrays.stream(ContainerFilterType.values())
+                    .filter(a-> a.getLabel().equals(label)).findFirst().orElse(null);
         }
 
         public String getLabel()

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -1306,6 +1306,20 @@ public class DataRegionTable extends DataRegion
         getViewsMenu().clickSubMenu(true, "Folder Filter", filterType.getLabel());
     }
 
+    public String getContainerFilter()
+    {
+        getViewsMenu().openMenuTo("Folder Filter", "Folder Filter");
+        var visibleFilterMenuItemOptions = getViewsMenu().findVisibleMenuItems();
+        for (WebElement el : visibleFilterMenuItemOptions)
+        {
+            if (Locator.tagWithClass("i", "fa-check-square-o").existsIn(el))
+            {
+                return el.getText();   // would be nice if enum.valueOf() allowed us to get the enum constant from its text but oh java you crazy
+            }
+        }
+        return null;
+    }
+
     /**
      * Set the current offset by manipulating the url rather than using the pagination buttons.
      */
@@ -1516,7 +1530,7 @@ public class DataRegionTable extends DataRegion
         private List<WebElement> summaryStatCells;
         private final WebElement toggleHeaderCell = Locator.tag("th").withClasses("labkey-column-header", "labkey-selectors").findWhenNeeded(columnHeaderRow);
         private final WebElement toggleAllOnPage = Locator.input(".toggle").findWhenNeeded(toggleHeaderCell); // tri-state checkbox
-        private SelectorMenu selectionMenu = new SelectorMenu(toggleHeaderCell);
+        private final SelectorMenu selectionMenu = new SelectorMenu(toggleHeaderCell);
 
         protected List<WebElement> getDataRows()
         {


### PR DESCRIPTION
#### Rationale
This adds some test coverage to cover new list behavior as described in [this spec](https://docs.google.com/document/d/1da08QkWFFdDATIQi9Xd8ZYbhu9GAxcqlTaN40tfEWEE/edit) and [issue 45826](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45826)

#### Related Pull Requests
n/a

#### Changes
added test cases to `CrossfolderListTest`
added method to `DataRegionTable `to add a getter for the containerfilter
