### PR TITLE
Test updates to align summary and detail views in Domain Designer

### DIFF
--- a/src/org/labkey/test/components/react/ToggleButton.java
+++ b/src/org/labkey/test/components/react/ToggleButton.java
@@ -39,9 +39,24 @@ public class ToggleButton extends WebDriverComponent<WebDriverComponent<?>.Eleme
         return this;
     }
 
+    /*
+        The componentElement will get the 'off' class when the slider is grayed out.
+     */
     public boolean get()
     {
         return !getComponentElement().getAttribute("class").contains("off");
+    }
+
+    /*
+        the 'off' status causes the child span with 'toggle-off' class to be shown; otherwise,
+        the one with 'toggle-on' is shown.
+     */
+    public String getSelectedStatus()
+    {
+        if (get())
+            return Locator.tagWithClass("span", "toggle-on").findElement(this).getText();
+        else
+            return Locator.tagWithClass("span", "toggle-off").findElement(this).getText();
     }
 
     public static class ToggleButtonFinder extends WebDriverComponentFinder<ToggleButton, ToggleButtonFinder>

--- a/src/org/labkey/test/tests/FieldEditorRowSelectionActionTest.java
+++ b/src/org/labkey/test/tests/FieldEditorRowSelectionActionTest.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Category(Daily.class)
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
 public class FieldEditorRowSelectionActionTest extends BaseWebDriverTest
@@ -92,18 +94,19 @@ public class FieldEditorRowSelectionActionTest extends BaseWebDriverTest
         checker().verifyTrue("Exported Fields are not same as UI", uiFields.equals(exportedFields));
 
         log("Verifying the toggle between summary view and detail view list domain");
-        checker().verifyTrue("Incorrect default display mode", domainFormPanel.isSummaryMode());
+        checker().verifyTrue("Incorrect default display mode", domainFormPanel.isDetailMode());
 
-        domainFormPanel.switchMode("Detail Mode");
-        checker().verifyTrue("Did not switch to Detail Mode", domainFormPanel.isDetailMode());
-        checker().verifyEquals("Incorrect header values in detail mode in list domain",
-                expectedListHeaders, domainFormPanel.getDetailModeHeaders());
+        domainFormPanel.switchMode("Summary Mode");
+        checker().verifyTrue("Did not switch to Summary Mode", domainFormPanel.isSummaryMode());
+        checker().wrapAssertion(()-> assertThat(domainFormPanel.getSummaryModeColumns())
+                .as("Incorrect header values in summary mode in list domain")
+                .containsAll(expectedListHeaders));
 
         Locator.linkWithText("FirstName").findElement(getDriver()).click();
         checker().verifyTrue("Clicking on the name data did not navigate to summary mode", domainFormPanel.isSummaryMode());
         checker().verifyTrue("Clicked row is not expanded in summary mode", domainFormPanel.getField("FirstName").isExpanded());
         checker().verifyEquals("Inconsistent number of rows in summary and detail mode",
-                domainFormPanel.fieldNames().size(), domainFormPanel.getRowCountInDetailMode());
+                domainFormPanel.fieldNames().size(), domainFormPanel.getRowcountInSummaryMode());
 
         domainDesignerPage.clickCancelWithUnsavedChanges().discardChanges();
     }
@@ -129,18 +132,20 @@ public class FieldEditorRowSelectionActionTest extends BaseWebDriverTest
         checker().verifyTrue("Exported Fields are not same as UI", exportedFields.equals(domainFormPanel.fieldNames()));
 
         log("Verifying the toggle between summary view and detail view");
-        checker().verifyTrue("Incorrect default display mode", domainFormPanel.isSummaryMode());
+        checker().verifyTrue("Incorrect default display mode", domainFormPanel.isDetailMode());
 
-        domainFormPanel.switchMode("Detail Mode");
-        checker().verifyTrue("Did not switch to Detail Mode", domainFormPanel.isDetailMode());
-        checker().verifyEquals("Incorrect header values in detail mode", expectedHeaders, domainFormPanel.getDetailModeHeaders());
+        domainFormPanel.switchMode("Summary Mode");
+        checker().verifyTrue("Did not switch to Summary Mode", domainFormPanel.isSummaryMode());
+        checker().wrapAssertion(()-> assertThat(domainFormPanel.getSummaryModeColumns())
+                        .as("Incorrect columns in summary mode")
+                        .containsAll(expectedHeaders));
 
         log("Checking the links in detail mode");
         Locator.linkWithText("Language").findElement(getDriver()).click();
         checker().verifyTrue("Clicking on the name data did not navigate to summary mode", domainFormPanel.isSummaryMode());
         checker().verifyTrue("Clicked row is not expanded in summary mode", domainFormPanel.getField("Language").isExpanded());
         checker().verifyEquals("Inconsistent number of rows in summary and detail mode",
-                domainFormPanel.fieldNames().size(), domainFormPanel.getRowCountInDetailMode());
+                domainFormPanel.fieldNames().size(), domainFormPanel.getRowcountInSummaryMode());
 
         domainDesignerPage.clickCancelWithUnsavedChanges().discardChanges();
 
@@ -203,18 +208,18 @@ public class FieldEditorRowSelectionActionTest extends BaseWebDriverTest
                 domainFormPanel.fieldNames().equals(getFieldsFromExportFile(downloadedFile)));
 
         log("Verifying the toggle between summary view and detail view for Results domain");
-        checker().verifyTrue("Incorrect default display mode for result domain", domainFormPanel.isSummaryMode());
+        checker().verifyTrue("Incorrect default display mode for result domain", domainFormPanel.isDetailMode());
 
-        domainFormPanel.switchMode("Detail Mode");
-        checker().verifyTrue("Did not switch to Detail Mode", domainFormPanel.isDetailMode());
-        List<String> actualHeaders = domainFormPanel.getDetailModeHeaders();
+        domainFormPanel.switchMode("Summary Mode");
+        checker().verifyTrue("Did not switch to Summary Mode", domainFormPanel.isSummaryMode());
+        List<String> actualHeaders = domainFormPanel.getSummaryModeColumns();
         checker().verifyEquals("Incorrect header values in detail mode in result domain", expectedHeaders, actualHeaders);
 
         Locator.linkWithText("Date").findElement(getDriver()).click();
-        checker().verifyTrue("Clicking on the name data did not navigate to summary mode", domainFormPanel.isSummaryMode());
-        checker().verifyTrue("Clicked row is not expanded in summary mode", domainFormPanel.getField("Date").isExpanded());
+        checker().verifyTrue("Clicking on the name data did not navigate to detail mode", domainFormPanel.isDetailMode());
+        checker().verifyTrue("Clicked row is not expanded in detail mode", domainFormPanel.getField("Date").isExpanded());
         checker().verifyEquals("Inconsistent number of rows in summary and detail mode",
-                domainFormPanel.fieldNames().size(), domainFormPanel.getRowCountInDetailMode());
+                domainFormPanel.fieldNames().size(), domainFormPanel.getRowcountInSummaryMode());
 
         assayDesignerPage.clickSave();
     }


### PR DESCRIPTION
#### Rationale
Recent feature work adds a table containing "Default System Fields" to the DomainFormPanel containing fields in the Domain Designer.  This addition caused some test failures because this new table interfered with the way the tests have been finding Summary-mode table columns (yes, two tables will be present now, in Sample and DataClass domains:) 
![image](https://user-images.githubusercontent.com/16809856/217675008-a1afdf59-6bab-4c1d-be7f-e6968ef78e76.png)

While investigating this, I discovered a curious inversion in the way DomainFormPanel understood Summary Mode vs. Details Mode- the logic of the way the tests worked was correct, but the labeling and terminology were inverted- when the toggle shows [Summary mode], the panel shows a (fairly detailed) table of domain fields with columns for their attributes, when it shows [Detail mode], it shows the FieldRows as expandable, editable, etc.  When reading the old code, toggling to go to 'summary mode' used to toggle the button to make it show 'Detail Mode', and vice versa- which I thought was confusing.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1099
- https://github.com/LabKey/platform/pull/4096
- https://github.com/LabKey/sampleManagement/pull/1594
- https://github.com/LabKey/biologics/pull/1913
- https://github.com/LabKey/inventory/pull/721
- https://github.com/LabKey/labkey-ui-premium/pull/40
- https://github.com/LabKey/testAutomation/pull/1372
- https://github.com/LabKey/ontology/pull/115

#### Changes

- [x] Implement the mode-toggle of DomainFormPanel to use a ToggleButton
- [x] Add the ability to confirm state in ToggleButton
- [x] Refactor DomainFormPanel methods related to mode to use 'summary'/'detail' according to toggle text
- [x] Update tests using these methods
- [x] Use summary grid to obtain its headers
- [x] add expand/collapse/get for new "System Default Fields" grid
