### PR TITLE
Fix FileBasedPipelineTest - API keys no longer have a specific prefix

### DIFF
--- a/src/org/labkey/test/tests/FileBasedPipelineTest.java
+++ b/src/org/labkey/test/tests/FileBasedPipelineTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @Category({Daily.class})
@@ -54,6 +55,8 @@ public class FileBasedPipelineTest extends BaseWebDriverTest
     private static final String PIPELINETEST_MODULE = "pipelinetest";
     private static final File SAMPLE_FILE = TestFileUtils.getSampleData("fileTypes/sample.txt");
     private final PipelineAnalysisHelper pipelineAnalysis = new PipelineAnalysisHelper(this);
+
+    private final static String API_KEY_LABEL = "apikey: ";
 
     @BeforeClass
     public static void doSetup() throws Exception
@@ -314,12 +317,19 @@ public class FileBasedPipelineTest extends BaseWebDriverTest
         resetErrors();
 
         clickAndWait(Locator.linkWithText("ERROR"));
+        String fullBodyText = getBodyText();
+        int apiKeyIndex = fullBodyText.indexOf(API_KEY_LABEL);
+        assertFalse("Couldn't find API key echoed in job log file", apiKeyIndex == -1);
+
+        // Grab the first 10 characters of the API key to check for in the arg list
+        String startOfApiKey = fullBodyText.substring(apiKeyIndex + API_KEY_LABEL.length(), apiKeyIndex + API_KEY_LABEL.length() + 10);
+
         assertTextPresent(
                 "INFO : hello java timeout world!",
                 // ${pipeline, protocol name} token replacement
                 "arg[2]=" + protocolName,
                 // ${httpSessionId} token replacement. Expect apikey prefix
-                "arg[3]=apikey|",
+                "arg[3]=" + startOfApiKey,
                 "sleeping for 8 seconds",
                 "Process killed after exceeding timeout of 3 seconds");
         assertTextNotPresent("goodbye java timeout world!");


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/platform/pull/4177 changed the format of our API keys. FileBasedPipelineTest noticed.

#### Changes
* Update test to check the actual key (available elsewhere in the log file) as the argument value