### PR TITLE
Don't crawl freezer manager

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -49,6 +49,7 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.seleniumhq.jetty9.util.URIUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -207,10 +208,11 @@ public class Crawler
             new ControllerActionId("reports", "streamFile"),
             new ControllerActionId("study", "manageStudyProperties"), // Intermittently triggers form dirty alert
 
-            // Disable crawler for single-page apps until we make `beginAt` work with them
+            // Disable crawler for single-page apps until we make the crawler able to navigate them
             new ControllerActionId("biologics", "app"),
             new ControllerActionId("cds", "app"),
             new ControllerActionId("samplemanager", "app"),
+            new ControllerActionId("freezermanager", "app"),
 
             // Actions that error from Admin->GoToModule->MoreModules when module is not enabled
             new ControllerActionId("biologics", "begin"),
@@ -589,7 +591,7 @@ public class Crawler
             String strippedRelativeURL = stripQueryParams(getRelativeURL());
 
             // never go to the exactly same URL (minus query params) twice:
-            if (_urlsChecked.contains(strippedRelativeURL))
+            if (_urlsChecked.contains(URIUtil.decodePath(strippedRelativeURL)))
                 return false;
 
             if (getRelativeURL().contains("export=")) //Study report export uses same URL for export. But don't mark visited yet
@@ -955,6 +957,7 @@ public class Crawler
         // Keep track of where crawler has been
         _actionsVisited.add(actionId);
         _urlsChecked.add(stripQueryParams(relativeURL));
+        _urlsChecked.add(URIUtil.decodePath(stripQueryParams(relativeURL)));
         URL origin = urlToCheck.getOrigin();
         int depth = urlToCheck.getDepth();
         String originMessage = (origin != null ? "\nOriginating page: " + origin : "") +


### PR DESCRIPTION
#### Rationale
Crawler doesn't know how to navigate within single-page apps. Freezer manager should be excluded (other's are already excluded)

```
java.lang.RuntimeException: Crawler threw TestTimeoutException.
Target page: /BiologicsAPI_Test%20Project/freezermanager-app.view#/
Originating page: https://accounterer-0b053da.lkpoc.labkey.com/BiologicsAPI_Test%20Project/freezermanager-app.view#/
Target Page: /BiologicsAPI_Test%20Project/freezermanager-app.view#/
  at org.labkey.test.util.Crawler.crawlLink(Crawler.java:1106)
  at org.labkey.test.util.Crawler.crawl(Crawler.java:829)
  at org.labkey.test.util.Crawler.crawlAllLinks(Crawler.java:792)
```

#### Related Pull Requests
* N/A

#### Changes
* Don't crawl freezer manager
* Don't re-crawl pages with different path encoding
