### PR TITLE
Detail panel editMode fix for show/hide labels

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -9,7 +9,6 @@ import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.react.FilteringReactSelect;
-import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.components.ui.files.FileUploadField;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -242,14 +241,15 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     }
 
     /**
-     * Get the value of an select field. This could be one or many values, because of this the result is returned as a list.
+     * Get the value of a select field.
      *
      * @param fieldCaption The caption/label of the field to get.
-     * @return A (String) list of the values selected.
+     * @return The selected value.
      **/
-    public List<String> getSelectValue(String fieldCaption)
+    public String getSelectedValue(String fieldCaption)
     {
-        return ReactSelect.finder(_driver).followingLabelWithSpan(fieldCaption).find().getSelections();
+        FilteringReactSelect reactSelect = elementCache().findSelect(fieldCaption);
+        return reactSelect.getValue();
     }
 
     /**
@@ -259,7 +259,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
      */
     public DetailTableEdit clearSelectionValues(String fieldCaption)
     {
-        ReactSelect reactSelect =  ReactSelect.finder(_driver).followingLabelWithSpan(fieldCaption).find();
+        FilteringReactSelect reactSelect = elementCache().findSelect(fieldCaption);
         reactSelect.clearSelection();
         return this;
     }


### PR DESCRIPTION
#### Rationale
see ui-components PR for rationale

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1028

#### Changes
* fix for select input finder now that labels aren't being rendered for edit mode inputs in the same way
