### PR TITLE
Domain designer loading state

### DIFF
--- a/src/org/labkey/test/components/DomainDesignerPage.java
+++ b/src/org/labkey/test/components/DomainDesignerPage.java
@@ -9,7 +9,6 @@ import org.labkey.test.components.domain.BaseDomainDesigner;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.domain.DomainPanel;
 import org.labkey.test.components.domain.UnsavedChangesModalDialog;
-import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.util.Maps;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -50,6 +49,7 @@ public class DomainDesignerPage extends BaseDomainDesigner<DomainDesignerPage.El
     // if you are looking for a specific one, use the fieldsPanel(title) helper
     public DomainFormPanel fieldsPanel()
     {
+        getWrapper().waitForElementToDisappear(Locator.tagWithText("span", "Loading..."));
         return elementCache().firstDomainFormPanel;
     }
 

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -226,6 +226,7 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
         if (isManuallyDefineFieldsPresent())
             return manuallyDefineFields(name);
 
+        getWrapper().waitForElementToDisappear(Locator.tagWithText("span", "Loading..."));
         getWrapper().scrollIntoView(elementCache().addFieldButton, true);
         getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().addFieldButton)); // give modal dialogs time to disappear
         elementCache().addFieldButton.click();

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -226,7 +226,6 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
         if (isManuallyDefineFieldsPresent())
             return manuallyDefineFields(name);
 
-        getWrapper().waitForElementToDisappear(Locator.tagWithText("span", "Loading..."));
         getWrapper().scrollIntoView(elementCache().addFieldButton, true);
         getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().addFieldButton)); // give modal dialogs time to disappear
         elementCache().addFieldButton.click();

--- a/src/org/labkey/test/pages/query/EditMetadataPage.java
+++ b/src/org/labkey/test/pages/query/EditMetadataPage.java
@@ -59,6 +59,7 @@ public class EditMetadataPage extends BaseDomainDesigner<EditMetadataPage.Elemen
 
     public DomainFormPanel fieldsPanel()
     {
+        getWrapper().waitForElementToDisappear(Locator.tagWithText("span", "Loading..."));
         return elementCache().firstDomainFormPanel;
     }
 


### PR DESCRIPTION
#### Rationale
Latest update to domain designer slowed down initialization enough that automated tests were adding fields before the component was completely initialized. The related PR updates the domain designer to have a loading state which prevents the tests from adding fields before initialization is done.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1165

#### Changes
* When getting the field panel in DomainDesignerPage and EditMetaDataPage, wait for the Loading... spinner to go away first.
