### PR TITLE
Add basic tests for links to and from background imports grid

### DIFF
--- a/src/org/labkey/test/components/ui/notifications/ServerNotificationMenu.java
+++ b/src/org/labkey/test/components/ui/notifications/ServerNotificationMenu.java
@@ -4,6 +4,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.react.BaseBootstrapMenu;
 import org.labkey.test.components.react.MultiMenu;
+import org.labkey.test.components.ui.pipeline.ImportsPage;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -35,8 +36,8 @@ public class ServerNotificationMenu extends BaseBootstrapMenu
         String text = "0";
         boolean stale = true;
 
-        // Bit of a challenge to get the count. The element can update (because, you know it's async) if it does then a
-        // StaleElementException will happen. Try to protect against that by getting the element again f stale.
+        // Bit of a challenge to get the count. The element can update (because, you know, it's async) if it does then a
+        // StaleElementException will happen. Try to protect against that by getting the element again if stale.
         // If it is not there at all it will return null and exit the loop gracefully.
         while(stale)
         {
@@ -112,6 +113,13 @@ public class ServerNotificationMenu extends BaseBootstrapMenu
     {
         expand();
         elementCache().markAll().click();
+    }
+
+    public ImportsPage clickViewAll()
+    {
+        expand();
+        elementCache().viewAllLink.click();
+        return new ImportsPage(getWrapper());
     }
 
     /**
@@ -235,6 +243,8 @@ public class ServerNotificationMenu extends BaseBootstrapMenu
                     .child(Locator.tagWithClass("div", "server-notifications-link"))
                     .refindWhenNeeded(this);
         }
+
+        public final WebElement viewAllLink = Locator.tagWithText("div", "View all activity").refindWhenNeeded(this);
 
     }
 

--- a/src/org/labkey/test/components/ui/pipeline/ImportsPage.java
+++ b/src/org/labkey/test/components/ui/pipeline/ImportsPage.java
@@ -37,11 +37,6 @@ public class ImportsPage extends LabKeyPage<LabKeyPage<?>.ElementCache>
                 2_500);
     }
 
-    public static ImportsPage beginAt(WebDriverWrapper webDriverWrapper)
-    {
-        return beginAt(webDriverWrapper, webDriverWrapper.getCurrentContainerPath());
-    }
-
     public static ImportsPage beginAt(WebDriverWrapper webDriverWrapper, String containerPath)
     {
         if (StringUtils.isBlank(containerPath) || "home".equalsIgnoreCase(containerPath))

--- a/src/org/labkey/test/components/ui/pipeline/ImportsPage.java
+++ b/src/org/labkey/test/components/ui/pipeline/ImportsPage.java
@@ -1,0 +1,96 @@
+package org.labkey.test.components.ui.pipeline;
+
+import org.apache.tika.utils.StringUtils;
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.components.ui.grids.QueryGrid;
+import org.labkey.test.pages.LabKeyPage;
+import org.labkey.test.util.URLBuilder;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebElement;
+
+public class ImportsPage extends LabKeyPage<LabKeyPage<?>.ElementCache>
+{
+
+    public ImportsPage(WebDriverWrapper driver)
+    {
+        super(driver);
+    }
+
+
+    @Override
+    protected void waitForPage()
+    {
+        waitFor(()-> {
+                    try
+                    {
+                        return elementCache().pageHeader().isDisplayed() &&
+                                elementCache().pipelineJobsGrid().isLoaded();
+                    }
+                    catch(NoSuchElementException | StaleElementReferenceException nse)
+                    {
+                        return false;
+                    }
+                },
+                "The 'Background Imports' page did not load in time.",
+                2_500);
+    }
+
+    public static ImportsPage beginAt(WebDriverWrapper webDriverWrapper)
+    {
+        return beginAt(webDriverWrapper, webDriverWrapper.getCurrentContainerPath());
+    }
+
+    public static ImportsPage beginAt(WebDriverWrapper webDriverWrapper, String containerPath)
+    {
+        if (StringUtils.isBlank(containerPath) || "home".equalsIgnoreCase(containerPath))
+        {
+            throw new IllegalArgumentException("Invalid app containerPath: " + containerPath);
+        }
+        webDriverWrapper.beginAt(new URLBuilder("sampleManager", "app", containerPath)
+                .setAppResourcePath("pipeline")
+                .buildURL());
+        return new ImportsPage(webDriverWrapper);
+    }
+
+    public String getPageHeader()
+    {
+        return elementCache().pageHeader().getText();
+    }
+
+    public QueryGrid getImportsGrid()
+    {
+        return elementCache().pipelineJobsGrid();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
+    {
+
+        final WebElement pageHeader()
+        {
+            return Locator.tagWithClass("div", "page-header")
+                    .child(Locator.tagWithClass("h2", "no-margin-top"))
+                    .findWhenNeeded(this);
+        }
+
+        final QueryGrid pipelineJobsGrid()
+        {
+            return new QueryGrid.QueryGridFinder(getDriver()).find(this);
+        }
+
+    }
+
+}

--- a/src/org/labkey/test/components/ui/pipeline/StatusPage.java
+++ b/src/org/labkey/test/components/ui/pipeline/StatusPage.java
@@ -1,0 +1,177 @@
+package org.labkey.test.components.ui.pipeline;
+
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.pages.LabKeyPage;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebElement;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class StatusPage extends LabKeyPage<LabKeyPage<?>.ElementCache>
+{
+
+    public StatusPage(WebDriverWrapper driver)
+    {
+        super(driver);
+    }
+
+    @Override
+    protected void waitForPage()
+    {
+        waitFor(()-> {
+                    try
+                    {
+                        return elementCache().pageHeader().isDisplayed() &&
+                                elementCache().statusDetailPanel().isDisplayed() &&
+                                elementCache().statusLogPanel().isDisplayed();
+                    }
+                    catch(NoSuchElementException | StaleElementReferenceException nse)
+                    {
+                        return false;
+                    }
+                },
+                "The 'Pipeline Status' page did not load in time.",
+                2_500);
+    }
+
+    public String getPageHeader()
+    {
+        return elementCache().pageHeader().getText();
+    }
+
+    private Map<String, String> internal_getDetailInfo()
+    {
+        // It may take a moment for the details to show up.
+        waitFor(()->elementCache().statusDetailPanel().isDisplayed(), "No details are visible.", 500);
+
+        List<WebElement> tableRows = Locator.tagWithClass("tr", "pipeline-job-status-detail-row")
+                .findElements(elementCache().statusDetailPanel());
+
+        Map<String, String> details = new HashMap<>();
+
+        for(WebElement tr : tableRows)
+        {
+            List<WebElement> tds = Locator.tag("td").findElements(tr);
+            String detailId = tds.get(0).getText().trim().replace(":", "");
+            details.put(detailId, tds.get(1).getText());
+        }
+
+        return details;
+    }
+
+    public Map<String, String> getDetailInfo()
+    {
+        // Trying to protect against elements going away because the page refreshed.
+        // If the caller was unlucky and hit this during a refresh, catching the exception and trying again should
+        // recover from that.
+        try
+        {
+            return internal_getDetailInfo();
+        }
+        catch (NoSuchElementException | StaleElementReferenceException exception)
+        {
+            log("Ouch! Hit a page refresh while getting log detail info.");
+            return internal_getDetailInfo();
+        }
+    }
+
+    private String internal_getLog()
+    {
+        // Wait a moment to make sure the log is loaded.
+        waitFor(()->elementCache().statusLogPanel().isDisplayed(), "No log is visible.", 500);
+
+        return Locator.tag("table")
+                .findElement(elementCache().statusLogPanel()).getText();
+    }
+
+    public String getLog()
+    {
+        // Trying to protect against elements going away because the page refreshed.
+        // If the caller was unlucky and hit this during a refresh, catching the exception and trying again should
+        // recover from that.
+        try
+        {
+            return internal_getLog();
+        }
+        catch (NoSuchElementException | StaleElementReferenceException exception)
+        {
+            log("Ouch! Hit a page refresh while getting log info.");
+            return internal_getLog();
+        }
+    }
+
+    public ImportsPage goToImportsPage()
+    {
+        elementCache().importsPageLink().click();
+        return new ImportsPage(this);
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
+    {
+
+        final WebElement pageHeader()
+        {
+            return Locator.tagWithClass("div", "page-header")
+                    .child(Locator.tagWithClass("h2", "no-margin-top"))
+                    .findWhenNeeded(this);
+        }
+
+        final WebElement statusDetailPanel()
+        {
+            return Locator.tagWithClass("div", "pipeline-job-status-detail")
+                    .child(Locator.tagWithClass("div", "panel-body"))
+                    .refindWhenNeeded(this);
+        }
+
+        final WebElement statusLogPanel()
+        {
+            return Locator.tagWithClass("div", "pipeline-job-status-log")
+                    .child(Locator.tagWithClass("div", "panel-body"))
+                    .refindWhenNeeded(this);
+        }
+
+        final WebElement importsPageLink()
+        {
+            return Locator.tagWithClass("div", "parent-nav")
+                    .child(Locator.linkWithHref("#/pipeline"))
+                    .findWhenNeeded(this);
+        }
+
+    }
+
+    public enum StatusInfo
+    {
+        CREATED("Created"),
+        STATUS("Status"),
+        INFO("Info");
+
+        private String value;
+
+        StatusInfo(String value)
+        {
+            this.value = value;
+        }
+
+        public String getValue()
+        {
+            return value;
+        }
+
+    }
+
+}


### PR DESCRIPTION
#### Rationale
In the related PRs, updates were made to our viewing and linkage of the server notification menu and page. We added some basic test coverage there as well that visits the imports page and status page to assure we stay in the application instead of linking to LKS.  Thus the pages are needed by both the LKB and LKSM tests.

#### Related Pull Requests
- https://github.com/LabKey/biologics/pull/1860
- https://github.com/LabKey/inventory/pull/689
- https://github.com/LabKey/labkey-ui-components/pull/1082
- https://github.com/LabKey/sampleManagement/pull/1543

#### Changes
* Move ImportsPage from sampleManagement to here
* Move StatusPage from sampleManagement to here
* Add `clickViewAll` to `ServerNotificationMenu`
