### PR TITLE
DomainFieldRow: scroll collapseToggle into view before attempting to click

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -227,6 +227,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
     {
         if (isExpanded())
         {
+            getWrapper().scrollIntoView(elementCache().collapseToggle);
             elementCache().collapseToggle.click();
             getWrapper().shortWait().until(LabKeyExpectedConditions.animationIsDone(getComponentElement())); // wait for transition to happen
             WebDriverWrapper.waitFor(() -> elementCache().expandToggleLoc.existsIn(this),


### PR DESCRIPTION
#### Rationale
My recent changes slightly changed the sticky behavior of the domain editor, this PR fixes the collapse method on DomainFieldRow which fixes the Luminex Test. This test fix requires the scroll-margin fix in the ui-components PR and platform PR.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1006
* https://github.com/LabKey/platform/pull/3803
* https://github.com/LabKey/labbook/pull/311
* https://github.com/LabKey/sampleManagement/pull/1348
* https://github.com/LabKey/biologics/pull/1695

#### Changes
* DomainFieldRow: scroll collapseToggle into view before attempting to click 
