### PR TITLE
Updated Test Components for Perf Tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ jettyRepackagedVersion=9.4.12.v20180830
 seleniumVersion=4.1.4
 mockserverNettyVersion=5.5.1
 
-labkeySchemasTestVersion=23.2-SNAPSHOT
+labkeySchemasTestVersion=23.3-SNAPSHOT

--- a/src/org/labkey/test/components/ui/Pager.java
+++ b/src/org/labkey/test/components/ui/Pager.java
@@ -49,6 +49,12 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
         return this;
     }
 
+    public MultiMenu getDropDownMenu()
+    {
+        elementCache().jumpToDropdown.expand();
+        return elementCache().jumpToDropdown;
+    }
+
     public int getCurrentPage()                 // only works on GridPanel
     {
         return Integer.parseInt(elementCache().currentPageButton.getText());

--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -239,7 +239,7 @@ public class EntityBulkUpdateDialog extends ModalDialog
         final Locator numberInputLoc = Locator.tagWithAttribute("input", "type", "number");
         final Locator checkBoxLoc = Locator.tagWithAttribute("input", "type", "checkbox");
 
-        final WebElement updateButton = Locator.tagWithClass("button", "test-loc-submit-button").findWhenNeeded(this);
+        final WebElement updateButton = Locator.tagWithClass("button", "btn-success").findWhenNeeded(this);
     }
 
 }

--- a/src/org/labkey/test/util/exp/DataClassAPIHelper.java
+++ b/src/org/labkey/test/util/exp/DataClassAPIHelper.java
@@ -1,6 +1,11 @@
 package org.labkey.test.util.exp;
 
+import org.junit.Assert;
 import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.query.Filter;
+import org.labkey.remoteapi.query.SelectRowsCommand;
+import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.DataClassDefinition;
@@ -9,7 +14,11 @@ import org.labkey.test.util.TestDataGenerator;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class DataClassAPIHelper
 {
@@ -49,6 +58,33 @@ public class DataClassAPIHelper
                 new FieldDefinition("sampleDate", FieldDefinition.ColumnType.DateAndTime),
                 new FieldDefinition("boolColumn", FieldDefinition.ColumnType.Boolean),
                 new FieldDefinition("attachmentColumn", FieldDefinition.ColumnType.Attachment));
+    }
+
+    public static Map<String, Integer> getRowIdsForDataEntity(String containerPath, String dataTypeName, List<String> entityNames) throws IOException, CommandException
+    {
+
+        Connection connection = WebTestHelper.getRemoteApiConnection();
+        SelectRowsCommand cmd = new SelectRowsCommand("exp.data", dataTypeName);
+        cmd.setColumns(Arrays.asList("RowId", "Name"));
+        cmd.addFilter("Name", String.join(";", entityNames), Filter.Operator.IN);
+
+        SelectRowsResponse response = cmd.execute(connection, containerPath);
+
+        Map<String, Integer> rowIds = new HashMap<>();
+
+        for(Map<String, Object> row : response.getRows())
+        {
+            Object name = row.get("Name");
+            Object value = row.get("RowId");
+            rowIds.put(name.toString(), Integer.parseInt(value.toString()));
+        }
+
+        // Check that the names returned from the query match the names sent in.
+        Set<String> names = new HashSet<>(entityNames);
+        Assert.assertTrue("The names of the data entities returned from the query do not match the names sent in.",
+                names.containsAll(rowIds.keySet()));
+
+        return rowIds;
     }
 
 }

--- a/src/org/labkey/test/util/exp/DataClassAPIHelper.java
+++ b/src/org/labkey/test/util/exp/DataClassAPIHelper.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class DataClassAPIHelper
 {
@@ -60,13 +59,23 @@ public class DataClassAPIHelper
                 new FieldDefinition("attachmentColumn", FieldDefinition.ColumnType.Attachment));
     }
 
-    public static Map<String, Integer> getRowIdsForDataEntity(String containerPath, String dataTypeName, List<String> entityNames) throws IOException, CommandException
+    /**
+     * Given a folder name, the name of a source type, and a list of source names return the list of row ids.
+     *
+     * @param containerPath Path of the container where the source type is defined.
+     * @param sourceTypeName Name of the source type that contains the sources.
+     * @param sourceNames List of sources to get row ids for.
+     * @return A map of containing source names and their corresponding row ids.
+     * @throws IOException Can be thrown by the call to SelectRowsCommand.
+     * @throws CommandException Can be thrown by the call to SelectRowsCommand.
+     */
+    public static Map<String, Integer> getRowIdsForSources(String containerPath, String sourceTypeName, List<String> sourceNames) throws IOException, CommandException
     {
 
         Connection connection = WebTestHelper.getRemoteApiConnection();
-        SelectRowsCommand cmd = new SelectRowsCommand("exp.data", dataTypeName);
+        SelectRowsCommand cmd = new SelectRowsCommand("exp.data", sourceTypeName);
         cmd.setColumns(Arrays.asList("RowId", "Name"));
-        cmd.addFilter("Name", String.join(";", entityNames), Filter.Operator.IN);
+        cmd.addFilter("Name", String.join(";", sourceNames), Filter.Operator.IN);
 
         SelectRowsResponse response = cmd.execute(connection, containerPath);
 
@@ -80,9 +89,8 @@ public class DataClassAPIHelper
         }
 
         // Check that the names returned from the query match the names sent in.
-        Set<String> names = new HashSet<>(entityNames);
-        Assert.assertTrue("The names of the data entities returned from the query do not match the names sent in.",
-                names.containsAll(rowIds.keySet()));
+        Assert.assertEquals("The names of the sources returned from the query do not match the names sent in.",
+                new HashSet<>(sourceNames), rowIds.keySet());
 
         return rowIds;
     }

--- a/src/org/labkey/test/util/exp/SampleTypeAPIHelper.java
+++ b/src/org/labkey/test/util/exp/SampleTypeAPIHelper.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class SampleTypeAPIHelper
 {
@@ -95,9 +94,8 @@ public class SampleTypeAPIHelper
         }
 
         // Check that the names returned from the query match the names sent in.
-        Set<String> names = new HashSet<>(sampleNames);
-        Assert.assertTrue("The sample names returned from the query do not match the sample names sent in.",
-                names.containsAll(rowIds.keySet()));
+        Assert.assertEquals("The sample names returned from the query do not match the sample names sent in.",
+                new HashSet<>(sampleNames), rowIds.keySet());
 
         return rowIds;
     }


### PR DESCRIPTION
#### Rationale
I needed to make some minor changes to accommodate the UI Perf tests.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/1552

#### Changes
* Added a getter for the grid Pager dropdown menu. The perf test uses it to get a reference to the menu item it needs to click.
* Use a more generic class name in the finder for the success button on the EntityBulkUpdateDialog. It wasn't finding the button when doing a bulk update from the 'Add New' page.
* Added DataClassAPIHelper.getRowIdsForDataEntity. Used to get the row id of an entity in a data class, specifically the row id of a source.
