### PR TITLE
regression coverage for issue 46738

### DIFF
--- a/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
+++ b/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
@@ -18,6 +18,7 @@ package org.labkey.test.pages.core.admin;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
+import org.labkey.test.components.DomainDesignerPage;
 import org.labkey.test.pages.ConfigureReportsAndScriptsPage;
 import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.pages.compliance.ComplianceSettingsAccountsPage;
@@ -116,6 +117,13 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
         goToSettingsSection();
         clickAndWait(elementCache().complianceSettings);
         return new ComplianceSettingsAccountsPage(getDriver());
+    }
+
+    public DomainDesignerPage clickChangeUserProperties()
+    {
+        goToSettingsSection();
+        clickAndWait(elementCache().changeUserPropertiesLink);
+        return new DomainDesignerPage(getDriver());
     }
 
     public void clickEmailCustomization()
@@ -232,6 +240,7 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
         protected WebElement authenticationLink = Locator.linkWithText("authentication").findWhenNeeded(this);
         protected WebElement configurePageElements = Locator.linkWithText("configure page elements").findWhenNeeded(this);
         protected WebElement complianceSettings = Locator.linkWithText("Compliance Settings").findWhenNeeded(this);
+        protected WebElement changeUserPropertiesLink = Locator.linkWithText("change user properties").findWhenNeeded(this);
         protected WebElement emailCustomizationLink = Locator.linkWithText("email customization").findWhenNeeded(this);
         protected WebElement notificationServiceAdminLink = Locator.linkWithText("notification service admin").findWhenNeeded(this);
         protected WebElement filesLink = Locator.linkWithText("files").findWhenNeeded(this);

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -219,7 +220,7 @@ public class AdminConsoleTest extends BaseWebDriverTest
         log("Verifying cannot be duplicate");
         setFormElement(Locator.name("newExternalRedirectHost"), host);
         clickButton("Save");
-        assertElementPresent(Locator.css(".labkey-error").withText("\'" + host + "\' already exists. Duplicate hosts not allowed."));
+        assertElementPresent(Locator.css(".labkey-error").withText("'" + host + "' already exists. Duplicate hosts not allowed."));
 
     }
 
@@ -233,6 +234,34 @@ public class AdminConsoleTest extends BaseWebDriverTest
         goToAdminConsole().clickCredits();
         log("Verifying the page is properly loaded");
         assertTextPresent("JAR Files Distributed with the API Module");
+    }
+
+    /*
+        adds regression coverage for Issue 46738
+        explicitly navigate between admin console, site users and user domain editor
+     */
+    @Test
+    public void testChangeUserPropertiesNavigation()
+    {
+        var console = goToAdminConsole();
+        var userEditPage = console.clickChangeUserProperties();
+        var adminConsoleUrl = getURL();
+        checker().wrapAssertion(()-> assertThat(userEditPage.fieldsPanel().fieldNames())
+                .as("expect any standard user fields to be present")
+                .contains("FirstName", "LastName", "Description"));
+        userEditPage.clickCancel();
+        checker().verifyEquals("expect redirect back to admin console",
+                adminConsoleUrl, getURL());
+
+        var siteUsers = goToSiteUsers();
+        var siteUsersURL = getURL();
+        var usersPropertyPage = siteUsers.clickChangeUserProperties();
+        checker().wrapAssertion(()-> assertThat(usersPropertyPage.fieldsPanel().fieldNames())
+                .as("expect any standard user fields to be present")
+                .contains("FirstName", "LastName", "Description"));
+        usersPropertyPage.clickCancel();
+        checker().verifyEquals("expect redirect back to site users",
+                siteUsersURL, getURL());
     }
 
     @Override

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -236,33 +235,7 @@ public class AdminConsoleTest extends BaseWebDriverTest
         assertTextPresent("JAR Files Distributed with the API Module");
     }
 
-    /*
-        adds regression coverage for Issue 46738
-        explicitly navigate between admin console, site users and user domain editor
-     */
-    @Test
-    public void testChangeUserPropertiesNavigation()
-    {
-        var console = goToAdminConsole();
-        var userEditPage = console.clickChangeUserProperties();
-        var adminConsoleUrl = getURL();
-        checker().wrapAssertion(()-> assertThat(userEditPage.fieldsPanel().fieldNames())
-                .as("expect any standard user fields to be present")
-                .contains("FirstName", "LastName", "Description"));
-        userEditPage.clickCancel();
-        checker().verifyEquals("expect redirect back to admin console",
-                adminConsoleUrl, getURL());
 
-        var siteUsers = goToSiteUsers();
-        var siteUsersURL = getURL();
-        var usersPropertyPage = siteUsers.clickChangeUserProperties();
-        checker().wrapAssertion(()-> assertThat(usersPropertyPage.fieldsPanel().fieldNames())
-                .as("expect any standard user fields to be present")
-                .contains("FirstName", "LastName", "Description"));
-        usersPropertyPage.clickCancel();
-        checker().verifyEquals("expect redirect back to site users",
-                siteUsersURL, getURL());
-    }
 
     @Override
     public List<String> getAssociatedModules()

--- a/src/org/labkey/test/tests/UserDomainEditNavigationTest.java
+++ b/src/org/labkey/test/tests/UserDomainEditNavigationTest.java
@@ -3,6 +3,7 @@ package org.labkey.test.tests;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.categories.Daily;
 
 import java.util.Arrays;
 import java.util.List;
@@ -14,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         adds regression coverage for Issue 46738
         explicitly navigate between admin console, site users and user domain editor
     */
-@Category({})
+@Category({Daily.class})
 public class UserDomainEditNavigationTest extends BaseWebDriverTest
 {
     @Test

--- a/src/org/labkey/test/tests/UserDomainEditNavigationTest.java
+++ b/src/org/labkey/test/tests/UserDomainEditNavigationTest.java
@@ -1,0 +1,59 @@
+package org.labkey.test.tests;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+    /*
+        adds regression coverage for Issue 46738
+        explicitly navigate between admin console, site users and user domain editor
+    */
+@Category({})
+public class UserDomainEditNavigationTest extends BaseWebDriverTest
+{
+    @Test
+    public void testNavigateFromAdminConsole()
+    {
+        var console = goToAdminConsole();
+        var userEditPage = console.clickChangeUserProperties();
+        var adminConsoleUrl = getURL();
+        checker().wrapAssertion(()-> assertThat(userEditPage.fieldsPanel().fieldNames())
+                .as("expect any standard user fields to be present")
+                .contains("FirstName", "LastName", "Description"));
+        userEditPage.clickCancel();
+        checker().verifyEquals("expect redirect back to admin console",
+                adminConsoleUrl, getURL());
+    }
+
+    @Test
+    public void testNavigateFromSiteUsers()
+    {
+        var siteUsers = goToSiteUsers();
+        var siteUsersURL = getURL();
+        var usersPropertyPage = siteUsers.clickChangeUserProperties();
+        checker().wrapAssertion(()-> assertThat(usersPropertyPage.fieldsPanel().fieldNames())
+                .as("expect any standard user fields to be present")
+                .contains("FirstName", "LastName", "Description"));
+        usersPropertyPage.clickCancel();
+        checker().verifyEquals("expect redirect back to site users",
+                siteUsersURL, getURL());
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return "UserDomainEditNavigationTest Project";
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Arrays.asList();
+    }
+}


### PR DESCRIPTION
#### Rationale
This change adds test coverage to ensure navigation between Admin Console, Site Users and the user domain editor.  In some deployments, links to the user domain editor page show 404s, this should let us know when we break that link

#### Related Pull Requests
n/a

#### Changes

- [x] New method in ShowAdminPage, supporting navigation to user fields editor
- [x] New test method in AdminConsoleTest, exercising this navigation and ensuring the page is functional