### PR TITLE
Add “ExpirationDate” field to exp.material

### DIFF
--- a/src/org/labkey/test/tests/component/EntityInsertPanelTest.java
+++ b/src/org/labkey/test/tests/component/EntityInsertPanelTest.java
@@ -64,9 +64,9 @@ public class EntityInsertPanelTest extends BaseWebDriverTest
         EntityInsertPanel testPanel = testPage.getEntityInsertPanel();
         testPanel.targetEntityTypeSelect().select(sampleTypeName);
 
-        String pasteText = "ed\tbrother\tthe quiet one\t\t2\tstringfellow\t11/11/2020\ttrue\n" +
-                "jed\tother brother\tthe squinty one\t\t3\tstrongfellow\t11/11/2020\tfalse\n" +
-                "ted\tother other brother\tisn't sure about the others\t\t4\tstrangefellow\t11/11/2020\ttrue";
+        String pasteText = "ed\tbrother\tthe quiet one\t\t\t2\tstringfellow\t11/11/2020\ttrue\n" +
+                "jed\tother brother\tthe squinty one\t\t\t3\tstrongfellow\t11/11/2020\tfalse\n" +
+                "ted\tother other brother\tisn't sure about the others\t\t\t4\tstrangefellow\t11/11/2020\ttrue";
 
         testPanel.clickAddRows()
                 .getEditableGrid().pasteFromCell(0, "Name *", pasteText);

--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -59,6 +59,7 @@ public class GridPanelTest extends GridPanelBaseTest
 
     // Column names.
     private static final String FILTER_NAME_COL = "Name";
+    private static final String FILTER_EXPDATE_COL = "Expiration Date";
     private static final String FILTER_STRING_COL = "Str";
     private static final String FILTER_INT_COL = "Int";
     private static final String FILTER_EXTEND_CHAR_COL = "\u0106\u00D8\u0139";
@@ -1497,6 +1498,7 @@ public class GridPanelTest extends GridPanelBaseTest
 
         expectedList = new ArrayList<>();
         expectedList.add(FILTER_NAME_COL);
+        expectedList.add(FILTER_EXPDATE_COL);
         expectedList.add(FILTER_INT_COL);
         expectedList.add(FILTER_STRING_COL);
         expectedList.add(FILTER_DATE_COL);
@@ -1554,6 +1556,7 @@ public class GridPanelTest extends GridPanelBaseTest
 
         expectedList = new ArrayList<>(extraColumnsHeaders);
         expectedList.add(FILTER_NAME_COL);
+        expectedList.add(FILTER_EXPDATE_COL);
         expectedList.add(FILTER_STRING_COL);
         expectedList.add(FILTER_INT_COL);
         expectedList.add(FILTER_BOOL_COL);


### PR DESCRIPTION
#### Rationale
Support "expirationdate" for samples

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4121
* https://github.com/LabKey/sampleManagement/pull/1607
* https://github.com/LabKey/biologics/pull/1932
* https://github.com/LabKey/inventory/pull/737

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
