### PR TITLE
add automated test coverage for user-supplied barcode fields

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -416,6 +416,30 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         return getWrapper().isElementPresent(elementCache().getCharScaleInputLocForRow(rowIndex));
     }
 
+    // barcode- scannable options
+
+    /**
+     *  Indicates that the field should be searched when
+     */
+    public boolean isFieldScannable()
+    {
+        expand();
+        return elementCache().scannableCheckbox.get();
+    }
+
+    public DomainFieldRow setFieldScannable(boolean checked)
+    {
+        expand();
+        elementCache().scannableCheckbox.set(checked);
+        return this;
+    }
+
+    public boolean isScannableCheckboxPresent()
+    {
+        expand();
+        return elementCache().scannableCheckboxLoc.existsIn(this);
+    }
+
     //
     // date field options.
 
@@ -1099,7 +1123,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
     {
         private final Locator.XPathLocator _baseLocator = Locator.tagWithClassContaining("div", "domain-field-row").withoutClass("domain-floating-hdr");
         private String _title = null;
-        private DomainFormPanel _domainFormPanel;
+        private final DomainFormPanel _domainFormPanel;
 
         public DomainFieldRowFinder(DomainFormPanel panel, WebDriver driver)
         {
@@ -1185,6 +1209,11 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
                 .refindWhenNeeded(this));
         public final Input charScaleInput = new Input(Locator.tagWithAttributeContaining("input", "id", "domainpropertiesrow-scale")
                 .refindWhenNeeded(this), getDriver());
+
+        // barcode option
+        public final Locator scannableCheckboxLoc = Locator.input("domainpropertiesrow-scannable");
+        public final Checkbox scannableCheckbox = new Checkbox(scannableCheckboxLoc.findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT));
+
         // date field options
         public final Input dateFormatInput = new Input(Locator.tagWithAttributeContaining("input", "id", "domainpropertiesrow-format")
                 .refindWhenNeeded(this), getDriver());

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -25,6 +25,7 @@ import org.openqa.selenium.support.ui.FluentWait;
 import org.openqa.selenium.support.ui.Select;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -98,6 +99,16 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
                 return ct;
         }
         throw new IllegalStateException("Unknown column type: " + typeString);
+    }
+
+    public List<String> getTypeOptions()
+    {
+        List<String> typeOptions = new ArrayList<>();
+        for (WebElement option : elementCache().fieldTypeSelectInput.getOptions())
+        {
+            typeOptions.add(option.getText());
+        }
+        return typeOptions;
     }
 
     /**
@@ -1211,8 +1222,8 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
                 .refindWhenNeeded(this), getDriver());
 
         // barcode option
-        public final Locator scannableCheckboxLoc = Locator.input("domainpropertiesrow-scannable");
-        public final Checkbox scannableCheckbox = new Checkbox(scannableCheckboxLoc.findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT));
+        protected final Locator scannableCheckboxLoc = Locator.input("domainpropertiesrow-scannable");
+        public final Checkbox scannableCheckbox = new Checkbox(scannableCheckboxLoc.refindWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT));
 
         // date field options
         public final Input dateFormatInput = new Input(Locator.tagWithAttributeContaining("input", "id", "domainpropertiesrow-format")

--- a/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
@@ -232,26 +232,6 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
         return elementCache().optionalWarningAlert();
     }
 
-    public String getStoredAmountDisplayUnits()
-    {
-        return elementCache().storedAmountDisplayUnitsSelect.getValue();
-    }
-
-    public T setStoredAmountDisplayUnits(String displayUnits)
-    {
-        elementCache().storedAmountDisplayUnitsSelect.select(displayUnits);
-        return getThis();
-    }
-
-    public boolean isBarcodeInfoShown()
-    {
-        return elementCache().uniqueIdMsgLoc.existsIn(this);
-    }
-
-    public String getBarcodeInfoMsg()
-    {
-        return elementCache().uniqueIdMsgLoc.waitForElement(this, WAIT_FOR_JAVASCRIPT).getText();
-    }
 
     /**
      * Dialog that allows the user to set the genId value.

--- a/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
@@ -8,6 +8,7 @@ import org.labkey.test.components.domain.DomainDesigner;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.html.SelectWrapper;
+import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.params.FieldDefinition;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -16,6 +17,7 @@ import org.openqa.selenium.support.ui.Select;
 import java.util.List;
 import java.util.Optional;
 
+import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 import static org.labkey.test.WebDriverWrapper.sleep;
 import static org.labkey.test.WebDriverWrapper.waitFor;
 
@@ -230,6 +232,27 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
         return elementCache().optionalWarningAlert();
     }
 
+    public String getStoredAmountDisplayUnits()
+    {
+        return elementCache().storedAmountDisplayUnitsSelect.getValue();
+    }
+
+    public T setStoredAmountDisplayUnits(String displayUnits)
+    {
+        elementCache().storedAmountDisplayUnitsSelect.select(displayUnits);
+        return getThis();
+    }
+
+    public boolean isBarcodeInfoShown()
+    {
+        return elementCache().uniqueIdMsgLoc.existsIn(this);
+    }
+
+    public String getBarcodeInfoMsg()
+    {
+        return elementCache().uniqueIdMsgLoc.waitForElement(this, WAIT_FOR_JAVASCRIPT).getText();
+    }
+
     /**
      * Dialog that allows the user to set the genId value.
      */
@@ -296,6 +319,11 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
         protected final WebElement editGenIdButton = Locator.tagWithClass("button", "edit-genid-btn").findWhenNeeded(this);
 
         protected final WebElement resetGenIdButton = Locator.tagWithClass("button", "reset-genid-btn").findWhenNeeded(this);
+
+        protected final ReactSelect storedAmountDisplayUnitsSelect = ReactSelect.finder(getDriver())
+                .withContainerClass("sampleset-metric-unit-select-container").timeout(WAIT_FOR_JAVASCRIPT).findWhenNeeded(this);
+
+        final Locator uniqueIdMsgLoc = Locator.tagWithClass("div", "uniqueid-msg");
 
     }
 


### PR DESCRIPTION
#### Rationale
This updates domain designer test classes to be able to interact with the 'scannable' checkbox, used to enable using a field as an alternate barcode field

#### Related Pull Requests
https://github.com/LabKey/sampleManagement/pull/1409

#### Changes
`DomainFieldRow `- added ability to interact with the scannable checkbox, and know whether it is present or not
'EntityTypeDesigner' - added ability to interact with stored amount display units, barcode info
