### PR TITLE
Regression coverage for Issue 46768

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -274,6 +274,15 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         return this;
     }
 
+    /*
+        This allows you to query a given select in the edit panel to see what options it offers
+     */
+    public List<String> getSelectOptions(String fieldCaption)
+    {
+        FilteringReactSelect reactSelect = elementCache().findSelect(fieldCaption);
+        return reactSelect.getOptions();
+    }
+
     /**
      * Select a single value from a select list.
      *


### PR DESCRIPTION
#### Rationale
This updates the DetailTableEdit component to allow tests to query a select in the edit pane to see which values it offers.  I wanted this to be able to see whether or not Biologics respects filtering of lookups, as required in [Issue 46768](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46768)

#### Related Pull Requests
biologics https://github.com/LabKey/biologics/pull/1999

#### Changes
new method, `getSelectOptions`
