### PR TITLE
Teach security API test about SampleWorkflowDeletePermission

### DIFF
--- a/data/api/security-api.xml
+++ b/data/api/security-api.xml
@@ -90,6 +90,7 @@
                                 "org.labkey.api.lists.permissions.ManagePicklistsPermission",
                                 "org.labkey.api.security.permissions.UpdatePermission",
                                 "org.labkey.announcements.model.SecureMessageBoardReadPermission",
+                                "org.labkey.api.security.permissions.SampleWorkflowDeletePermission",
                                 "org.labkey.api.security.permissions.SampleWorkflowJobPermission",
                                 "org.labkey.api.security.permissions.AssayReadPermission",
                                 "org.labkey.api.security.permissions.NotebookReadPermission",

--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -658,7 +658,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(childSampleType));
         samplesTable = DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
         samplesTable.setFilter("Name", "Equals", "derivedChildSample");
-        checker().verifyEquals("Incorrect child row created", Arrays.asList("derivedChildSample", "", "", "2.0", now + " 00:00", "P2", "linked"),
+        checker().verifyEquals("Incorrect child row created", Arrays.asList("derivedChildSample", " ", "", "2.0", now + " 00:00", "P2", "linked"),
                 samplesTable.getRowDataAsText(0));
     }
 


### PR DESCRIPTION
#### Rationale
The Editor role now has `SampleWorkflowDeletePermission`. The test needs to know to expect it.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4140

#### Changes
* Teach security API test about SampleWorkflowDeletePermission
