### PR TITLE
Add tests for bulk update of amount and units

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -69,6 +69,11 @@ public class EntityBulkUpdateDialog extends ModalDialog
         return this;
     }
 
+    public List<String> getSelectionOptions(String fieldKey)
+    {
+        return enableAndWait(fieldKey, elementCache().getSelect(fieldKey)).getOptions();
+    }
+
     public List<String> getSelectionFieldValues(String fieldKey)
     {
         return elementCache().getSelect(fieldKey).getSelections();
@@ -95,7 +100,7 @@ public class EntityBulkUpdateDialog extends ModalDialog
 
     public String getTextField(String fieldKey)
     {
-        return elementCache().textInput(fieldKey).get();
+        return enableAndWait(fieldKey, elementCache().textInput(fieldKey)).get();
     }
 
     public EntityBulkUpdateDialog setNumericField(String fieldKey, String value)

--- a/src/org/labkey/test/util/DeferredErrorCollector.java
+++ b/src/org/labkey/test/util/DeferredErrorCollector.java
@@ -240,7 +240,7 @@ public class DeferredErrorCollector
     }
 
     /**
-     * Sort the collections before checking to for equal. If not equal record an error message.
+     * Sort the collections before checking for equal. If not equal record an error message.
      *
      * @param message Message to show if check fails.
      * @param expected The expected collection of objects.


### PR DESCRIPTION
#### Rationale
We want to add tests for the update of bulk amounts and units, one of which verifies that the menu options for units are filtered to the units corresponding to the sample type's display units.

#### Related Pull Requests
- https://github.com/LabKey/biologics/pull/2015
- https://github.com/LabKey/sampleManagement/pull/1696
- https://github.com/LabKey/inventory/pull/781
- https://github.com/LabKey/labkey-ui-components/pull/1144

#### Changes
* Add `getSelectionOptions` method to `EntityBulkUpdateDialog`.
