### PR TITLE
Fix failures caused by update to `FieldDefinition`

### DIFF
--- a/src/org/labkey/test/pages/DatasetInsertPage.java
+++ b/src/org/labkey/test/pages/DatasetInsertPage.java
@@ -44,10 +44,38 @@ public class DatasetInsertPage extends InsertPage
 
     public void insert(Map<String, String> values)
     {
-        insert(values, true, "");
+        tryInsert(values);
+
+        assertElementNotPresent(Locators.labkeyError);
     }
 
-    public void insert(Map<String, String> values, boolean expectSuccess, String errorMsg)
+    public void insert(Map<String, String> values, boolean b, String s)
+    {
+        tryInsert(values);
+
+        assertElementNotPresent(Locators.labkeyError);
+    }
+
+    public void insertExpectingError(Map<String, String> values)
+    {
+        insertExpectingError(values, null);
+    }
+
+    public void insertExpectingError(Map<String, String> values, String errorMsg)
+    {
+        tryInsert(values);
+
+        if (StringUtils.isBlank(errorMsg))
+        {
+            assertElementPresent(Locators.labkeyError);
+        }
+        else
+        {
+            assertTextPresent(errorMsg);
+        }
+    }
+
+    private void tryInsert(Map<String, String> values)
     {
         for (Map.Entry<String, String> entry : values.entrySet())
         {
@@ -82,18 +110,5 @@ public class DatasetInsertPage extends InsertPage
         }
 
         clickAndWait(Locator.lkButton("Submit"));
-
-        if (expectSuccess)
-        {
-            assertElementNotPresent(Locators.labkeyError);
-        }
-        else if (!StringUtils.isBlank(errorMsg))
-        {
-            assertTextNotPresent(errorMsg);
-        }
-        else
-        {
-            assertElementPresent(Locators.labkeyError);
-        }
     }
 }

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -59,6 +59,10 @@ public class FieldDefinition extends PropertyDescriptor
     {
         setName(name);
         setType(type);
+        // Clear out default advanced properties to avoid opening advanced field properties dialog
+        setMeasure(null);
+        setDimension(null);
+        setMvEnabled(null);
     }
 
     /**

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -1685,28 +1685,28 @@ public class DomainDesignerTest extends BaseWebDriverTest
     private void verifyExpectedFieldProperties(PropertyDescriptor intendedField,  PropertyDescriptor actualField)
     {
         log("verifying properties for field [" +intendedField.getName()+ "]");
-        assertThat("Description does not match expected",
-                actualField.getDescription(), is(intendedField.getDescription()));
-        assertThat("Label does not match intended label",
-                actualField.getLabel(), is(intendedField.getLabel()));
-        assertThat("Required bit does not match expected",
-                actualField.getRequired(), is(intendedField.getRequired()));
-        assertThat("Hidden value does not match expected",
-                actualField.getHidden(), is(intendedField.getHidden()));
-        assertThat("MvEnabled bit does not match expected",
-                actualField.getMvEnabled(), is(intendedField.getMvEnabled()));
-        assertThat("Dimension does not match expected",
-                actualField.getDimension(), is(intendedField.getDimension()));
-        if (intendedField.getPHI() != null)
-            assertThat("PHI does not match specified value",
-                    actualField.getPHI(), is(intendedField.getPHI()));
-        assertThat("Expect measure bit to match intended measure",
-                actualField.getMeasure(), is(intendedField.getMeasure()));
-        assertThat("Format property should export",
-                actualField.getFormat(), is(intendedField.getFormat()));
-        assertThat("Key field property should export",
-                nullToFalse(actualField.getAllProperties().get("isPrimaryKey")),
-                is(nullToFalse(intendedField.getAllProperties().get("isPrimaryKey"))));
+        checker().verifyEquals("Description does not match expected",
+                intendedField.getDescription(), actualField.getDescription());
+        checker().verifyEquals("Label does not match intended label",
+                intendedField.getLabel(), actualField.getLabel());
+        checker().verifyEquals("Required bit does not match expected",
+                intendedField.getRequired(), actualField.getRequired());
+        checker().verifyEquals("Hidden value does not match expected",
+                intendedField.getHidden(), actualField.getHidden());
+        checker().verifyEquals("MvEnabled bit does not match expected",
+                nullToFalse(intendedField.getMvEnabled()), actualField.getMvEnabled());
+        checker().verifyEquals("Dimension does not match expected",
+                nullToFalse(intendedField.getDimension()), actualField.getDimension());
+        checker().verifyEquals("PHI does not match specified value",
+                (intendedField.getPHI() == null ? FieldDefinition.PhiSelectType.NotPHI.name() : intendedField.getPHI()),
+                actualField.getPHI());
+        checker().verifyEquals("Expect measure bit to match intended measure",
+                nullToFalse(intendedField.getMeasure()), actualField.getMeasure());
+        checker().verifyEquals("Format property should export",
+                intendedField.getFormat(), actualField.getFormat());
+        checker().verifyEquals("Key field property should export",
+                nullToFalse(intendedField.getAllProperties().get("isPrimaryKey")),
+                nullToFalse(actualField.getAllProperties().get("isPrimaryKey")));
 
         Assertions.assertThat(actualField.getConditionalFormats().stream().map(f -> f.toJSON().toMap()))
                 .as("Exported conditional fields.")


### PR DESCRIPTION
#### Rationale
In `PropertyDescriptor`, the measure, dimension, and mv flags default to `false`. `FieldDefinition` needs to null them out to avoid opening the advanced field options when adding new fields (see `DomainFormPanel.advancedSettingsFromFieldDefinition`).

#### Related Pull Requests
* #1414

#### Changes
* Null out some field properties to avoid opening advanced field properties dialog
* Updating `DatasetInsertPage` to have separate `insert` and `insertExpectingError` methods
* Update `TroubleshooterRoleTest` to use an audit table that works
