### PR TITLE
Revert unnecessary change to ModalDialog

### DIFF
--- a/src/org/labkey/test/components/bootstrap/ModalDialog.java
+++ b/src/org/labkey/test/components/bootstrap/ModalDialog.java
@@ -100,16 +100,11 @@ public class ModalDialog extends WebDriverComponent<ModalDialog.ElementCache>
 
     public void dismiss()
     {
-        dismiss(10);
-    }
-
-    public void dismiss(Integer waitSeconds)
-    {
         WebElement button = Locator.tagWithClass("button", "close").findElement(getComponentElement());
         new WebDriverWait(getDriver(), Duration.ofMillis(WAIT_FOR_JAVASCRIPT))
                 .until(ExpectedConditions.elementToBeClickable(button));
         button.click();
-        waitForClose(waitSeconds);
+        waitForClose();
     }
 
     public void dismiss(String buttonText)

--- a/src/org/labkey/test/pages/assay/AssayRunsPage.java
+++ b/src/org/labkey/test/pages/assay/AssayRunsPage.java
@@ -100,7 +100,7 @@ public class AssayRunsPage extends LabKeyPage<AssayRunsPage.ElementCache>
             clickButton("update", 0);
             ModalDialog dialog = new LabKeyAlert(getDriver());
             Assert.assertEquals("A comment is required when changing a QC State for the selected run(s).", dialog.getBodyText());
-            dialog.dismiss(0);
+            dialog.dismiss();
             return updatePage.clickCancel();
         }
 


### PR DESCRIPTION
#### Rationale
The failure the previous fix was addressing was already fixed in 23.3; it just hadn't been merged forward yet.

#### Related Pull Requests
* Reverting: #1459 
* Failure was already fixed with: #1435 

#### Changes
* Revert unnecessary change to ModalDialog
