### PR TITLE
Fix intermittent test failure with schema browser tooltips

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -39,7 +39,6 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.junit.runners.model.TestTimedOutException;
 import org.labkey.junit.rules.TestWatcher;
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
@@ -69,6 +68,7 @@ import org.labkey.test.util.ext4cmp.Ext4FieldRef;
 import org.labkey.test.util.query.QueryUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
+import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.UnhandledAlertException;
@@ -2036,7 +2036,15 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                 WebElement folderIcon = loc.findElement(getDriver());
                 // Moving to desired tree node should dismiss tooltip from previously clicked folder
                 new Actions(getDriver()).moveToElement(folderIcon).perform();
-                folderIcon.click();
+                try
+                {
+                    folderIcon.click();
+                }
+                catch (ElementClickInterceptedException retry)
+                {
+                    sleep(500); // Tooltip needs a moment to update
+                    folderIcon.click();
+                }
             }, "queryTreeSelectionChange");
             waitForElement(selectedSchema, 60000);
         }


### PR DESCRIPTION
#### Rationale
Despite past efforts to prevent test helpers from getting tripped up by schema browser tooltips, tests have recently started hitting this sort of exception with some regularity.
```
org.openqa.selenium.ElementClickInterceptedException: Element <img class=" x4-tree-icon x4-tree-icon-parent " src="data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="> is not clickable at point (61,263) because another element <div id="ext-quicktips-tip" class="x4-tip x4-layer x4-tip-default x4-border-box"> obscures it
[...]
  at app//org.labkey.test.selenium.ReclickingWebElement.click(ReclickingWebElement.java:75)
  at app//org.labkey.test.BaseWebDriverTest.lambda$8(BaseWebDriverTest.java:2039)
  at app//org.labkey.test.WebDriverWrapper.doAndWaitForElementToRefresh(WebDriverWrapper.java:2150)
  at app//org.labkey.test.WebDriverWrapper.doAndWaitForElementToRefresh(WebDriverWrapper.java:2162)
  at app//org.labkey.test.WebDriverWrapper.doAndWaitForElementToRefresh(WebDriverWrapper.java:2167)
  at app//org.labkey.test.WebDriverWrapper.doAndWaitForRepeatedPageSignal(WebDriverWrapper.java:2109)
  at app//org.labkey.test.WebDriverWrapper.doAndWaitForPageSignal(WebDriverWrapper.java:2085)
  at app//org.labkey.test.WebDriverWrapper.doAndWaitForPageSignal(WebDriverWrapper.java:2073)
  at app//org.labkey.test.BaseWebDriverTest.selectSchema(BaseWebDriverTest.java:2035)
  at app//org.labkey.test.BaseWebDriverTest.selectQuery(BaseWebDriverTest.java:2048)
  at app//org.labkey.test.BaseWebDriverTest.viewQueryData(BaseWebDriverTest.java:2063)
  at app//org.labkey.test.BaseWebDriverTest.viewQueryData(BaseWebDriverTest.java:2058)
```

#### Related Pull Requests
* N/A

#### Changes
* Add a sleep/retry to `BaseWebDriverTest.selectSchema`
