### PR TITLE
Handle update and clarify merge - LKS

### DIFF
--- a/src/org/labkey/test/pages/ImportDataPage.java
+++ b/src/org/labkey/test/pages/ImportDataPage.java
@@ -23,6 +23,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.components.ext4.Checkbox;
 import org.labkey.test.components.ext4.ComboBox;
+import org.labkey.test.components.ext4.RadioButton;
 import org.labkey.test.util.Ext4Helper;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -138,6 +139,85 @@ public class ImportDataPage extends LabKeyPage<ImportDataPage.ElementCache>
         return doAndWaitForDownload(()->elementCache().getDownloadTemplateButton().click());
     }
 
+    public void setFileInsertOption(boolean isUpdate)
+    {
+        setInsertOption(true, isUpdate);
+    }
+
+    public void setFileMerge(boolean isMerge)
+    {
+        setFileMerge(isMerge, isMerge);
+    }
+
+    public void setFileMerge(boolean isMerge, boolean isUpdate)
+    {
+        setFileInsertOption(isUpdate || isMerge);
+
+        if (isMerge && !isFileMergeChecked())
+            elementCache().mergeFile.check();
+        else if (!isMerge && isFileMergeChecked())
+            elementCache().mergeFile.uncheck();
+
+    }
+
+    public boolean isFileMergeChecked()
+    {
+        return elementCache().mergeFile.isChecked();
+    }
+
+    public boolean isFileMergeOptionPresent()
+    {
+        return elementCache().mergeFileOptional != null;
+    }
+
+    public void setCopyPasteInsertOption(boolean isUpdate)
+    {
+        setInsertOption(false, isUpdate);
+    }
+
+    public void setCopyPasteMerge(boolean isMerge)
+    {
+        setCopyPasteMerge(isMerge, isMerge);
+    }
+
+    public void setCopyPasteMerge(boolean isMerge, boolean isUpdate)
+    {
+        setCopyPasteInsertOption(isUpdate || isMerge);
+
+        if (isMerge && !isCopyPasteMergeChecked())
+            elementCache().mergePaste.check();
+        else if (!isMerge && isCopyPasteMergeChecked())
+            elementCache().mergePaste.uncheck();
+    }
+
+    public boolean isCopyPasteMergeChecked()
+    {
+        return elementCache().mergePaste.isChecked();
+    }
+
+    public void setInsertOption(boolean isFile, boolean isUpdate)
+    {
+        if (isFile)
+        {
+            if (isUpdate)
+                elementCache().updateRowsFile.set(true);
+            else
+                elementCache().addRowsFile.set(true);
+        }
+        else
+        {
+            if (isUpdate)
+                elementCache().updateRowsPaste.set(true);
+            else
+                elementCache().addRowsPaste.set(true);
+        }
+    }
+
+    public boolean isPasteMergeOptionPresent()
+    {
+        return elementCache().mergePasteOptional != null;
+    }
+
     public enum Format
     {
         TSV("Tab-separated text (tsv)"), CSV("Comma-separated text (csv)");
@@ -173,6 +253,10 @@ public class ImportDataPage extends LabKeyPage<ImportDataPage.ElementCache>
         WebElement uploadFileDiv = Locator.byClass("panel-body").findWhenNeeded(uploadPanel);
         WebElement uploadExpando = Locator.byClass("lk-import-expando").findWhenNeeded(uploadPanel);
         WebElement uploadFileFilePath = Locator.input("file").findWhenNeeded(uploadFileDiv);
+        RadioButton addRowsFile = RadioButton.RadioButton().withLabelContaining("Add").findWhenNeeded(uploadPanel);
+        RadioButton updateRowsFile = RadioButton.RadioButton().withLabelContaining("Update").findWhenNeeded(uploadPanel);
+        Checkbox mergeFile = Ext4Checkbox().withLabelContaining("Allow new").findWhenNeeded(uploadPanel);
+        Checkbox mergeFileOptional = Ext4Checkbox().withLabelContaining("Allow new").findOrNull(uploadPanel);
 
         // Paste data
         WebElement copyPastePanel = Locator.tagWithAttribute("div", "data-panel-name", "copyPastePanel").findWhenNeeded(this);
@@ -180,6 +264,10 @@ public class ImportDataPage extends LabKeyPage<ImportDataPage.ElementCache>
         WebElement copyPasteExpando = Locator.byClass("lk-import-expando").findWhenNeeded(copyPastePanel);
         WebElement pasteDataTextArea = Locator.tag("textarea").findWhenNeeded(copyPasteDiv);
         ComboBox formatCombo = new ComboBox.ComboBoxFinder(getDriver()).withLabel("Format:").findWhenNeeded(copyPastePanel);
+        RadioButton addRowsPaste = RadioButton.RadioButton().withLabelContaining("Add").findWhenNeeded(copyPastePanel);
+        RadioButton updateRowsPaste = RadioButton.RadioButton().withLabelContaining("Update").findWhenNeeded(copyPastePanel);
+        Checkbox mergePaste = Ext4Checkbox().withLabelContaining("Allow new").findWhenNeeded(copyPastePanel);
+        Checkbox mergePasteOptional = Ext4Checkbox().withLabelContaining("Allow new").findOrNull(copyPastePanel);
 
         WebElement getExpandedPanel()
         {

--- a/src/org/labkey/test/tests/ExternalSchemaTest.java
+++ b/src/org/labkey/test/tests/ExternalSchemaTest.java
@@ -373,7 +373,7 @@ public class ExternalSchemaTest extends BaseWebDriverTest
         }
         catch (CommandException ex)
         {
-            assertEquals(403, ex.getStatusCode());
+            assertEquals(400, ex.getStatusCode());
 //            assertEquals("The row is from the wrong container.", ex.getMessage());
 //            assertEquals("org.labkey.api.view.UnauthorizedException", ex.getProperties().get("exceptionClass"));
         }

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -283,7 +283,7 @@ public class SampleTypeTest extends BaseWebDriverTest
         log("Try to import overlapping data with TSV");
 
         DataRegionTable drt = sampleHelper.getSamplesDataRegionTable();
-        drt.clickImportBulkData();
+        ImportDataPage importDataPage = drt.clickImportBulkData();
         String header = "Name\t" + fieldNames.get(0) + "\n";
         String overlap =  "Name1\tToBee\n";
         String newData = "Name2\tSee\n";
@@ -291,7 +291,7 @@ public class SampleTypeTest extends BaseWebDriverTest
         clickButton("Submit", "duplicate key");
 
         log("Switch to 'Insert and Replace'");
-        sampleHelper.selectImportOption(SampleTypeHelper.MERGE_OPTION, 1);
+        importDataPage.setCopyPasteMerge(true);
         clickButton("Submit");
 
         log("Validate data was updated and new data added");
@@ -310,7 +310,7 @@ public class SampleTypeTest extends BaseWebDriverTest
 
         log("Try to import overlapping data from file");
         final File sampleData = TestFileUtils.getSampleData("simpleSampleType.xls");
-        final ImportDataPage importDataPage = drt.clickImportBulkData();
+        importDataPage = drt.clickImportBulkData();
         importDataPage.setFile(sampleData);
         final String errorText = importDataPage.submitExpectingError();
         Assert.assertTrue("Wrong error when importing duplicate samples. " + errorText, errorText.contains("duplicate key"));
@@ -318,7 +318,7 @@ public class SampleTypeTest extends BaseWebDriverTest
         // Assert.assertTrue("Wrong error when importing duplicate samples. " + errorText, errorText.length() < 100);
 
         log ("Switch to 'Insert and Replace'");
-        sampleHelper.selectImportOption(SampleTypeHelper.MERGE_OPTION, 0);
+        importDataPage.setFileMerge(true);
         importDataPage
                 .setFile(sampleData)
                 .submit();

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -291,7 +291,7 @@ public class SampleTypeTest extends BaseWebDriverTest
         clickButton("Submit", "duplicate key");
 
         log("Switch to 'Insert and Replace'");
-        sampleHelper.selectImportOption(SampleTypeHelper.MERGE_DATA_LABEL, 1);
+        sampleHelper.selectImportOption(SampleTypeHelper.MERGE_OPTION, 1);
         clickButton("Submit");
 
         log("Validate data was updated and new data added");
@@ -318,7 +318,7 @@ public class SampleTypeTest extends BaseWebDriverTest
         // Assert.assertTrue("Wrong error when importing duplicate samples. " + errorText, errorText.length() < 100);
 
         log ("Switch to 'Insert and Replace'");
-        sampleHelper.selectImportOption(SampleTypeHelper.MERGE_DATA_LABEL, 0);
+        sampleHelper.selectImportOption(SampleTypeHelper.MERGE_OPTION, 0);
         importDataPage
                 .setFile(sampleData)
                 .submit();
@@ -1119,7 +1119,7 @@ public class SampleTypeTest extends BaseWebDriverTest
         log("Validate that the required field check works as expected.");
         updateSampleData = new ArrayList<>();
         updateSampleData.add(Map.of("Name", "mv10", REQUIRED_FIELD_NAME, "", MISSING_FIELD_NAME, "There should be no value in the required field.", INDICATOR_FIELD_NAME, ""));
-        sampleHelper.bulkImportExpectingError(updateSampleData, SampleTypeHelper.IMPORT_DATA_LABEL);
+        sampleHelper.bulkImportExpectingError(updateSampleData, SampleTypeHelper.IMPORT_OPTION);
 
         try
         {

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -703,10 +703,10 @@ public class ListTest extends BaseWebDriverTest
         createList(mergeListName, BatchListColumns, BatchListData);
         _listHelper.beginAtList(PROJECT_VERIFY, mergeListName);
 
-        _listHelper.clickImportData();
-        checker().verifyTrue("For list with an integer, non-auto-increment key, merge option should be available for copy/paste", _listHelper.isMergeOptionPresent());
+        ImportDataPage importDataPage = _listHelper.clickImportData();
+        checker().verifyTrue("For list with an integer, non-auto-increment key, merge option should be available for copy/paste", importDataPage.isPasteMergeOptionPresent());
         _listHelper.chooseFileUpload();
-        checker().verifyTrue("For list with an integer, non-auto-increment key, merge option should be available for file upload", _listHelper.isMergeOptionPresent());
+        checker().verifyTrue("For list with an integer, non-auto-increment key, merge option should be available for file upload", importDataPage.isFileMergeOptionPresent());
         _listHelper.chooseCopyPasteText();
 
         log("Try to upload the same data without choosing to merge.  Errors are expected.");
@@ -718,14 +718,14 @@ public class ListTest extends BaseWebDriverTest
         _listHelper.verifyListData(BatchListColumns, BatchListData, checker());
 
         log("Upload the same data using the merge operation. No errors should result.");
-        _listHelper.clickImportData();
-        _listHelper.chooseMerge(false);
+        importDataPage = _listHelper.clickImportData();
+        importDataPage.setCopyPasteMerge(true);
         setListImportAsTestDataField(toTSV(BatchListColumns, BatchListData));
         _listHelper.verifyListData(BatchListColumns, BatchListData, checker());
 
         log("Now upload some new data and modify existing data");
-        _listHelper.clickImportData();
-        _listHelper.chooseMerge(false);
+        importDataPage = _listHelper.clickImportData();
+        importDataPage.setCopyPasteMerge(true);
         setListImportAsTestDataField(toTSV(BatchListMergeColumns, BatchListMergeData));
         _listHelper.verifyListData(BatchListColumns, BatchListAfterMergeData, checker());
     }
@@ -737,8 +737,8 @@ public class ListTest extends BaseWebDriverTest
 
         _listHelper.createList(PROJECT_VERIFY, mergeListName, ListColumnType.AutoInteger, "Key", col("Name", ColumnType.String));
 
-        _listHelper.clickImportData();
-        checker().verifyFalse("For list with an integer, auto-increment key, merge option should not be available", _listHelper.isMergeOptionPresent());
+        ImportDataPage importDataPage = _listHelper.clickImportData();
+        checker().verifyFalse("For list with an integer, auto-increment key, merge option should not be available", importDataPage.isPasteMergeOptionPresent());
     }
 
     @Test

--- a/src/org/labkey/test/util/ListHelper.java
+++ b/src/org/labkey/test/util/ListHelper.java
@@ -333,16 +333,6 @@ public class ListHelper extends LabKeySiteWrapper
                 .submit();
     }
 
-    public boolean isMergeOptionPresent()
-    {
-        return isElementPresent(Locator.tagContainingText("label", "Update data"));
-    }
-
-    public void chooseMerge(boolean isFileUpload)
-    {
-        click(tag("input").withAttribute("type", "button").index(isFileUpload ? 0 : 2));
-    }
-
     public EditListDefinitionPage goToEditDesign(String listName)
     {
         goToList(listName);

--- a/src/org/labkey/test/util/SampleTypeHelper.java
+++ b/src/org/labkey/test/util/SampleTypeHelper.java
@@ -155,14 +155,6 @@ public class SampleTypeHelper extends WebDriverWrapper
         return new CreateSampleTypePage(getDriver());
     }
 
-    public void selectImportOption(String option, int index)
-    {
-        waitForText("Import Lookups by Alternate Key");
-        String componentId = "insertOptionHidden" + index;
-        String script = "Ext4.ComponentManager.get('" + componentId + "').setValue('" + option + "')";
-        executeScript(script);
-    }
-
     public SampleTypeHelper goToSampleType(String name)
     {
         TestLogger.log("Go to the sample type '" + name + "'");
@@ -234,7 +226,10 @@ public class SampleTypeHelper extends WebDriverWrapper
         TestLogger.log("Adding data from file");
         ImportDataPage importDataPage = drt.clickImportBulkData();
         importDataPage.setFile(dataFile);
-        selectImportOption(importOption, 0);
+        if (MERGE_OPTION.equals(importOption))
+            importDataPage.setFileMerge(true);
+        else if (UPDATE_OPTION.equals(importOption))
+            importDataPage.setFileInsertOption(true);
         importDataPage.submit();
     }
 
@@ -278,7 +273,10 @@ public class SampleTypeHelper extends WebDriverWrapper
     {
         DataRegionTable drt = getSamplesDataRegionTable();
         ImportDataPage importDataPage = drt.clickImportBulkData();
-        selectImportOption(importOption, 1);
+        if (MERGE_OPTION.equals(importOption))
+            importDataPage.setCopyPasteMerge(true);
+        else if (UPDATE_OPTION.equals(importOption))
+            importDataPage.setCopyPasteInsertOption(true);
         importDataPage.setText(tsv);
         return importDataPage;
     }

--- a/src/org/labkey/test/util/SampleTypeHelper.java
+++ b/src/org/labkey/test/util/SampleTypeHelper.java
@@ -50,8 +50,9 @@ import static org.labkey.test.util.exp.SampleTypeAPIHelper.SAMPLE_TYPE_DATA_REGI
  */
 public class SampleTypeHelper extends WebDriverWrapper
 {
-    public static final String IMPORT_DATA_LABEL = "Insert";
-    public static final String MERGE_DATA_LABEL = "Insert and Replace";
+    public static final String IMPORT_OPTION = "IMPORT";
+    public static final String MERGE_OPTION = "MERGE";
+    public static final String UPDATE_OPTION = "UPDATE";
     private final WebDriver _driver;
 
     public enum StatusType {
@@ -154,12 +155,11 @@ public class SampleTypeHelper extends WebDriverWrapper
         return new CreateSampleTypePage(getDriver());
     }
 
-    public void selectImportOption(String label, int index)
+    public void selectImportOption(String option, int index)
     {
         waitForText("Import Lookups by Alternate Key");
-        boolean merge = MERGE_DATA_LABEL.equals(label);
-        String componentId = "insertOption" + index;
-        String script = "Ext4.ComponentManager.get('" + componentId + "').setValue(" + (merge ? "1" : "0") + ")";
+        String componentId = "insertOptionHidden" + index;
+        String script = "Ext4.ComponentManager.get('" + componentId + "').setValue('" + option + "')";
         executeScript(script);
     }
 
@@ -220,12 +220,12 @@ public class SampleTypeHelper extends WebDriverWrapper
 
     public void bulkImport(File dataFile)
     {
-        fileImport(dataFile, IMPORT_DATA_LABEL);
+        fileImport(dataFile, IMPORT_OPTION);
     }
 
     public void mergeImport(File dataFile)
     {
-        fileImport(dataFile, MERGE_DATA_LABEL);
+        fileImport(dataFile, MERGE_OPTION);
     }
 
     private void fileImport(File dataFile, String importOption)
@@ -240,19 +240,19 @@ public class SampleTypeHelper extends WebDriverWrapper
 
     public void bulkImport(String tsvData)
     {
-        startTsvImport(tsvData, IMPORT_DATA_LABEL)
+        startTsvImport(tsvData, IMPORT_OPTION)
                 .submit();
     }
 
     public void mergeImport(String tsvData)
     {
-        startTsvImport(tsvData, SampleTypeHelper.MERGE_DATA_LABEL)
+        startTsvImport(tsvData, SampleTypeHelper.MERGE_OPTION)
                 .submit();
     }
 
     public void bulkImport(List<Map<String, String>> data)
     {
-        startTsvImport(data, IMPORT_DATA_LABEL)
+        startTsvImport(data, IMPORT_OPTION)
                 .submit();
     }
 
@@ -264,13 +264,13 @@ public class SampleTypeHelper extends WebDriverWrapper
 
     public void mergeImport(List<Map<String, String>> data)
     {
-        startTsvImport(data, SampleTypeHelper.MERGE_DATA_LABEL)
+        startTsvImport(data, SampleTypeHelper.MERGE_OPTION)
                 .submit();
     }
 
     public void mergeImportExpectingError(List<Map<String, String>> data)
     {
-        startTsvImport(data, SampleTypeHelper.MERGE_DATA_LABEL)
+        startTsvImport(data, SampleTypeHelper.MERGE_OPTION)
                 .submitExpectingError();
     }
 


### PR DESCRIPTION
#### Rationale
The bulk update page for lists, datasets, samples and dataclasses now support an explicit UPDATE option.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4089
* https://github.com/LabKey/testAutomation/pull/1369

#### Changes
* update ImportDataPage to reflect the new update/merge UI
