### PR TITLE
Issue 47340: App to allow comment on data delete of Assay Results

### DIFF
--- a/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
+++ b/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
@@ -1,9 +1,11 @@
 package org.labkey.test.components.ui;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.pages.LabKeyPage;
+import org.openqa.selenium.WebElement;
 
 import java.util.function.Supplier;
 
@@ -56,5 +58,13 @@ public class DeleteConfirmationDialog<SourcePage extends WebDriverWrapper, Confi
     {
         this.dismiss("Dismiss");
         return _sourcePage;
+    }
+
+    public DeleteConfirmationDialog setUserComment(String comment)
+    {
+        WebElement commentInput = Locator.tag("textarea").findWhenNeeded(this);
+        commentInput.click();
+        commentInput.sendKeys(comment);
+        return this;
     }
 }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47340

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-premium/pull/51

#### Changes
* DeleteConfirmationDialog update to add method for setting user audit comment in modal textarea
