### PR TITLE
Handle update and clarify merge - use DIB for updateRows

### DIFF
--- a/src/org/labkey/test/tests/TriggerScriptTest.java
+++ b/src/org/labkey/test/tests/TriggerScriptTest.java
@@ -544,22 +544,13 @@ public class TriggerScriptTest extends BaseWebDriverTest
 
         row3 = resp.getRows().get(1);
 
-        //Check After Update Event
-        step = "AfterUpdate";
-        log("** " + testName + " " + step + " Event");
-        UpdateRowsCommand updCmd = new UpdateRowsCommand(schemaName, queryName);
-        row2.put(flagField, "AfterUpdate");
-        updCmd.addRow(row2);
-        updCmd.addRow(row3);
-        assertAPIErrorMessage(updCmd, AFTER_UPDATE_ERROR, cn);
-
         //Check Before Update Event
         step = "BeforeUpdate";
         log("** " + testName + " " + step + " Event");
-        updCmd = new UpdateRowsCommand(schemaName,queryName);
+        UpdateRowsCommand updCmd = new UpdateRowsCommand(schemaName,queryName);
         row2.put(flagField, "BeforeUpdate");
         row2.put(updateField, "Labkey");
-        row3.put(flagField,"BeforeDelete");  //For later.
+        row3.put(flagField, "BeforeDelete");  //For later.
         updCmd.addRow(row2);
         updCmd.addRow(row3);
         resp = updCmd.execute(cn, getProjectName());
@@ -567,6 +558,15 @@ public class TriggerScriptTest extends BaseWebDriverTest
         Assert.assertEquals(BEFORE_UPDATE_COMPANY, updateCo.get(updateField));
         //Check update persisted
         Assert.assertEquals("BeforeUpdate", updateCo.get(flagField));
+
+        //Check After Update Event
+        step = "AfterUpdate";
+        log("** " + testName + " " + step + " Event");
+        updCmd = new UpdateRowsCommand(schemaName, queryName);
+        row2.put(flagField, "AfterUpdate");
+        updCmd.addRow(row2);
+        updCmd.addRow(row3);
+        assertAPIErrorMessage(updCmd, AFTER_UPDATE_ERROR, cn);
 
         //Check After Delete Event
         step = "After Delete";


### PR DESCRIPTION
#### Rationale
UpdateRows will now throw error instead of returning results when an error is encountered during update. The TriggerScriptTest had a test case that checks returned result when a error is thrown during afterUpdate, which is no longer supported.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1088
- https://github.com/LabKey/biologics/pull/1875
- https://github.com/LabKey/commonAssays/pull/568
- https://github.com/LabKey/inventory/pull/699
- https://github.com/LabKey/labbook/pull/391
- https://github.com/LabKey/platform/pull/4044
- https://github.com/LabKey/premium/pull/361
- https://github.com/LabKey/recipe/pull/79
- https://github.com/LabKey/sampleManagement/pull/1556
- https://github.com/LabKey/signing/pull/12
- https://github.com/LabKey/adjudication/pull/71
- https://github.com/LabKey/customModules/pull/110
- https://github.com/LabKey/OConnorLabModules/pull/100

#### Changes
* Update tests
