### PR TITLE
Make `signIn` work better on CAS-only servers

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -36,7 +36,6 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
@@ -333,7 +332,10 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         }
         waitForStartup();
         log("Signing in");
-        simpleSignOut();
+        if (isSignedIn())
+        {
+            simpleSignOut();
+        }
         checkForUpgrade();
         simpleSignIn();
         assertEquals("Signed in as wrong user.", PasswordUtil.getUsername(), getCurrentUser());

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -37,6 +37,7 @@ import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.PostCommand;

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -36,8 +36,8 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Command;
+import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.PostCommand;
@@ -333,7 +333,8 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         }
         waitForStartup();
         log("Signing in");
-        if (isSignedIn())
+        Number userId = whoAmI().getUserId();
+        if (userId != null && userId.longValue() > 0)
         {
             simpleSignOut();
         }

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -505,8 +505,10 @@ public abstract class WebDriverWrapper implements WrapsDriver
         // Enable/disable server side logging of client errors.
         if (isScriptCheckEnabled())
         {
-            // Don't use browser session. Some tests need to pause briefly, while impersonating.
-            Connection cn = WebTestHelper.getRemoteApiConnection(false);
+            WhoAmIResponse whoAmI = whoAmI();
+            // Don't use browser session when impersonating. Impersonated user/role might not have correct permission.
+            boolean useBrowserSession = PasswordUtil.getUsername().equals(whoAmI.getEmail()) && !whoAmI.isImpersonated();
+            Connection cn = WebTestHelper.getRemoteApiConnection(useBrowserSession);
             ExperimentalFeaturesHelper.setExperimentalFeature(cn, "javascriptErrorServerLogging", b);
         }
     }


### PR DESCRIPTION
#### Rationale
`signOutHTTP` uses the wrong session info when the server auto-redirects to CAS login, resulting in a 401 response. This only happens when the user isn't even logged in so signing out is unnecessary.

#### Related Pull Requests
* N/A

#### Changes
* Don't call `simpleSignOut` unnecessarily
* Use authenticated connection for enabling JS error checker
