### PR TITLE
prevent test from cleaning up a project it never created

### DIFF
--- a/src/org/labkey/test/tests/UserDomainEditNavigationTest.java
+++ b/src/org/labkey/test/tests/UserDomainEditNavigationTest.java
@@ -18,6 +18,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Category({Daily.class})
 public class UserDomainEditNavigationTest extends BaseWebDriverTest
 {
+
+    // explicitly override cleanup to prevent base class implementation from trying to clean up a project this test never creates
+    @Override
+    public void cleanup(){}
+
     @Test
     public void testNavigateFromAdminConsole()
     {

--- a/src/org/labkey/test/tests/UserDomainEditNavigationTest.java
+++ b/src/org/labkey/test/tests/UserDomainEditNavigationTest.java
@@ -19,9 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class UserDomainEditNavigationTest extends BaseWebDriverTest
 {
 
-    // explicitly override cleanup to prevent base class implementation from trying to clean up a project this test never creates
+    // override doCleanup, prevent base class from trying to clean up a project this test never creates
     @Override
-    public void cleanup(){}
+    protected void doCleanup(boolean afterTest){}
 
     @Test
     public void testNavigateFromAdminConsole()
@@ -54,7 +54,7 @@ public class UserDomainEditNavigationTest extends BaseWebDriverTest
     @Override
     protected String getProjectName()
     {
-        return "UserDomainEditNavigationTest Project";
+        return null;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
`UserDomainEditNavigationTest` is failing because it assumes no cleanup is required for a project it didn't create. Unfortunately, the default implementation of cleanup (in `BaseWebDriverTest`) attempts to clean up the project.
This overrides cleanup to not do that in this test class

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/1461

#### Changes

