### PR TITLE
Wait For Error Banner in SampleFinderDialog

### DIFF
--- a/src/org/labkey/test/components/ui/search/ManageSampleFinderViewsModal.java
+++ b/src/org/labkey/test/components/ui/search/ManageSampleFinderViewsModal.java
@@ -1,6 +1,7 @@
 package org.labkey.test.components.ui.search;
 
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.bootstrap.ModalDialog;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
@@ -125,7 +126,10 @@ public class ManageSampleFinderViewsModal extends ModalDialog
 
     public String getErrorMsg()
     {
-        return elementCache().errorMsg.getText();
+        if(WebDriverWrapper.waitFor(()->elementCache().errorMsg.isDisplayed(), 1_000))
+            return elementCache().errorMsg.getText();
+        else
+            return "";
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Trying to address some test failures the expected error message was not present in the dialog. The artifacts show the error message so I believe the ManageSampleFinderViewsModal.getErrorMsg was not waiting for the error message to show up. This should address that.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/1512

#### Changes
* Add a waitFor in ManageSampleFinderViewsModal.getErrorMsg
