### PR TITLE
Add support for create-value in DetailTableEdit

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -9,6 +9,7 @@ import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.react.FilteringReactSelect;
+import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.components.ui.files.FileUploadField;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -295,6 +296,15 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         List<String> selection = Arrays.asList(selectValue);
         return setSelectValue(fieldCaption, selection);
     }
+
+    public DetailTableEdit createSelectValue(String fieldCaption, String value)
+    {
+        WebElement container = Locator.tag("td").withAttribute("data-caption", fieldCaption).findElement(this);
+        var select = ReactSelect.finder(getDriver()).waitFor(container);
+        select.createValue(value);
+        return this;
+    }
+
 
     /**
      * Select multiple values from a select list.


### PR DESCRIPTION
#### Rationale
This adds support for adding a new value to a field select in DetailTableEdit.
We want this because it's useful to add values like aliases to the product.
There is similar functionality on editableGrid, I'm open to better naming for it if you have better suggestions

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/2091 <- test coverage for issue 47229, which concerns itself with alias values failing to round-trip or encode special characters

#### Changes

- [x] New method on DetailTableEdit
