### PR TITLE
Fix tests failures with materialExpDate

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -658,7 +658,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(childSampleType));
         samplesTable = DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
         samplesTable.setFilter("Name", "Equals", "derivedChildSample");
-        checker().verifyEquals("Incorrect child row created", Arrays.asList("derivedChildSample", "", "2.0", now + " 00:00", "P2", "linked"),
+        checker().verifyEquals("Incorrect child row created", Arrays.asList("derivedChildSample", "", "", "2.0", now + " 00:00", "P2", "linked"),
                 samplesTable.getRowDataAsText(0));
     }
 

--- a/src/org/labkey/test/tests/SampleTypeLinkedStudyExportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkedStudyExportTest.java
@@ -114,7 +114,7 @@ public class SampleTypeLinkedStudyExportTest extends BaseWebDriverTest
         goToProjectHome(IMPORT_PROJECT);
         clickAndWait(Locator.linkWithText(SAMPLE_TYPE));
         DataRegionTable table = DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
-        checker().verifyEquals("Incorrect Columns in imported sample type", Arrays.asList("Name", "Flag", "Visit ID", "Date", "Participant ID",
+        checker().verifyEquals("Incorrect Columns in imported sample type", Arrays.asList("Name", "Expiration Date", "Flag", "Visit ID", "Date", "Participant ID",
                 "Linked to " + LINKED_STUDY + " Study"), table.getColumnLabels());
 
         clickAndWait(Locator.linkWithText("linked"));

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -1380,6 +1380,7 @@ public class SampleTypeTest extends BaseWebDriverTest
 
         Set<String> expectedHeaders = new HashSet<>();
         expectedHeaders.add("Name");
+        expectedHeaders.add("Expiration Date");
         expectedHeaders.add("Flag");
         expectedHeaders.add("Other Prop");
         expectedHeaders.add("File Attachment");

--- a/src/org/labkey/test/util/SampleTypeHelper.java
+++ b/src/org/labkey/test/util/SampleTypeHelper.java
@@ -175,6 +175,7 @@ public class SampleTypeHelper extends WebDriverWrapper
         Set<String> actualNames = new HashSet<>(getSampleTypeFields());
         Set<String> expectedNames = _fields.stream().map(FieldDefinition::getName).collect(Collectors.toSet());
         expectedNames.add("Name");
+        expectedNames.add("MaterialExpDate");
         expectedNames.add("Flag");
         assertEquals("Fields in sample type.", expectedNames, actualNames);
     }


### PR DESCRIPTION
#### Rationale
[SampleTypeLinkToStudyTest](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyPostgres_2/2296516?buildTab=tests&status=failed&suite=org.labkey.test.Runner%3A+&package=org.labkey.test.tests&class=SampleTypeLinkToStudyTest).[testSubjectTimepointFromParentSample](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyPostgres_2/2296516?buildTab=tests&status=failed&expandedTest=build%3A%28id%3A2296511%29%2Cid%3A12347), [SampleTypeLinkedStudyExportTest](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyPostgres_2/2296516?buildTab=tests&status=failed&suite=org.labkey.test.Runner%3A+&package=org.labkey.test.tests&class=SampleTypeLinkedStudyExportTest).[testImportSampleTypeFolder](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyPostgres_2/2296516?buildTab=tests&status=failed)

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
