### PR TITLE
Remove references to non-existent 'internal' module

### DIFF
--- a/buildTestModules/communityArtifacts/build.gradle
+++ b/buildTestModules/communityArtifacts/build.gradle
@@ -9,9 +9,6 @@ dependencies {
     modules ("org.labkey.module:api:${labkeyVersion}@module") {
         transitive = true
     }
-    modules ("org.labkey.module:internal:${labkeyVersion}@module") {
-        transitive = true
-    }
     modules ("org.labkey.module:audit:${labkeyVersion}@module") {
         transitive = true
     }

--- a/buildTestModules/starterArtifacts/build.gradle
+++ b/buildTestModules/starterArtifacts/build.gradle
@@ -9,9 +9,6 @@ dependencies {
     modules ("org.labkey.module:api:${labkeyVersion}@module") {
         transitive = true
     }
-    modules ("org.labkey.module:internal:${labkeyVersion}@module") {
-        transitive = true
-    }
     modules ("org.labkey.module:audit:${labkeyVersion}@module") {
         transitive = true
     }


### PR DESCRIPTION
#### Rationale
The 'internal' module has been removed. Don't try to pull it from artifactory.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4099

#### Changes
* Remove references to 'internal' module
