### PR TITLE
Adjust for copy constructor removal

### DIFF
--- a/src/org/labkey/remoteapi/admin/GetModulesCommand.java
+++ b/src/org/labkey/remoteapi/admin/GetModulesCommand.java
@@ -28,6 +28,6 @@ public class GetModulesCommand extends GetCommand<GetModulesResponse>
     @Override
     protected GetModulesResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
-        return new GetModulesResponse(text, status, contentType, json, this);
+        return new GetModulesResponse(text, status, contentType, json);
     }
 }

--- a/src/org/labkey/remoteapi/admin/GetModulesCommand.java
+++ b/src/org/labkey/remoteapi/admin/GetModulesCommand.java
@@ -16,9 +16,9 @@
 package org.labkey.remoteapi.admin;
 
 import org.json.JSONObject;
-import org.labkey.remoteapi.Command;
+import org.labkey.remoteapi.GetCommand;
 
-public class GetModulesCommand extends Command<GetModulesResponse>
+public class GetModulesCommand extends GetCommand<GetModulesResponse>
 {
     public GetModulesCommand()
     {

--- a/src/org/labkey/remoteapi/admin/GetModulesResponse.java
+++ b/src/org/labkey/remoteapi/admin/GetModulesResponse.java
@@ -16,8 +16,8 @@
 package org.labkey.remoteapi.admin;
 
 import org.json.JSONObject;
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.HasRequiredVersion;
 import org.labkey.remoteapi.ResponseObject;
 
 import java.util.List;
@@ -31,9 +31,9 @@ public class GetModulesResponse extends CommandResponse
 
     private Set<Module> _modules;
 
-    public GetModulesResponse(String text, int statusCode, String contentType, JSONObject json, Command sourceCommand)
+    public GetModulesResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
     {
-        super(text, statusCode, contentType, json, sourceCommand);
+        super(text, statusCode, contentType, json, hasRequiredVersion);
         _folderType = getProperty("folderType");
     }
 

--- a/src/org/labkey/remoteapi/admin/GetModulesResponse.java
+++ b/src/org/labkey/remoteapi/admin/GetModulesResponse.java
@@ -17,7 +17,6 @@ package org.labkey.remoteapi.admin;
 
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
-import org.labkey.remoteapi.HasRequiredVersion;
 import org.labkey.remoteapi.ResponseObject;
 
 import java.util.List;
@@ -31,9 +30,9 @@ public class GetModulesResponse extends CommandResponse
 
     private Set<Module> _modules;
 
-    public GetModulesResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
+    public GetModulesResponse(String text, int statusCode, String contentType, JSONObject json)
     {
-        super(text, statusCode, contentType, json, hasRequiredVersion);
+        super(text, statusCode, contentType, json);
         _folderType = getProperty("folderType");
     }
 

--- a/src/org/labkey/remoteapi/announcements/AbstractMessageThreadCommand.java
+++ b/src/org/labkey/remoteapi/announcements/AbstractMessageThreadCommand.java
@@ -14,6 +14,6 @@ public abstract class AbstractMessageThreadCommand extends PostCommand<MessageTh
     @Override
     protected MessageThreadResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
-        return new MessageThreadResponse(text, status, contentType, json, this);
+        return new MessageThreadResponse(text, status, contentType, json);
     }
 }

--- a/src/org/labkey/remoteapi/announcements/DeleteMessageThreadCommand.java
+++ b/src/org/labkey/remoteapi/announcements/DeleteMessageThreadCommand.java
@@ -33,7 +33,7 @@ public class DeleteMessageThreadCommand extends PostCommand<DeleteMessageThreadR
     @Override
     protected DeleteMessageThreadResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
-        return new DeleteMessageThreadResponse(text, status, contentType, json, this);
+        return new DeleteMessageThreadResponse(text, status, contentType, json);
     }
 
     public void setEntityId(String entityId)

--- a/src/org/labkey/remoteapi/announcements/DeleteMessageThreadResponse.java
+++ b/src/org/labkey/remoteapi/announcements/DeleteMessageThreadResponse.java
@@ -2,12 +2,13 @@ package org.labkey.remoteapi.announcements;
 
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.HasRequiredVersion;
 
 public class DeleteMessageThreadResponse extends CommandResponse
 {
     public DeleteMessageThreadResponse(String text, int statusCode, String contentType, JSONObject json,
-                                       DeleteMessageThreadCommand sourceCommand)
+                                       HasRequiredVersion hasRequiredVersion)
     {
-        super(text, statusCode, contentType, json, sourceCommand);
+        super(text, statusCode, contentType, json, hasRequiredVersion);
     }
 }

--- a/src/org/labkey/remoteapi/announcements/DeleteMessageThreadResponse.java
+++ b/src/org/labkey/remoteapi/announcements/DeleteMessageThreadResponse.java
@@ -2,13 +2,11 @@ package org.labkey.remoteapi.announcements;
 
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
-import org.labkey.remoteapi.HasRequiredVersion;
 
 public class DeleteMessageThreadResponse extends CommandResponse
 {
-    public DeleteMessageThreadResponse(String text, int statusCode, String contentType, JSONObject json,
-                                       HasRequiredVersion hasRequiredVersion)
+    public DeleteMessageThreadResponse(String text, int statusCode, String contentType, JSONObject json)
     {
-        super(text, statusCode, contentType, json, hasRequiredVersion);
+        super(text, statusCode, contentType, json);
     }
 }

--- a/src/org/labkey/remoteapi/announcements/GetDiscussionsCommand.java
+++ b/src/org/labkey/remoteapi/announcements/GetDiscussionsCommand.java
@@ -17,7 +17,7 @@ public class GetDiscussionsCommand extends PostCommand<GetDiscussionsResponse>
     @Override
     protected GetDiscussionsResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
-        return new GetDiscussionsResponse(text, status, contentType, json, this);
+        return new GetDiscussionsResponse(text, status, contentType, json);
     }
 
     @Override

--- a/src/org/labkey/remoteapi/announcements/GetDiscussionsResponse.java
+++ b/src/org/labkey/remoteapi/announcements/GetDiscussionsResponse.java
@@ -3,7 +3,6 @@ package org.labkey.remoteapi.announcements;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
-import org.labkey.remoteapi.HasRequiredVersion;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,10 +11,9 @@ public class GetDiscussionsResponse extends CommandResponse
 {
     private final List<AnnouncementModel> _threads;
 
-    public GetDiscussionsResponse(String text, int statusCode, String contentType, JSONObject json,
-                                  HasRequiredVersion hasRequiredVersion)
+    public GetDiscussionsResponse(String text, int statusCode, String contentType, JSONObject json)
     {
-        super(text, statusCode, contentType, json, hasRequiredVersion);
+        super(text, statusCode, contentType, json);
 
         // populate _threads from payload
         _threads = new ArrayList<>();

--- a/src/org/labkey/remoteapi/announcements/GetDiscussionsResponse.java
+++ b/src/org/labkey/remoteapi/announcements/GetDiscussionsResponse.java
@@ -3,6 +3,7 @@ package org.labkey.remoteapi.announcements;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.HasRequiredVersion;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,9 +13,9 @@ public class GetDiscussionsResponse extends CommandResponse
     private final List<AnnouncementModel> _threads;
 
     public GetDiscussionsResponse(String text, int statusCode, String contentType, JSONObject json,
-                                  GetDiscussionsCommand sourceCommand)
+                                  HasRequiredVersion hasRequiredVersion)
     {
-        super(text, statusCode, contentType, json, sourceCommand);
+        super(text, statusCode, contentType, json, hasRequiredVersion);
 
         // populate _threads from payload
         _threads = new ArrayList<>();

--- a/src/org/labkey/remoteapi/announcements/MessageThreadResponse.java
+++ b/src/org/labkey/remoteapi/announcements/MessageThreadResponse.java
@@ -2,15 +2,14 @@ package org.labkey.remoteapi.announcements;
 
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
-import org.labkey.remoteapi.HasRequiredVersion;
 
 public class MessageThreadResponse extends CommandResponse
 {
     private final AnnouncementModel _announcementModel;
 
-    public MessageThreadResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
+    public MessageThreadResponse(String text, int statusCode, String contentType, JSONObject json)
     {
-        super(text, statusCode, contentType, json, hasRequiredVersion);
+        super(text, statusCode, contentType, json);
         _announcementModel = new AnnouncementModel((JSONObject) json.get("data"));
     }
 

--- a/src/org/labkey/remoteapi/announcements/MessageThreadResponse.java
+++ b/src/org/labkey/remoteapi/announcements/MessageThreadResponse.java
@@ -1,16 +1,16 @@
 package org.labkey.remoteapi.announcements;
 
 import org.json.JSONObject;
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.HasRequiredVersion;
 
 public class MessageThreadResponse extends CommandResponse
 {
     private final AnnouncementModel _announcementModel;
 
-    public MessageThreadResponse(String text, int statusCode, String contentType, JSONObject json, Command sourceCommand)
+    public MessageThreadResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
     {
-        super(text, statusCode, contentType, json, sourceCommand);
+        super(text, statusCode, contentType, json, hasRequiredVersion);
         _announcementModel = new AnnouncementModel((JSONObject) json.get("data"));
     }
 

--- a/src/org/labkey/remoteapi/assay/AddXarFileCommand.java
+++ b/src/org/labkey/remoteapi/assay/AddXarFileCommand.java
@@ -1,7 +1,6 @@
 package org.labkey.remoteapi.assay;
 
 import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.core5.http.ContentType;
 import org.labkey.remoteapi.PostCommand;
@@ -20,7 +19,7 @@ public class AddXarFileCommand extends PostCommand
     }
 
     @Override
-    protected HttpUriRequest createRequest(URI uri)
+    protected HttpPost createRequest(URI uri)
     {
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();
 

--- a/src/org/labkey/remoteapi/domain/InferDomainCommand.java
+++ b/src/org/labkey/remoteapi/domain/InferDomainCommand.java
@@ -32,7 +32,7 @@ public class InferDomainCommand extends PostCommand<InferDomainResponse>
     @Override
     protected InferDomainResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
-        return new InferDomainResponse(text, status, contentType, json, this);
+        return new InferDomainResponse(text, status, contentType, json);
     }
 
     @Override

--- a/src/org/labkey/remoteapi/domain/InferDomainCommand.java
+++ b/src/org/labkey/remoteapi/domain/InferDomainCommand.java
@@ -1,16 +1,15 @@
 package org.labkey.remoteapi.domain;
 
 import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.core5.http.ContentType;
 import org.json.JSONObject;
-import org.labkey.remoteapi.Command;
+import org.labkey.remoteapi.PostCommand;
 
 import java.io.File;
 import java.net.URI;
 
-public class InferDomainCommand extends Command<InferDomainResponse>
+public class InferDomainCommand extends PostCommand<InferDomainResponse>
 {
     private final File _file;
     private final String _domainKindName;
@@ -37,7 +36,7 @@ public class InferDomainCommand extends Command<InferDomainResponse>
     }
 
     @Override
-    protected HttpUriRequest createRequest(URI uri)
+    protected HttpPost createRequest(URI uri)
     {
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();
 

--- a/src/org/labkey/remoteapi/domain/InferDomainResponse.java
+++ b/src/org/labkey/remoteapi/domain/InferDomainResponse.java
@@ -2,6 +2,7 @@ package org.labkey.remoteapi.domain;
 
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.HasRequiredVersion;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -12,9 +13,9 @@ public class InferDomainResponse extends CommandResponse
 {
     List<PropertyDescriptor> _fields;
 
-    public InferDomainResponse(String text, int statusCode, String contentType, JSONObject json, InferDomainCommand sourceCommand)
+    public InferDomainResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
     {
-        super(text, statusCode, contentType, json, sourceCommand);
+        super(text, statusCode, contentType, json, hasRequiredVersion);
     }
 
     public List<PropertyDescriptor> getFields()

--- a/src/org/labkey/remoteapi/domain/InferDomainResponse.java
+++ b/src/org/labkey/remoteapi/domain/InferDomainResponse.java
@@ -2,7 +2,6 @@ package org.labkey.remoteapi.domain;
 
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
-import org.labkey.remoteapi.HasRequiredVersion;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,9 +12,9 @@ public class InferDomainResponse extends CommandResponse
 {
     List<PropertyDescriptor> _fields;
 
-    public InferDomainResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
+    public InferDomainResponse(String text, int statusCode, String contentType, JSONObject json)
     {
-        super(text, statusCode, contentType, json, hasRequiredVersion);
+        super(text, statusCode, contentType, json);
     }
 
     public List<PropertyDescriptor> getFields()

--- a/src/org/labkey/remoteapi/issues/GetIssueCommand.java
+++ b/src/org/labkey/remoteapi/issues/GetIssueCommand.java
@@ -16,7 +16,7 @@ public class GetIssueCommand extends PostCommand<GetIssueResponse>
     @Override
     protected GetIssueResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
-        return new GetIssueResponse(text, status, contentType, json, this);
+        return new GetIssueResponse(text, status, contentType, json);
     }
 
     @Override

--- a/src/org/labkey/remoteapi/issues/GetIssueResponse.java
+++ b/src/org/labkey/remoteapi/issues/GetIssueResponse.java
@@ -2,14 +2,15 @@ package org.labkey.remoteapi.issues;
 
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.HasRequiredVersion;
 
 public class GetIssueResponse extends CommandResponse
 {
     private final IssueResponseModel _issueModel;
 
-    public GetIssueResponse(String text, int statusCode, String contentType, JSONObject json, GetIssueCommand sourceCommand)
+    public GetIssueResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
     {
-        super(text, statusCode, contentType, json, sourceCommand);
+        super(text, statusCode, contentType, json, hasRequiredVersion);
 
         // parse json into issueModel here
         _issueModel = new IssueResponseModel(json);

--- a/src/org/labkey/remoteapi/issues/GetIssueResponse.java
+++ b/src/org/labkey/remoteapi/issues/GetIssueResponse.java
@@ -2,15 +2,14 @@ package org.labkey.remoteapi.issues;
 
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
-import org.labkey.remoteapi.HasRequiredVersion;
 
 public class GetIssueResponse extends CommandResponse
 {
     private final IssueResponseModel _issueModel;
 
-    public GetIssueResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
+    public GetIssueResponse(String text, int statusCode, String contentType, JSONObject json)
     {
-        super(text, statusCode, contentType, json, hasRequiredVersion);
+        super(text, statusCode, contentType, json);
 
         // parse json into issueModel here
         _issueModel = new IssueResponseModel(json);

--- a/src/org/labkey/remoteapi/issues/IssueResponse.java
+++ b/src/org/labkey/remoteapi/issues/IssueResponse.java
@@ -3,7 +3,6 @@ package org.labkey.remoteapi.issues;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
-import org.labkey.remoteapi.HasRequiredVersion;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,11 +18,10 @@ public class IssueResponse extends CommandResponse
      * @param statusCode         The HTTP status code
      * @param contentType        The response content type
      * @param json               The parsed JSONObject (or null if JSON was not returned)
-     * @param hasRequiredVersion An object that implements HasRequiredVersion
      */
-    public IssueResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
+    public IssueResponse(String text, int statusCode, String contentType, JSONObject json)
     {
-        super(text, statusCode, contentType, json, hasRequiredVersion);
+        super(text, statusCode, contentType, json);
 
         JSONArray issuesArray = (JSONArray)json.get("issues");
         for (int i=0; i< issuesArray.length(); i++)

--- a/src/org/labkey/remoteapi/issues/IssueResponse.java
+++ b/src/org/labkey/remoteapi/issues/IssueResponse.java
@@ -3,6 +3,7 @@ package org.labkey.remoteapi.issues;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.HasRequiredVersion;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,18 +13,17 @@ public class IssueResponse extends CommandResponse
     private final List<Long> _issueIds = new ArrayList<>();
 
     /**
-     * Constructs a new CommandResponse, initialized with the provided
-     * response text and status code.
+     * Constructs a new CommandResponse, initialized with the provided response text and status code.
      *
-     * @param text          The response text
-     * @param statusCode    The HTTP status code
-     * @param contentType   The response content type
-     * @param json          The parsed JSONObject (or null if JSON was not returned).
-     * @param sourceCommand A copy of the command that created this response
+     * @param text               The response text
+     * @param statusCode         The HTTP status code
+     * @param contentType        The response content type
+     * @param json               The parsed JSONObject (or null if JSON was not returned)
+     * @param hasRequiredVersion An object that implements HasRequiredVersion
      */
-    public IssueResponse(String text, int statusCode, String contentType, JSONObject json, IssuesCommand sourceCommand)
+    public IssueResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
     {
-        super(text, statusCode, contentType, json, sourceCommand);
+        super(text, statusCode, contentType, json, hasRequiredVersion);
 
         JSONArray issuesArray = (JSONArray)json.get("issues");
         for (int i=0; i< issuesArray.length(); i++)

--- a/src/org/labkey/remoteapi/issues/IssuesCommand.java
+++ b/src/org/labkey/remoteapi/issues/IssuesCommand.java
@@ -30,7 +30,7 @@ public class IssuesCommand extends PostCommand<IssueResponse>
     @Override
     protected IssueResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
-        return new IssueResponse(text, status, contentType, json, this);
+        return new IssueResponse(text, status, contentType, json);
     }
 
     public void setIssues(List<IssueModel> issues)

--- a/src/org/labkey/remoteapi/issues/IssuesCommand.java
+++ b/src/org/labkey/remoteapi/issues/IssuesCommand.java
@@ -1,7 +1,6 @@
 package org.labkey.remoteapi.issues;
 
 import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
 import org.apache.hc.client5.http.entity.mime.HttpMultipartMode;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.core5.http.ContentType;
@@ -46,7 +45,7 @@ public class IssuesCommand extends PostCommand<IssueResponse>
     }
 
     @Override
-    protected HttpUriRequest createRequest(URI uri)
+    protected HttpPost createRequest(URI uri)
     {
         HttpPost request = new HttpPost(uri);
 

--- a/src/org/labkey/remoteapi/olap/MdxCommand.java
+++ b/src/org/labkey/remoteapi/olap/MdxCommand.java
@@ -20,7 +20,6 @@ import org.json.JSONTokener;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.PostCommand;
-import org.labkey.serverapi.reader.Readers;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -88,7 +87,7 @@ public class MdxCommand extends PostCommand<MdxResponse>
     @Override
     protected MdxResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
-        return new MdxResponse(text, status, contentType, json, this);
+        return new MdxResponse(text, status, contentType, json);
     }
 
     @Override

--- a/src/org/labkey/remoteapi/olap/MdxCommand.java
+++ b/src/org/labkey/remoteapi/olap/MdxCommand.java
@@ -37,15 +37,6 @@ public class MdxCommand extends PostCommand<MdxResponse>
     private String _cubeName;
     private String _query;
 
-    public MdxCommand(MdxCommand source)
-    {
-        super(source);
-        _configId = source.getConfigId();
-        _schemaName = source.getSchemaName();
-        _cubeName = source.getCubeName();
-        _query = source.getQuery();
-    }
-
     public MdxCommand(String configId, String schema, String query)
     {
         super("olap", "executeMdx");

--- a/src/org/labkey/remoteapi/olap/MdxCommand.java
+++ b/src/org/labkey/remoteapi/olap/MdxCommand.java
@@ -94,17 +94,12 @@ public class MdxCommand extends PostCommand<MdxResponse>
     @Override
     public JSONObject getJsonObject()
     {
-        JSONObject result = super.getJsonObject();
-        if (result == null)
-        {
-            result = new JSONObject();
-        }
+        JSONObject result = new JSONObject();
         result.put("configId", _configId);
         result.put("schemaName", _schemaName);
         if (_cubeName != null)
             result.put("cubeName", _cubeName);
         result.put("query", _query);
-        setJsonObject(result);
         return result;
     }
 

--- a/src/org/labkey/remoteapi/olap/MdxResponse.java
+++ b/src/org/labkey/remoteapi/olap/MdxResponse.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
-import org.labkey.remoteapi.HasRequiredVersion;
 
 import java.util.List;
 import java.util.Map;
@@ -38,11 +37,10 @@ public class MdxResponse extends CommandResponse
      * @param statusCode         The HTTP status code
      * @param contentType        The response content type
      * @param json               The parsed JSONObject (or null if JSON was not returned)
-     * @param hasRequiredVersion An object that implements HasRequiredVersion
      */
-    public MdxResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
+    public MdxResponse(String text, int statusCode, String contentType, JSONObject json)
     {
-        super(text, statusCode, contentType, json, hasRequiredVersion);
+        super(text, statusCode, contentType, json);
     }
 
     public List<Map<String,Object>> getAxes()

--- a/src/org/labkey/remoteapi/olap/MdxResponse.java
+++ b/src/org/labkey/remoteapi/olap/MdxResponse.java
@@ -18,8 +18,8 @@ package org.labkey.remoteapi.olap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.HasRequiredVersion;
 
 import java.util.List;
 import java.util.Map;
@@ -34,15 +34,15 @@ public class MdxResponse extends CommandResponse
      * Constructs a new MdxResponse, initialized with the provided
      * response text and status code.
      *
-     * @param text          The response text
-     * @param statusCode    The HTTP status code
-     * @param contentType   The response content type
-     * @param json          The parsed JSONObject (or null if JSON was not returned).
-     * @param sourceCommand A copy of the command that created this response
+     * @param text               The response text
+     * @param statusCode         The HTTP status code
+     * @param contentType        The response content type
+     * @param json               The parsed JSONObject (or null if JSON was not returned)
+     * @param hasRequiredVersion An object that implements HasRequiredVersion
      */
-    public MdxResponse(String text, int statusCode, String contentType, JSONObject json, Command sourceCommand)
+    public MdxResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
     {
-        super(text, statusCode, contentType, json, sourceCommand);
+        super(text, statusCode, contentType, json, hasRequiredVersion);
     }
 
     public List<Map<String,Object>> getAxes()

--- a/src/org/labkey/remoteapi/query/InsertExternalSchemaCommand.java
+++ b/src/org/labkey/remoteapi/query/InsertExternalSchemaCommand.java
@@ -1,7 +1,6 @@
 package org.labkey.remoteapi.query;
 
 import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
@@ -30,9 +29,9 @@ public class InsertExternalSchemaCommand extends PostCommand<CommandResponse>
     }
 
     @Override
-    protected HttpUriRequest createRequest(URI uri)
+    protected HttpPost createRequest(URI uri)
     {
-        HttpPost request = (HttpPost) super.createRequest(uri);
+        HttpPost request = super.createRequest(uri);
 
         try
         {

--- a/src/org/labkey/remoteapi/reports/GetCategoriesCommand.java
+++ b/src/org/labkey/remoteapi/reports/GetCategoriesCommand.java
@@ -16,9 +16,9 @@
 package org.labkey.remoteapi.reports;
 
 import org.json.JSONObject;
-import org.labkey.remoteapi.Command;
+import org.labkey.remoteapi.GetCommand;
 
-public class GetCategoriesCommand extends Command<GetCategoriesResponse>
+public class GetCategoriesCommand extends GetCommand<GetCategoriesResponse>
 {
     public GetCategoriesCommand()
     {

--- a/src/org/labkey/remoteapi/reports/GetCategoriesCommand.java
+++ b/src/org/labkey/remoteapi/reports/GetCategoriesCommand.java
@@ -28,6 +28,6 @@ public class GetCategoriesCommand extends GetCommand<GetCategoriesResponse>
     @Override
     protected GetCategoriesResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
-        return new GetCategoriesResponse(text, status, contentType, json, this);
+        return new GetCategoriesResponse(text, status, contentType, json);
     }
 }

--- a/src/org/labkey/remoteapi/reports/GetCategoriesResponse.java
+++ b/src/org/labkey/remoteapi/reports/GetCategoriesResponse.java
@@ -17,7 +17,6 @@ package org.labkey.remoteapi.reports;
 
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
-import org.labkey.remoteapi.HasRequiredVersion;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,9 +26,9 @@ public class GetCategoriesResponse extends CommandResponse
 {
     private final List<Category> _categoryList;
 
-    public GetCategoriesResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
+    public GetCategoriesResponse(String text, int statusCode, String contentType, JSONObject json)
     {
-        super(text, statusCode, contentType, json, hasRequiredVersion);
+        super(text, statusCode, contentType, json);
         _categoryList = new ArrayList<>();
         for ( Map<String, Object> categoryMap : (List<Map<String, Object>>)getProperty("categories"))
         {

--- a/src/org/labkey/remoteapi/reports/GetCategoriesResponse.java
+++ b/src/org/labkey/remoteapi/reports/GetCategoriesResponse.java
@@ -17,6 +17,7 @@ package org.labkey.remoteapi.reports;
 
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.HasRequiredVersion;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,11 +25,11 @@ import java.util.Map;
 
 public class GetCategoriesResponse extends CommandResponse
 {
-    private List<Category> _categoryList;
+    private final List<Category> _categoryList;
 
-    public GetCategoriesResponse(String text, int statusCode, String contentType, JSONObject json, GetCategoriesCommand sourceCommand)
+    public GetCategoriesResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
     {
-        super(text, statusCode, contentType, json, sourceCommand);
+        super(text, statusCode, contentType, json, hasRequiredVersion);
         _categoryList = new ArrayList<>();
         for ( Map<String, Object> categoryMap : (List<Map<String, Object>>)getProperty("categories"))
         {

--- a/src/org/labkey/remoteapi/security/BulkUpdateGroupCommand.java
+++ b/src/org/labkey/remoteapi/security/BulkUpdateGroupCommand.java
@@ -117,7 +117,7 @@ public class BulkUpdateGroupCommand extends PostCommand<BulkUpdateGroupResponse>
     @Override
     protected BulkUpdateGroupResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
-        return new BulkUpdateGroupResponse(text, status, contentType, json, this);
+        return new BulkUpdateGroupResponse(text, status, contentType, json);
     }
 
     @Override

--- a/src/org/labkey/remoteapi/security/BulkUpdateGroupCommand.java
+++ b/src/org/labkey/remoteapi/security/BulkUpdateGroupCommand.java
@@ -123,11 +123,7 @@ public class BulkUpdateGroupCommand extends PostCommand<BulkUpdateGroupResponse>
     @Override
     public JSONObject getJsonObject()
     {
-        JSONObject result = super.getJsonObject();
-        if (result == null)
-        {
-            result = new JSONObject();
-        }
+        JSONObject result = new JSONObject();
         if (_groupId != null) result.put("groupId", _groupId);
         if (_groupName != null) result.put("groupName", _groupName);
         result.put("createGroup", _createGroup);

--- a/src/org/labkey/remoteapi/security/BulkUpdateGroupResponse.java
+++ b/src/org/labkey/remoteapi/security/BulkUpdateGroupResponse.java
@@ -16,17 +16,17 @@
 package org.labkey.remoteapi.security;
 
 import org.json.JSONObject;
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.HasRequiredVersion;
 
 import java.util.List;
 import java.util.Map;
 
 public class BulkUpdateGroupResponse extends CommandResponse
 {
-    public BulkUpdateGroupResponse(String text, int statusCode, String contentType, JSONObject json, Command sourceCommand)
+    public BulkUpdateGroupResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
     {
-        super(text, statusCode, contentType, json, sourceCommand);
+        super(text, statusCode, contentType, json, hasRequiredVersion);
     }
 
     public Number getId()

--- a/src/org/labkey/remoteapi/security/BulkUpdateGroupResponse.java
+++ b/src/org/labkey/remoteapi/security/BulkUpdateGroupResponse.java
@@ -17,16 +17,15 @@ package org.labkey.remoteapi.security;
 
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
-import org.labkey.remoteapi.HasRequiredVersion;
 
 import java.util.List;
 import java.util.Map;
 
 public class BulkUpdateGroupResponse extends CommandResponse
 {
-    public BulkUpdateGroupResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
+    public BulkUpdateGroupResponse(String text, int statusCode, String contentType, JSONObject json)
     {
-        super(text, statusCode, contentType, json, hasRequiredVersion);
+        super(text, statusCode, contentType, json);
     }
 
     public Number getId()

--- a/src/org/labkey/remoteapi/security/DeletePolicyCommand.java
+++ b/src/org/labkey/remoteapi/security/DeletePolicyCommand.java
@@ -37,9 +37,4 @@ public class DeletePolicyCommand extends PostCommand<CommandResponse>
         result.put("resourceId", resourceId);
         return result;
     }
-
-    public DeletePolicyCommand(PostCommand source)
-    {
-        super(source);
-    }
 }

--- a/src/org/labkey/remoteapi/security/GetRolesCommand.java
+++ b/src/org/labkey/remoteapi/security/GetRolesCommand.java
@@ -28,6 +28,6 @@ public class GetRolesCommand extends GetCommand<GetRolesResponse>
     @Override
     protected GetRolesResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
-        return new GetRolesResponse(text, status, contentType, json, this);
+        return new GetRolesResponse(text, status, contentType, json);
     }
 }

--- a/src/org/labkey/remoteapi/security/GetRolesCommand.java
+++ b/src/org/labkey/remoteapi/security/GetRolesCommand.java
@@ -16,9 +16,9 @@
 package org.labkey.remoteapi.security;
 
 import org.json.JSONObject;
-import org.labkey.remoteapi.Command;
+import org.labkey.remoteapi.GetCommand;
 
-public class GetRolesCommand extends Command<GetRolesResponse>
+public class GetRolesCommand extends GetCommand<GetRolesResponse>
 {
     public GetRolesCommand()
     {

--- a/src/org/labkey/remoteapi/security/GetRolesResponse.java
+++ b/src/org/labkey/remoteapi/security/GetRolesResponse.java
@@ -16,8 +16,8 @@
 package org.labkey.remoteapi.security;
 
 import org.json.JSONObject;
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.HasRequiredVersion;
 import org.labkey.remoteapi.ResponseObject;
 
 import java.util.ArrayList;
@@ -28,9 +28,9 @@ public class GetRolesResponse extends CommandResponse
 {
     private List<Role> _roles;
 
-    public GetRolesResponse(String text, int statusCode, String contentType, JSONObject json, Command sourceCommand)
+    public GetRolesResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
     {
-        super(text, statusCode, contentType, json, sourceCommand);
+        super(text, statusCode, contentType, json, hasRequiredVersion);
     }
 
     public List<Role> getRoles()

--- a/src/org/labkey/remoteapi/security/GetRolesResponse.java
+++ b/src/org/labkey/remoteapi/security/GetRolesResponse.java
@@ -17,7 +17,6 @@ package org.labkey.remoteapi.security;
 
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
-import org.labkey.remoteapi.HasRequiredVersion;
 import org.labkey.remoteapi.ResponseObject;
 
 import java.util.ArrayList;
@@ -28,9 +27,9 @@ public class GetRolesResponse extends CommandResponse
 {
     private List<Role> _roles;
 
-    public GetRolesResponse(String text, int statusCode, String contentType, JSONObject json, HasRequiredVersion hasRequiredVersion)
+    public GetRolesResponse(String text, int statusCode, String contentType, JSONObject json)
     {
-        super(text, statusCode, contentType, json, hasRequiredVersion);
+        super(text, statusCode, contentType, json);
     }
 
     public List<Role> getRoles()

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -43,7 +43,8 @@ import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimpleGetCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.labkey.remoteapi.query.ContainerFilter;
 import org.labkey.remoteapi.query.Filter;
@@ -637,7 +638,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             return; // app admin can't enable stack traces
         }
         Connection cn = createDefaultConnection();
-        PostCommand<?> command = new PostCommand<>("mini-profiler", "enableTroubleshootingStacktraces");
+        SimplePostCommand command = new SimplePostCommand("mini-profiler", "enableTroubleshootingStacktraces");
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("enabled", true);
         command.setJsonObject(jsonObject);
@@ -1140,7 +1141,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
     private int getPendingRequestCount(Connection connection)
     {
-        Command<?> getPendingRequestCount = new Command<>("admin", "getPendingRequestCount");
+        SimpleGetCommand getPendingRequestCount = new SimpleGetCommand("admin", "getPendingRequestCount");
         try
         {
             CommandResponse response = getPendingRequestCount.execute(connection, null);
@@ -1319,7 +1320,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
     /**
      * TODO: 7695: Custom views are not deleted when list is deleted
-     * @return List of view names which are no longer valid
+     * @return Set of view names which are no longer valid
      */
     protected Set<String> getOrphanedViews()
     {

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -1222,7 +1222,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
     public void setAuthenticationProvider(@LoggedParam String provider, @LoggedParam boolean enabled, Connection cn)
     {
         Command<?> command = new PostCommand<>("login", "setProviderEnabled");
-        command.setParameters(new HashMap<>(Maps.of("provider", provider, "enabled", enabled)));
+        command.setParameters(Maps.of("provider", provider, "enabled", enabled));
         try
         {
             command.execute(cn, null);

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -41,7 +41,8 @@ import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimpleGetCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.query.ContainerFilter;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.SelectRowsCommand;
@@ -1134,7 +1135,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
     public boolean isMiniProfilerEnabled()
     {
         Connection cn = createDefaultConnection();
-        Command<?> command = new Command<>("mini-profiler", "isEnabled");
+        SimpleGetCommand command = new SimpleGetCommand("mini-profiler", "isEnabled");
         try
         {
             CommandResponse r = command.execute(cn, null);
@@ -1161,7 +1162,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
     public void setMiniProfilerEnabled(boolean enabled)
     {
         Connection cn = createDefaultConnection();
-        PostCommand<?> setEnabled = new PostCommand<>("mini-profiler", "enable");
+        SimplePostCommand setEnabled = new SimplePostCommand("mini-profiler", "enable");
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("enabled", enabled);
         setEnabled.setJsonObject(jsonObject);
@@ -1221,7 +1222,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
     @LogMethod(quiet = true)
     public void setAuthenticationProvider(@LoggedParam String provider, @LoggedParam boolean enabled, Connection cn)
     {
-        Command<?> command = new PostCommand<>("login", "setProviderEnabled");
+        SimplePostCommand command = new SimplePostCommand("login", "setProviderEnabled");
         command.setParameters(Maps.of("provider", provider, "enabled", enabled));
         try
         {
@@ -1237,7 +1238,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
     @LogMethod(quiet = true)
     protected void invokeApiAction(@Nullable String folderPath, String controllerName, String actionName, String failureMessage)
     {
-        Command<CommandResponse> command = new PostCommand<>(controllerName, actionName);
+        SimplePostCommand command = new SimplePostCommand(controllerName, actionName);
         Connection connection = WebTestHelper.getRemoteApiConnection();
 
         try

--- a/src/org/labkey/test/TestScrubber.java
+++ b/src/org/labkey/test/TestScrubber.java
@@ -17,9 +17,8 @@ package org.labkey.test;
 
 import org.apache.hc.core5.http.HttpStatus;
 import org.labkey.remoteapi.CommandException;
-import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.pages.core.admin.ConfigureFileSystemAccessPage;
 import org.labkey.test.pages.core.admin.LimitActiveUserPage;
@@ -146,7 +145,7 @@ public class TestScrubber extends ExtraSiteWrapper
     @LogMethod(quiet = true)
     private void disableLoginAttemptLimit() throws IOException, CommandException
     {
-        PostCommand<CommandResponse> command = new PostCommand<>("compliance", "complianceSettings");
+        SimplePostCommand command = new SimplePostCommand("compliance", "complianceSettings");
         Map<String, Object> params = new HashMap<>();
         params.put("tab", "login");
         params.put("attemptEnabled", "false");
@@ -158,7 +157,7 @@ public class TestScrubber extends ExtraSiteWrapper
     @LogMethod(quiet = true)
     private void resetPremiumPageElements() throws IOException, CommandException
     {
-        PostCommand<CommandResponse> command = new PostCommand<>("premium", "adminConsoleConfigurePageElements");
+        SimplePostCommand command = new SimplePostCommand("premium", "adminConsoleConfigurePageElements");
         Map<String, Object> params = new HashMap<>();
         params.put("headerModule", "none");
         params.put("bannerModule", "none");
@@ -168,7 +167,7 @@ public class TestScrubber extends ExtraSiteWrapper
         executeIgnoring404(command);
     }
 
-    private void executeIgnoring404(PostCommand<CommandResponse> command) throws IOException, CommandException
+    private void executeIgnoring404(SimplePostCommand command) throws IOException, CommandException
     {
         Connection connection = getRemoteApiConnection();
         try
@@ -188,7 +187,7 @@ public class TestScrubber extends ExtraSiteWrapper
     {
         if (TestProperties.isTestRunningOnTeamCity())
         {
-            PostCommand<CommandResponse> command = new PostCommand<>("admin", "filesSiteSettings");
+            SimplePostCommand command = new SimplePostCommand("admin", "filesSiteSettings");
             // POST'ing without any parameters will enable upload without touching site level file root
             command.execute(createDefaultConnection(), "/");
         }

--- a/src/org/labkey/test/WebTestHelper.java
+++ b/src/org/labkey/test/WebTestHelper.java
@@ -524,13 +524,13 @@ public class WebTestHelper
         }
     }
 
-    public static void logToServer(String message)
+    public static void logToServer(@NotNull String message)
     {
         logToServer(message, getRemoteApiConnection());
     }
 
     // Writes message to the labkey server log. Message parameter is output as sent
-    public static void logToServer(String message, Connection connection)
+    public static void logToServer(@NotNull String message, Connection connection)
     {
         if (message.contains("\n"))
         {
@@ -544,9 +544,7 @@ public class WebTestHelper
         }
 
         PostCommand<?> command = new PostCommand<>("admin", "log");
-        Map<String, Object> params = new HashMap<>();
-        params.put("message", message);
-        command.setParameters(params);
+        command.setParameters(Map.of("message", message));
         try
         {
             command.execute(connection, "/");

--- a/src/org/labkey/test/WebTestHelper.java
+++ b/src/org/labkey/test/WebTestHelper.java
@@ -45,7 +45,7 @@ import org.json.JSONObject;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.serverapi.reader.Readers;
 import org.labkey.test.util.InstallCert;
 import org.labkey.test.util.LogMethod;
@@ -140,7 +140,7 @@ public class WebTestHelper
         if (!savedSessionKeys.containsKey(sessionId))
         {
             Connection connection = getRemoteApiConnection(user, true);
-            PostCommand<?> command = new PostCommand<>("security", "createApiKey");
+            SimplePostCommand command = new SimplePostCommand("security", "createApiKey");
             JSONObject json = new JSONObject();
             json.put("type", "session");
             command.setJsonObject(json);
@@ -543,7 +543,7 @@ public class WebTestHelper
             return;
         }
 
-        PostCommand<?> command = new PostCommand<>("admin", "log");
+        SimplePostCommand command = new SimplePostCommand("admin", "log");
         command.setParameters(Map.of("message", message));
         try
         {

--- a/src/org/labkey/test/pages/core/admin/LimitActiveUserPage.java
+++ b/src/org/labkey/test/pages/core/admin/LimitActiveUserPage.java
@@ -2,9 +2,8 @@ package org.labkey.test.pages.core.admin;
 
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandException;
-import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.WebDriverWrapper;
@@ -154,7 +153,7 @@ public class LimitActiveUserPage extends LabKeyPage<LimitActiveUserPage.ElementC
     {
         if (initialSettings != null)
         {
-            PostCommand<CommandResponse> command = new PostCommand<>("user", "limitActiveUsers");
+            SimplePostCommand command = new SimplePostCommand("user", "limitActiveUsers");
             command.setJsonObject(initialSettings.toJsonObject());
             command.execute(cn, "/");
             initialSettings = null;

--- a/src/org/labkey/test/pages/core/login/DatabaseAuthConfigureDialog.java
+++ b/src/org/labkey/test/pages/core/login/DatabaseAuthConfigureDialog.java
@@ -3,7 +3,7 @@ package org.labkey.test.pages.core.login;
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.html.OptionSelect;
@@ -89,7 +89,7 @@ public class DatabaseAuthConfigureDialog extends AuthDialogBase<DatabaseAuthConf
             JSONObject params = new JSONObject();
             params.put("expiration", oldExpiration != null ? oldExpiration.name() : PasswordExpiration.Never.name());
             params.put("strength", oldStrength != null ? oldStrength.name() : PasswordStrength.Strong.name());
-            PostCommand<?> postCommand = new PostCommand<>("login", "SaveDbLoginProperties");
+            SimplePostCommand postCommand = new SimplePostCommand("login", "SaveDbLoginProperties");
             postCommand.setJsonObject(params);
             try
             {

--- a/src/org/labkey/test/tests/ApiKeyTest.java
+++ b/src/org/labkey/test/tests/ApiKeyTest.java
@@ -23,7 +23,7 @@ import org.labkey.remoteapi.ApiKeyCredentialsProvider;
 import org.labkey.remoteapi.BasicAuthCredentialsProvider;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.query.DeleteRowsCommand;
 import org.labkey.remoteapi.query.GetQueryDetailsCommand;
 import org.labkey.remoteapi.query.GetQueryDetailsResponse;
@@ -214,7 +214,7 @@ public class ApiKeyTest extends BaseWebDriverTest
                 .setAllowSessionKeys(true)
                 .save();
         Connection cn = createDefaultConnection();
-        PostCommand generateAPIKeyCommand = new PostCommand("security", "createApiKey");
+        SimplePostCommand generateAPIKeyCommand = new SimplePostCommand("security", "createApiKey");
         generateAPIKeyCommand.setParameters(new HashMap<>(Maps.of("type", "apikey")));
         try
         {
@@ -239,7 +239,7 @@ public class ApiKeyTest extends BaseWebDriverTest
                 .setAllowSessionKeys(false)
                 .save();
         Connection cn = createDefaultConnection();
-        PostCommand generateAPIKeyCommand = new PostCommand("security", "createApiKey");
+        SimplePostCommand generateAPIKeyCommand = new SimplePostCommand("security", "createApiKey");
         generateAPIKeyCommand.setParameters(new HashMap<>(Maps.of("type", "session")));
         try
         {

--- a/src/org/labkey/test/tests/ClientAPITest.java
+++ b/src/org/labkey/test/tests/ClientAPITest.java
@@ -1477,7 +1477,7 @@ public class ClientAPITest extends BaseWebDriverTest
 
         try
         {
-            new Command<>(source.getControllerName(), source.getActionName())
+            Command<CommandResponse> cmd = new Command<>(source.getControllerName(), source.getActionName())
             {
                 @Override
                 protected HttpUriRequest getHttpRequest(Connection connection, String folderPath) throws URISyntaxException
@@ -1487,7 +1487,9 @@ public class ClientAPITest extends BaseWebDriverTest
 
                     return request;
                 }
-            }.execute(cn, folderPath);
+            };
+            cmd.setParameters(source.getParameters());
+            cmd.execute(cn, folderPath);
         }
         catch (IOException e)
         {

--- a/src/org/labkey/test/tests/ClientAPITest.java
+++ b/src/org/labkey/test/tests/ClientAPITest.java
@@ -1477,10 +1477,10 @@ public class ClientAPITest extends BaseWebDriverTest
 
         try
         {
-            new Command<>(source)
+            new Command<>(source.getControllerName(), source.getActionName())
             {
                 @Override
-                protected HttpUriRequest getHttpRequest(Connection connection, String folderPath) throws CommandException, URISyntaxException
+                protected HttpUriRequest getHttpRequest(Connection connection, String folderPath) throws URISyntaxException
                 {
                     HttpUriRequest request = super.getHttpRequest(connection, folderPath);
                     request.setHeader("Content-Type", requestContentType);

--- a/src/org/labkey/test/tests/ClientAPITest.java
+++ b/src/org/labkey/test/tests/ClientAPITest.java
@@ -1403,8 +1403,7 @@ public class ClientAPITest extends BaseWebDriverTest
         Connection cn = getConnection(true);
         SimpleGetCommand command = new SimpleGetCommand("bam", "boozled");
 
-        final String bogusProjectName = "BOGUS---CONTAINER---PATH";
-        final String bogusContainerPath = "/" + bogusProjectName;
+        final String bogusContainerPath = "/BOGUS---CONTAINER---PATH";
 
         runCommand(cn, command, "application/json", "text/html", 404, null);
         runCommand(cn, command, "text/xml", "text/html", 404, null);
@@ -1426,7 +1425,7 @@ public class ClientAPITest extends BaseWebDriverTest
         command = new SimpleGetCommand("query", "selectRows.api");
         validateUnauthorizedResponses(cn, command, expectedProps);
 
-        expectedProps.put("exception", "No such project: " + bogusContainerPath); // Might need to change back to bogusProjectName, see Issue 46969.
+        expectedProps.put("exception", "No such project: " + bogusContainerPath);
 
         // Reset command so that it's not requesting XML responses
         command = new SimpleGetCommand("query", "selectRows.api");

--- a/src/org/labkey/test/tests/ClientAPITest.java
+++ b/src/org/labkey/test/tests/ClientAPITest.java
@@ -1435,7 +1435,7 @@ public class ClientAPITest extends BaseWebDriverTest
         // Check that a bad container path produces the right kind of response
         runCommand(cn, command, "application/json", "application/json", 404, expectedProps, bogusContainerPath);
         // Try again requesting an XML response
-        command.getParameters().put("respFormat", "xml");
+        command.setParameters(Map.of("respFormat", "xml"));
         runCommand(cn, command, "application/json", "text/xml", 404, null, bogusContainerPath);
 
         command = new Command<>("query", "selectRows.api");
@@ -1445,7 +1445,7 @@ public class ClientAPITest extends BaseWebDriverTest
         runCommand(cn, command, "application/json", "application/json", 404, expectedProps);
 
         // Try again requesting an XML response
-        command.getParameters().put("respFormat", "xml");
+        command.setParameters(Map.of("respFormat", "xml"));
         runCommand(cn, command, "application/json", "text/xml", 404, null);
     }
 
@@ -1455,7 +1455,7 @@ public class ClientAPITest extends BaseWebDriverTest
         runCommand(cn, command, "text/xml", "application/json", 401, expectedProps);
         runCommand(cn, command, "text/html", "application/json", 401, expectedProps);
 
-        command.getParameters().put("respFormat", "xml");
+        command.setParameters(Map.of("respFormat", "xml"));
 
         runCommand(cn, command, "application/json", "text/xml", 401, expectedProps);
         runCommand(cn, command, "text/xml", "text/xml", 401, expectedProps);

--- a/src/org/labkey/test/tests/JUnitTest.java
+++ b/src/org/labkey/test/tests/JUnitTest.java
@@ -37,11 +37,10 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.experimental.categories.Category;
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Runner;
@@ -63,7 +62,6 @@ import java.io.OutputStream;
 import java.net.SocketTimeoutException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -378,7 +376,7 @@ public class JUnitTest extends TestSuite
             long startTime = System.currentTimeMillis();
             try
             {
-                Command<CommandResponse> command = new PostCommand<>("junit", "go");
+                SimplePostCommand command = new SimplePostCommand("junit", "go");
                 command.setParameters(Map.of("testCase", _remoteClass));
                 command.setTimeout(_timeout * 1000);
 

--- a/src/org/labkey/test/tests/JUnitTest.java
+++ b/src/org/labkey/test/tests/JUnitTest.java
@@ -379,9 +379,7 @@ public class JUnitTest extends TestSuite
             try
             {
                 Command<CommandResponse> command = new PostCommand<>("junit", "go");
-                Map<String, Object> params = new HashMap<>();
-                params.put("testCase", _remoteClass);
-                command.setParameters(params);
+                command.setParameters(Map.of("testCase", _remoteClass));
                 command.setTimeout(_timeout * 1000);
 
                 CommandResponse response = command.execute(connection, "/");

--- a/src/org/labkey/test/tests/JavaClientApiTest.java
+++ b/src/org/labkey/test/tests/JavaClientApiTest.java
@@ -82,7 +82,7 @@ import static org.junit.Assert.fail;
 /**
  * Test for the Java Client API library. This test is written in
  * Selenium because we don't yet have a way to create a list via
- * the API, so this test will setup a list and then use the Java
+ * the API, so this test will set up a list and then use the Java
  * client API library to insert, read, update, and delete from that list
  */
 @Category({Daily.class})

--- a/src/org/labkey/test/tests/ScriptValidationTest.java
+++ b/src/org/labkey/test/tests/ScriptValidationTest.java
@@ -27,6 +27,7 @@ import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.InsertRowsCommand;
 import org.labkey.remoteapi.query.SaveRowsResponse;
@@ -171,7 +172,7 @@ public class ScriptValidationTest extends BaseWebDriverTest
 
     private PostCommand<CommandResponse> prepareSaveRowsCommand(String command, String containerPath, String schema, String queryName, String pkName, String[] fieldNames, Object[][] rows, @Nullable Object[][] oldKeys)
     {
-        PostCommand<CommandResponse> postCommand = new PostCommand<>("query", "saveRows");
+        SimplePostCommand postCommand = new SimplePostCommand("query", "saveRows");
 
         JSONObject commandJson = new JSONObject();
         commandJson.put("containerPath", containerPath);

--- a/src/org/labkey/test/tests/SecurityTest.java
+++ b/src/org/labkey/test/tests/SecurityTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.serverapi.reader.Readers;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
@@ -265,7 +265,7 @@ public class SecurityTest extends BaseWebDriverTest
     public void passwordParameterTest()
     {
         // 31000: fail login actions if parameters present on URL
-        PostCommand command = new PostCommand("login", "loginAPI");
+        SimplePostCommand command = new SimplePostCommand("login", "loginAPI");
 
         Map<String, Object> params = new HashMap<>();
         params.put("email", NORMAL_USER);

--- a/src/org/labkey/test/tests/UserDetailsPermissionTest.java
+++ b/src/org/labkey/test/tests/UserDetailsPermissionTest.java
@@ -18,10 +18,9 @@ package org.labkey.test.tests;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
-import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.SimpleGetCommand;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
@@ -228,7 +227,7 @@ public class UserDetailsPermissionTest extends BaseWebDriverTest
     private List<Map<String, String>> getAutoCompleteResponse(String user, String containerPath) throws IOException
     {
         Connection connection = new Connection(WebTestHelper.getBaseURL(), user, PasswordUtil.getPassword());
-        Command<CommandResponse> command = new Command<>("security", "CompleteUserRead");
+        SimpleGetCommand command = new SimpleGetCommand("security", "CompleteUserRead");
 
         try
         {

--- a/src/org/labkey/test/util/APIContainerHelper.java
+++ b/src/org/labkey/test/util/APIContainerHelper.java
@@ -247,15 +247,11 @@ public class APIContainerHelper extends AbstractContainerHelper
             @Override
             public JSONObject getJsonObject()
             {
-                JSONObject result = super.getJsonObject();
-                if (result == null)
-                {
-                    result = new JSONObject();
-                }
+                JSONObject result = new JSONObject();
                 result.put("container", containerPath);
                 result.put("parent", newParent);
                 result.put("addAlias", createAlias);
-                setJsonObject(result);
+
                 return result;
             }
         };

--- a/src/org/labkey/test/util/APIContainerHelper.java
+++ b/src/org/labkey/test/util/APIContainerHelper.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.security.CreateContainerCommand;
 import org.labkey.remoteapi.security.CreateContainerResponse;
 import org.labkey.remoteapi.security.DeleteContainerCommand;
@@ -242,7 +242,7 @@ public class APIContainerHelper extends AbstractContainerHelper
         Connection connection = WebTestHelper.getRemoteApiConnection();
 
         final String containerPath = projectName + "/" + folderName;
-        PostCommand command = new PostCommand("core", "moveContainer")
+        SimplePostCommand command = new SimplePostCommand("core", "moveContainer")
         {
             @Override
             public JSONObject getJsonObject()

--- a/src/org/labkey/test/util/ApiPermissionsHelper.java
+++ b/src/org/labkey/test/util/ApiPermissionsHelper.java
@@ -17,10 +17,10 @@ package org.labkey.test.util;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.SimpleGetCommand;
 import org.labkey.remoteapi.security.AddAssignmentCommand;
 import org.labkey.remoteapi.security.AddGroupMembersCommand;
 import org.labkey.remoteapi.security.BulkUpdateGroupCommand;
@@ -38,7 +38,6 @@ import org.labkey.test.WebTestHelper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -279,7 +278,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
         }
 
         Connection connection = getConnection();
-        Command<?> command = new Command<>("security", "getGroupMembers");
+        SimpleGetCommand command = new SimpleGetCommand("security", "getGroupMembers");
         command.setParameters(Maps.of("groupId", groupId));
 
         CommandResponse response;
@@ -315,7 +314,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
     private CommandResponse getUserPerms(String container, String user) throws CommandException
     {
         Connection connection = getConnection();
-        Command<?> command = new Command<>("security", "getUserPerms");
+        SimpleGetCommand command = new SimpleGetCommand("security", "getUserPerms");
         command.setParameters(Maps.of("userEmail", user));
 
         CommandResponse response;

--- a/src/org/labkey/test/util/ApiPermissionsHelper.java
+++ b/src/org/labkey/test/util/ApiPermissionsHelper.java
@@ -280,7 +280,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
 
         Connection connection = getConnection();
         Command<?> command = new Command<>("security", "getGroupMembers");
-        command.setParameters(new HashMap<>(Maps.of("groupId", groupId)));
+        command.setParameters(Maps.of("groupId", groupId));
 
         CommandResponse response;
         try
@@ -316,7 +316,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
     {
         Connection connection = getConnection();
         Command<?> command = new Command<>("security", "getUserPerms");
-        command.setParameters(new HashMap<>(Maps.of("userEmail", user)));
+        command.setParameters(Maps.of("userEmail", user));
 
         CommandResponse response;
         try

--- a/src/org/labkey/test/util/ExperimentalFeaturesHelper.java
+++ b/src/org/labkey/test/util/ExperimentalFeaturesHelper.java
@@ -15,11 +15,11 @@
  */
 package org.labkey.test.util;
 
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimpleGetCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.TestProperties;
 
 import java.io.IOException;
@@ -49,7 +49,7 @@ public class ExperimentalFeaturesHelper
         parameters.put("feature", feature);
         parameters.put("enabled", enable);
 
-        PostCommand<CommandResponse> command = new PostCommand<>("admin", "experimentalFeature");
+        SimplePostCommand command = new SimplePostCommand("admin", "experimentalFeature");
         command.setParameters(parameters);
         try
         {
@@ -70,7 +70,7 @@ public class ExperimentalFeaturesHelper
 
     public static boolean isExperimentalFeatureEnabled(Connection cn, String feature)
     {
-        Command<CommandResponse> command = new Command<>("admin", "experimentalFeature");
+        SimpleGetCommand command = new SimpleGetCommand("admin", "experimentalFeature");
         command.setParameters(Map.of("feature", feature));
         try
         {

--- a/src/org/labkey/test/util/ExperimentalFeaturesHelper.java
+++ b/src/org/labkey/test/util/ExperimentalFeaturesHelper.java
@@ -71,7 +71,7 @@ public class ExperimentalFeaturesHelper
     public static boolean isExperimentalFeatureEnabled(Connection cn, String feature)
     {
         Command<CommandResponse> command = new Command<>("admin", "experimentalFeature");
-        command.setParameters(new HashMap<>(Map.of("feature", feature)));
+        command.setParameters(Map.of("feature", feature));
         try
         {
             CommandResponse r = command.execute(cn, null);

--- a/src/org/labkey/test/util/Log4jUtils.java
+++ b/src/org/labkey/test/util/Log4jUtils.java
@@ -17,7 +17,7 @@ package org.labkey.test.util;
 
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.TestProperties;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
@@ -42,7 +42,7 @@ public abstract class Log4jUtils
             return;
 
         Connection connection = WebTestHelper.getRemoteApiConnection();
-        PostCommand<?> command = new PostCommand<>("logger", "update");
+        SimplePostCommand command = new SimplePostCommand("logger", "update");
         Map<String, Object> params = new HashMap<>();
         params.put("name", name);
         params.put("level", level.name());
@@ -73,7 +73,7 @@ public abstract class Log4jUtils
             return;
 
         Connection connection = WebTestHelper.getRemoteApiConnection();
-        PostCommand<?> command = new PostCommand<>("logger", "reset");
+        SimplePostCommand command = new SimplePostCommand("logger", "reset");
         try
         {
             command.execute(connection, "/");
@@ -97,7 +97,7 @@ public abstract class Log4jUtils
     public static void resetLogMark() throws IOException, CommandException
     {
         Connection connection = WebTestHelper.getRemoteApiConnection();
-        PostCommand<?> command = new PostCommand<>("admin", "resetPrimaryLogMark");
+        SimplePostCommand command = new SimplePostCommand("admin", "resetPrimaryLogMark");
         command.execute(connection, "/");
     }
 

--- a/src/org/labkey/test/util/QuickBootstrapPseudoTest.java
+++ b/src/org/labkey/test/util/QuickBootstrapPseudoTest.java
@@ -3,12 +3,12 @@ package org.labkey.test.util;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.GuestCredentialsProvider;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimpleGetCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.LabKeySiteWrapper;
 import org.labkey.test.Locator;
@@ -55,7 +55,7 @@ public class QuickBootstrapPseudoTest extends BaseWebDriverTest
     private void waitForStartup()
     {
         Connection cn = new Connection(WebTestHelper.getBaseURL(), new GuestCredentialsProvider());
-        Command<?> command = new Command<>("admin", "healthCheck");
+        SimpleGetCommand command = new SimpleGetCommand("admin", "healthCheck");
         Exception lastException = null;
 
         Timer timer = new Timer(Duration.ofMinutes(5));
@@ -93,7 +93,7 @@ public class QuickBootstrapPseudoTest extends BaseWebDriverTest
     private boolean isInitialUserCreated()
     {
         Connection cn = new Connection(WebTestHelper.getBaseURL(), new GuestCredentialsProvider());
-        PostCommand<?> command = new PostCommand<>("admin", "configurationSummary");
+        SimplePostCommand command = new SimplePostCommand("admin", "configurationSummary");
 
         try
         {
@@ -130,7 +130,7 @@ public class QuickBootstrapPseudoTest extends BaseWebDriverTest
     private void createInitialUser_API()
     {
         Connection cn = createDefaultConnection();
-        PostCommand<?> initialUserCommand = new PostCommand<>("login", "initialUser");
+        SimplePostCommand initialUserCommand = new SimplePostCommand("login", "initialUser");
         JSONObject params = new JSONObject();
         params.put("email", PasswordUtil.getUsername());
         params.put("password", PasswordUtil.getPassword());
@@ -151,7 +151,7 @@ public class QuickBootstrapPseudoTest extends BaseWebDriverTest
     private void waitForBootstrap()
     {
         Connection cn = WebTestHelper.getRemoteApiConnection(false);
-        Command<?> command = new Command<>("admin", "startupStatus");
+        SimpleGetCommand command = new SimpleGetCommand("admin", "startupStatus");
         Exception lastException = null;
 
         Timer timer = new Timer(Duration.ofMinutes(5));

--- a/src/org/labkey/test/util/UIUserHelper.java
+++ b/src/org/labkey/test/util/UIUserHelper.java
@@ -70,7 +70,7 @@ public class UIUserHelper extends AbstractUserHelper
             userId = null;
         }
 
-        return new CreateUserResponse(null, 200, null, null, null){
+        return new CreateUserResponse(null, 200, null, null){
             @Override
             public Integer getUserId()
             {

--- a/src/org/labkey/test/util/login/AuthenticationAPIUtils.java
+++ b/src/org/labkey/test/util/login/AuthenticationAPIUtils.java
@@ -1,11 +1,11 @@
 package org.labkey.test.util.login;
 
 import org.json.JSONObject;
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimpleGetCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.TestLogger;
@@ -80,7 +80,7 @@ public class AuthenticationAPIUtils
 
     private static List<Configuration> getAllConfigurations(Connection connection)
     {
-        Command<?> initialMount = new Command<>("login", "initialMount");
+        SimpleGetCommand initialMount = new SimpleGetCommand("login", "initialMount");
         try
         {
             CommandResponse response = initialMount.execute(connection, "/");
@@ -136,7 +136,7 @@ public class AuthenticationAPIUtils
 
     private static void deleteConfiguration(Configuration configuration, Connection connection)
     {
-        PostCommand<?> delete = new PostCommand<>("login", "deleteConfiguration");
+        SimplePostCommand delete = new SimplePostCommand("login", "deleteConfiguration");
         JSONObject json = new JSONObject();
         json.put("configuration", configuration._configuration);
         delete.setJsonObject(json);

--- a/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
+++ b/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
@@ -17,7 +17,7 @@ package org.labkey.test.util.puppeteer;
 
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.puppeteer.PuppeteerSettings;
 import org.labkey.remoteapi.puppeteer.PuppeteerStatus;
 import org.labkey.test.WebTestHelper;
@@ -43,14 +43,14 @@ public class PuppeteerHelper
 
     public static PuppeteerStatus getStatus(Connection connection) throws IOException, CommandException
     {
-        var statusCmd = new PostCommand<>("puppeteer", "status.api");
+        var statusCmd = new SimplePostCommand("puppeteer", "status.api");
         var response = statusCmd.execute(connection, "/");
         return new PuppeteerStatus(response);
     }
 
     public static PuppeteerSettings updateSettings(Connection connection, PuppeteerSettings settings) throws IOException, CommandException
     {
-        var updateCmd = new PostCommand<>("puppeteer", "updateSettings.api");
+        var updateCmd = new SimplePostCommand("puppeteer", "updateSettings.api");
         updateCmd.setRequiredVersion(0);
         updateCmd.setJsonObject(settings.toJSON());
         var response = updateCmd.execute(connection, "/");

--- a/src/org/labkey/test/util/search/SearchAdminAPIHelper.java
+++ b/src/org/labkey/test/util/search/SearchAdminAPIHelper.java
@@ -64,7 +64,7 @@ public abstract class SearchAdminAPIHelper
         // Invoke a special server action that waits until all previous indexer tasks are complete, even wait for background indexing tasks to complete (e.g. deleteContainer)
         var cmd = new PostCommand("search", "waitForIndexer");
         cmd.setTimeout(timeout);
-        cmd.setParameters(new HashMap<>(Map.of("priority", "background")));
+        cmd.setParameters(Map.of("priority", "background"));
 
         executeWaitForIndexer(cmd);
     }

--- a/src/org/labkey/test/util/search/SearchAdminAPIHelper.java
+++ b/src/org/labkey/test/util/search/SearchAdminAPIHelper.java
@@ -17,6 +17,7 @@ package org.labkey.test.util.search;
 
 import org.apache.hc.core5.http.HttpStatus;
 import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
@@ -26,7 +27,6 @@ import org.labkey.test.util.SimpleHttpResponse;
 import org.openqa.selenium.WebDriver;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -47,7 +47,7 @@ public abstract class SearchAdminAPIHelper
     public static void waitForIndexer(int timeout)
     {
         // Invoke a special server action that waits until all previous indexer tasks are complete
-        var cmd = new PostCommand("search", "waitForIndexer");
+        var cmd = new SimplePostCommand("search", "waitForIndexer");
         cmd.setTimeout(timeout);
 
        executeWaitForIndexer(cmd);
@@ -62,7 +62,7 @@ public abstract class SearchAdminAPIHelper
     public static void waitForIndexerBackground(int timeout)
     {
         // Invoke a special server action that waits until all previous indexer tasks are complete, even wait for background indexing tasks to complete (e.g. deleteContainer)
-        var cmd = new PostCommand("search", "waitForIndexer");
+        var cmd = new SimplePostCommand("search", "waitForIndexer");
         cmd.setTimeout(timeout);
         cmd.setParameters(Map.of("priority", "background"));
 

--- a/src/org/labkey/test/util/wiki/ApiWikiHelper.java
+++ b/src/org/labkey/test/util/wiki/ApiWikiHelper.java
@@ -4,7 +4,7 @@ import org.junit.Assert;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.params.wiki.SaveWikiParams;
 
@@ -14,7 +14,7 @@ public class ApiWikiHelper
 {
     public void createWiki(String containerPath, SaveWikiParams wikiParams) throws CommandException
     {
-        PostCommand<CommandResponse> command = new PostCommand<>("wiki", "saveWiki");
+        SimplePostCommand command = new SimplePostCommand("wiki", "saveWiki");
         command.setJsonObject(wikiParams.toJSON());
         Connection connection = WebTestHelper.getRemoteApiConnection(true);
 


### PR DESCRIPTION
#### Rationale
We've removed copy constructors plus `getHttpRequest()` no longer throws `CommandException`

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/48