### PR TITLE
ModalDialog dismiss() option that allows for passing through a waitSeconds param

### DIFF
--- a/src/org/labkey/test/components/bootstrap/ModalDialog.java
+++ b/src/org/labkey/test/components/bootstrap/ModalDialog.java
@@ -100,11 +100,16 @@ public class ModalDialog extends WebDriverComponent<ModalDialog.ElementCache>
 
     public void dismiss()
     {
+        dismiss(10);
+    }
+
+    public void dismiss(Integer waitSeconds)
+    {
         WebElement button = Locator.tagWithClass("button", "close").findElement(getComponentElement());
         new WebDriverWait(getDriver(), Duration.ofMillis(WAIT_FOR_JAVASCRIPT))
                 .until(ExpectedConditions.elementToBeClickable(button));
         button.click();
-        waitForClose();
+        waitForClose(waitSeconds);
     }
 
     public void dismiss(String buttonText)

--- a/src/org/labkey/test/pages/assay/AssayRunsPage.java
+++ b/src/org/labkey/test/pages/assay/AssayRunsPage.java
@@ -99,7 +99,7 @@ public class AssayRunsPage extends LabKeyPage<AssayRunsPage.ElementCache>
             clickButton("update", 0);
             ModalDialog dialog = new ModalDialog.ModalDialogFinder(getDriver()).withTitle("Error").find();
             Assert.assertEquals("A comment is required when changing a QC State for the selected run(s).", dialog.getBodyText());
-            dialog.dismiss();
+            dialog.dismiss(0);
             return updatePage.clickCancel();
         }
 


### PR DESCRIPTION
#### Rationale
The AssayQCTest.testQCStateChangeRequiresComment test failure was from a recent change in the ModalDialog related to the dismiss method call to waitForClose(). This PR adds a method signature that allows for passing through the `waitSeconds` param to `dismiss()`.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1430/files#diff-34ea1f18083c4eea07a452968d844878119d228d63a1bedec19ec2ed4f2b64beR132

#### Changes
* adds a method signature that allows for passing through the `waitSeconds` param to `dismiss()`
