### PR TITLE
Make Crawler handle anchor navigation

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -917,7 +917,8 @@ public class Crawler
                             return true; // Stop waiting
                         }
                     }
-                    if (!_test.getDriver().getCurrentUrl().equals(initialUrl))
+                    String currentUrl = _test.getDriver().getCurrentUrl();
+                    if (!currentUrl.equals(initialUrl) && stripHash(currentUrl).equals(stripHash(initialUrl)))
                     {
                         // URL changed without document going stale.
                         // Probably a single-page app navigation or page anchor navigation.

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -884,6 +884,7 @@ public class Crawler
             final File[] existingDownloads = downloadDir.listFiles();
 
             long elapsedTime = _test.doAndMaybeWaitForPageToLoad(WebDriverWrapper.WAIT_FOR_PAGE, () -> {
+                final String initialUrl = _test.getDriver().getCurrentUrl();
                 final WebElement mightGoStale = Locators.documentRoot.findElement(_test.getDriver());
                 ExpectedCondition<Boolean> stalenessOf = ExpectedConditions.stalenessOf(mightGoStale);
                 // 'getDriver().navigate().to(fullURL)' assumes navigation and fails for file downloads
@@ -915,6 +916,13 @@ public class Crawler
                             navigated.setValue(false); // Don't wait for page load when a download occurs
                             return true; // Stop waiting
                         }
+                    }
+                    if (!_test.getDriver().getCurrentUrl().equals(initialUrl))
+                    {
+                        // URL changed without document going stale.
+                        // Probably a single-page app navigation or page anchor navigation.
+                        navigated.setValue(false);
+                        return true; // Stop waiting
                     }
                     return false; // No navigation or download detected. Continue waiting.
                 }, WebDriverWrapper.WAIT_FOR_PAGE))


### PR DESCRIPTION
#### Rationale
Some non-app navigation doesn't trigger a page load.
For example, when navigating from `query-begin.view` to `query-begin.view#sbh-ssp-coreTarget`

#### Related Pull Requests
* N/A

#### Changes
* Make Crawler handle anchor navigation.
