### PR TITLE
Add script for cleaning up a trial db dump

### DIFF
--- a/data/pgrestore/README.md
+++ b/data/pgrestore/README.md
@@ -28,3 +28,4 @@ Things that you might want to update (via SQL script or through LabKey UI after 
 - serverGUID
 - DefaultDomain
 - remove email template overrides
+- pipeline tools directory

--- a/data/pgrestore/README.md
+++ b/data/pgrestore/README.md
@@ -1,0 +1,30 @@
+### Dumping trial db
+Pre-dump preparation
+- Create site admin user admin@local.host
+  - Set password and record it for use by others
+
+### Restoring trial db
+After restoring the database dump, before starting LabKey, run the included script ([cleanPgDump.sh](./cleanPgDump.sh)).
+You can also run the individual queries listed below.
+- Update baseServerURL (usually http://localhost:8080) so redirects for changing passwords don't go to the trial instance
+  - `UPDATE prop.properties SET value = 'http://localhost:8080' WHERE name = 'baseServerURL';`
+- Disable 'autoredirect' for SSO providers
+  - `UPDATE core.authenticationconfigurations SET autoredirect = 'FALSE' WHERE TRUE;`
+- Disable SSL
+  - `UPDATE prop.properties SET value = 'FALSE' WHERE name = 'sslRequired';`
+- Update site file root (Use your actual file root location)
+  - `UPDATE prop.properties SET value = '<$LABKEY_HOME/build/deploy/files>' WHERE name = 'siteFileRoot';`
+- Disable mothership reporting
+  - `UPDATE prop.properties SET value = 'NONE' WHERE name = 'exceptionReportingLevel';`
+  - `UPDATE prop.properties SET value = 'NONE' WHERE name = 'usageReportingLevel';`
+- Disable tracking and analytics
+  - `UPDATE prop.properties SET value = '' WHERE name = 'accountId';`
+  - `UPDATE prop.properties SET value = '' WHERE name = 'trackingScript';`
+
+Things that you might want to update:
+- search index file path
+- systemShortName
+- systemDescription
+- serverGUID
+- DefaultDomain
+- remove email template overrides

--- a/data/pgrestore/README.md
+++ b/data/pgrestore/README.md
@@ -21,7 +21,7 @@ You can also run the individual queries listed below.
   - `UPDATE prop.properties SET value = '' WHERE name = 'accountId';`
   - `UPDATE prop.properties SET value = '' WHERE name = 'trackingScript';`
 
-Things that you might want to update:
+Things that you might want to update (via SQL script or through LabKey UI after starting the server):
 - search index file path
 - systemShortName
 - systemDescription

--- a/data/pgrestore/cleanPgDump.sh
+++ b/data/pgrestore/cleanPgDump.sh
@@ -9,6 +9,7 @@ export PGDATABASE=${PGDATABASE:-labkey_restored}
 
 BASE_SERVER_URL=${BASE_SERVER_URL:-http://localhost:8080}
 LABKEY_FILES=${LABKEY_FILES:-$LABKEY_HOME/build/deploy/files}
+LABKEY_PIPELINE_TOOLS=${LABKEY_PIPELINE_TOOLS:-$LABKEY_HOME/build/deploy/bin}
 
 ## Check that we can connect to DB
 psql -ew -c "SELECT 1" &> /dev/null || (
@@ -26,6 +27,10 @@ psql -ew -c "UPDATE prop.properties p1 SET value = '${BASE_SERVER_URL}'
 psql -ew -c "UPDATE prop.properties p1 SET value = '${LABKEY_FILES}'
     FROM prop.propertysets p2 WHERE p1.set = p2.set
     AND p1.name = 'siteFileRoot' AND p2.category = 'SiteConfig';"
+# Update pipeline tools directory
+psql -ew -c "UPDATE prop.properties p1 SET value = '${LABKEY_PIPELINE_TOOLS}'
+    FROM prop.propertysets p2 WHERE p1.set = p2.set
+    AND p1.name = 'pipelineToolsDirectory' AND p2.category = 'SiteConfig';"
 # Disable SSL requirement
 psql -ew -c "UPDATE prop.properties p1 SET value = 'FALSE'
     FROM prop.propertysets p2 WHERE p1.set = p2.set

--- a/data/pgrestore/cleanPgDump.sh
+++ b/data/pgrestore/cleanPgDump.sh
@@ -62,3 +62,9 @@ psql -ew -c "UPDATE prop.properties p1 SET value = ''
 psql -ew -c "UPDATE prop.properties p1 SET value = ''
     FROM prop.propertysets p2 WHERE p1.set = p2.set
     AND p1.name = 'trackingScript' AND p2.category = 'analytics';"
+
+## Clear trial server properties
+psql -ew -c "UPDATE prop.properties p1 SET value = ''
+    WHERE p1.name = 'EvaluationContent Settings/manageHostedSiteUrl';"
+psql -ew -c "UPDATE prop.properties p1 SET value = ''
+    WHERE p1.name = 'EvaluationContent Settings/trialEndDate';"

--- a/data/pgrestore/cleanPgDump.sh
+++ b/data/pgrestore/cleanPgDump.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -eu
+
+export PGHOST=${PGHOST:-localhost}
+export PGPORT=${PGPORT:-5432}
+export PGUSER=${PGUSER:-postgres}
+export PGDATABASE=${PGDATABASE:-labkey_restored}
+
+BASE_SERVER_URL=${BASE_SERVER_URL:-http://localhost:8080}
+LABKEY_FILES=${LABKEY_FILES:-$LABKEY_HOME/build/deploy/files}
+
+## Check that we can connect to DB
+psql -ew -c "SELECT 1" &> /dev/null || (
+ echo "Unable to connect to database." &&
+ echo "How to define connection variables: https://www.postgresql.org/docs/current/libpq-envars.html" &&
+ echo "How to authenticate: https://www.postgresql.org/docs/current/libpq-pgpass.html" &&
+ exit 1)
+
+## Update site config settings
+# Update base server URL so that various redirects and notifications are correct
+psql -ew -c "UPDATE prop.properties p1 SET value = '${BASE_SERVER_URL}'
+    FROM prop.propertysets p2 WHERE p1.set = p2.set
+    AND p1.name = 'baseServerURL' AND p2.category = 'SiteConfig';"
+# Update site file root
+psql -ew -c "UPDATE prop.properties p1 SET value = '${LABKEY_FILES}'
+    FROM prop.propertysets p2 WHERE p1.set = p2.set
+    AND p1.name = 'siteFileRoot' AND p2.category = 'SiteConfig';"
+# Disable SSL requirement
+psql -ew -c "UPDATE prop.properties p1 SET value = 'FALSE'
+    FROM prop.propertysets p2 WHERE p1.set = p2.set
+    AND p1.name = 'sslRequired' AND p2.category = 'SiteConfig';"
+# Disable reporting exceptions to mothership
+psql -ew -c "UPDATE prop.properties p1 SET value = 'NONE'
+    FROM prop.propertysets p2 WHERE p1.set = p2.set
+    AND p1.name = 'exceptionReportingLevel' AND p2.category = 'SiteConfig';"
+# Disable reporting usage to mothership
+psql -ew -c "UPDATE prop.properties p1 SET value = 'NONE'
+    FROM prop.propertysets p2 WHERE p1.set = p2.set
+    AND p1.name = 'usageReportingLevel' AND p2.category = 'SiteConfig';"
+
+## Update authentication settings
+# Disable reporting usage to mothership
+psql -ew -c "UPDATE prop.properties p1 SET value = 'localhost'
+    FROM prop.propertysets p2 WHERE p1.set = p2.set
+    AND p1.name = 'DefaultDomain' AND p2.category = 'Authentication';"
+# Disable autoredirect for all authentication configs (usually just CAS)
+psql -ew -c "UPDATE core.authenticationconfigurations SET autoredirect=FALSE;"
+
+## Update look and feel settings
+psql -ew -c "UPDATE prop.properties p1 SET value = 'LabKey Server'
+    FROM prop.propertysets p2 WHERE p1.set = p2.set
+    AND p1.name = 'systemShortName' AND p2.category = 'LookAndFeel';"
+psql -ew -c "UPDATE prop.properties p1 SET value = 'LabKey Server'
+    FROM prop.propertysets p2 WHERE p1.set = p2.set
+    AND p1.name = 'systemDescription' AND p2.category = 'LookAndFeel';"
+
+## Remove analytics tracking script
+psql -ew -c "UPDATE prop.properties p1 SET value = ''
+    FROM prop.propertysets p2 WHERE p1.set = p2.set
+    AND p1.name = 'accountId' AND p2.category = 'analytics';"
+psql -ew -c "UPDATE prop.properties p1 SET value = ''
+    FROM prop.propertysets p2 WHERE p1.set = p2.set
+    AND p1.name = 'trackingScript' AND p2.category = 'analytics';"


### PR DESCRIPTION
#### Rationale
We run these queries on TeamCity to prep the database for selenium tests. Adding the script to source control to allow folks to run them locally and so they aren't hidden away in a TeamCity build configuration.

#### Related Pull Requests
* N/A

#### Changes
* Add script for cleaning up a trial db dump