### PR TITLE
Fix for module property name not the same as the label on the page

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1588,7 +1588,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         map.put("moduleName", property.getModuleName());
         map.put("containerPath", property.getContainerPath());
         map.put("propName", property.getPropertyName());
-        waitForText(property.getPropertyName()); //wait for the property name to appear
+        waitForText(property.getPropertyLabel()); //wait for the property name to appear
         String query = ComponentQuery.fromAttributes("field", map);
         return _ext4Helper.queryOne(query, Ext4FieldRef.class);
     }

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1588,7 +1588,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         map.put("moduleName", property.getModuleName());
         map.put("containerPath", property.getContainerPath());
         map.put("propName", property.getPropertyName());
-        waitForText(property.getPropertyLabel()); //wait for the property name to appear
+        waitForText(property.getPropertyLabel()); //wait for the property label to appear
         String query = ComponentQuery.fromAttributes("field", map);
         return _ext4Helper.queryOne(query, Ext4FieldRef.class);
     }

--- a/src/org/labkey/test/ModulePropertyValue.java
+++ b/src/org/labkey/test/ModulePropertyValue.java
@@ -81,14 +81,30 @@ public class ModulePropertyValue extends ModuleProperty
         _inputType = inputType;
     }
 
+    public ModulePropertyValue(String moduleName, String containerPath, String propertyName, String propertyLabel, Object value, InputType inputType)
+    {
+        super(moduleName, containerPath, propertyName, propertyLabel, value);
+        _inputType = inputType;
+    }
+
     public ModulePropertyValue(String moduleName, String containerPath, String propertyName, String value)
     {
         this(moduleName, containerPath, propertyName, value, InputType.text);
     }
 
+    public ModulePropertyValue(String moduleName, String containerPath, String propertyName, String propertyLabel, String value)
+    {
+        this(moduleName, containerPath, propertyName, propertyLabel, value, InputType.text);
+    }
+
     public ModulePropertyValue(String moduleName, String containerPath, String propertyName, boolean value)
     {
         this(moduleName, containerPath, propertyName, value, InputType.checkbox);
+    }
+
+    public ModulePropertyValue(String moduleName, String containerPath, String propertyName, String propertyLabel, boolean value)
+    {
+        this(moduleName, containerPath, propertyName, propertyLabel, value, InputType.checkbox);
     }
 
     public InputType getInputType()

--- a/src/org/labkey/test/params/ModuleProperty.java
+++ b/src/org/labkey/test/params/ModuleProperty.java
@@ -6,8 +6,14 @@ public class ModuleProperty
     private final String _containerPath;
     private final String _propertyName;
     private final Object _value;
+    private final String _propertLabel;
 
     public ModuleProperty(String moduleName, String containerPath, String propertyName, Object value)
+    {
+        this(moduleName, containerPath, propertyName, null, value);
+    }
+
+    public ModuleProperty(String moduleName, String containerPath, String propertyName, String propertyLabel, Object value)
     {
         _moduleName = moduleName;
         if (!containerPath.startsWith("/"))
@@ -16,6 +22,9 @@ public class ModuleProperty
             _containerPath = containerPath;
         _propertyName = propertyName;
         _value = value;
+
+        // If no label is provided use the name.
+        _propertLabel = (null == propertyLabel) || (propertyLabel.isEmpty()) ? propertyName : propertyLabel;
     }
 
     public String getModuleName()
@@ -31,6 +40,11 @@ public class ModuleProperty
     public String getPropertyName()
     {
         return _propertyName;
+    }
+
+    public String getPropertyLabel()
+    {
+        return _propertLabel;
     }
 
     public Object getValue()


### PR DESCRIPTION
#### Rationale
Fix for failures in the Accounts test. Updates to return the new Json object is causing problems with custom module property. The existing test code was assuming that the property name would match the label on the page. That is no longer a valid assumption 100% of the time. This fix allows for the module properties test object to have a label property to help find it on the page.

#### Related Pull Requests
* None

#### Changes
* Added a label property to ModuleProperty (added a getter).
* Added overloaded constructor to the ModuleProperty to take a label value. If no label is provided use the property name as the label.
* Overloaded constructors in ModulePropertyValue object that can take a label property.
* Modify BaseWebDriverTest.getModulePropertyFieldRef to wait for property label.

