### PR TITLE
Avoid 'ElementClickInterceptedException' when unchecking 'sendEmail'

### DIFF
--- a/src/org/labkey/test/util/UIPermissionsHelper.java
+++ b/src/org/labkey/test/util/UIPermissionsHelper.java
@@ -86,8 +86,8 @@ public class UIPermissionsHelper extends PermissionsHelper
         _driver.log("Adding [" + namesList.toString() + "] to group " + groupName + "...");
         _driver.waitAndClickAndWait(Locator.tagContainingText("a", "manage group"));
         _driver.waitForElement(Locator.name("names"));
-        _driver.setFormElement(Locator.name("names"), namesList.toString());
         _driver.uncheckCheckbox(Locator.name("sendEmail"));
+        _driver.setFormElement(Locator.name("names"), namesList.toString());
 
         Integer groupId = Integer.parseInt(WebTestHelper.parseUrlQuery(_driver.getURL()).get("id"));
         _driver.clickButton("Update Group Membership");
@@ -446,8 +446,8 @@ public class UIPermissionsHelper extends PermissionsHelper
     public void addUserToGroupFromGroupScreen(String userName)
     {
         _driver.waitForElement(Locator.name("names"));
-        _driver.setFormElement(Locator.name("names"), userName);
         _driver.uncheckCheckbox(Locator.name("sendEmail"));
+        _driver.setFormElement(Locator.name("names"), userName);
         _driver.clickButton("Update Group Membership");
     }
 


### PR DESCRIPTION
#### Rationale
Intermittently, an auto-complete popup gets in the way of the 'sendEmail' checkbox. Clicking the checkbox first should avoid this.
```
org.openqa.selenium.ElementClickInterceptedException: Element <input name="sendEmail" type="checkbox"> is not clickable at point (27,551) because another element <span> obscures it
[...]
  at app//org.labkey.test.WebDriverWrapper.uncheckCheckbox(WebDriverWrapper.java:1)
  at app//org.labkey.test.util.UIPermissionsHelper.createGlobalPermissionsGroup(UIPermissionsHelper.java:90)
  at app//org.labkey.test.util.UIPermissionsHelper.createGlobalPermissionsGroup(UIPermissionsHelper.java:51)
  at app//org.labkey.test.tests.GroupTest.testSteps(GroupTest.java:112)
```
![image](https://user-images.githubusercontent.com/5263798/200032341-d4ad9bbd-cdcd-48e1-9d5e-782357598508.png)

#### Related Pull Requests
* N/A

#### Changes
* Uncheck checkbox before setting 'names' input
