### PR TITLE
Add support to sample finder for assay result filtering

### DIFF
--- a/src/org/labkey/test/components/ui/grids/GridFilterModal.java
+++ b/src/org/labkey/test/components/ui/grids/GridFilterModal.java
@@ -3,6 +3,7 @@ package org.labkey.test.components.ui.grids;
 import org.labkey.test.Locator;
 import org.labkey.test.components.UpdatingComponent;
 import org.labkey.test.components.bootstrap.ModalDialog;
+import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.react.Tabs;
 import org.labkey.test.components.ui.search.FilterExpressionPanel;
 import org.labkey.test.components.ui.search.FilterFacetedPanel;
@@ -44,6 +45,19 @@ public class GridFilterModal extends ModalDialog
         Locator.byClass("field-modal__col-sub-title").withText("Find values for " + fieldLabel)
                 .waitForElement(elementCache().filterPanel, 10_000);
 
+        return this;
+    }
+
+    /**
+     * Sets the 'Find Samples without [selected assay] results
+     * @param checked whether or not to check the box
+     * @return this component
+     */
+    public GridFilterModal checkNoDataCheckbox(boolean checked)
+    {
+        Checkbox noDataBox = Checkbox.Checkbox(Locator.input("field-value-nodata-check"))
+                .waitFor(elementCache().fieldsSelectionPanel);
+        noDataBox.set(checked);
         return this;
     }
 


### PR DESCRIPTION
#### Rationale
This adds support for interacting with the 'no data' checkbox on the sample finder's field filter panel.  A new test covering this behavior is in the related PR

#### Related Pull Requests
https://github.com/LabKey/sampleManagement/pull/1553

#### Changes
gives the test/user the ability to check the box to be shown samples with no data for the given/selected assay
