### PR TITLE
Fix for pipeline description change

### DIFF
--- a/src/org/labkey/test/tests/FileBasedPipelineTest.java
+++ b/src/org/labkey/test/tests/FileBasedPipelineTest.java
@@ -137,7 +137,7 @@ public class FileBasedPipelineTest extends BaseWebDriverTest
         assertExtMsgBox("Error", "Cannot redefine an existing protocol", "OK");
 
         // Delete the job, including any referenced runs
-        deletePipelineJob(jobDescription, true);
+        deletePipelineJob(jobDescription, true, true);
 
         // Verify the analysis dir was deleted
         verifyPipelineAnalysisDeleted(pipelineName, protocolName);
@@ -242,7 +242,7 @@ public class FileBasedPipelineTest extends BaseWebDriverTest
         pipelineAnalysis.verifyPipelineAnalysis(pipelineName, protocolName, null, jobDescription, fileRoot, outputFiles);
 
         // Delete the job, including any referenced runs
-        deletePipelineJob(jobDescription, true);
+        deletePipelineJob(jobDescription, true, true);
 
         // Verify the analysis dir was deleted
         verifyPipelineAnalysisDeleted(pipelineName, protocolName);

--- a/src/org/labkey/test/tests/RlabkeyTest.java
+++ b/src/org/labkey/test/tests/RlabkeyTest.java
@@ -210,7 +210,7 @@ public class RlabkeyTest extends BaseWebDriverTest
         // verify the expected pipeline jobs where run and completed
         goToProjectHome();
         PipelineStatusTable pipelineStatusTable = goToDataPipeline();
-        assertEquals("COMPLETE", pipelineStatusTable.getJobStatus("@files/sample (Rlabkey RCopy Test 1)"));
+        assertEquals("COMPLETE", pipelineStatusTable.getJobStatus("@files/sample (Rlabkey RCopy Test 1) (sample.txt)"));
         assertEquals("COMPLETE", pipelineStatusTable.getJobStatus("test pipe desc"));
     }
 

--- a/src/org/labkey/test/util/PipelineAnalysisHelper.java
+++ b/src/org/labkey/test/util/PipelineAnalysisHelper.java
@@ -145,7 +145,7 @@ public class PipelineAnalysisHelper
 
         if (runName != null)
         {
-            _test.clickAndWait(Locator.linkWithText(runName));
+            _test.clickAndWait(Locator.linkContainingText(runName));
 
             _test.assertElementContains(Locator.xpath("//tr/td[contains(text(), 'Name')]/../td[2]"), runName);
             if (description != null)


### PR DESCRIPTION
#### Rationale
The pipeline job description can now include the list of input files. This fixes some of the test failures by not needing to match the entire description OR including the filename in the description.