### PR TITLE
Remove "blank" as an Expected Option

### DIFF
--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -877,7 +877,7 @@ public class GridPanelTest extends GridPanelBaseTest
         actualValues = facetedPanel.getAvailableValues();
 
         // Hard coding the string combinations (AB, AC, etc...) to make the code more readable.
-        expectedValues = Arrays.asList(ALL_OPTION, BLANK_OPTION, "AB", "AC", "BC", "C", NUMBER_STRING, FIVE_RECORD_STRING, MULTI_PAGE_STRING);
+        expectedValues = Arrays.asList(ALL_OPTION, "AB", "AC", "BC", "C", NUMBER_STRING, FIVE_RECORD_STRING, MULTI_PAGE_STRING);
 
         Collections.sort(actualValues);
         Collections.sort(expectedValues);
@@ -1611,7 +1611,6 @@ public class GridPanelTest extends GridPanelBaseTest
             }
         }
         expectedList.add(ALL_OPTION);
-        expectedList.add(BLANK_OPTION);
 
         log(String.format("Validate that the list of values for the '%s' is as expected.", FILTER_STRING_COL));
         filterDialog.selectField(FILTER_STRING_COL);
@@ -1685,7 +1684,7 @@ public class GridPanelTest extends GridPanelBaseTest
         actualList = filterDialog.selectFacetTab().getAvailableValues();
 
         // Going to hard code the expected values rather try and be clever and figure them out.
-        expectedList = new ArrayList<>(Arrays.asList(ALL_OPTION, BLANK_OPTION, "A", "AB", "ABC", "ABCD", "ABD", "AC", "ACD", "AD"));
+        expectedList = new ArrayList<>(Arrays.asList(ALL_OPTION, "A", "AB", "ABC", "ABCD", "ABD", "AC", "ACD", "AD"));
 
         Collections.sort(expectedList);
         Collections.sort(actualList);


### PR DESCRIPTION
#### Rationale
"blank" is no longer shown as an option when filtering a column (where all fields have a value).

#### Related Pull Requests
* None

#### Changes
* Remove "blank" from the expected options for the appropriate tests.
