### PR TITLE
Make `ReclickingWebElement.revealElement` more strict

### DIFF
--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -11,7 +11,7 @@
             <AppenderRef ref="CONSOLE"/>
         </Root>
 
-        <Logger name="org.labkey.test" additivity="false" level="DEBUG">
+        <Logger name="org.labkey.test" additivity="false" level="INFO">
             <AppenderRef ref="CONSOLE"/>
         </Logger>
 

--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -11,7 +11,7 @@
             <AppenderRef ref="CONSOLE"/>
         </Root>
 
-        <Logger name="org.labkey.test" additivity="false" level="INFO">
+        <Logger name="org.labkey.test" additivity="false" level="DEBUG">
             <AppenderRef ref="CONSOLE"/>
         </Logger>
 

--- a/src/org/labkey/test/components/bootstrap/ModalDialog.java
+++ b/src/org/labkey/test/components/bootstrap/ModalDialog.java
@@ -128,7 +128,10 @@ public class ModalDialog extends WebDriverComponent<ModalDialog.ElementCache>
     {
         if (waitSeconds > 0) // Zero to not expect dialog to close
         {
-            new WebDriverWait(getDriver(), Duration.ofSeconds(waitSeconds)).until(ExpectedConditions.stalenessOf(getComponentElement()));
+            new WebDriverWait(getDriver(), Duration.ofSeconds(waitSeconds)).until(ExpectedConditions.and(
+                    ExpectedConditions.invisibilityOf(getComponentElement()),
+                    ExpectedConditions.invisibilityOfElementLocated(Locator.byClass("modal")),
+                    ExpectedConditions.invisibilityOfElementLocated(Locator.byClass("modal-backdrop"))));
         }
     }
 

--- a/src/org/labkey/test/components/bootstrap/ModalDialog.java
+++ b/src/org/labkey/test/components/bootstrap/ModalDialog.java
@@ -134,7 +134,10 @@ public class ModalDialog extends WebDriverComponent<ModalDialog.ElementCache>
             elements.add(getComponentElement());
             elements.addAll(Locator.byClass("modal").findElements(getDriver()));
             new WebDriverWait(getDriver(), Duration.ofSeconds(waitSeconds))
-                    .until(ExpectedConditions.invisibilityOfAllElements(elements));
+                    .until(ExpectedConditions.and(
+                            ExpectedConditions.invisibilityOfAllElements(elements),
+                            ExpectedConditions.invisibilityOfElementLocated(Locator.byClass("modal")) // Another mask might appear
+                    ));
         }
     }
 

--- a/src/org/labkey/test/components/bootstrap/ModalDialog.java
+++ b/src/org/labkey/test/components/bootstrap/ModalDialog.java
@@ -25,8 +25,6 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 
@@ -130,14 +128,7 @@ public class ModalDialog extends WebDriverComponent<ModalDialog.ElementCache>
     {
         if (waitSeconds > 0) // Zero to not expect dialog to close
         {
-            List<WebElement> elements = new ArrayList<>();
-            elements.add(getComponentElement());
-            elements.addAll(Locator.byClass("modal").findElements(getDriver()));
-            new WebDriverWait(getDriver(), Duration.ofSeconds(waitSeconds))
-                    .until(ExpectedConditions.and(
-                            ExpectedConditions.invisibilityOfAllElements(elements),
-                            ExpectedConditions.invisibilityOfElementLocated(Locator.byClass("modal")) // Another mask might appear
-                    ));
+            new WebDriverWait(getDriver(), Duration.ofSeconds(waitSeconds)).until(ExpectedConditions.stalenessOf(getComponentElement()));
         }
     }
 

--- a/src/org/labkey/test/components/bootstrap/ModalDialog.java
+++ b/src/org/labkey/test/components/bootstrap/ModalDialog.java
@@ -128,10 +128,8 @@ public class ModalDialog extends WebDriverComponent<ModalDialog.ElementCache>
     {
         if (waitSeconds > 0) // Zero to not expect dialog to close
         {
-            new WebDriverWait(getDriver(), Duration.ofSeconds(waitSeconds)).until(ExpectedConditions.and(
-                    ExpectedConditions.invisibilityOf(getComponentElement()),
-                    ExpectedConditions.invisibilityOfElementLocated(Locator.byClass("modal")),
-                    ExpectedConditions.invisibilityOfElementLocated(Locator.byClass("modal-backdrop"))));
+            new WebDriverWait(getDriver(), Duration.ofSeconds(waitSeconds))
+                    .until(ExpectedConditions.stalenessOf(getComponentElement()));
         }
     }
 

--- a/src/org/labkey/test/components/labkey/LabKeyAlert.java
+++ b/src/org/labkey/test/components/labkey/LabKeyAlert.java
@@ -20,6 +20,10 @@ import org.labkey.test.components.bootstrap.ModalDialog;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
 
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 
@@ -82,6 +86,18 @@ public class LabKeyAlert extends ModalDialog implements Alert
     public void clickButton(String buttonText)
     {
         getWrapper().clickAndWait(Locator.linkWithText(buttonText).findElement(this));
+    }
+
+    @Override
+    protected void waitForClose(Integer waitSeconds)
+    {
+        if (waitSeconds > 0) // Zero to not expect dialog to close
+        {
+            new WebDriverWait(getDriver(), Duration.ofSeconds(waitSeconds)).until(ExpectedConditions.and(
+                    ExpectedConditions.invisibilityOf(getComponentElement()),
+                    ExpectedConditions.invisibilityOfElementLocated(Locator.byClass("modal")),
+                    ExpectedConditions.invisibilityOfElementLocated(Locator.byClass("modal-backdrop"))));
+        }
     }
 
     public static class ExtraLocators {

--- a/src/org/labkey/test/selenium/ReclickingWebElement.java
+++ b/src/org/labkey/test/selenium/ReclickingWebElement.java
@@ -21,8 +21,8 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.core.ProjectMenu;
-import org.labkey.test.util.LabKeyExpectedConditions;
 import org.labkey.test.util.TestLogger;
 import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.By;
@@ -35,7 +35,6 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.FluentWait;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -206,22 +205,29 @@ public class ReclickingWebElement extends WebElementDecorator
         }
         catch (WebDriverException ignore) {}
 
-        WebDriverUtils.ScrollUtil scrollUtil = new WebDriverUtils.ScrollUtil(getDriver());
-        scrollUtil.scrollUnderFloatingHeader(el);
-
-        Locator.XPathLocator interceptingElLoc = parseInterceptingElementLoc(shortMessage);
-        if (interceptingElLoc != null)
+        boolean blockedByFloatingHeader = new WebDriverUtils.ScrollUtil(getDriver()).scrollUnderFloatingHeader(el);
+        if (!blockedByFloatingHeader)
         {
-            List<WebElement> interceptingElements = interceptingElLoc.findElements(getDriver());
-            if (!interceptingElements.isEmpty())
+            Locator.XPathLocator interceptingElLoc = parseInterceptingElementLoc(shortMessage);
+            if (interceptingElLoc != null)
             {
-                final ExpectedCondition<?>[] expectations = (ExpectedCondition<?>[]) interceptingElements.stream()
-                        .map(interceptingElement -> ExpectedConditions.or(
-                                LabKeyExpectedConditions.animationIsDone(interceptingElement),
-                                ExpectedConditions.invisibilityOf(interceptingElement)
-                        )).toArray(ExpectedCondition[]::new);
-                new WebDriverWait(getDriver(), Duration.ofSeconds(5))
-                        .until(ExpectedConditions.and(expectations));
+                List<WebElement> interceptingElements = interceptingElLoc.findElements(getDriver());
+                if (interceptingElements.size() == 1)
+                {
+                    new WebDriverWait(getDriver(), Duration.ofSeconds(5))
+                            .until(ExpectedConditions.invisibilityOf(interceptingElements.get(0)));
+                }
+                else if (interceptingElements.size() > 1)
+                {
+                    // Intercepting element Locator wasn't specific enough, just wait a moment
+                    WebDriverWrapper.sleep(1_000);
+                }
+                // If nothing matched the locator, assume the intercepting element disappeared
+            }
+            else
+            {
+                // Unable to determine locator from exception, just wait a moment
+                WebDriverWrapper.sleep(1_000);
             }
         }
     }

--- a/src/org/labkey/test/selenium/ReclickingWebElement.java
+++ b/src/org/labkey/test/selenium/ReclickingWebElement.java
@@ -212,6 +212,7 @@ public class ReclickingWebElement extends WebElementDecorator
             if (interceptingElLoc != null)
             {
                 List<WebElement> interceptingElements = interceptingElLoc.findElements(getDriver());
+                TestLogger.debug("Found %s element(s) matching extracted locator: %s".formatted(interceptingElements.size(), shortMessage));
                 if (interceptingElements.size() == 1)
                 {
                     new WebDriverWait(getDriver(), Duration.ofSeconds(5))
@@ -226,6 +227,7 @@ public class ReclickingWebElement extends WebElementDecorator
             }
             else
             {
+                TestLogger.debug("Unable to extract intercepting element locator: " + shortMessage);
                 // Unable to determine locator from exception, just wait a moment
                 WebDriverWrapper.sleep(1_000);
             }

--- a/src/org/labkey/test/selenium/ReclickingWebElement.java
+++ b/src/org/labkey/test/selenium/ReclickingWebElement.java
@@ -215,7 +215,7 @@ public class ReclickingWebElement extends WebElementDecorator
                 if (interceptingElements.size() == 1)
                 {
                     //noinspection ResultOfMethodCallIgnored
-                    WebDriverWrapper.waitFor(() -> ExpectedConditions.invisibilityOf(interceptingElements.get(0)).apply(getDriver()), 2_000);
+                    WebDriverWrapper.waitFor(() -> ExpectedConditions.stalenessOf(interceptingElements.get(0)).apply(getDriver()), 1_000);
                 }
                 else if (interceptingElements.size() > 1)
                 {

--- a/src/org/labkey/test/selenium/ReclickingWebElement.java
+++ b/src/org/labkey/test/selenium/ReclickingWebElement.java
@@ -37,7 +37,6 @@ import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -215,8 +214,8 @@ public class ReclickingWebElement extends WebElementDecorator
                 TestLogger.debug("Found %s element(s) matching extracted locator: %s".formatted(interceptingElements.size(), shortMessage));
                 if (interceptingElements.size() == 1)
                 {
-                    new WebDriverWait(getDriver(), Duration.ofSeconds(5))
-                            .until(ExpectedConditions.invisibilityOf(interceptingElements.get(0)));
+                    //noinspection ResultOfMethodCallIgnored
+                    WebDriverWrapper.waitFor(() -> ExpectedConditions.invisibilityOf(interceptingElements.get(0)).apply(getDriver()), 2_000);
                 }
                 else if (interceptingElements.size() > 1)
                 {

--- a/src/org/labkey/test/tests/GpatAssayTest.java
+++ b/src/org/labkey/test/tests/GpatAssayTest.java
@@ -34,7 +34,6 @@ import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
-import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.core.webdav.WebDavUploadHelper;
 
 import java.io.File;
@@ -66,14 +65,11 @@ public class GpatAssayTest extends BaseWebDriverTest
     private static final String ASSAY_NAME_FNA_MULTIPLE = "FASTA Assay - Multiple file upload";
     private static final String ASSAY_NAME_FNA_MULTIPLE_SINGLE_INPUT = "FASTA Assay - Multiple file single input upload";
 
-    private final WebDavUploadHelper _uploadHelper = new WebDavUploadHelper(getProjectName());
-
     @BeforeClass
     public static void doSetup()
     {
         GpatAssayTest init = (GpatAssayTest) getCurrentTest();
         init._containerHelper.createProject(init.getProjectName(), "Assay");
-        PortalHelper portalHelper = new PortalHelper(init.getDriver());
         init.goToProjectHome();
     }
 
@@ -228,7 +224,7 @@ public class GpatAssayTest extends BaseWebDriverTest
     private void startCreateGpatAssay(File dataFile, @LoggedParam String assayName)
     {
         log("Create GPAT assay from " + dataFile.getName());
-        _uploadHelper.uploadFile(dataFile);
+        new WebDavUploadHelper(getProjectName()).uploadFile(dataFile);
         beginAt(WebTestHelper.buildURL("pipeline", getProjectName(), "browse"));
         _fileBrowserHelper.importFile(dataFile.getName(), "Create New Standard Assay Design");
         waitForText(WAIT_FOR_JAVASCRIPT, "SpecimenID");

--- a/src/org/labkey/test/util/selenium/WebDriverUtils.java
+++ b/src/org/labkey/test/util/selenium/WebDriverUtils.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.SystemUtils;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
@@ -28,6 +29,7 @@ import org.openqa.selenium.WrapsElement;
 import org.openqa.selenium.interactions.Locatable;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public abstract class WebDriverUtils
 {
@@ -82,6 +84,7 @@ public abstract class WebDriverUtils
             {
                 int elHeight = blockedElement.getSize().getHeight();
                 scrollBy(0, -(headerHeight + elHeight));
+                TestLogger.debug("Scrolled under floating headers:\n" + floatingHeaders.stream().map(WebElement::toString).collect(Collectors.joining("\n")));
                 return true;
             }
             return false;

--- a/src/org/labkey/test/util/selenium/WebDriverUtils.java
+++ b/src/org/labkey/test/util/selenium/WebDriverUtils.java
@@ -80,14 +80,22 @@ public abstract class WebDriverUtils
             {
                 headerHeight += floatingHeader.getSize().getHeight();
             }
-            if (headerHeight > 0 && headerHeight > ((Locatable) blockedElement).getCoordinates().inViewPort().getY())
+            if (headerHeight > 0)
             {
-                int elHeight = blockedElement.getSize().getHeight();
-                scrollBy(0, -(headerHeight + elHeight));
-                TestLogger.debug("Scrolled under floating headers:\n" + floatingHeaders.stream().map(WebElement::toString).collect(Collectors.joining("\n")));
-                return true;
+                int elYInViewPort = blockedElement.getLocation().getY() - getWindowScrollY().intValue();
+                if (headerHeight > elYInViewPort)
+                {
+                    TestLogger.debug("Scrolled under floating headers:\n" + floatingHeaders.stream().map(WebElement::toString).collect(Collectors.joining("\n")));
+                    ((Locatable) blockedElement).getCoordinates().inViewPort(); // 'inViewPort()' will scroll element into view
+                    return true;
+                }
             }
             return false;
+        }
+
+        private Long getWindowScrollY()
+        {
+            return (Long) ((JavascriptExecutor)_webDriver).executeScript("return window.scrollY;");
         }
 
         public WebElement scrollIntoView(WebElement el)


### PR DESCRIPTION
#### Rationale
`ReclickingWebElement.revealElement` was attempting to handle too many scenarios, which made it fail in some scenarios where it should be able to succeed (e.g. tooltips).

#### Related Pull Requests
* N/A

#### Changes
* Wait for tooltips to disappear (not just stop animating)
