### PR TITLE
LKSM Starter/Pro: Split up test batches across composite suites

### DIFF
--- a/src/org/labkey/test/Runner.java
+++ b/src/org/labkey/test/Runner.java
@@ -1128,9 +1128,11 @@ class BatchInfo
     {
         if (_instance == null)
         {
-            int currentBatch = Integer.parseInt(System.getProperty("webtest.parallelTests.currentBatch", "1"));
-            int totalBatches = Integer.parseInt(System.getProperty("webtest.parallelTests.totalBatches", "1"));
-            _instance = new BatchInfo(currentBatch, totalBatches);
+            String currentBatch = StringUtils.trimToNull(System.getProperty("webtest.parallelTests.currentBatch"));
+            String totalBatches = StringUtils.trimToNull(System.getProperty("webtest.parallelTests.totalBatches"));
+            _instance = new BatchInfo(
+                    currentBatch != null ? Integer.parseInt(currentBatch) : 1,
+                    totalBatches != null ? Integer.parseInt(totalBatches) : 1);
         }
         return _instance;
     }

--- a/src/org/labkey/test/SuiteFactory.java
+++ b/src/org/labkey/test/SuiteFactory.java
@@ -54,7 +54,6 @@ public class SuiteFactory
     private final Map<String, Set<Class<?>>> _suites;
     private final Map<String, Class<?>> _testsByName;
     private final Map<String, List<String>> _missingTests;
-    private final BatchInfo _batchInfo;
 
     private SuiteFactory()
     {
@@ -62,7 +61,6 @@ public class SuiteFactory
         _suites = new CaseInsensitiveHashMap<>();
         _testsByName = new CaseInsensitiveHashMap<>();
         _missingTests = new CaseInsensitiveHashMap<>();
-        _batchInfo = new BatchInfo();
         loadSuites();
     }
 
@@ -392,34 +390,6 @@ public class SuiteFactory
         public boolean isOptional()
         {
             return optional;
-        }
-    }
-
-    public static class BatchInfo
-    {
-        private final Integer currentBatch;
-        private final Integer totalBatches;
-
-        public BatchInfo(Integer currentBatch, Integer totalBatches)
-        {
-            this.currentBatch = currentBatch;
-            this.totalBatches = totalBatches;
-        }
-
-        private BatchInfo()
-        {
-            currentBatch = Integer.parseInt(System.getProperty("webtest.parallelTests.currentBatch", "1"));
-            totalBatches = Integer.parseInt(System.getProperty("webtest.parallelTests.totalBatches", "1"));
-        }
-
-        public Integer getCurrentBatch()
-        {
-            return currentBatch;
-        }
-
-        public Integer getTotalBatches()
-        {
-            return totalBatches;
         }
     }
 }

--- a/src/org/labkey/test/TestSet.java
+++ b/src/org/labkey/test/TestSet.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 public class TestSet
 {
-    private String _suite;
+    private final String _suite;
     private List<Class<?>> _tests;
 
     TestSet(@NotNull Set<Class<?>> tests, @NotNull String suite)

--- a/src/org/labkey/test/testpicker/TestHelper.java
+++ b/src/org/labkey/test/testpicker/TestHelper.java
@@ -16,7 +16,7 @@
 
 package org.labkey.test.testpicker;
 
-import org.labkey.test.SuiteBuilder;
+import org.labkey.test.SuiteFactory;
 import org.labkey.test.TestConfig;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestSet;
@@ -271,14 +271,14 @@ public class TestHelper
         _treeRoot = new CheckNode(_rootName);
         _testTree = new JTree(_treeRoot);
 
-        SuiteBuilder suiteBuilder = SuiteBuilder.getInstance();
+        SuiteFactory suiteFactory = SuiteFactory.getInstance();
 
-        List<String> suites = new ArrayList<>(suiteBuilder.getSuites());
+        List<String> suites = new ArrayList<>(suiteFactory.getSuites());
         Collections.sort(suites);
 
         for (String suite : suites)
         {
-            TestSet testSet = suiteBuilder.getTestSet(suite);
+            TestSet testSet = suiteFactory.getTestSet(suite);
             if (!testSet.getTestNames().isEmpty())
             {
                 CheckNode suiteNode = new CheckNode(testSet.getSuite());
@@ -392,7 +392,7 @@ public class TestHelper
             @Override
             public void actionPerformed(ActionEvent e)
             {
-                setResult(SuiteBuilder.getInstance().getTestSet(Continue.class.getSimpleName()), new ArrayList<String>());
+                setResult(SuiteFactory.getInstance().getTestSet(Continue.class.getSimpleName()), new ArrayList<String>());
                 _window.dispose();
             }
         });
@@ -831,7 +831,7 @@ public class TestHelper
 
             if (selectedTests.size() != 0 )
             {
-                setResult(SuiteBuilder.getInstance().getTestSet(Test.class.getSimpleName()), selectedTests);
+                setResult(SuiteFactory.getInstance().getTestSet(Test.class.getSimpleName()), selectedTests);
             }
             _window.dispose();
         }

--- a/src/org/labkey/test/tests/JUnitTest.java
+++ b/src/org/labkey/test/tests/JUnitTest.java
@@ -170,7 +170,8 @@ public class JUnitTest extends TestSuite
                 }
                 for (SuiteFactory.SuiteInfo suiteInfo : suiteInfos)
                 {
-                    if (testCategories.contains(suiteInfo.getName()))
+                    if (testCategories.contains(suiteInfo.getName()) &&
+                            suiteInfo.getSubset() == suiteInfo.getSubsetCount()) // Only run in last shard for sharded suite
                         return true;
                 }
                 return testCategories.contains("smoke"); // Always run smoke tests

--- a/src/org/labkey/test/tests/JUnitTest.java
+++ b/src/org/labkey/test/tests/JUnitTest.java
@@ -45,7 +45,7 @@ import org.labkey.remoteapi.PostCommand;
 import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Runner;
-import org.labkey.test.SuiteBuilder;
+import org.labkey.test.SuiteFactory;
 import org.labkey.test.TestProperties;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
@@ -158,7 +158,7 @@ public class JUnitTest extends TestSuite
         if (categories.isEmpty())
             return new TestSuite();
 
-        final List<SuiteBuilder.SuiteInfo> suiteInfos = categories.stream().map(SuiteBuilder.SuiteInfo::new).toList();
+        final List<SuiteFactory.SuiteInfo> suiteInfos = categories.stream().map(SuiteFactory.SuiteInfo::new).toList();
         try
         {
             return _suite(testProps -> {
@@ -168,10 +168,9 @@ public class JUnitTest extends TestSuite
                     if (testCategories.contains(excludedCategory))
                         return false;
                 }
-                for (SuiteBuilder.SuiteInfo suiteInfo : suiteInfos)
+                for (SuiteFactory.SuiteInfo suiteInfo : suiteInfos)
                 {
-                    if (testCategories.contains(suiteInfo.getName()) &&
-                            suiteInfo.getSubset() == suiteInfo.getSubsetCount()) // Only run in last shard for sharded suite
+                    if (testCategories.contains(suiteInfo.getName()))
                         return true;
                 }
                 return testCategories.contains("smoke"); // Always run smoke tests


### PR DESCRIPTION
#### Rationale
We currently split up some test suites to run in parallel with the syntax `BVT[a/b]` where `a` is the batch number and `b` is the total number of batches. The is inadequate in the case where we want to parallelize more complicated suite definitions (e.g. `samplemanagement,-SMStarter`). If we make the shard numbers separate parameters, we can parallelize such suites and keep the batches.

Designed to integrate with TeamCity parallel test batching: https://www.jetbrains.com/help/teamcity/parallel-tests.html#custom-tests

#### Related Pull Requests
* N/A

#### Changes
* Add parameters for splitting composite suites into batches
  * `webtest.parallelTests.currentBatch`
  * `webtest.parallelTests.totalBatches`
