### PR TITLE
Don't show AliquotCreateCount and AliquotVolume columns in default view in LKS

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -658,7 +658,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(childSampleType));
         samplesTable = DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
         samplesTable.setFilter("Name", "Equals", "derivedChildSample");
-        checker().verifyEquals("Incorrect child row created", Arrays.asList("derivedChildSample", " ", "", "2.0", now + " 00:00", "P2", "linked"),
+        checker().verifyEquals("Incorrect child row created", Arrays.asList("derivedChildSample", " ", "",  " " , " ", "2.0", now + " 00:00", "P2", "linked"),
                 samplesTable.getRowDataAsText(0));
     }
 

--- a/src/org/labkey/test/tests/SampleTypeLinkedStudyExportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkedStudyExportTest.java
@@ -114,7 +114,7 @@ public class SampleTypeLinkedStudyExportTest extends BaseWebDriverTest
         goToProjectHome(IMPORT_PROJECT);
         clickAndWait(Locator.linkWithText(SAMPLE_TYPE));
         DataRegionTable table = DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
-        checker().verifyEquals("Incorrect Columns in imported sample type", Arrays.asList("Name", "Expiration Date", "Flag", "Visit ID", "Date", "Participant ID",
+        checker().verifyEquals("Incorrect Columns in imported sample type", Arrays.asList("Name", "Expiration Date", "Flag", "Visit ID", "Date", "Participant ID", "Amount", "Units",
                 "Linked to " + LINKED_STUDY + " Study"), table.getColumnLabels());
 
         clickAndWait(Locator.linkWithText("linked"));

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -1431,8 +1431,6 @@ public class SampleTypeTest extends BaseWebDriverTest
         expectedHeaders.add("File Attachment");
         expectedHeaders.add("Amount");
         expectedHeaders.add("Units");
-        expectedHeaders.add("Aliquots Created Count");
-        expectedHeaders.add("Aliquots Total Amount");
 
         setFileAttachment(0, experimentFilePath);
         setFileAttachment(1, TestFileUtils.getSampleData( "RawAndSummary~!@#$%^&()_+-[]{};',..xlsx"));

--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -66,8 +66,6 @@ public class GridPanelTest extends GridPanelBaseTest
     private static final String FILTER_BOOL_COL = "Bool";
     private static final String FILTER_DATE_COL = "Date";
     private static final String FILTER_STORED_AMOUNT_COL = "Amount";
-    private static final String FILTER_ALIQUOT_AMOUNT_COL = "Aliquot Total Amount";
-    private static final String FILTER_ALIQUOT_COUNT_COL = "Aliquots Created Count";
 
     // Views and columns used in the views. The views are only applied to the small sample type (Small_SampleType).
     private static final String VIEW_EXTRA_COLUMNS = "Extra_Columns";
@@ -1588,8 +1586,6 @@ public class GridPanelTest extends GridPanelBaseTest
         expectedList.add(FILTER_STRING_COL);
         expectedList.add(FILTER_DATE_COL);
         expectedList.add(FILTER_STORED_AMOUNT_COL);
-        expectedList.add(FILTER_ALIQUOT_AMOUNT_COL);
-        expectedList.add(FILTER_ALIQUOT_COUNT_COL);
 
         actualList = filterDialog.getAvailableFields();
 
@@ -1649,8 +1645,6 @@ public class GridPanelTest extends GridPanelBaseTest
         expectedList.add(FILTER_INT_COL);
         expectedList.add(FILTER_BOOL_COL);
         expectedList.add(FILTER_DATE_COL);
-        expectedList.add(FILTER_ALIQUOT_COUNT_COL);
-        expectedList.add(FILTER_ALIQUOT_AMOUNT_COL);
         expectedList.add(FILTER_STORED_AMOUNT_COL);
 
         filterDialog = grid.getGridBar().openFilterDialog();

--- a/src/org/labkey/test/util/SampleTypeHelper.java
+++ b/src/org/labkey/test/util/SampleTypeHelper.java
@@ -179,8 +179,6 @@ public class SampleTypeHelper extends WebDriverWrapper
         expectedNames.add("StoredAmount");
         expectedNames.add("Units");
         expectedNames.add("Flag");
-        expectedNames.add("AliquotCount");
-        expectedNames.add("AliquotVolume");
         assertEquals("Fields in sample type.", expectedNames, actualNames);
     }
 


### PR DESCRIPTION
#### Rationale
See related [platform PR](https://github.com/LabKey/platform/pull/4130)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4130
* https://github.com/LabKey/sampleManagement/pull/1659
* https://github.com/LabKey/inventory/pull/766


#### Changes
* Remove expectations for aliquot-related columns in default sample grids for LKS
