### PR TITLE
regression coverage for issue46488

### DIFF
--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -427,6 +427,29 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
     }
 
     /**
+     * Creates a value in a select that allows the user to insert/create a value, vs. selecting from an existing/populated set
+     * @param row   the row
+     * @param columnName    name of the column
+     * @param value     value to insert
+     */
+    public void setNewSelectValue(int row, String columnName, String value)
+    {
+        // Get a reference to the cell.
+        WebElement gridCell = getCell(row, columnName);
+
+        // Select the cell.
+        selectCell(gridCell);
+
+        // Activate the cell.
+        activateCell(gridCell);
+
+        ReactSelect createSelect = elementCache().lookupSelect();
+
+        waitFor(()->createSelect.isInteractive() && !createSelect.isLoading(), "Select control is not ready.", 1_000);
+        createSelect.createValue(value);
+    }
+
+    /**
      * Search for a row and then clear the given cell (columnNameToClear) on the row.
      *
      * @param columnNameToSearch Column to search.


### PR DESCRIPTION
#### Rationale
This adds a new method `setNewSelectValue  `to the `EditableGrid `class, enabling the test to interact with a select in a cell that allows the user to create an option in the select.  (the most-common use case for interacting with a cell-select is selecting an existing option from the list, but this is particularly for columns that allow user-created values)

This behavior was a missing, issue 46488 calls for creating an Alias in a derived entity (doing that used to crash the app, ugh such a fun test hole) so this change addresses that need

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/1724

#### Changes
Just the new method on `EditableGrid`
