### PR TITLE
Remove unnecessary scroll from typeAheadSelect

### DIFF
--- a/src/org/labkey/test/components/react/FilteringReactSelect.java
+++ b/src/org/labkey/test/components/react/FilteringReactSelect.java
@@ -85,7 +85,6 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
 
         try
         {
-            getWrapper().scrollIntoView(optionToClick);
             getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(optionToClick));
             optionToClick.click();
         }


### PR DESCRIPTION
#### Rationale
Explicitly scrolling causes some items to scroll too high so that the center point is out of view and unclickable.

![image](https://user-images.githubusercontent.com/5263798/200890260-788db469-c3d0-4ebe-9a0f-b70ba4be2e8c.png)

#### Related Pull Requests
* N/A

#### Changes
* Remove explicit scroll from `FilteringReactSelect.typeAheadSelect`
