### PR TITLE
App header Projects and Menu consolidation

### DIFF
--- a/src/org/labkey/test/components/ui/navigation/ProductMenu.java
+++ b/src/org/labkey/test/components/ui/navigation/ProductMenu.java
@@ -103,11 +103,37 @@ public class ProductMenu extends BaseBootstrapMenu
                 .collect(Collectors.toList());
     }
 
-
     public void clickMenuItem(String headerText, String menuText)
     {
         expand();
         elementCache().menuSectionLink(headerText, menuText).click();
+    }
+
+    public ProductMenu clickFolderItem(String folderName)
+    {
+        expand();
+        elementCache().folderItemLink(folderName).click();
+        return this;
+    }
+
+    public void goToFolder(String folderName)
+    {
+        clickFolderItem(folderName);
+        clickMenuColumnHeader("Dashboard");
+    }
+
+    public String getButtonTitle()
+    {
+        WebElement buttonTitle = Locator.tagWithId("button", "product-menu")
+                .child(Locator.tagWithClass("div", "title")).findElement(this);
+        return buttonTitle.getText();
+    }
+
+    public String getButtonSubtitle()
+    {
+        WebElement buttonSubtitle = Locator.tagWithId("button", "product-menu")
+                .child(Locator.tagWithClass("div", "subtitle")).findElement(this);
+        return buttonSubtitle.getText();
     }
 
     @Override
@@ -152,6 +178,11 @@ public class ProductMenu extends BaseBootstrapMenu
         WebElement menuSectionLink(String headerText, String linkText)
         {
             return Locator.linkWithText(linkText).findElement(menuSectionBody(headerText));
+        }
+
+        WebElement folderItemLink(String folderName)
+        {
+            return Locator.tagWithClass("a", "menu-folder-item").withText(folderName).findElement(elementCache().menuContent);
         }
     }
 }

--- a/src/org/labkey/test/components/ui/navigation/ProductMenu.java
+++ b/src/org/labkey/test/components/ui/navigation/ProductMenu.java
@@ -8,7 +8,6 @@ import org.labkey.test.Locator;
 import org.labkey.test.components.react.BaseBootstrapMenu;
 import org.labkey.test.components.react.MultiMenu;
 import org.labkey.test.util.TestLogger;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -111,25 +110,6 @@ public class ProductMenu extends BaseBootstrapMenu
         elementCache().menuSectionLink(headerText, menuText).click();
     }
 
-    public boolean sectionHasOverflowLink(String headerText)
-    {
-        expand();
-        try
-        {
-            return elementCache().overFlowLink(headerText).isDisplayed();
-        }
-        catch(NoSuchElementException nse)
-        {
-            return false;
-        }
-    }
-
-    public void clickOverflowLink(String headerText)
-    {
-        expand();
-        elementCache().overFlowLink(headerText).click();
-    }
-
     @Override
     protected Locator getToggleLocator()
     {
@@ -152,32 +132,26 @@ public class ProductMenu extends BaseBootstrapMenu
     {
         private final WebElement menuContent = Locator.tagWithClass("div", "product-menu-content").findWhenNeeded(this);
 
-        private final Map<String, WebElement> menuSections = new HashMap<>();
         Locator.XPathLocator menuSectionHeaderLoc(String headerText)
         {
             return Locator.tagWithClass("div", "menu-section")
-                    .child(Locator.tagWithClass("span", "menu-section-header").withText(Locator.NBSP + headerText));
+                    .child(Locator.tag("ul"))
+                    .child(Locator.tagWithClass("li", "menu-section-header").containing(headerText));
         }
 
         WebElement menuSectionHeader(String headerText)
         {
-            return menuSectionHeaderLoc(headerText).child(Locator.linkWithText(Locator.NBSP + headerText)).findElement(elementCache().menuContent);
+            return menuSectionHeaderLoc(headerText).child(Locator.linkContainingText(headerText)).findElement(elementCache().menuContent);
         }
 
         WebElement menuSectionBody(String headerText)
         {
-            return menuSectionHeaderLoc(headerText).followingSibling("ul").findElement(elementCache().menuContent);
+            return menuSectionHeaderLoc(headerText).parent("ul").findElement(elementCache().menuContent);
         }
 
         WebElement menuSectionLink(String headerText, String linkText)
         {
             return Locator.linkWithText(linkText).findElement(menuSectionBody(headerText));
-        }
-
-        WebElement overFlowLink(String headerText)
-        {
-            return menuSectionHeaderLoc(headerText)
-                    .followingSibling("span").withClass("overflow-link").findElement(elementCache().menuContent);
         }
     }
 }

--- a/src/org/labkey/test/components/ui/navigation/ProductMenu.java
+++ b/src/org/labkey/test/components/ui/navigation/ProductMenu.java
@@ -65,14 +65,14 @@ public class ProductMenu extends BaseBootstrapMenu
     public List<String> getMenuSectionHeaders()
     {
         expand();
-        List<WebElement> headersElements = Locator.tagWithClass("span", "menu-section-header").findElements(this);
+        List<WebElement> headersElements = MENU_SECTION_HEADER_LOC.findElements(this);
         return getWrapper().getTexts(headersElements).stream().map(String::trim).collect(Collectors.toList());
     }
 
     public Map<String, String> getMenuSectionHeaderLinks()
     {
         expand();
-        List<WebElement> headerElements = Locator.tagWithClass("span", "menu-section-header").findElements(this);
+        List<WebElement> headerElements = MENU_SECTION_HEADER_LOC.findElements(this);
         Map<String, String> links = new HashMap<>();
         headerElements.forEach((header) -> {
             links.put(header.getText().trim(),Locator.tag("a").findElement(header).getAttribute("href"));

--- a/src/org/labkey/test/components/ui/navigation/ProductMenu.java
+++ b/src/org/labkey/test/components/ui/navigation/ProductMenu.java
@@ -162,7 +162,7 @@ public class ProductMenu extends BaseBootstrapMenu
         {
             return Locator.tagWithClass("div", "menu-section")
                     .child(Locator.tag("ul"))
-                    .child(Locator.tagWithClass("li", "menu-section-header").containing(headerText));
+                    .child(Locator.tagWithClass("li", "menu-section-header").endsWith(headerText));
         }
 
         WebElement menuSectionHeader(String headerText)


### PR DESCRIPTION
#### Rationale
We are updating the current two-menu app header display to consolidate down to a single button and menu for the apps. This single menu will include both the listing of projects along with the mega menu content for the selected project.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1066

#### Changes
* Update ProductMenu locators and remove menu overflow helpers since we are now showing all items in menu sections
