### PR TITLE
Migrate test helpers HttpClient 4.x -> 5.2

### DIFF
--- a/src/org/labkey/test/WebTestHelper.java
+++ b/src/org/labkey/test/WebTestHelper.java
@@ -624,18 +624,14 @@ public class WebTestHelper
         HttpHost targetHost = new HttpHost(target.getScheme(), target.getHost(), target.getPort());
         AuthScope authScope = new AuthScope(targetHost.getHostName(), target.getPort());
         UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(username, password.toCharArray());
-
         BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(authScope, credentials);
-
-        RequestConfig requestConfig = requestConfigBuilder
-            .build();
 
         HttpClientBuilder clientBuilder = HttpClientBuilder.create()
             .setConnectionManager(SELF_SIGNED_CONNECTION_MANAGER)
             .setConnectionManagerShared(true)
             .setDefaultCredentialsProvider(credentialsProvider)
-            .setDefaultRequestConfig(requestConfig);
+            .setDefaultRequestConfig(requestConfigBuilder.build());
 
         Map<String, Cookie> cookies = getCookies(username);
         if (!cookies.isEmpty())

--- a/src/org/labkey/test/WebTestHelper.java
+++ b/src/org/labkey/test/WebTestHelper.java
@@ -17,25 +17,26 @@
 package org.labkey.test;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpResponse;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.AuthCache;
-import org.apache.http.client.CookieStore;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.config.ConnectionConfig;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
-import org.apache.http.impl.auth.BasicScheme;
-import org.apache.http.impl.client.BasicAuthCache;
-import org.apache.http.impl.client.BasicCookieStore;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.hc.client5.http.auth.AuthCache;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.cookie.BasicCookieStore;
+import org.apache.hc.client5.http.cookie.CookieStore;
+import org.apache.hc.client5.http.impl.auth.BasicAuthCache;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.ManagedHttpClientConnectionFactory;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.TrustSelfSignedStrategy;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.config.CharCodingConfig;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -81,6 +82,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Static methods for getting properties of and communicating with a running LabKey server
@@ -559,12 +561,12 @@ public class WebTestHelper
         }
     }
 
-    public static HttpClient getHttpClient()
+    public static CloseableHttpClient getHttpClient()
     {
         return getHttpClient(PasswordUtil.getUsername(), PasswordUtil.getPassword());
     }
 
-    public static HttpClient getHttpClient(String username, String password)
+    public static CloseableHttpClient getHttpClient(String username, String password)
     {
         return getHttpClientBuilder(username, password).build();
     }
@@ -577,10 +579,34 @@ public class WebTestHelper
     public static HttpClientBuilder getHttpClientBuilder(String username, String password)
     {
         RequestConfig.Builder requestConfigBuilder = RequestConfig.custom()
-                .setSocketTimeout(60000)
-                .setConnectTimeout(60000)
-                .setConnectionRequestTimeout(60000);
+            .setResponseTimeout(60000, TimeUnit.MILLISECONDS)
+            .setConnectTimeout(60000, TimeUnit.MILLISECONDS)
+            .setConnectionRequestTimeout(60000, TimeUnit.MILLISECONDS);
         return getHttpClientBuilder(username, password, requestConfigBuilder);
+    }
+
+    private static final HttpClientConnectionManager SELF_SIGNED_CONNECTION_MANAGER;
+
+    static
+    {
+        try
+        {
+            SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
+            sslContextBuilder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
+            SSLConnectionSocketFactory sslConnectionSocketFactory = new SSLConnectionSocketFactory(sslContextBuilder.build());
+            SELF_SIGNED_CONNECTION_MANAGER = PoolingHttpClientConnectionManagerBuilder.create()
+                .setSSLSocketFactory(sslConnectionSocketFactory)
+                .setConnectionFactory(
+                    ManagedHttpClientConnectionFactory.builder().charCodingConfig(
+                        CharCodingConfig.custom().setCharset(StandardCharsets.UTF_8).build()
+                    ).build()
+                )
+                .build();
+        }
+        catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException e)
+        {
+            throw new RuntimeException(e);
+        }
     }
 
     public static HttpClientBuilder getHttpClientBuilder(String username, String password, RequestConfig.Builder requestConfigBuilder)
@@ -595,37 +621,20 @@ public class WebTestHelper
             throw new RuntimeException(ex);
         }
 
-        HttpHost targetHost = new HttpHost(target.getHost(), target.getPort(), target.getScheme());
+        HttpHost targetHost = new HttpHost(target.getScheme(), target.getHost(), target.getPort());
         AuthScope authScope = new AuthScope(targetHost.getHostName(), target.getPort());
-        UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(username, password);
+        UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(username, password.toCharArray());
 
-        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(authScope, credentials);
 
         RequestConfig requestConfig = requestConfigBuilder
-                .build();
-
-        ConnectionConfig connectionConfig = ConnectionConfig.custom()
-                .setCharset(StandardCharsets.UTF_8)
-                .build();
-
-        SSLConnectionSocketFactory socketFactory;
-        try
-        {
-            SSLContextBuilder builder = new SSLContextBuilder();
-            builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
-            socketFactory = new SSLConnectionSocketFactory(builder.build());
-        }
-        catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException ex)
-        {
-            throw new RuntimeException(ex);
-        }
+            .build();
 
         HttpClientBuilder clientBuilder = HttpClientBuilder.create()
-                .setDefaultCredentialsProvider(credentialsProvider)
-                .setDefaultRequestConfig(requestConfig)
-                .setDefaultConnectionConfig(connectionConfig)
-                .setSSLSocketFactory(socketFactory);
+            .setConnectionManager(SELF_SIGNED_CONNECTION_MANAGER)
+            .setDefaultCredentialsProvider(credentialsProvider)
+            .setDefaultRequestConfig(requestConfig);
 
         Map<String, Cookie> cookies = getCookies(username);
         if (!cookies.isEmpty())
@@ -639,9 +648,9 @@ public class WebTestHelper
     }
 
     @NotNull
-    private static org.apache.http.cookie.Cookie seleniumCookieToApacheCookie(Cookie c)
+    private static org.apache.hc.client5.http.cookie.Cookie seleniumCookieToApacheCookie(Cookie c)
     {
-        return new org.apache.http.cookie.Cookie()
+        return new org.apache.hc.client5.http.cookie.Cookie()
         {
             @Override
             public String getName()
@@ -653,18 +662,6 @@ public class WebTestHelper
             public String getValue()
             {
                 return c.getValue();
-            }
-
-            @Override
-            public String getComment()
-            {
-                return c.toString();
-            }
-
-            @Override
-            public String getCommentURL()
-            {
-                return null;
             }
 
             @Override
@@ -692,21 +689,9 @@ public class WebTestHelper
             }
 
             @Override
-            public int[] getPorts()
-            {
-                return new int[0];
-            }
-
-            @Override
             public boolean isSecure()
             {
                 return c.isSecure();
-            }
-
-            @Override
-            public int getVersion()
-            {
-                return 0;
             }
 
             @Override
@@ -714,35 +699,40 @@ public class WebTestHelper
             {
                 return getExpiryDate() != null && date.compareTo(getExpiryDate()) > 0;
             }
+
+            @Override
+            public String getAttribute(String name)
+            {
+                return null;
+            }
+
+            @Override
+            public boolean containsAttribute(String name)
+            {
+                return false;
+            }
+
+            @Override
+            public Date getCreationDate()
+            {
+                return null;
+            }
         };
     }
 
     public static HttpClientContext getBasicHttpContext()
     {
-        try
-        {
-            URI target = new URI(getBaseURL());
-            HttpHost targetHost = new HttpHost(target.getHost(), target.getPort(), target.getScheme());
+        // Create AuthCache instance
+        AuthCache authCache = new BasicAuthCache();
 
-            // Create AuthCache instance
-            AuthCache authCache = new BasicAuthCache();
-            // Generate BASIC scheme object and add it to the local auth cache
-            BasicScheme basicAuth = new BasicScheme();
-            authCache.put(targetHost, basicAuth);
+        // Add AuthCache to the execution context
+        HttpClientContext localcontext = HttpClientContext.create();
+        localcontext.setAuthCache(authCache);
 
-            // Add AuthCache to the execution context
-            HttpClientContext localcontext = HttpClientContext.create();
-            localcontext.setAuthCache(authCache);
-
-            return localcontext;
-        }
-        catch (URISyntaxException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return localcontext;
     }
 
-    public static String getHttpResponseBody(HttpResponse response)
+    public static String getHttpResponseBody(CloseableHttpResponse response)
     {
         StringBuilder builder = new StringBuilder();
         try

--- a/src/org/labkey/test/WebTestHelper.java
+++ b/src/org/labkey/test/WebTestHelper.java
@@ -633,6 +633,7 @@ public class WebTestHelper
 
         HttpClientBuilder clientBuilder = HttpClientBuilder.create()
             .setConnectionManager(SELF_SIGNED_CONNECTION_MANAGER)
+            .setConnectionManagerShared(true)
             .setDefaultCredentialsProvider(credentialsProvider)
             .setDefaultRequestConfig(requestConfig);
 

--- a/src/org/labkey/test/tests/JUnitTest.java
+++ b/src/org/labkey/test/tests/JUnitTest.java
@@ -21,12 +21,12 @@ import junit.framework.JUnit4TestAdapter;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.protocol.HttpContext;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -200,8 +200,8 @@ public class JUnitTest extends TestSuite
         }
 
         HttpContext context = WebTestHelper.getBasicHttpContext();
-        HttpResponse response = null;
-        try (CloseableHttpClient client = (CloseableHttpClient)WebTestHelper.getHttpClient())
+        CloseableHttpResponse response = null;
+        try (CloseableHttpClient client = WebTestHelper.getHttpClient())
         {
             final String url = WebTestHelper.getBaseURL() + "/junit-testlist.view?";
             HttpGet method = new HttpGet(url);
@@ -223,7 +223,7 @@ public class JUnitTest extends TestSuite
                     return failsuite;
                 }
             }
-            int status = response.getStatusLine().getStatusCode();
+            int status = response.getCode();
             if (status == HttpStatus.SC_OK)
             {
                 final String responseBody = WebTestHelper.getHttpResponseBody(response);
@@ -346,7 +346,7 @@ public class JUnitTest extends TestSuite
                 LOG.error("Getting unit test list from server failed with error code " + status + ". Error page content is:");
                 final OutputStream streamLogger = IoBuilder.forLogger(LOG).setLevel(Level.ERROR).buildOutputStream();
                 response.getEntity().writeTo(streamLogger);
-                throw new AssertionFailedError("Failed to fetch remote junit test list (" + status + " - " + response.getStatusLine() + "): " + url);
+                throw new AssertionFailedError("Failed to fetch remote junit test list (" + status + " - " + response.getReasonPhrase() + "): " + url);
             }
         }
         finally

--- a/src/org/labkey/test/util/APITestHelper.java
+++ b/src/org/labkey/test/util/APITestHelper.java
@@ -16,16 +16,16 @@
 package org.labkey.test.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpStatus;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.protocol.HttpContext;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.xmlbeans.XmlException;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.query.xml.ApiTestsDocument;
@@ -153,26 +153,23 @@ public class APITestHelper
     {
         HttpContext context = WebTestHelper.getBasicHttpContext();
         HttpUriRequest method = null;
-        HttpResponse response = null;
         String requestUrl = WebTestHelper.getBaseURL() + '/' + url;
 
         switch (type)
         {
-            case "get":
-                method = new HttpGet(requestUrl);
-                break;
-            case "post":
+            case "get" -> method = new HttpGet(requestUrl);
+            case "post" ->
+            {
                 method = new HttpPost(requestUrl);
-                ((HttpPost)method).setEntity(new StringEntity(formData, ContentType.create("application/json", "UTF-8")));
-                break;
+                method.setEntity(new StringEntity(formData, ContentType.create("application/json", "UTF-8")));
+            }
         }
 
         injectCookies(username, method);
 
-        try (CloseableHttpClient client = (CloseableHttpClient) WebTestHelper.getHttpClient(username, password))
+        try (CloseableHttpClient client = WebTestHelper.getHttpClient(username, password); CloseableHttpResponse response = client.execute(method, context))
         {
-            response = client.execute(method, context);
-            int status = response.getStatusLine().getStatusCode();
+            int status = response.getCode();
             String responseBody = WebTestHelper.getHttpResponseBody(response);
             if (status == HttpStatus.SC_OK || acceptErrors)
             {
@@ -180,15 +177,11 @@ public class APITestHelper
             }
             else
                 fail(String.format("FAILED: test %s failed with status code: %s%s", name, status, "\n" + responseBody));
+            EntityUtils.consumeQuietly(response.getEntity());
         }
         catch (IOException e)
         {
             throw new RuntimeException("Test failed requesting the URL,", e);
-        }
-        finally
-        {
-            if (response != null)
-                EntityUtils.consumeQuietly(response.getEntity());
         }
     }
 


### PR DESCRIPTION
#### Rationale
HttpClient 5.2 is the most recent version