### PR TITLE
Fix test race condition on participant webpart

### DIFF
--- a/src/org/labkey/test/tests/ParticipantReportTest.java
+++ b/src/org/labkey/test/tests/ParticipantReportTest.java
@@ -134,7 +134,8 @@ public class ParticipantReportTest extends ReportTest
 
         // Check that group has correct number of participants
         clickAndWait(Locator.linkWithText("Mice"));
-        waitForElement(Locator.css(".lk-filter-panel-label")); // Wait for participant list to appear.
+        waitForElement(Locator.css(".lk-filter-panel-label.group-label")); // Wait for group checkboxes
+        waitForElement(Locator.css(".subjectlist")); // Wait for participant list to appear
         _ext4Helper.deselectAllParticipantFilter();
         waitForText("No matching enrolled Mice");
         _ext4Helper.checkGridRowCheckbox(MICE_C);


### PR DESCRIPTION
#### Rationale
`ParticipantReportTest` fails regularly on TeamCity because it starts checking checkboxes before the form is ready.
![image](https://user-images.githubusercontent.com/5263798/217686622-ffd527d9-e480-4a61-85ab-903713b15b4d.png)

#### Changes
* Wait for more stuff on participant webpart
