### PR TITLE
Fix PuppeteerSettings response handling

### DIFF
--- a/src/org/labkey/remoteapi/puppeteer/PuppeteerSettings.java
+++ b/src/org/labkey/remoteapi/puppeteer/PuppeteerSettings.java
@@ -17,6 +17,7 @@ package org.labkey.remoteapi.puppeteer;
 
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
+import org.labkey.test.util.TestLogger;
 
 import java.util.Map;
 
@@ -35,6 +36,7 @@ public class PuppeteerSettings
     public PuppeteerSettings(JSONObject json)
     {
         this();
+        TestLogger.log(json.toString());
         _enabled = json.getBoolean("enabled");
         _mode = json.getString("mode");
         _dockerImage = json.getString("docker.image");

--- a/src/org/labkey/remoteapi/puppeteer/PuppeteerSettings.java
+++ b/src/org/labkey/remoteapi/puppeteer/PuppeteerSettings.java
@@ -18,6 +18,8 @@ package org.labkey.remoteapi.puppeteer;
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
 
+import java.util.Map;
+
 public class PuppeteerSettings
 {
     private Boolean _enabled;
@@ -50,7 +52,7 @@ public class PuppeteerSettings
 
     public PuppeteerSettings(CommandResponse response)
     {
-        this(new JSONObject(response.getParsedData().get("data")));
+        this(new JSONObject((Map<String, Object>)response.getParsedData().get("data")));
     }
 
     public Boolean getEnabled()

--- a/src/org/labkey/remoteapi/puppeteer/PuppeteerSettings.java
+++ b/src/org/labkey/remoteapi/puppeteer/PuppeteerSettings.java
@@ -36,19 +36,10 @@ public class PuppeteerSettings
     public PuppeteerSettings(JSONObject json)
     {
         this();
-        TestLogger.log(json.toString());
         _enabled = json.getBoolean("enabled");
         _mode = json.getString("mode");
-        _dockerImage = json.getString("docker.image");
-
-        try
-        {
-            _dockerPort = Integer.parseInt(json.getString("docker.port"));
-        }
-        catch (NumberFormatException ignored)
-        {
-        }
-
+        _dockerImage = json.optString("docker.image", null);
+        _dockerPort = json.optInt("docker.port");
         _remoteUrl = json.getString("remote.url");
     }
 

--- a/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
+++ b/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
@@ -18,10 +18,9 @@ package org.labkey.test.util.puppeteer;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.PostCommand;
-import org.labkey.test.WebTestHelper;
 import org.labkey.remoteapi.puppeteer.PuppeteerSettings;
 import org.labkey.remoteapi.puppeteer.PuppeteerStatus;
-import org.labkey.test.util.TestLogger;
+import org.labkey.test.WebTestHelper;
 
 import java.io.IOException;
 
@@ -55,7 +54,6 @@ public class PuppeteerHelper
         updateCmd.setRequiredVersion(0);
         updateCmd.setJsonObject(settings.toJSON());
         var response = updateCmd.execute(connection, "/");
-        TestLogger.log(response.toString());
         return new PuppeteerSettings(response);
     }
 }

--- a/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
+++ b/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
@@ -21,6 +21,7 @@ import org.labkey.remoteapi.PostCommand;
 import org.labkey.test.WebTestHelper;
 import org.labkey.remoteapi.puppeteer.PuppeteerSettings;
 import org.labkey.remoteapi.puppeteer.PuppeteerStatus;
+import org.labkey.test.util.TestLogger;
 
 import java.io.IOException;
 
@@ -54,6 +55,7 @@ public class PuppeteerHelper
         updateCmd.setRequiredVersion(0);
         updateCmd.setJsonObject(settings.toJSON());
         var response = updateCmd.execute(connection, "/");
+        TestLogger.log(response.toString());
         return new PuppeteerSettings(response);
     }
 }


### PR DESCRIPTION
#### Rationale
NotebookExportTest is failing due to `PuppeteerSettings` having problems parsing the JSON response from `UpdateSettingsAction`. The new `JSONObject(Object)` constructor doesn't handle `Map` parameters like the old one did; a simple cast should do the trick.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1287
