### PR TITLE
Update fieldEditor test to wait for DomainFormPanel mode switch

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -393,6 +393,19 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
                 .waitFor(this);
     }
 
+    /*
+
+     */
+    public DomainFormPanel clickSummaryGridNameLink(String linkText)
+    {
+        var targetCell = getSummaryModeGrid().getRow("Name", linkText).getCell("Name");
+        var clickable = Locator.linkWithText(linkText).findElement(targetCell);
+        clickable.click();
+        WebDriverWrapper.waitFor(()-> isDetailMode(),
+                "DomainFormPanel did not switch to detail mode as expected", 2000);
+        return this;
+    }
+
     public List<String> getSummaryModeColumns()
     {
         var rawColumns = getSummaryModeGrid().getColumnNames();

--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -357,7 +357,7 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
 
         var selectParent = FilteringReactSelect.finder(getDriver())
                 .withNamedInput(String.format("parentEntityValue_%s", typeName))
-                .find(this);
+                .waitFor(this);
 
         for (String id : parentIds)
         {

--- a/src/org/labkey/test/tests/FieldEditorRowSelectionActionTest.java
+++ b/src/org/labkey/test/tests/FieldEditorRowSelectionActionTest.java
@@ -102,8 +102,8 @@ public class FieldEditorRowSelectionActionTest extends BaseWebDriverTest
                 .as("Incorrect header values in summary mode in list domain")
                 .containsAll(expectedListHeaders));
 
-        Locator.linkWithText("FirstName").findElement(getDriver()).click();
-        checker().verifyTrue("Clicking on the name data did not navigate to summary mode", domainFormPanel.isSummaryMode());
+        domainFormPanel.clickSummaryGridNameLink("FirstName");
+        checker().verifyTrue("Clicking on the name data did not navigate to summary mode", domainFormPanel.isDetailMode());
         checker().verifyTrue("Clicked row is not expanded in summary mode", domainFormPanel.getField("FirstName").isExpanded());
         checker().verifyEquals("Inconsistent number of rows in summary and detail mode",
                 domainFormPanel.fieldNames().size(), domainFormPanel.getRowcountInSummaryMode());
@@ -140,10 +140,10 @@ public class FieldEditorRowSelectionActionTest extends BaseWebDriverTest
                         .as("Incorrect columns in summary mode")
                         .containsAll(expectedHeaders));
 
-        log("Checking the links in detail mode");
-        Locator.linkWithText("Language").findElement(getDriver()).click();
-        checker().verifyTrue("Clicking on the name data did not navigate to summary mode", domainFormPanel.isSummaryMode());
-        checker().verifyTrue("Clicked row is not expanded in summary mode", domainFormPanel.getField("Language").isExpanded());
+        log("Checking the links in summary mode");
+        domainFormPanel.clickSummaryGridNameLink("Language");
+        checker().verifyTrue("Clicking on the name data did not navigate to detail mode", domainFormPanel.isDetailMode());
+        checker().verifyTrue("Clicked row is not expanded in detail mode", domainFormPanel.getField("Language").isExpanded());
         checker().verifyEquals("Inconsistent number of rows in summary and detail mode",
                 domainFormPanel.fieldNames().size(), domainFormPanel.getRowcountInSummaryMode());
 
@@ -213,9 +213,11 @@ public class FieldEditorRowSelectionActionTest extends BaseWebDriverTest
         domainFormPanel.switchMode("Summary Mode");
         checker().verifyTrue("Did not switch to Summary Mode", domainFormPanel.isSummaryMode());
         List<String> actualHeaders = domainFormPanel.getSummaryModeColumns();
-        checker().verifyEquals("Incorrect header values in detail mode in result domain", expectedHeaders, actualHeaders);
+        checker().wrapAssertion(()-> assertThat(actualHeaders)
+                .as("Incorrect header values in detail mode in result domain")
+                .containsAll(expectedHeaders));
 
-        Locator.linkWithText("Date").findElement(getDriver()).click();
+        domainFormPanel.clickSummaryGridNameLink("Date");
         checker().verifyTrue("Clicking on the name data did not navigate to detail mode", domainFormPanel.isDetailMode());
         checker().verifyTrue("Clicked row is not expanded in detail mode", domainFormPanel.getField("Date").isExpanded());
         checker().verifyEquals("Inconsistent number of rows in summary and detail mode",


### PR DESCRIPTION
#### Rationale
Several test methods in `FieldEditorRowSelectionActionTest `click on links and immediately check to see that clicking the link will cause the `DomainFormPanel `to be in Details Mode- this adds a method to `DomainFormPanel `to click the specified link and await the expected mode-switch.

Today a test in Biologics[ failed](https://teamcity.labkey.org/viewLog.html?buildId=2280713&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsCPostgres&fromSakuraUI=true#testNameId722163783123437889) to find the parent select that was present in the html artifact; it appears that `ParentEditEntityPanel.addParents()` is vulnerable to this sort of timing issue, so changing it to wait for the select (vs. expecting it to be instantly there) seems to be a way to avoid test noise.


#### Related Pull Requests
n/a

#### Changes

- [x] Add clickSummaryGridNameLink() to DomainFormPanel
- [x] update ParentEntityEditPanel to wait for the parent select vs. expecting it to already be there
- [x] Update FieldEditorRowSelectionActionTest methods to use clickSummaryGridNameLink() vs. clicking links and assuming the UI will update before the next line of code
- [x] Update field verification in test to verify the expected field attributes are present, (as opposed to strictly equal) because that will fail locally if you've got modules (like ontology) local that will add field attributes
