### PR TITLE
Change How ReactDatePicker.clickTime Finds the List Item

### DIFF
--- a/src/org/labkey/test/components/react/ReactDatePicker.java
+++ b/src/org/labkey/test/components/react/ReactDatePicker.java
@@ -85,7 +85,10 @@ public class ReactDatePicker extends WebDriverComponent<ReactDatePicker.ElementC
     public ReactDatePicker clickTime(String time)
     {
         expand();
-        elementCache().timeListItem(time).click();
+        WebElement liElement = Locator.tagWithClass("ul", "react-datepicker__time-list")
+                .child(Locator.tagWithText("li", time)).findElement(elementCache().popup);
+        getWrapper().fireEvent(liElement, WebDriverWrapper.SeleniumEvent.click);
+
         WebDriverWrapper.waitFor(()-> !isExpanded(), "Date picker didn't close", 1000);
         return this;
     }
@@ -147,20 +150,9 @@ public class ReactDatePicker extends WebDriverComponent<ReactDatePicker.ElementC
         WebElement popup = Locator.xpath(".").followingSibling("div").withClass("react-datepicker__tab-loop")
                 .refindWhenNeeded(this);
 
-        WebElement timeList = Locator.tagWithClass("div", "react-datepicker__time-box")
-                    .child(Locator.tagWithClass("ul", "react-datepicker__time-list"))
-                    .refindWhenNeeded(popup);
-
-        WebElement timeListItem(String text)
-        {
-            return Locator.tagWithClass("li", "react-datepicker__time-list-item").withText(text)
-                    .findElement(timeList);
-        }
-
         /**
          * Return the date cell div of react datepicker
          * @param day '01', '02', ... '31'
-         * @return
          */
         WebElement datePickerDateCell(String day)
         {


### PR DESCRIPTION
#### Rationale
The SMSampleCreateTest.testCreateWithDateInputs in SampleManage has been failing with this error:
```
ElementNotInteractableException: Click failed; try clicking a child element. Firefox doesn't like clicking certain wrapping elements
Element <li class="react-datepicker__time-list-item "> could not be scrolled into view
```
This attempts to address that issue in the same way as the [fix for SampleLocationPanel in inventory](https://github.com/LabKey/inventory/commit/0989ad2d6c52ab39706a6dcb58df2fbe422f1921).

#### Related Pull Requests
* None

#### Changes
* Changed how the ReactDatePicker.clickTIme finds and clicks on the time value in the list. 
