### PR TITLE
Use `executeAsyncScript` to create domain via JavaScript

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -18,6 +18,7 @@ package org.labkey.test.tests;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -1412,25 +1413,31 @@ public class SampleTypeTest extends BaseWebDriverTest
     public void testCreateViaScript()
     {
         String sampleTypeName = "Created_by_Script";
-        String createScript = "LABKEY.Domain.create({\n" +
-                "  domainKind: \"SampleSet\",\n" +
-                "  domainDesign: {\n" +
-                "    name: \"" + sampleTypeName +"\",\n" +
-                "    fields: [{\n" +
-                "       name: \"name\", rangeURI: \"string\"\n" +
-                "    },{\n" +
-                "       name: \"intField\", rangeURI: \"int\"\n" +
-                "    },{\n" +
-                "       name: \"strField\", rangeURI: \"string\"\n" +
-                "    }]\n" +
-                "  }\n" +
-                "});";
+        String createScript = String.format("""
+                LABKEY.Domain.create({
+                  domainKind: "SampleSet",
+                  domainDesign: {
+                    name: "%s",
+                    fields: [{
+                       name: "name", rangeURI: "string"
+                    },{
+                       name: "intField", rangeURI: "int"
+                    },{
+                       name: "strField", rangeURI: "string"
+                    }]
+                  },
+                  success: callback,
+                  failure: callback
+                });
+                """, sampleTypeName);
 
         log("Go to project home.");
         goToProjectHome();
 
         log("Create a Sample Type using script.");
-        executeScript(createScript);
+        Map<String, Object> response = executeAsyncScript(createScript, Map.class);
+        Assertions.assertThat(response).as("'LABKEY.Domain.create' response")
+                .containsEntry("success", true);
 
         List<String> sampleNames = Arrays.asList("P-1", "P-2", "P-3", "P-4", "P-5");
         List<Map<String, String>> sampleData = new ArrayList<>();


### PR DESCRIPTION
#### Rationale
`LABKEY.Domain.create` is an async operation. The test should use `executeAsyncScript` to avoid navigating before its execution has completed.

```
org.openqa.selenium.NoSuchElementException: Unable to find element: link=Created_by_Script
For documentation on this error, please visit: https://selenium.dev/exceptions/#no_such_element
[...]
  at app//org.labkey.test.WebDriverWrapper.clickAndWait(WebDriverWrapper.java:1)
  at app//org.labkey.test.util.SampleTypeHelper.goToSampleType(SampleTypeHelper.java:169)
  at app//org.labkey.test.tests.SampleTypeTest.testCreateViaScript(SampleTypeTest.java:1446)
```

#### Related Pull Requests
* N/A

#### Changes
* Use `executeAsyncScript` to create domain via JavaScript
