### PR TITLE
Misc app fixes in @labkey/components and @labkey/premium for 23.2

### DIFF
--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -412,6 +412,15 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
             {
                 WebElement inputCell = elementCache().inputCell();
                 inputCell.clear();
+
+                // the clear may end up deactivating the cell
+                if (elementCache().inputCell() == null)
+                {
+                    selectCell(gridCell);
+                    activateCell(gridCell);
+                    inputCell = elementCache().inputCell();
+                }
+
                 inputCell.sendKeys(Keys.END + value.toString() + Keys.RETURN); // Add the RETURN to close the inputCell.
             }
 
@@ -829,7 +838,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         public final WebElement selectColumn = Locator.xpath("//th/input[@type='checkbox']").findWhenNeeded(getComponentElement());
         public WebElement inputCell()
         {
-            return Locators.inputCell.findElement(getComponentElement());
+            return Locators.inputCell.findElementOrNull(getComponentElement());
         }
 
         public ReactSelect lookupSelect()


### PR DESCRIPTION
#### Rationale
Issue [46581](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46581): LKSM/LKB: Edit Grids don't de-focus cells if you click outside the table

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1075

#### Changes
* EditableGrid setCellValue - cell de-select/focus behavior change
