### PR TITLE
Update links from users to display user detail data via modal for those who have permission

### DIFF
--- a/src/org/labkey/test/components/ui/permissions/GroupDetailsPanel.java
+++ b/src/org/labkey/test/components/ui/permissions/GroupDetailsPanel.java
@@ -9,7 +9,7 @@ import org.openqa.selenium.WebElement;
 
 public class GroupDetailsPanel extends WebDriverComponent<GroupDetailsPanel.ElementCache>
 {
-    protected static final Locator LOC = BootstrapLocators.panel("Group Details");
+    protected static final Locator LOC = Locator.byClass("group-details-panel");
     private final WebElement _el;
     private final WebDriver _driver;
 
@@ -56,7 +56,7 @@ public class GroupDetailsPanel extends WebDriverComponent<GroupDetailsPanel.Elem
 
     protected class ElementCache extends Component<?>.ElementCache
     {
-        final WebElement title = Locator.tagWithClass("p", "principal-title-primary").findWhenNeeded(this);
+        final WebElement title = Locator.tagWithClass("p", "panel-heading").findWhenNeeded(this);
 
         WebElement detailValueEl(String label)
         {

--- a/src/org/labkey/test/components/ui/permissions/UserDetailsPanel.java
+++ b/src/org/labkey/test/components/ui/permissions/UserDetailsPanel.java
@@ -40,10 +40,10 @@ public class UserDetailsPanel extends WebDriverComponent<Component<?>.ElementCac
                 .map(WebElement::getText).orElse(null);
     }
 
-    public List<String> getMemberships()
+    public List<String> getGroups()
     {
-        var membersList = Locator.tagWithClass("div", "principal-detail-label").withText("Member of")
-                .followingSibling("ul").findElement(this);
+        var membersList = Locator.tagWithClass("div", "principal-detail-label").withText("Groups")
+                .parent().descendant("ul").findElement(this);
         return getWrapper().getTexts(Locator.tag("li").findElements(membersList));
     }
 

--- a/src/org/labkey/test/components/ui/permissions/UserDetailsPanel.java
+++ b/src/org/labkey/test/components/ui/permissions/UserDetailsPanel.java
@@ -1,6 +1,5 @@
 package org.labkey.test.components.ui.permissions;
 
-import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
@@ -11,7 +10,7 @@ import java.util.List;
 
 public class UserDetailsPanel extends WebDriverComponent<Component<?>.ElementCache>
 {
-    protected static final Locator LOC = BootstrapLocators.panel("User Details");
+    protected static final Locator LOC = Locator.byClass("user-details-panel");
 
     private final WebElement _el;
     private final WebDriver _driver;
@@ -36,7 +35,7 @@ public class UserDetailsPanel extends WebDriverComponent<Component<?>.ElementCac
 
     public String getSelectedUser()
     {
-        return Locator.byClass("principal-title-primary")
+        return Locator.byClass("panel-heading")
                 .findOptionalElement(this)
                 .map(WebElement::getText).orElse(null);
     }

--- a/src/org/labkey/test/components/ui/permissions/UserDetailsPanelPermissionsPage.java
+++ b/src/org/labkey/test/components/ui/permissions/UserDetailsPanelPermissionsPage.java
@@ -21,7 +21,7 @@ public class UserDetailsPanelPermissionsPage extends UserDetailsPanel
 
     public List<String> getEffectiveRoles()
     {
-        var listContainer=  Locator.tagWithClass("div", "principal-detail-label").withText("Permissions")
+        var listContainer=  Locator.tagWithClass("div", "principal-detail-label").withText("Effective Roles")
                 .parent().descendant("ul").waitForElement(this, 2000);
         return Locator.tag("li")
                 .findElements(listContainer)

--- a/src/org/labkey/test/components/ui/permissions/UserDetailsPanelPermissionsPage.java
+++ b/src/org/labkey/test/components/ui/permissions/UserDetailsPanelPermissionsPage.java
@@ -21,8 +21,8 @@ public class UserDetailsPanelPermissionsPage extends UserDetailsPanel
 
     public List<String> getEffectiveRoles()
     {
-        var listContainer=  Locator.tagWithClass("div", "principal-detail-label").withText("Effective Roles")
-                .followingSibling("ul").waitForElement(this, 2000);
+        var listContainer=  Locator.tagWithClass("div", "principal-detail-label").withText("Permissions")
+                .parent().descendant("ul").waitForElement(this, 2000);
         return Locator.tag("li")
                 .findElements(listContainer)
                 .stream().map(WebElement::getText).collect(Collectors.toList());


### PR DESCRIPTION
#### Rationale
Currently in our apps, if a user clicks on a user display name in a grid, details page, timeline event, etc. they are taken to the #/q view context to view the details of that user (if they have "can view user details" permissions). This takes the user out of the context they were in and sometimes results in a mostly empty page (for users with only read perm, for examples). This story changes that so that we render user display names as clickable links, if current user has perm to see user details, that will open a modal with the user information without any page navigation.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1092

#### Changes
- User and Group details panel locator updates
