### PR TITLE
Export system diagnostics after running tests against a remote server

### DIFF
--- a/src/org/labkey/test/Runner.java
+++ b/src/org/labkey/test/Runner.java
@@ -47,11 +47,10 @@ import org.labkey.test.categories.Continue;
 import org.labkey.test.categories.Empty;
 import org.labkey.test.teamcity.TeamCityUtils;
 import org.labkey.test.testpicker.TestHelper;
-import org.labkey.test.tests.BasicTest;
-import org.labkey.test.tests.DatabaseDiagnosticsTest;
 import org.labkey.test.tests.JUnitTest;
 import org.labkey.test.util.Crawler;
 import org.labkey.test.util.DevModeOnlyTest;
+import org.labkey.test.util.ExportDiagnosticsPseudoTest;
 import org.labkey.test.util.NonWindowsTest;
 import org.labkey.test.util.PostgresOnlyTest;
 import org.labkey.test.util.SqlserverOnlyTest;
@@ -975,11 +974,12 @@ public class Runner extends TestSuite
             }
         }
 
-        set.prioritizeTest(BasicTest.class, 0); // Always start with BasicTest (if present)
+        List<Class<?>> testClasses = testNames.isEmpty() ? set.getSortedTestList() : getTestClasses(testNames);
 
-        set.prioritizeTest(DatabaseDiagnosticsTest.class, set.getTestList().size() - 1); // Always end with DatabaseDiagnosticsTest (if present)
-
-        List<Class<?>> testClasses = testNames.isEmpty() ? set.getTestList() : getTestClasses(testNames);
+        if (TestProperties.isServerRemote() && TestProperties.isTestRunningOnTeamCity() || TestProperties.isDiagnosticsExportEnabled())
+        {
+            testClasses.add(ExportDiagnosticsPseudoTest.class);
+        }
 
         TestSuite suite = getSuite(testClasses, cleanOnly);
 

--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -386,6 +386,22 @@ public abstract class TestFileUtils
      * @return File object pointing to the new file
      * @throws IOException If an I/O error occurs when opening or writing to the file
      */
+    public static File writeTempFile(String name, InputStream contents) throws IOException
+    {
+        File file = new File(getTestTempDir(), name);
+        FileUtils.forceMkdirParent(file);
+
+        FileUtils.copyInputStreamToFile(contents, file);
+        return file;
+    }
+
+    /**
+     * Write text to a file in the test temp directory. Temp directory will be created if it does not exist.
+     * @param name Name of the file to be created. An existing file will be overwritten
+     * @param contents text to write to the file
+     * @return File object pointing to the new file
+     * @throws IOException If an I/O error occurs when opening or writing to the file
+     */
     public static File writeTempFile(String name, String contents) throws IOException
     {
         File file = new File(getTestTempDir(), name);

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -138,6 +138,11 @@ public abstract class TestProperties
         return "true".equals(System.getProperty("webtest.enable.heap.dump"));
     }
 
+    public static boolean isDiagnosticsExportEnabled()
+    {
+        return "true".equals(System.getProperty("webtest.enable.export.diagnostics"));
+    }
+
     public static boolean isRunWebDriverHeadless()
     {
         return "true".equals(System.getProperty("webtest.webdriver.headless"));

--- a/src/org/labkey/test/TestSet.java
+++ b/src/org/labkey/test/TestSet.java
@@ -17,10 +17,12 @@
 package org.labkey.test;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.test.util.Prioritized;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -88,6 +90,40 @@ public class TestSet
     public List<Class<?>> getTestList()
     {
         return _tests;
+    }
+
+    public List<Class<?>> getSortedTestList()
+    {
+        List<Class<?>> firstTests = new ArrayList<>();
+        List<Class<?>> unprioritized = new ArrayList<>();
+        List<Class<?>> lastTests = new ArrayList<>();
+        for (Class<?> next : _tests)
+        {
+            Prioritized annotation = next.getAnnotation(Prioritized.class);
+            double priority = annotation != null ? annotation.priority() : 0;
+            if (priority > 0)
+            {
+                firstTests.add(next);
+            }
+            else if (priority < 0)
+            {
+                lastTests.add(next);
+            }
+            else
+            {
+                unprioritized.add(next);
+            }
+        }
+        firstTests.sort(Comparator.comparingDouble(c -> c.getAnnotation(Prioritized.class).priority()));
+        Collections.reverse(firstTests);
+        lastTests.sort(Comparator.comparingDouble(c -> c.getAnnotation(Prioritized.class).priority()));
+        Collections.reverse(lastTests);
+
+        List<Class<?>> sortedTests = new ArrayList<>(_tests.size());
+        sortedTests.addAll(firstTests);
+        sortedTests.addAll(unprioritized);
+        sortedTests.addAll(lastTests);
+        return sortedTests;
     }
 
     public List<String> getTestNames()

--- a/src/org/labkey/test/tests/BasicTest.java
+++ b/src/org/labkey/test/tests/BasicTest.java
@@ -19,9 +19,7 @@ package org.labkey.test.tests;
 import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.labkey.test.BaseWebDriverTest;
-import org.labkey.test.Locator;
 import org.labkey.test.TestProperties;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Base;
@@ -30,24 +28,15 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Git;
 import org.labkey.test.categories.Hosting;
 import org.labkey.test.categories.Smoke;
-import org.labkey.test.components.BodyWebPart;
-import org.labkey.test.components.WebPart;
-import org.openqa.selenium.WebElement;
+import org.labkey.test.util.Prioritized;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static org.junit.Assert.assertTrue;
 
 /**
  * Short test to verify installed modules are well-formed
  */
 @Category({Base.class, DRT.class, Daily.class, Git.class, Hosting.class, Smoke.class})
+@Prioritized(priority = 1)
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class BasicTest extends BaseWebDriverTest
 {

--- a/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
+++ b/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
@@ -29,6 +29,7 @@ import org.labkey.test.io.Grep;
 import org.labkey.test.util.Maps;
 import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.PipelineStatusTable;
+import org.labkey.test.util.Prioritized;
 import org.openqa.selenium.WebElement;
 
 import java.io.File;
@@ -40,6 +41,7 @@ import java.util.TreeMap;
 import static org.junit.Assert.assertTrue;
 
 @Category({BVT.class, Daily.class, Git.class, CustomModules.class})
+@Prioritized(priority = -1)
 @BaseWebDriverTest.ClassTimeout(minutes = 20)
 public class DatabaseDiagnosticsTest extends BaseWebDriverTest
 {

--- a/src/org/labkey/test/util/ArtifactCollector.java
+++ b/src/org/labkey/test/util/ArtifactCollector.java
@@ -113,6 +113,10 @@ public class ArtifactCollector
 
     private void publishArtifact(File file, @Nullable String destination)
     {
+        if (file.isDirectory() && destination == null)
+        {
+            destination = file.getName() + ".tar.gz";
+        }
         TeamCityUtils.publishArtifact(file, destination);
     }
 

--- a/src/org/labkey/test/util/ExportDiagnosticsPseudoTest.java
+++ b/src/org/labkey/test/util/ExportDiagnosticsPseudoTest.java
@@ -1,8 +1,10 @@
 package org.labkey.test.util;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebTestHelper;
 
 import java.io.File;
@@ -16,10 +18,35 @@ public class ExportDiagnosticsPseudoTest extends BaseWebDriverTest
     @Test
     public void exportDiagnostics() throws Exception
     {
-        SimpleHttpRequest req = new SimpleHttpRequest(WebTestHelper.buildURL("diagnostics", "exportDiagnostics"), "POST");
-        req.copySession(getDriver());
-        File diagnosticsFile = req.getResponseAsFile();
-        getArtifactCollector().publishArtifact(diagnosticsFile);
+        File diagnosticsDir = new File(TestFileUtils.getTestTempDir(), "diagnostics");
+        if (diagnosticsDir.exists())
+        {
+            FileUtils.forceDelete(diagnosticsDir);
+        }
+        FileUtils.forceMkdir(diagnosticsDir);
+
+        if (_containerHelper.getAllModules().contains("Premium"))
+        {
+            SimpleHttpRequest req = new SimpleHttpRequest(WebTestHelper.buildURL("diagnostics", "exportDiagnostics"), "POST");
+            req.copySession(getDriver());
+            File diagnosticsFile = req.getResponseAsFile(diagnosticsDir);
+            getArtifactCollector().publishArtifact(diagnosticsFile);
+        }
+        else
+        {
+
+            TestLogger.info("Premium module not available, dumping logs manually");
+            SimpleHttpRequest req = new SimpleHttpRequest(WebTestHelper.buildURL("admin", "showPrimaryLog"));
+            req.copySession(getDriver());
+            req.getResponseAsFile(new File(diagnosticsDir, "labkey.log"));
+            req = new SimpleHttpRequest(WebTestHelper.buildURL("admin", "showAllErrors"));
+            req.copySession(getDriver());
+            req.getResponseAsFile(new File(diagnosticsDir, "labkey-errors.log"));
+            req = new SimpleHttpRequest(WebTestHelper.buildURL("admin", "exportQueries"), "POST");
+            req.copySession(getDriver());
+            req.getResponseAsFile(diagnosticsDir);
+            getArtifactCollector().publishArtifact(diagnosticsDir);
+        }
     }
 
     @Override

--- a/src/org/labkey/test/util/ExportDiagnosticsPseudoTest.java
+++ b/src/org/labkey/test/util/ExportDiagnosticsPseudoTest.java
@@ -1,0 +1,36 @@
+package org.labkey.test.util;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.WebTestHelper;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+@Category({})
+@Prioritized(priority = -100) // Export diagnostics last
+public class ExportDiagnosticsPseudoTest extends BaseWebDriverTest
+{
+    @Test
+    public void exportDiagnostics() throws Exception
+    {
+        SimpleHttpRequest req = new SimpleHttpRequest(WebTestHelper.buildURL("diagnostics", "exportDiagnostics"), "POST");
+        req.copySession(getDriver());
+        File diagnosticsFile = req.getResponseAsFile();
+        getArtifactCollector().publishArtifact(diagnosticsFile);
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return null;
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Arrays.asList();
+    }
+}

--- a/src/org/labkey/test/util/Prioritized.java
+++ b/src/org/labkey/test/util/Prioritized.java
@@ -1,0 +1,18 @@
+package org.labkey.test.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Prioritized
+{
+    /**
+     * Test class priority. Test runner will use this annotation to sort test classes.
+     * Higher priority values will run first. Tests will run in order from highest to lowest. Non-annotated tests are
+     * treated as having a priority of zero.
+     */
+    double priority() default 0.0;
+}

--- a/src/org/labkey/test/util/SimpleHttpRequest.java
+++ b/src/org/labkey/test/util/SimpleHttpRequest.java
@@ -15,10 +15,15 @@
  */
 package org.labkey.test.util;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.labkey.remoteapi.Connection;
+import org.labkey.test.TestFileUtils;
 import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebDriver;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.Authenticator;
 import java.net.HttpURLConnection;
@@ -29,6 +34,7 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -123,6 +129,83 @@ public class SimpleHttpRequest
             if (con != null)
                 con.disconnect();
             Authenticator.setDefault(null);
+        }
+    }
+
+    public File getResponseAsFile() throws IOException
+    {
+        return getResponseAsFile(null);
+    }
+
+    public File getResponseAsFile(String fileName) throws IOException
+    {
+        HttpURLConnection con = null;
+
+        try
+        {
+            URL url = new URL(_url);
+            con = (HttpURLConnection)url.openConnection();
+            con.setRequestMethod(_requestMethod);
+            con.setReadTimeout(_timeout);
+
+            if (!_cookies.isEmpty())
+            {
+                useCopiedSession(con);
+            }
+            else
+            {
+                // Authenticator.setDefault() call above doesn't seem to work (I don't know why), so add the basic auth header explicitly
+                String encoded = Base64.getEncoder().encodeToString((_username + ":" + _password).getBytes(StandardCharsets.UTF_8));
+                con.setRequestProperty("Authorization", "Basic " + encoded);
+            }
+
+            con.connect();
+
+            if (con.getResponseCode() != 200)
+            {
+                TestLogger.error(IOUtils.toString(con.getErrorStream(), StandardCharsets.UTF_8));
+                throw new RuntimeException("Failed to download file [%d]: %s".formatted(con.getResponseCode(), con.getResponseMessage()));
+            }
+            else
+            {
+                // Extract file name from response header.
+                // Example:
+                // attachment; filename="diagnostics_2023-03-31_12-36-31.zip"
+                String contentDisposition = con.getHeaderField("Content-Disposition");
+                String[] splitDisposition = contentDisposition.split("; ");
+                Map<String, String> params = new LinkedHashMap<>();
+                for (String s : splitDisposition)
+                {
+                    String[] param = s.split("=", 2);
+                    params.put(param[0], param.length == 2 ? StringUtils.strip(param[1], "\"") : null);
+                }
+                String responseFilename = params.get("filename");
+                if (fileName == null)
+                {
+                    if (responseFilename == null)
+                    {
+                        throw new IllegalArgumentException("Unable to determine filename for download.");
+                    }
+                    fileName = responseFilename;
+                }
+                else if (responseFilename != null && fileName.contains("."))
+                {
+                    // Verify correct extension
+                    String expectedExtension = fileName.split("\\.", 2)[1];
+                    if (!responseFilename.endsWith("." + expectedExtension))
+                    {
+                        throw new IllegalArgumentException("Download didn't match expected extension.\n%s\n%s".formatted(responseFilename, fileName));
+                    }
+                }
+                File file = TestFileUtils.writeTempFile(fileName, con.getInputStream());
+                TestLogger.info("%s: Downloaded [%s] from %s".formatted(file.getName(), FileUtils.byteCountToDisplaySize(file.length()), _url));
+                return file;
+            }
+        }
+        finally
+        {
+            if (con != null)
+                con.disconnect();
         }
     }
 


### PR DESCRIPTION
#### Rationale
Tests don't have file-system access to remote servers, so we can't dump tomcat logs to TeamCity. We can, however, export the server's system diagnostics. The diagnostics includes server logs as well as other, possibly useful, information.
This adds a new pseudo-test (`ExportDiagnosticsPseudoTest`) to download these diagnostics after running tests against a remote server (or via a new `webtest.enable.export.diagnostics` flag).

This is the third test that we want to force to run in a particular order (in addition to `BasicTest` and `DatabaseDiagnosticsTest`). Rather than adding more special handling for the new test (it should run last), I created a `Prioritized` annotation for tests to specify that they should run before/after other tests.

#### Related Pull Requests
* N/A

#### Changes
* Export system diagnostics after running tests against a remote server
* Create new annotation control test priority
* Add helper to download directly to a file
