### PR TITLE
ELN, Group Assignment test

### DIFF
--- a/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
+++ b/src/org/labkey/test/components/ui/permissions/PermissionsRowBase.java
@@ -86,7 +86,7 @@ public abstract class PermissionsRowBase<T extends PermissionsRowBase<T>> extend
     {
         expand();
         elementCache().userMemberSelect.select(email);
-        WebDriverWrapper.waitFor(()-> getMemberEmails().contains(email),
+        WebDriverWrapper.waitFor(()-> getMemberEmails().stream().anyMatch(a-> a.startsWith(email)),
                 "member was not added in time", 2000);
         return getThis();
     }


### PR DESCRIPTION
#### Rationale
This updates `PermissionsRowBase `to not fail when adding a user that happens to have a suffix (such as their userDisplayName in parenthesis) added to the expected email.  (the `addMember `method waits for the list of member chips in it to have one with the added email- this updates that check to be satisfied when one starts with the email)

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/1722
https://github.com/LabKey/labbook/pull/319

#### Changes
updates `addMember `to tolerate new behavior
