### PR TITLE
Make text entry work for editable grid

### DIFF
--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -400,7 +400,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
             String str = value.toString();
             WebElement inputCell = elementCache().inputCell();
-            inputCell.sendKeys(str, Keys.RETURN); // Add the RETURN to close the inputCell.
+            inputCell.sendKeys(Keys.BACK_SPACE, str, Keys.RETURN); // Add the RETURN to close the inputCell.
 
             getWrapper().shortWait().until(ExpectedConditions.stalenessOf(inputCell));
 

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -396,11 +396,11 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         }
         else
         {
-            String str = value.toString();
-            new Actions(getDriver()).sendKeys(str).perform(); // Type into no particular element
+            new Actions(getDriver()).sendKeys(" ").perform(); // Type into no particular element to activate input
 
+            String str = value.toString();
             WebElement inputCell = elementCache().inputCell();
-            inputCell.sendKeys(Keys.RETURN); // Add the RETURN to close the inputCell.
+            inputCell.sendKeys(str, Keys.RETURN); // Add the RETURN to close the inputCell.
 
             getWrapper().shortWait().until(ExpectedConditions.stalenessOf(inputCell));
 


### PR DESCRIPTION
#### Rationale
My recent change to `EditableGrid` broke tests when merged forward to 23.4. It started swallowing the first key typed into the editable grid. Just need to type an extra key to activate editing mode for the cell.
_Note: The grid works as expected when I try to repro manually._

#### Related Pull Requests
* #1469 

#### Changes
* Type a space to enter editing mode for editable grid cell
