### PR TITLE
Add wait for gridBar button to become enabled before clicking it

### DIFF
--- a/src/org/labkey/test/components/ui/grids/GridBar.java
+++ b/src/org/labkey/test/components/ui/grids/GridBar.java
@@ -20,6 +20,7 @@ import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -230,7 +231,9 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
      */
     public void clickButton(String buttonCaption)
     {
-        BootstrapLocators.button(buttonCaption).waitForElement(this, 5_000).click();
+        var btn = BootstrapLocators.button(buttonCaption).waitForElement(this, 5_000);
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(btn));   // for cases when a disabled button
+        btn.click();                                                                    // awaits being enabled, for example by selecting grid items
     }
 
     public void doMenuAction(String buttonText, List<String> menuActions)


### PR DESCRIPTION
#### Rationale
This adds a wait for the specified gridbar button to become clickable before attempting to click it

Found this when attempting to remove a sample from a job, in a situation where the 'remove samples' button doesn't become enabled until a sample is selected for removal. (Found this while testing against a remote eval instance, seems like a purely test failure)
It seems that the button becoming enabled can take longer to happen after selecting samples than it takes for automation to find and click it:

This call, from AppWorkflowSamplesPage, selects a sample and seems to click the 'remove samples' button before it's enabled
```
 grid().clearAllSelections();
        for (String sample : sampleNames)
        {
            grid().selectRow("Sample ID", sample, true);
        }
        grid().getGridBar().clickButton("Remove Samples");
```

![image](https://user-images.githubusercontent.com/16809856/207733735-398f249e-950d-4781-85e3-cbbe4427c28a.png)


#### Related Pull Requests
n/a

#### Changes
Adds a wait for the button to become clickable in addition to awaiting for it to be there
