### PR TITLE
Make Helpers More Reliable

### DIFF
--- a/src/org/labkey/test/components/ui/navigation/FindByIdsDialog.java
+++ b/src/org/labkey/test/components/ui/navigation/FindByIdsDialog.java
@@ -53,11 +53,13 @@ public class FindByIdsDialog extends ModalDialog
     public void clickCancel()
     {
         elementCache().cancelButton.click();
+        waitForClose();
     }
 
     public void clickFindSamples()
     {
         elementCache().findSamplesButton.click();
+        waitForClose();
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
The FindSamplesById dialog was returning immediately after clicking the dismiss button. Some tests would immediately look at the results grid before before it was populated. This adds a waitForClose which will wait for the dialog to close before returning to the test.

#### Related Pull Requests
* None

#### Changes
* Add waitForClose to the dismiss methods.
