### PR TITLE
Fix some link crawler false-positives

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -30,8 +30,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
+import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.labkey.test.BaseWebDriverTest;
@@ -1058,8 +1057,8 @@ public class Crawler
                                 if (target.equals("_blank"))
                                 {
                                     // Issue 40708: Create automated tests to look for anchor tags with link to an outside server
-                                    MatcherAssert.assertThat(String.format("Bad 'rel' attribute for link to %s. On Page: %s", href, actualUrl),
-                                            rel, CoreMatchers.hasItems("noopener", "noreferrer"));
+                                    Assertions.assertThat(rel).as("Bad 'rel' attribute for link to %s. On Page: %s".formatted(href, actualUrl))
+                                            .containsAll(List.of("noopener", "noreferrer"));
                                 }
                             }
                         }

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -488,7 +488,14 @@ public class Crawler
                     if (!relativeURL.isBlank())
                     {
                         _relativeURL = relativeURL;
-                        _actionId = new ControllerActionId(_relativeURL);
+
+                        ControllerActionId tempActionId = null;
+                        try
+                        {
+                            tempActionId = new ControllerActionId(_relativeURL);;
+                        }
+                        catch (IllegalArgumentException ignore) { } // Probably a resource, not an action.
+                        _actionId = tempActionId;
                     }
                     else
                     {
@@ -709,8 +716,6 @@ public class Crawler
                 rootRelativeURL = rootRelativeURL.substring(postControllerSlashIdx+1);
             }
             _folder = StringUtils.strip(rootRelativeURL, "/");
-            if (_folder.endsWith("/"))
-                _folder = _folder.substring(0,_folder.length()-1);
         }
 
         @NotNull public String getAction()
@@ -1043,7 +1048,9 @@ public class Crawler
                         for (Pair<String, Map<String, String>> linkWithAttributes : linksWithAttributes)
                         {
                             String href = linkWithAttributes.getLeft();
-                            if (href.contains("://") && !href.startsWith(WebTestHelper.getBaseURL())) // Remote URL
+                            if ((href.startsWith("http://") || href.startsWith("https://")) && // Full URL
+                                    !href.startsWith(WebTestHelper.getBaseURL()) && // Not self
+                                    !href.startsWith("https://www.labkey.com/")) // Trust links to labkey.com
                             {
                                 Map<String, String> attributes = linkWithAttributes.getRight();
                                 String target = StringUtils.trimToEmpty(attributes.get("target"));


### PR DESCRIPTION
#### Rationale
The crawler can't handle links to non-action resources (e.g. `<a href="/logo.image?revision=3">`)
```
Caused by: java.lang.IllegalArgumentException: Unable to parse folder out of relative URL: "logo.image"
  at org.labkey.test.util.Crawler$ControllerActionId.<init>(Crawler.java:707)
  at org.labkey.test.util.Crawler$UrlToCheck.<init>(Crawler.java:491)
  at org.labkey.test.util.Crawler.crawlLink(Crawler.java:1067)
```

The crawler also complains about the structure of links to `labkey.com` on trial instances. We should trust these links.
```
java.lang.AssertionError: Bad 'rel' attribute for link to https://www.labkey.com/platform/go-premium/. On Page: https://eval-ami-0596c3e6b35bc9ddc-2389352.lkpoc.labkey.com/ReportVerifyProject/security-externalToolsView.view?returnUrl=%2FReportVerifyProject%2Fproject-begin.view
Expected: (a collection containing "noopener" and a collection containing "noreferrer")
     but: a collection containing "noopener" was ""
  at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
  at org.labkey.test.util.Crawler.crawlLink(Crawler.java:1054)
  at org.labkey.test.util.Crawler.crawl(Crawler.java:831)
  at org.labkey.test.util.Crawler.crawlAllLinks(Crawler.java:794)
```

#### Related Pull Requests
* N/A

#### Changes
* Don't fail if crawler finds links to server resources
* Don't check `rel` attribute of links to `labkey.com`
