### PR TITLE
Make memCheck see leaks during startup

### DIFF
--- a/src/org/labkey/test/tests/JUnitTest.java
+++ b/src/org/labkey/test/tests/JUnitTest.java
@@ -468,8 +468,6 @@ public class JUnitTest extends TestSuite
 
     public static class BaseJUnitTestWrapper extends BaseWebDriverTest
     {
-        // Used by 'JUnitFooter' to check for leaks from server-side tests
-        protected static Long startTime = null;
         // Don't configure pipeline tools or R for smoke suite
         protected static boolean extraSetup = false;
 

--- a/src/org/labkey/test/util/JUnitFooter.java
+++ b/src/org/labkey/test/util/JUnitFooter.java
@@ -49,10 +49,4 @@ public class JUnitFooter extends JUnitTest.BaseJUnitTestWrapper
     {
         // Skip normal check. Server-side tests might generate expected errors.
     }
-
-    @Override
-    protected void checkLeaks(Long leakCutoffTime)
-    {
-        super.checkLeaks(startTime);
-    }
 }

--- a/src/org/labkey/test/util/JUnitHeader.java
+++ b/src/org/labkey/test/util/JUnitHeader.java
@@ -71,7 +71,6 @@ public class JUnitHeader extends JUnitTest.BaseJUnitTestWrapper
     @AfterClass
     public static void logStart()
     {
-        startTime = System.currentTimeMillis();
         logToServer("=== Starting Server-side JUnit Tests ===");
     }
 }


### PR DESCRIPTION
#### Rationale
`BWDT.checkLeaks` can't catch leaks that were generated during initial startup. The previous solution to avoid failing numerous tests due to a single leak was unnecessarily elaborate. This modifies `checkLeaks` to keep track of which leaks it has already seen. This also makes it unnecessary for `JUnitHeader` and `JUnitFooter` to jump through hoops to check for leaks from server-side tests.

#### Related Pull Requests
* N/A

#### Changes
* Make memCheck see leaks during startup
