### PR TITLE
fix for testAuditTableLinkedSchema

### DIFF
--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -846,7 +846,7 @@ public class LinkedSchemaTest extends BaseWebDriverTest
 
         goToSchemaBrowser();
         table = viewQueryData(linkedSchemaName, "DomainAuditEvent");
-        checker().verifyEquals("Incorrect number of rows in DomainAuditEvent", 38, table.getDataRowCount());
+        checker().verifyEquals("Incorrect number of rows in DomainAuditEvent", 33, table.getDataRowCount());
     }
 
     protected void goToSchemaBrowserTable(String schemaName, String tableName)


### PR DESCRIPTION
#### Rationale
This PR : https://github.com/LabKey/platform/pull/3987 altered the container that the 5 study design domains were created in from the current study folder to the project so that it matched the domain URI.

We just need to change the test expectations since those audit entries will now be in a different folder.