### PR TITLE
Improve reliability of EditableGrid test component

### DIFF
--- a/src/org/labkey/test/components/react/ReactDatePicker.java
+++ b/src/org/labkey/test/components/react/ReactDatePicker.java
@@ -68,7 +68,7 @@ public class ReactDatePicker extends WebDriverComponent<ReactDatePicker.ElementC
     {
         set("", false);
         set(value.getYear() + "-" + value.getMonthValue(), false); // use keyboard input to set year and month
-        elementCache().datePickerDateCell(String.valueOf(value.getDayOfMonth())).click(); // use calendar ui to select day
+        elementCache().datePickerDateCell(value.getDayOfMonth()).click(); // use calendar ui to select day
         if (!value.toLocalTime().equals(LocalTime.MIDNIGHT)) // use timepicker to select time
             clickTime(value.toLocalTime());
         else
@@ -134,9 +134,10 @@ public class ReactDatePicker extends WebDriverComponent<ReactDatePicker.ElementC
          * Return the date cell div of react datepicker
          * @param day '01', '02', ... '31'
          */
-        WebElement datePickerDateCell(String day)
+        WebElement datePickerDateCell(int day)
         {
-            return datePickerDateLoc(day).findElement(popup);
+            String dayStr = (day < 10 ? "0" : "") + day; // Add leading zero if necessary
+            return datePickerDateLoc(dayStr).findElement(popup);
         }
     }
 

--- a/src/org/labkey/test/components/react/ReactDatePicker.java
+++ b/src/org/labkey/test/components/react/ReactDatePicker.java
@@ -1,6 +1,5 @@
 package org.labkey.test.components.react;
 
-import org.apache.commons.lang3.StringUtils;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
@@ -10,13 +9,13 @@ import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
 public class ReactDatePicker extends WebDriverComponent<ReactDatePicker.ElementCache>
 {
     private final WebDriver _driver;
     private final WebElement _el;
-
-    private static final String YMD = "\\d{4}-\\d{2}-\\d{2}";
-    private static final String YMDHS = "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}";
 
     protected ReactDatePicker(WebElement element, WebDriver driver)
     {
@@ -45,7 +44,14 @@ public class ReactDatePicker extends WebDriverComponent<ReactDatePicker.ElementC
     {
         elementCache().input.set(value);
         if (close)
-            elementCache().input.getComponentElement().sendKeys(Keys.ENTER); // Dismiss date picker
+            dismiss();
+    }
+
+    private void dismiss()
+    {
+        elementCache().input.getComponentElement().sendKeys(Keys.ENTER); // Dismiss date picker
+
+        WebDriverWrapper.waitFor(()-> !isExpanded(), "Date picker didn't close", 1000);
     }
 
     public void set(String value)
@@ -53,44 +59,46 @@ public class ReactDatePicker extends WebDriverComponent<ReactDatePicker.ElementC
         set(value, true);
     }
 
-
     /**
-     * use keyboard input to set year, month. then use picker to select day and time
-     * @param value date or datetime string
-     * @return false if date string is not one of "yyyy-MM-dddd" or "yyyy-MM-dddd hh:ss" format
+     * Use keyboard input to set year, month. then use picker to select day and time
+     * Midnight time values will be ignored
+     * @param value date or datetime value
      */
-    public boolean select(String value)
+    public void select(LocalDateTime value)
     {
-        if (value.matches(YMD) || value.matches(YMDHS))
-        {
-            set("", false);
-            String[] dateParts = getParsedDateParts(value);
-            set(dateParts[0], false); // use keyboard input to set year and month
-            elementCache().datePickerDateCell(dateParts[1]).click(); // use calendar ui to select day
-            if (!StringUtils.isEmpty(dateParts[2])) // use timepicker to select time
-                clickTime(dateParts[2]);
-
-            return true;
-        }
-
-        return false;
+        set("", false);
+        set(value.getYear() + "-" + value.getMonthValue(), false); // use keyboard input to set year and month
+        elementCache().datePickerDateCell(String.valueOf(value.getDayOfMonth())).click(); // use calendar ui to select day
+        if (!value.toLocalTime().equals(LocalTime.MIDNIGHT)) // use timepicker to select time
+            clickTime(value.toLocalTime());
+        else
+            dismiss();
     }
 
     public void clear()
     {
         set("");
-        WebDriverWrapper.waitFor(()-> !isExpanded(), "Date picker didn't close", 1000);
     }
 
-    public ReactDatePicker clickTime(String time)
+    private void clickTime(LocalTime time)
     {
-        expand();
+        int hour = time.getHour();
+        String amPm = "AM";
+        if (hour == 0)
+            hour = 12;
+        else if (hour == 12)
+            amPm = "PM";
+        else if (hour > 12)
+        {
+            hour -= 12;
+            amPm = "PM";
+        }
+        String timeStr = "%d:%d %s".formatted(hour, time.getMinute(), amPm);
         WebElement liElement = Locator.tagWithClass("ul", "react-datepicker__time-list")
-                .child(Locator.tagWithText("li", time)).findElement(elementCache().popup);
+                .child(Locator.tagWithText("li", timeStr)).findElement(elementCache().popup);
         getWrapper().fireEvent(liElement, WebDriverWrapper.SeleniumEvent.click);
 
         WebDriverWrapper.waitFor(()-> !isExpanded(), "Date picker didn't close", 1000);
-        return this;
     }
 
     private boolean isExpanded()
@@ -105,34 +113,6 @@ public class ReactDatePicker extends WebDriverComponent<ReactDatePicker.ElementC
             getComponentElement().click();
             WebDriverWrapper.waitFor(this::isExpanded, "Date picker didn't open", 1500);
         }
-    }
-
-    /**
-     * Parse "2022-07-11 08:30" to ["2022-07", "11", "8:30 AM"]
-     * @param fullDateStr
-     * @return
-     */
-    private String[] getParsedDateParts(String fullDateStr)
-    {
-        String[] parts = fullDateStr.split(" ") ;
-        String[] dayParts = parts[0].split("-");
-        String yearMon = dayParts[0] + "-" + dayParts[1];
-        String dayPart = dayParts[2];
-        String timePart = parts.length > 1 ? parts[1] : "";
-        if (!StringUtils.isEmpty(timePart))
-        {
-            String[] timeParts = timePart.split(":");
-            String amPM = "AM";
-            int hour = Integer.parseInt(timeParts[0]);
-            if (hour > 12)
-            {
-                amPM = "PM";
-                hour -= 12;
-            }
-            timePart = hour + ":" + timeParts[1] + " " + amPM;
-        }
-
-        return new String[]{yearMon, dayPart, timePart};
     }
 
     @Override

--- a/src/org/labkey/test/components/react/ReactDatePicker.java
+++ b/src/org/labkey/test/components/react/ReactDatePicker.java
@@ -1,5 +1,6 @@
 package org.labkey.test.components.react;
 
+import org.apache.commons.lang3.StringUtils;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
@@ -93,12 +94,17 @@ public class ReactDatePicker extends WebDriverComponent<ReactDatePicker.ElementC
             hour -= 12;
             amPm = "PM";
         }
-        String timeStr = "%d:%d %s".formatted(hour, time.getMinute(), amPm);
+        String timeStr = "%d:%s %s".formatted(hour, withLeadingZero(time.getMinute()), amPm);
         WebElement liElement = Locator.tagWithClass("ul", "react-datepicker__time-list")
                 .child(Locator.tagWithText("li", timeStr)).findElement(elementCache().popup);
         getWrapper().fireEvent(liElement, WebDriverWrapper.SeleniumEvent.click);
 
         WebDriverWrapper.waitFor(()-> !isExpanded(), "Date picker didn't close", 1000);
+    }
+
+    private String withLeadingZero(int i)
+    {
+        return StringUtils.leftPad(String.valueOf(i), 2, "0");
     }
 
     private boolean isExpanded()
@@ -136,8 +142,7 @@ public class ReactDatePicker extends WebDriverComponent<ReactDatePicker.ElementC
          */
         WebElement datePickerDateCell(int day)
         {
-            String dayStr = (day < 10 ? "0" : "") + day; // Add leading zero if necessary
-            return datePickerDateLoc(dayStr).findElement(popup);
+            return datePickerDateLoc(withLeadingZero(day)).findElement(popup);
         }
     }
 


### PR DESCRIPTION
#### Rationale
EditableGrid lookupSelect:
Double-clicking to activate the react select has had some reliability problems. Hopefully just clicking the caret will work a little better.

EditableGrid input fields:
We can use `Actions.sendKeys` to type into text fields without having to double click them to activate them. This will more accurately reflect real usage and, hopefully, improve reliability.

Remove `useDatePicker` flag:
Passing this special flag around to decide when to use the date picker is pretty fiddly. Instead, we can pass a different data type in to indicate that the editable grid's date picker should be used. This is similar to how we pass in a `List` to indicate that the select dropdown should be used.
Also updating `ReactDatePicker.select` to take a `LocalDateTime` object instead of a String that it has to verify.

#### Related Pull Requests
* N/A

#### Changes
* Remove 'useDatePicker' flag from setters
* Centralize activation of ReactSelects in grid cells
