### PR TITLE
Use correct JSON to save category

### DIFF
--- a/src/org/labkey/remoteapi/reports/SaveCategoriesCommand.java
+++ b/src/org/labkey/remoteapi/reports/SaveCategoriesCommand.java
@@ -50,7 +50,7 @@ public class SaveCategoriesCommand extends PostCommand<CommandResponse>
         JSONArray jsonArray = new JSONArray();
         for (org.labkey.remoteapi.reports.Category cat : _categories)
         {
-            jsonArray.put(cat.getAllProperties());
+            jsonArray.put(cat.toJSONObject());
         }
         jsonObject.put("categories", jsonArray);
         return jsonObject;


### PR DESCRIPTION
#### Rationale
`getAllProperties` now returns an immutable collection and is not suitable for resaving with modifications.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/41

#### Changes
* Don't use `Category.getAllProperties` to save category changes
