### PR TITLE
Update tests to not assume 'labkey' context path

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ hamcrestCoreVersion=1.3
 
 lookfirstSardineVersion=5.7
 jettyRepackagedVersion=9.4.12.v20180830
-seleniumVersion=4.8.1
+seleniumVersion=4.1.4
 mockserverNettyVersion=5.5.1
 
 labkeySchemasTestVersion=23.3-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ hamcrestCoreVersion=1.3
 
 lookfirstSardineVersion=5.7
 jettyRepackagedVersion=9.4.12.v20180830
-seleniumVersion=4.1.4
+seleniumVersion=4.8.1
 mockserverNettyVersion=5.5.1
 
 labkeySchemasTestVersion=23.3-SNAPSHOT

--- a/src/org/labkey/test/pipeline/PipelineTestsBase.java
+++ b/src/org/labkey/test/pipeline/PipelineTestsBase.java
@@ -15,11 +15,16 @@
  */
 package org.labkey.test.pipeline;
 
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.util.ExperimentRunTable;
 import org.labkey.test.util.PipelineStatusTable;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertFalse;
 
@@ -90,7 +95,7 @@ public class PipelineTestsBase
 
     public void beginAt()
     {
-        _test.beginAt("/labkey/Project/" + _test.getProjectName() + "/" + _folder.getFolderName() + "/begin.view");        
+        _test.beginAt(WebTestHelper.buildURL("project", _test.getProjectName() + "/" + _folder.getFolderName(), "begin"));
     }
     
     public void clean()

--- a/src/org/labkey/test/tests/LookupToSampleIDTest.java
+++ b/src/org/labkey/test/tests/LookupToSampleIDTest.java
@@ -23,6 +23,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
@@ -212,7 +213,7 @@ public class LookupToSampleIDTest extends BaseWebDriverTest
     {
         clickAndWait(Locator.linkContainingText(assayName));
         clickAndWait(new DataRegionTable("Batches", this).link(0, "Name"));
-        clickAndWait(Locator.tag("img").withAttribute("src", "/labkey/experiment/images/graphIcon.gif"));
+        clickAndWait(Locator.tag("img").withAttribute("src", WebTestHelper.getContextPath() + "/experiment/images/graphIcon.gif"));
         clickAndWait(Locator.linkWithText("Text View"));
         clickAndWait(Locator.linkContainingText("123456"));
     }

--- a/src/org/labkey/test/tests/ProjectTermsOfUseTest.java
+++ b/src/org/labkey/test/tests/ProjectTermsOfUseTest.java
@@ -58,7 +58,7 @@ public class ProjectTermsOfUseTest extends BaseTermsOfUseTest
 
         // simulate a session expiration and make sure you can still log in to a project with terms.
         signOut();
-        beginAt(WebTestHelper.buildURL("login", "login", Maps.of("returnUrl", "/labkey/project/" + PUBLIC_TERMS_PROJECT_NAME + "/begin.view?")));
+        beginAt(WebTestHelper.buildURL("login", "login", Maps.of("returnUrl", WebTestHelper.getContextPath() + "/" + PUBLIC_TERMS_PROJECT_NAME + "/project-begin.view")));
         attemptSignIn(PasswordUtil.getUsername(), PasswordUtil.getPassword());
         waitForElement(Locators.labkeyError.containing("you must log in and approve the terms of use"));
         assertTextPresent(PROJECT_TERMS_SNIPPET);

--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -59,9 +59,6 @@ public class WikiLongTest extends BaseWebDriverTest
     private static final String WIKI_PAGE8_TITLE = "Page 8 Title For Delete Subtree Test " + BaseWebDriverTest.INJECT_CHARS_1;
     private static final String WIKI_PAGE8_NAME= "Page 8 Name For Delete Subtree Test " + BaseWebDriverTest.INJECT_CHARS_1;
 
-    private static final String WIKI_PAGE1_TITLE_LINK = "/labkey/wiki/WikiCopied/page.view?name=Page%201%20Wiki%20Name";
-    private static final String WIKI_PAGE1_TITLE_LINK_COPY = "/labkey/wiki/WikiCopied/page.view?name=Page%201%20Wiki%20Name1";
-
     private static final String DISC1_TITLE = "Let's Talk";
     private static final String DISC1_BODY = "I don't know how normal this wiki is";
     private static final String RESP1_TITLE = "Let's Keep Talking";


### PR DESCRIPTION
#### Rationale
Remote instances and servers with embedded tomcat don't have a context path. Tests shouldn't assume the server under test has a particular context path.

#### Changes
- Update tests to not assume 'labkey' context path