### PR TITLE
Issue 47434: APIKey improvements

### DIFF
--- a/src/org/labkey/test/tests/ApiKeyTest.java
+++ b/src/org/labkey/test/tests/ApiKeyTest.java
@@ -281,14 +281,16 @@ public class ApiKeyTest extends BaseWebDriverTest
     {
         goToExternalToolPage();
         waitForText("API keys are used to authorize");
-        clickButton("Generate session key", "session|");
+        clickButton("Generate session key", 0);
+        waitForFormElementToNotEqual(Locator.inputById("session-token"), "");
         return Locator.inputById("session-token").findElement(getDriver()).getAttribute("value");
     }
 
     private String generateAPIKey(List<Map<String, Object>> _generatedApiKeys) throws IOException
     {
         goToExternalToolPage();
-        clickButton("Generate API key", "apikey|");
+        clickButton("Generate API key", 0);
+        waitForFormElementToNotEqual(Locator.inputById("apikey-token"), "");
         String apiKey = Locator.inputById("apikey-token").findElement(getDriver()).getAttribute("value");
         // get record
         _generatedApiKeys.add(getLastAPIKeyRecord());


### PR DESCRIPTION
#### Rationale
Users reported headaches with the pipe character in the key when passing values through environment variables. We can omit the prefix altogether

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4177

#### Changes
* Drop the `apikey_` and `session_` prefixes from API keys
