### PR TITLE
Add test case to go with dataintegration/202

### DIFF
--- a/modules/ETLtest/resources/ETLs/localInvalidDestinationSchemaName.xml
+++ b/modules/ETLtest/resources/ETLs/localInvalidDestinationSchemaName.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+<name>Test Bad Destination Schema</name>
+<description>append rows from source to invalid target</description>
+<transforms>
+    <transform id="step1">
+        <description>Copy to target</description>
+        <source schemaName="etltest" queryName="source" />
+        <destination schemaName="study_buddy" queryName="etl target" targetOption="truncate"/>
+    </transform>
+</transforms>
+<incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified" />
+    <schedule>
+        <poll interval="15s" />
+    </schedule>
+</etl>

--- a/modules/ETLtest/resources/ETLs/remoteConnectionTargetMerge.xml
+++ b/modules/ETLtest/resources/ETLs/remoteConnectionTargetMerge.xml
@@ -1,5 +1,5 @@
 <etl xmlns="http://labkey.org/etl/xml">
-    <name>Remote connectoin with target option</name>
+    <name>Remote connection with target option</name>
     <description>User Defined ETL</description>
     <transforms>
         <transform id="step1forEditTest" type="org.labkey.di.pipeline.TransformTask">

--- a/modules/ETLtest/resources/ETLs/remoteWithRemoteDeleteSource.xml
+++ b/modules/ETLtest/resources/ETLs/remoteWithRemoteDeleteSource.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+<name>Remote Test With Remote Delete</name>
+<description>append rows from "remote" source to target, with "remote" delete based on the audit trail</description>
+    <transforms>
+        <transform type="RemoteQueryTransformStep" id="step1">
+            <description>Copy to target</description>
+            <source remoteSource="EtlTest_RemoteConnection2" schemaName="lists" queryName="SourceListForRemoteDelete" >
+                <sourceColumns>
+                    <column>name</column>
+                    <column>ditransformrunid</column>
+                    <column>EntityId</column>
+                </sourceColumns>
+            </source>
+            <destination schemaName="etltest" queryName="target" targetOption="append">
+                <columnTransforms>
+                    <!-- switch columns so data length fits-->
+                    <column source="name" target="id" />
+                    <column source="EntityId" target="name" />
+                </columnTransforms>
+            </destination>
+        </transform>
+    </transforms>
+    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="Modified">
+        <deletedRowsSource remoteSource="EtlTest_RemoteConnection2" schemaName="AuditLog" queryName="ListAuditEvent" deletedSourceKeyColumnName="listitementityid" targetKeyColumnName="id" timestampColumnName="Created">
+            <sourceFilters>
+                <sourceFilter column="listname" operator="eq" value="SourceListForRemoteDelete"/>
+                <sourceFilter column="comment" operator="eq" value="An existing list record was deleted"/>
+            </sourceFilters>
+        </deletedRowsSource>
+    </incrementalFilter>
+</etl>

--- a/modules/ETLtest/resources/ETLs/remoteWithRemoteDeleteSource.xml
+++ b/modules/ETLtest/resources/ETLs/remoteWithRemoteDeleteSource.xml
@@ -22,7 +22,7 @@
         </transform>
     </transforms>
     <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="Modified">
-        <deletedRowsSource remoteSource="EtlTest_RemoteConnection2" schemaName="AuditLog" queryName="ListAuditEvent" deletedSourceKeyColumnName="listitementityid" targetKeyColumnName="id" timestampColumnName="Created">
+        <deletedRowsSource remoteSource="EtlTest_RemoteConnection2" schemaName="AuditLog" queryName="ListAuditEvent" deletedSourceKeyColumnName="listitementityid" targetKeyColumnName="name" timestampColumnName="Created">
             <sourceFilters>
                 <sourceFilter column="listname" operator="eq" value="SourceListForRemoteDelete"/>
                 <sourceFilter column="comment" operator="eq" value="An existing list record was deleted"/>


### PR DESCRIPTION
- Add test case exercising the new remote ETL delete rows source.
- Add test case verifying invalid destination