### PR TITLE
Automation test for "Assays are messed up after folder rename" issue

### DIFF
--- a/src/org/labkey/test/pages/admin/FolderManagementPage.java
+++ b/src/org/labkey/test/pages/admin/FolderManagementPage.java
@@ -148,6 +148,12 @@ public class FolderManagementPage extends LabKeyPage<FolderManagementPage.Elemen
         return new ReorderFoldersPage(getDriver());
     }
 
+    public RenameFolderPage clickFolderRename()
+    {
+        beginAt(WebTestHelper.buildRelativeUrl("admin", getCurrentContainerPath(), "renameFolder"));
+        return new RenameFolderPage(getDriver());
+    }
+
     @Override
     protected ElementCache newElementCache()
     {

--- a/src/org/labkey/test/pages/admin/RenameFolderPage.java
+++ b/src/org/labkey/test/pages/admin/RenameFolderPage.java
@@ -14,10 +14,10 @@ public class RenameFolderPage extends LabKeyPage<RenameFolderPage.ElementCache>
         super(driver);
     }
 
-    public static ReorderFoldersPage beginAt(WebDriverWrapper driver, String containerPath)
+    public static RenameFolderPage beginAt(WebDriverWrapper driver, String containerPath)
     {
         driver.beginAt(WebTestHelper.buildURL("admin", containerPath, "renameFolder"));
-        return new ReorderFoldersPage(driver.getDriver());
+        return new RenameFolderPage(driver.getDriver());
     }
 
     public String getProjectName()

--- a/src/org/labkey/test/pages/admin/RenameFolderPage.java
+++ b/src/org/labkey/test/pages/admin/RenameFolderPage.java
@@ -1,0 +1,84 @@
+package org.labkey.test.pages.admin;
+
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.pages.LabKeyPage;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class RenameFolderPage extends LabKeyPage<RenameFolderPage.ElementCache>
+{
+    public RenameFolderPage(WebDriver driver)
+    {
+        super(driver);
+    }
+
+    public static ReorderFoldersPage beginAt(WebDriverWrapper driver, String containerPath)
+    {
+        driver.beginAt(WebTestHelper.buildURL("admin", containerPath, "renameFolder"));
+        return new ReorderFoldersPage(driver.getDriver());
+    }
+
+    public String getProjectName()
+    {
+        return elementCache().projectName.getText();
+    }
+
+    public RenameFolderPage setProjectName(String value)
+    {
+        setFormElement(elementCache().projectName, value);
+        return this;
+    }
+
+    public RenameFolderPage setTitleSameAsName(boolean value)
+    {
+        setCheckbox(elementCache().sameAsNameCheckbox, value);
+        return this;
+    }
+
+    public String getProjectTitle()
+    {
+        return elementCache().projectTitle.getText();
+    }
+
+    public RenameFolderPage setProjectTitle(String value)
+    {
+        setFormElement(elementCache().projectTitle, value);
+        return this;
+    }
+
+    public RenameFolderPage setAlias(boolean value)
+    {
+        setCheckbox(elementCache().aliasCheckbox, value);
+        return this;
+    }
+
+    public FolderManagementPage save()
+    {
+        clickAndWait(elementCache().save);
+        return new FolderManagementPage(getDriver());
+    }
+
+    public FolderManagementPage cancel()
+    {
+        clickAndWait(elementCache().cancel);
+        return new FolderManagementPage(getDriver());
+    }
+
+    @Override
+    protected RenameFolderPage.ElementCache newElementCache()
+    {
+        return new RenameFolderPage.ElementCache();
+    }
+
+    protected class ElementCache extends LabKeyPage.ElementCache
+    {
+        private final WebElement projectName = Locator.name("name").findWhenNeeded(this);
+        private final WebElement projectTitle = Locator.name("title").findWhenNeeded(this);
+        private final WebElement sameAsNameCheckbox = Locator.name("titleSameAsName").findWhenNeeded(this);
+        private final WebElement aliasCheckbox = Locator.name("addAlias").findWhenNeeded(this);
+        private final WebElement save = Locator.tagWithText("span", "Save").findWhenNeeded(this);
+        private final WebElement cancel = Locator.tagWithText("span", "Cancel").findWhenNeeded(this);
+    }
+}


### PR DESCRIPTION
#### Rationale
 Test coverage : Issue 46473: Assays are messed up after folder rename
 https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46473

1. Create an Assay project.
2. Create an assay design in that project.
3. Rename the project from Folder Management --> Rename and uncheck the Alias current name (recommended).
4. Manage Assay design --> Edit assay design should navigate to original assay design created and renamed folder.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/3794

#### Changes
New test page src/org/labkey/test/pages/admin/RenameFolderPage.java
