### PR TITLE
Issue 47280: LKSM: Trailing whitespace in Source name won't resolve when deriving samples

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -658,7 +658,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(childSampleType));
         samplesTable = DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
         samplesTable.setFilter("Name", "Equals", "derivedChildSample");
-        checker().verifyEquals("Incorrect child row created", Arrays.asList("derivedChildSample", "", "", "2.0", now + " 00:00", "P2", "linked"),
+        checker().verifyEquals("Incorrect child row created", Arrays.asList("derivedChildSample", " ", "", "2.0", now + " 00:00", "P2", "linked"),
                 samplesTable.getRowDataAsText(0));
     }
 

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -170,7 +170,7 @@ public class SampleTypeTest extends BaseWebDriverTest
         sampleTypeHelper.verifyDataValues(data);
     }
 
-    // Issue 47280: LKSM: Trailing whitespace in Source name won't resolve when deriving samples
+    // Issue 47280: LKSM: Trailing/Leading whitespace in Source name won't resolve when deriving samples
     @Test
     public void testImportSamplesWithTrailingSpace()
     {
@@ -190,7 +190,7 @@ public class SampleTypeTest extends BaseWebDriverTest
         sampleTypeHelper.goToSampleType(sampleTypeName);
 
         log("Add a single row to the sample type, with trailing spaces");
-        Map<String, String> fieldMap = Map.of("Name", "S-1 ", "StringCol", "Ess ", "IntCol", "1 ");
+        Map<String, String> fieldMap = Map.of("Name", " S-1 ", "StringCol", "Ess ", "IntCol", "1 ");
         sampleTypeHelper.insertRow(fieldMap);
 
         log("Verify values were saved are without trailing spaces");
@@ -198,8 +198,8 @@ public class SampleTypeTest extends BaseWebDriverTest
 
         log("Bulk insert into to the sample type, with trailing spaces");
         List<Map<String, String>> data = new ArrayList<>();
-        data.add(Map.of("Name", "S-2 ", "StringCol", "Tee ", "IntCol", "2 ", "BoolCol", "true "));
-        data.add(Map.of("Name", "S-3 ", "StringCol", "Ewe ", "IntCol", "3 ", "BoolCol", "false "));
+        data.add(Map.of("Name", " S-2 ", "StringCol", "Tee ", "IntCol", "2 ", "BoolCol", "true "));
+        data.add(Map.of("Name", " S-3 ", "StringCol", "Ewe ", "IntCol", "3 ", "BoolCol", "false "));
         sampleTypeHelper.bulkImport(data);
         assertEquals("Number of samples not as expected", 3, sampleTypeHelper.getSampleCount());
 

--- a/src/org/labkey/test/util/SampleTypeHelper.java
+++ b/src/org/labkey/test/util/SampleTypeHelper.java
@@ -308,7 +308,7 @@ public class SampleTypeHelper extends WebDriverWrapper
 
         for (Map.Entry<String, String> field : expectedData.entrySet())
         {
-            assertEquals(field.getKey() + " not as expected at index " + index, field.getValue(), actualData.get(field.getKey()));
+            assertEquals(field.getKey() + " not as expected at index " + index, field.getValue().trim(), actualData.get(field.getKey()));
         }
     }
 
@@ -317,7 +317,7 @@ public class SampleTypeHelper extends WebDriverWrapper
         DataRegionTable drt = getSamplesDataRegionTable();
         for (Map<String, String> expectedRow : data)
         {
-            int index = drt.getRowIndex("Name", expectedRow.get("Name"));
+            int index = drt.getRowIndex("Name", expectedRow.get("Name").trim());
             verifyDataRow(expectedRow, index, drt);
         }
     }


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4150
* https://github.com/LabKey/testAutomation/pull/1393

#### Changes
* add test coverage for inserting and importing samples with trailing spaces in name and other fields
