### PR TITLE
Centralize test handling of toggling experiment run graph

### DIFF
--- a/src/org/labkey/test/components/ui/lineage/LineageGraph.java
+++ b/src/org/labkey/test/components/ui/lineage/LineageGraph.java
@@ -7,7 +7,10 @@ import org.labkey.test.components.ui.grids.DetailTable;
 import org.labkey.test.components.ui.grids.ResponsiveGrid;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -25,6 +28,22 @@ public class LineageGraph extends WebDriverComponent<LineageGraph.ElementCache>
     {
         _el = element;
         _driver = driver;
+    }
+
+    /**
+     * Switch from old 'graphviz' run graph to the "Beta" run graph
+     * "Beta" run graph might be the default if 'graphviz' isn't installed
+     * Assumes the caller has already navigated to 'experiment-showRunGraph.view' somehow
+     */
+    public static LineageGraph showLineageGraph(WebDriver driver)
+    {
+        LineageGraph lineageGraph = new LineageGraph.LineageGraphFinder(driver).findWhenNeeded();
+        if (!lineageGraph.getComponentElement().isDisplayed())
+        {
+            Locator.linkWithSpan("Toggle Beta Graph (new!)").findElement(driver).click();
+        }
+        new WebDriverWait(driver, Duration.ofSeconds(2)).until(ExpectedConditions.visibilityOf(lineageGraph.getComponentElement()));
+        return lineageGraph;
     }
 
     public Map<String, String> getCurrentNodeData()

--- a/src/org/labkey/test/tests/ExpTest.java
+++ b/src/org/labkey/test/tests/ExpTest.java
@@ -29,7 +29,6 @@ import org.labkey.test.components.domain.DomainFieldRow;
 import org.labkey.test.components.ui.lineage.LineageGraph;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.PortalHelper;
-import org.openqa.selenium.WebElement;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -101,10 +100,7 @@ public class ExpTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(RUN_NAME));
         clickAndWait(Locator.linkWithText("Graph Summary View"));
 
-        LineageGraph graph = shortWait().until(wd -> {
-            Locator.linkWithSpan("Toggle Beta Graph (new!)").findOptionalElement(getDriver()).ifPresent(WebElement::click);
-            return new LineageGraph.LineageGraphFinder(getDriver()).findOptional().orElse(null);
-        });
+        LineageGraph graph = LineageGraph.showLineageGraph(getDriver());
         graph.getDetailGroup("Data Parents").getItemByTitle("Data: CAexample_mini.mzXML").clickOverViewLink(true);
         assertTextPresent("CAexample_mini.mzXML", "File Not Found");
 


### PR DESCRIPTION
#### Rationale
`ExpTest` has been failing intermittently. The previous solution seems to be toggling the experiment run graph multiple times, leaving it invisible. Need a more reliable solution that doesn't risk clicking the toggle button multiple times.
Also, moving the handling of the "Toggle Beta Graph (new!)" button into the `LineageGraph` should make it easier to maintain.

Error:
```
org.openqa.selenium.TimeoutException: Expected condition failed: waiting for visibility of [[[[[[[[FirefoxDriver: firefox on WINDOWS (1665390c-f2d9-4bf4-b1d2-0f825510c229)] -> xpath: //div[contains(concat(' ',normalize-space(@class),' '), " row ")][div[contains(concat(' ',normalize-space(@class),' '), " col-md-8 ")][div[contains(concat(' ',normalize-space(@class),' '), " lineage-visgraph-ct ")]]]]] -> css selector: div.lineage-node-detail-container]] -> xpath: .//details[summary[contains(concat(' ',normalize-space(@class),' '), " lineage-name ")]][summary[h6[contains(text(), "Data Parents")]]]]] -> css selector: li > div.lineage-name[title="Data: CAexample_mini.mzXML"]] (tried for 10 second(s) with 500 milliseconds interval)
  at app//org.labkey.test.components.ui.lineage.NodeDetail.waitForReady(NodeDetail.java:34)
  at app//org.labkey.test.components.Component.elementCache(Component.java:73)
  at app//org.labkey.test.components.ui.lineage.NodeDetail.clickOverViewLink(NodeDetail.java:44)
  at app//org.labkey.test.tests.ExpTest.testSteps(ExpTest.java:108)
```

#### Related Pull Requests
* #1273 

#### Changes
* Centralize and improve test toggling of experiment run graph
