### PR TITLE
Update expected spacing for impersonated / stopped impersonating roles

### DIFF
--- a/src/org/labkey/test/components/ui/pipeline/ImportsPage.java
+++ b/src/org/labkey/test/components/ui/pipeline/ImportsPage.java
@@ -1,6 +1,6 @@
 package org.labkey.test.components.ui.pipeline;
 
-import org.apache.tika.utils.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.ui.grids.QueryGrid;

--- a/src/org/labkey/test/tests/AuditLogTest.java
+++ b/src/org/labkey/test/tests/AuditLogTest.java
@@ -279,10 +279,10 @@ public class AuditLogTest extends BaseWebDriverTest
         expectedLogValues.add(getUsername() + " stopped impersonating " + AUDIT_TEST_USER);
 
         impersonateRoles(PROJECT_ADMIN_ROLE, AUTHOR_ROLE);
-        expectedLogValues.add(getUsername() + " impersonated roles: " + PROJECT_ADMIN_ROLE + "," + AUTHOR_ROLE);
+        expectedLogValues.add(getUsername() + " impersonated roles: " + PROJECT_ADMIN_ROLE + ", " + AUTHOR_ROLE);
 
         stopImpersonating();
-        expectedLogValues.add(getUsername() + " stopped impersonating roles: " + PROJECT_ADMIN_ROLE + "," + AUTHOR_ROLE);
+        expectedLogValues.add(getUsername() + " stopped impersonating roles: " + PROJECT_ADMIN_ROLE + ", " + AUTHOR_ROLE);
 
         String adminGroup = "Administrator";
         impersonateGroup(adminGroup, true);


### PR DESCRIPTION
#### Rationale
`AuditLogTest` is failing because my removal of errant `StringUtils` libraries lead to a trivial spacing change in the impersonate roles list. Teach the test to expect the new way.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4124
