### PR TITLE
Handle missing or poorly defined parallel test parameters

### DIFF
--- a/src/org/labkey/test/Runner.java
+++ b/src/org/labkey/test/Runner.java
@@ -1130,9 +1130,14 @@ class BatchInfo
         {
             String currentBatch = StringUtils.trimToNull(System.getProperty("webtest.parallelTests.currentBatch"));
             String totalBatches = StringUtils.trimToNull(System.getProperty("webtest.parallelTests.totalBatches"));
-            _instance = new BatchInfo(
-                    currentBatch != null ? Integer.parseInt(currentBatch) : 1,
-                    totalBatches != null ? Integer.parseInt(totalBatches) : 1);
+            try
+            {
+                _instance = new BatchInfo(Integer.parseInt(currentBatch), Integer.parseInt(totalBatches));
+            }
+            catch (NumberFormatException ex)
+            {
+                _instance = new BatchInfo(1, 1);
+            }
         }
         return _instance;
     }


### PR DESCRIPTION
#### Rationale
The first time TeamCity runs a build with parallel tests enabled, it doesn't actually populate the batch parameters.

```
java.lang.NumberFormatException: For input string: "%teamcity.build.parallelTests.currentBatch%"
  at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
  at java.base/java.lang.Integer.parseInt(Integer.java:654)
  at java.base/java.lang.Integer.parseInt(Integer.java:786)
  at org.labkey.test.BatchInfo.get(Runner.java:1134)
  at org.labkey.test.Runner.suite(Runner.java:804)
```

#### Related Pull Requests
* #1321 

#### Changes
* Ignore `NuberFormatException` when parsing test batch parameters
