### PR TITLE
Update selectors associated with FontAwesome

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -1147,13 +1147,13 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
 
         public final Locator expandToggleLoc = Locator.tagWithClass("div", "field-icon")
-                .child(Locator.tagWithClassContaining("svg", "fa-plus-square"));
+                .child(Locator.tagWithClassContaining("span", "fa-plus-square"));
         public final Locator collapseToggleLoc = Locator.tagWithClass("div", "field-icon")
-                .child(Locator.tagWithClassContaining("svg", "fa-minus-square"));
+                .child(Locator.tagWithClassContaining("span", "fa-minus-square"));
         public final WebElement expandToggle = expandToggleLoc.findWhenNeeded(this);
 
         public final Locator removeFieldLoc = Locator.tagWithClass("span", "field-icon")
-                .child(Locator.tagWithClassContaining("svg", "domain-field-delete-icon"));
+                .child(Locator.tagWithClassContaining("span", "domain-field-delete-icon"));
         public final WebElement removeField = removeFieldLoc.findWhenNeeded(this);
 
         // controls revealed when expanded

--- a/src/org/labkey/test/components/list/AdvancedListSettingsDialog.java
+++ b/src/org/labkey/test/components/list/AdvancedListSettingsDialog.java
@@ -102,7 +102,7 @@ public class AdvancedListSettingsDialog extends ModalDialog
 
     private boolean isPaneExpanded(WebElement expandCollapsePane)
     {
-        return Locator.tagWithClass("svg", "fa-angle-down").existsIn(expandCollapsePane);
+        return Locator.tagWithClass("span", "fa-angle-down").existsIn(expandCollapsePane);
     }
 
     public AdvancedListSettingsDialog setIndexFileAttachments(boolean checked)

--- a/src/org/labkey/test/components/ui/CollapsiblePanel.java
+++ b/src/org/labkey/test/components/ui/CollapsiblePanel.java
@@ -74,8 +74,8 @@ public class CollapsiblePanel extends WebDriverComponent<CollapsiblePanel.Elemen
         WebElement expandCollapseToggle = Locator.tagWithClass("span", "pull-right")
                 .findWhenNeeded(header).withTimeout(2000);
         private Locator.XPathLocator body = Locator.tagWithClass("div", "panel-collapse");
-        Locator expandedLoc = Locator.tagWithAttributeContaining("svg", "class", "fa-minus-square");
-        Locator collapsedLoc = Locator.tagWithAttributeContaining("svg", "class", "fa-plus-square");
+        Locator expandedLoc = Locator.tagWithAttributeContaining("span", "class", "fa-minus-square");
+        Locator collapsedLoc = Locator.tagWithAttributeContaining("span", "class", "fa-plus-square");
 
         WebElement waitForBody()
         {

--- a/src/org/labkey/test/pages/core/login/LoginConfigRow.java
+++ b/src/org/labkey/test/pages/core/login/LoginConfigRow.java
@@ -83,11 +83,11 @@ public class LoginConfigRow extends WebDriverComponent<LoginConfigRow.ElementCac
         final WebElement provider = Locator.tagWithClass("div", "provider").findWhenNeeded(baseFieldsElement);
 
         WebElement statusElement = Locator.tagWithClass("div", "col-xs-7")
-                .withChild(Locator.tagWithClass("svg", "fa-circle")).findWhenNeeded(this);
+                .withChild(Locator.tagWithClass("span", "fa-circle")).findWhenNeeded(this);
 
-        final WebElement deleteButton = Locator.tagWithClass("svg", "fa-times-circle")
+        final WebElement deleteButton = Locator.tagWithClass("span", "fa-times-circle")
                 .findWhenNeeded(this).withTimeout(2000);
-        Locator editButtonLoc = Locator.tagWithClass("svg", "fa-pencil-alt");
+        Locator editButtonLoc = Locator.tagWithClass("span", "fa-pencil-alt");
         final WebElement editButton = editButtonLoc.findWhenNeeded(this).withTimeout(2000);
     }
 

--- a/src/org/labkey/test/pages/core/login/LoginConfigRow.java
+++ b/src/org/labkey/test/pages/core/login/LoginConfigRow.java
@@ -87,7 +87,7 @@ public class LoginConfigRow extends WebDriverComponent<LoginConfigRow.ElementCac
 
         final WebElement deleteButton = Locator.tagWithClass("span", "fa-times-circle")
                 .findWhenNeeded(this).withTimeout(2000);
-        Locator editButtonLoc = Locator.tagWithClass("span", "fa-pencil-alt");
+        Locator editButtonLoc = Locator.tagWithClass("span", "fa-pencil");
         final WebElement editButton = editButtonLoc.findWhenNeeded(this).withTimeout(2000);
     }
 


### PR DESCRIPTION
#### Rationale
I have removed FortAwesome dependencies from ui-components and changed our usages to use spans with font awesome classes

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1011
* https://github.com/LabKey/biologics/pull/1705
* https://github.com/LabKey/sampleManagement/pull/1363
* https://github.com/LabKey/labbook/pull/314
* https://github.com/LabKey/inventory/pull/597
* https://github.com/LabKey/provenance/pull/130
* https://github.com/LabKey/platform/pull/3820
* https://github.com/LabKey/testAutomation/pull/1305

#### Changes
* Update test selectors
