### PR TITLE
Consistent labeling of fields (title casing and no trailing colons) 

### DIFF
--- a/src/org/labkey/test/components/ui/permissions/UserDetailsPanel.java
+++ b/src/org/labkey/test/components/ui/permissions/UserDetailsPanel.java
@@ -43,7 +43,7 @@ public class UserDetailsPanel extends WebDriverComponent<Component<?>.ElementCac
 
     public List<String> getMemberships()
     {
-        var membersList = Locator.tagWithClass("div", "principal-detail-label").withText("Member of:")
+        var membersList = Locator.tagWithClass("div", "principal-detail-label").withText("Member of")
                 .followingSibling("ul").findElement(this);
         return getWrapper().getTexts(Locator.tag("li").findElements(membersList));
     }

--- a/src/org/labkey/test/components/ui/permissions/UserDetailsPanelPermissionsPage.java
+++ b/src/org/labkey/test/components/ui/permissions/UserDetailsPanelPermissionsPage.java
@@ -21,7 +21,7 @@ public class UserDetailsPanelPermissionsPage extends UserDetailsPanel
 
     public List<String> getEffectiveRoles()
     {
-        var listContainer=  Locator.tagWithClass("div", "principal-detail-label").withText("Effective Roles:")
+        var listContainer=  Locator.tagWithClass("div", "principal-detail-label").withText("Effective Roles")
                 .followingSibling("ul").waitForElement(this, 2000);
         return Locator.tag("li")
                 .findElements(listContainer)


### PR DESCRIPTION
#### Rationale
We want consistent labeling of fields in our applications. For the moment, at least, this means using title casing (except for some known exceptional treatment of the word "by") and removing trailing colons. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1002

#### Changes
* Update some locators for updated label text
