### PR TITLE
Avoid click interception on group creation page

### DIFF
--- a/src/org/labkey/test/pages/PermissionsEditor.java
+++ b/src/org/labkey/test/pages/PermissionsEditor.java
@@ -363,8 +363,8 @@ public class PermissionsEditor
     {
         clickManageGroup(groupName);
 
-        _test.setFormElement(Locator.name("names"), String.join("\n", userNames));
         _test.uncheckCheckbox(Locator.name("sendEmail"));
+        _test.setFormElement(Locator.name("names"), String.join("\n", userNames));
         _test.clickButton("Update Group Membership");
     }
 }

--- a/src/org/labkey/test/pages/admin/PermissionsPage.java
+++ b/src/org/labkey/test/pages/admin/PermissionsPage.java
@@ -428,17 +428,13 @@ public class PermissionsPage extends LabKeyPage<PermissionsPage.ElementCache>
     {
         clickManageGroup(groupName);
 
-        setFormElement(Locator.name("names"), String.join("\n", userNames));
-        uncheckCheckbox(Locator.name("sendEmail"));
-        clickButton("Update Group Membership");
-        return this;
+        return addUserToGroupFromGroupScreen(userNames);
     }
 
-    public PermissionsPage addUserToGroupFromGroupScreen(String userName)
+    public PermissionsPage addUserToGroupFromGroupScreen(@LoggedParam String... userNames)
     {
-        waitForElement(Locator.name("names"));
-        setFormElement(Locator.name("names"), userName);
         uncheckCheckbox(Locator.name("sendEmail"));
+        setFormElement(Locator.name("names"), String.join("\n", userNames));
         clickButton("Update Group Membership");
         return this;
     }

--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -417,8 +417,8 @@ public class WikiLongTest extends BaseWebDriverTest
         log("Create fake user for permissions check");
         _permissionsHelper.enterPermissionsUI();
         _permissionsHelper.clickManageGroup(USERS_GROUP);
-        setFormElement(Locator.name("names"), USER1);
         uncheckCheckbox(Locator.name("sendEmail"));
+        setFormElement(Locator.name("names"), USER1);
         clickButton("Update Group Membership");
 
         log("Check if permissions work");


### PR DESCRIPTION
#### Rationale
The email auto-complete popup blocks the 'sendEmail' checkbox. The easy fix is to just uncheck the checkbox before entering any emails.
```
org.openqa.selenium.ElementClickInterceptedException: Element <input name="sendEmail" type="checkbox"> is not clickable at point (27,551) because another element <span> obscures it
[...]
  at app//org.labkey.test.WebDriverWrapper.uncheckCheckbox(WebDriverWrapper.java:1)
  at app//org.labkey.test.util.UIPermissionsHelper.createGlobalPermissionsGroup(UIPermissionsHelper.java:90)
  at app//org.labkey.test.util.UIPermissionsHelper.createGlobalPermissionsGroup(UIPermissionsHelper.java:51)
```
![image](https://user-images.githubusercontent.com/5263798/219728782-692b8236-d2c2-4110-ba75-239c78b4c57f.png)

#### Related Pull Requests
* N/A

#### Changes
* Uncheck checkbox before entering emails
