### PR TITLE
Use appropriate test component for Assay QC alert

### DIFF
--- a/src/org/labkey/test/pages/assay/AssayRunsPage.java
+++ b/src/org/labkey/test/pages/assay/AssayRunsPage.java
@@ -20,6 +20,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.bootstrap.ModalDialog;
+import org.labkey.test.components.labkey.LabKeyAlert;
 import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ExperimentRunTable;
@@ -97,7 +98,7 @@ public class AssayRunsPage extends LabKeyPage<AssayRunsPage.ElementCache>
         if (expectError)
         {
             clickButton("update", 0);
-            ModalDialog dialog = new ModalDialog.ModalDialogFinder(getDriver()).withTitle("Error").find();
+            ModalDialog dialog = new LabKeyAlert(getDriver());
             Assert.assertEquals("A comment is required when changing a QC State for the selected run(s).", dialog.getBodyText());
             dialog.dismiss();
             return updatePage.clickCancel();


### PR DESCRIPTION
#### Rationale
`ModalDialog` expects the component to go stale when closing the dialog. `LabKeyAlert` (wrapping `LABKEY.Utils.alert`)  does not.

#### Related Pull Requests
* #1430 

#### Changes
* Use appropriate test component for Assay QC alert
