### PR TITLE
Fix path issue in APIAssayHelper.

### DIFF
--- a/src/org/labkey/test/util/APIAssayHelper.java
+++ b/src/org/labkey/test/util/APIAssayHelper.java
@@ -65,8 +65,9 @@ public class APIAssayHelper extends AbstractAssayHelper
     {
         ImportRunCommand  irc = new ImportRunCommand(assayID, file);
         irc.setBatchProperties(batchProperties);
-        irc.setTimeout(180000); // Wait 3 minutes for assay import
-        return irc.execute(_test.createDefaultConnection(), "/" + projectPath);
+        irc.setTimeout(180000); // Wait 3 minutes for
+        projectPath = projectPath.startsWith("/") ? projectPath : "/" + projectPath;// assay import
+        return irc.execute(_test.createDefaultConnection(), projectPath);
     }
 
     @LogMethod(quiet = true)
@@ -76,7 +77,8 @@ public class APIAssayHelper extends AbstractAssayHelper
         irc.setRunFilePath(runFilePath);
         irc.setBatchProperties(batchProperties);
         irc.setTimeout(180000); // Wait 3 minutes for assay import
-        return irc.execute(_test.createDefaultConnection(), "/" + projectPath);
+        projectPath = projectPath.startsWith("/") ? projectPath : "/" + projectPath;
+        return irc.execute(_test.createDefaultConnection(), projectPath);
     }
 
     @LogMethod(quiet = true)
@@ -88,7 +90,8 @@ public class APIAssayHelper extends AbstractAssayHelper
         irc.setProperties(runProperties);
         irc.setBatchProperties(batchProperties);
         irc.setTimeout(180000); // Wait 3 minutes for assay import
-        return irc.execute(_test.createDefaultConnection(), "/" + projectPath);
+        projectPath = projectPath.startsWith("/") ? projectPath : "/" + projectPath;
+        return irc.execute(_test.createDefaultConnection(), projectPath);
     }
 
     @LogMethod(quiet = true)
@@ -124,8 +127,10 @@ public class APIAssayHelper extends AbstractAssayHelper
         if(null != batchProperties)
             irc.setBatchProperties(batchProperties);
 
+        projectPath = projectPath.startsWith("/") ? projectPath : "/" + projectPath;
+
         irc.setTimeout(180000); // Wait 3 minutes for assay import
-        return irc.execute(_test.createDefaultConnection(), "/" + projectPath);
+        return irc.execute(_test.createDefaultConnection(), projectPath);
     }
 
     @Override
@@ -240,9 +245,7 @@ public class APIAssayHelper extends AbstractAssayHelper
         SelectRowsCommand cmd = new SelectRowsCommand("assay", "AssayList");
         cmd.setColumns(Arrays.asList("Name", "Description", "Type"));
 
-        String formattedContainerPath = containerPath;
-        if(!formattedContainerPath.startsWith("/"))
-            formattedContainerPath = "/" + formattedContainerPath;
+        String formattedContainerPath = containerPath.startsWith("/") ? containerPath : "/" + containerPath;
 
         List<String> resultData = new ArrayList<>();
 
@@ -276,7 +279,8 @@ public class APIAssayHelper extends AbstractAssayHelper
     {
         SaveAssayBatchCommand cmd = new SaveAssayBatchCommand(assayId, batch);
         cmd.setTimeout(180000); // Wait 3 minutes for assay import
-        cmd.execute(_test.createDefaultConnection(), "/" + projectPath);
+        projectPath = projectPath.startsWith("/") ? projectPath : "/" + projectPath;
+        cmd.execute(_test.createDefaultConnection(), projectPath);
     }
 
     public Protocol createAssayDesignWithDefaults(String containerPath, String providerName, String assayName) throws IOException, CommandException

--- a/src/org/labkey/test/util/APIAssayHelper.java
+++ b/src/org/labkey/test/util/APIAssayHelper.java
@@ -65,7 +65,7 @@ public class APIAssayHelper extends AbstractAssayHelper
     {
         ImportRunCommand  irc = new ImportRunCommand(assayID, file);
         irc.setBatchProperties(batchProperties);
-        irc.setTimeout(180000); // Wait 3 minutes for
+        irc.setTimeout(180000); // Wait 3 minutes for assay import
         return irc.execute(_test.createDefaultConnection(), projectPath);
     }
 

--- a/src/org/labkey/test/util/APIAssayHelper.java
+++ b/src/org/labkey/test/util/APIAssayHelper.java
@@ -66,7 +66,6 @@ public class APIAssayHelper extends AbstractAssayHelper
         ImportRunCommand  irc = new ImportRunCommand(assayID, file);
         irc.setBatchProperties(batchProperties);
         irc.setTimeout(180000); // Wait 3 minutes for
-        projectPath = projectPath.startsWith("/") ? projectPath : "/" + projectPath;// assay import
         return irc.execute(_test.createDefaultConnection(), projectPath);
     }
 
@@ -77,7 +76,6 @@ public class APIAssayHelper extends AbstractAssayHelper
         irc.setRunFilePath(runFilePath);
         irc.setBatchProperties(batchProperties);
         irc.setTimeout(180000); // Wait 3 minutes for assay import
-        projectPath = projectPath.startsWith("/") ? projectPath : "/" + projectPath;
         return irc.execute(_test.createDefaultConnection(), projectPath);
     }
 
@@ -90,7 +88,6 @@ public class APIAssayHelper extends AbstractAssayHelper
         irc.setProperties(runProperties);
         irc.setBatchProperties(batchProperties);
         irc.setTimeout(180000); // Wait 3 minutes for assay import
-        projectPath = projectPath.startsWith("/") ? projectPath : "/" + projectPath;
         return irc.execute(_test.createDefaultConnection(), projectPath);
     }
 
@@ -126,8 +123,6 @@ public class APIAssayHelper extends AbstractAssayHelper
 
         if(null != batchProperties)
             irc.setBatchProperties(batchProperties);
-
-        projectPath = projectPath.startsWith("/") ? projectPath : "/" + projectPath;
 
         irc.setTimeout(180000); // Wait 3 minutes for assay import
         return irc.execute(_test.createDefaultConnection(), projectPath);
@@ -207,7 +202,6 @@ public class APIAssayHelper extends AbstractAssayHelper
         AssayListResponse alr = null;
         try
         {
-            projectPath = projectPath.startsWith("/") ? projectPath : "/" + projectPath;
             alr = alc.execute(_test.createDefaultConnection(), projectPath);
         }
         catch (CommandException | IOException e)
@@ -245,11 +239,9 @@ public class APIAssayHelper extends AbstractAssayHelper
         SelectRowsCommand cmd = new SelectRowsCommand("assay", "AssayList");
         cmd.setColumns(Arrays.asList("Name", "Description", "Type"));
 
-        String formattedContainerPath = containerPath.startsWith("/") ? containerPath : "/" + containerPath;
-
         List<String> resultData = new ArrayList<>();
 
-        SelectRowsResponse response = cmd.execute(connection, formattedContainerPath);
+        SelectRowsResponse response = cmd.execute(connection, containerPath);
         for(Row row : response.getRowset())
         {
             resultData.add(row.getValue("Name").toString());
@@ -279,7 +271,6 @@ public class APIAssayHelper extends AbstractAssayHelper
     {
         SaveAssayBatchCommand cmd = new SaveAssayBatchCommand(assayId, batch);
         cmd.setTimeout(180000); // Wait 3 minutes for assay import
-        projectPath = projectPath.startsWith("/") ? projectPath : "/" + projectPath;
         cmd.execute(_test.createDefaultConnection(), projectPath);
     }
 

--- a/src/org/labkey/test/util/APIAssayHelper.java
+++ b/src/org/labkey/test/util/APIAssayHelper.java
@@ -202,7 +202,8 @@ public class APIAssayHelper extends AbstractAssayHelper
         AssayListResponse alr = null;
         try
         {
-            alr = alc.execute(_test.createDefaultConnection(), "/" + projectPath);
+            projectPath = projectPath.startsWith("/") ? projectPath : "/" + projectPath;
+            alr = alc.execute(_test.createDefaultConnection(), projectPath);
         }
         catch (CommandException | IOException e)
         {


### PR DESCRIPTION
#### Rationale
Test started failing recently on the embedded test suite with a [IllegalArgumentException: URI path begins with multiple slashes](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Internal_Embedded_SampleManagerEmbeddedPostgres/2180604?buildTab=tests&status=failed&name=org.labkey.test.tests.samplemanagement.aliquots.SMProAliquotRollupSourcesTest.testAssaysPage). The call stacks pointed to various methods in APIAssayHelper where they would always prepend a "/" to the path sent int. This change checks if the path sent in already has a leading "/" before appending one.

#### Related Pull Requests
* None

#### Changes
* Update various methods in APIAssayHelper to check before prepending a "/" to the path parameter.
