### PR TITLE
Issue 46796: NAb copy to study can be very slow on SQL Server

### DIFF
--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -379,6 +379,10 @@ public class NabAssayTest extends AbstractAssayTest
                 "Host Cell changed from blank to 'EditedHostCell'",
                 "Name changed from 'ptid + visit + specimenid' to 'NameEdited.xlsx'");
 
+        // Issue 46796 - try forcing an immediate stats update to prompt a better query plan selection
+        startSystemMaintenance("Database");
+        waitForSystemMaintenanceCompletion();
+
         // Return to the run list
         navigateToFolder(getProjectName(), TEST_ASSAY_FLDR_NAB);
         clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));


### PR DESCRIPTION
#### Rationale
During the NabAssayTest, SQL Server sometimes chooses a bad query plan for the query involved in copying NAb data to a study. Forcing it to update the stats helps it catch up after loading data into the tables

#### Changes
* After importing the assay data and before copying to the study, use system maintenance to update the DB's stats