### PR TITLE
Test coverage for metadataQuery-sourceQuery workflow

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3994,6 +3994,11 @@ public abstract class WebDriverWrapper implements WrapsDriver
         _extHelper.setCodeMirrorValue(id, value);
     }
 
+    protected String getCodeEditorValue(String id)
+    {
+        return _extHelper.getCodeMirrorValue(id);
+    }
+
     public void waitForElements(final Locator loc, final int count)
     {
         waitForElements(loc, count, WAIT_FOR_JAVASCRIPT);

--- a/src/org/labkey/test/pages/query/EditMetadataPage.java
+++ b/src/org/labkey/test/pages/query/EditMetadataPage.java
@@ -3,6 +3,7 @@ package org.labkey.test.pages.query;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.components.domain.BaseDomainDesigner;
 import org.labkey.test.components.domain.DomainFormPanel;
@@ -10,6 +11,8 @@ import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.util.DataRegionTable;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+
+import java.util.Map;
 
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 
@@ -20,21 +23,35 @@ public class EditMetadataPage extends BaseDomainDesigner<EditMetadataPage.Elemen
         super(driver);
     }
 
+    public static EditMetadataPage beginAt(WebDriverWrapper webDriverWrapper, String containerPath, String schemaName, String queryName)
+    {
+        webDriverWrapper.beginAt(WebTestHelper.buildURL("query", containerPath, "metadataQuery",
+                Map.of("schemaName", schemaName, "query.queryName", queryName)));
+        return new EditMetadataPage (webDriverWrapper.getDriver());
+    }
 
     public DataRegionTable clickViewData(BaseWebDriverTest test, String schemaName, String queryName)
     {
         return test.viewQueryData(schemaName, queryName);
     }
 
-    public void clickEditSourcePage()
+    public SourceQueryPage clickEditSource()
     {
-        elementCache().editSourceBtn.click();
+        getWrapper().clickAndWait(elementCache().editSourceBtn);
+        return new SourceQueryPage(getDriver());
     }
 
+    @Override
     public EditMetadataPage clickSave()
     {
         elementCache().saveBtn.click();
         return this;
+    }
+
+    public String waitForSuccess()
+    {
+        return Locator.tagWithClass("div", "alert-success").waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT)
+                .getText();
     }
 
     public void resetToDefault()

--- a/src/org/labkey/test/pages/query/SourceQueryPage.java
+++ b/src/org/labkey/test/pages/query/SourceQueryPage.java
@@ -73,6 +73,12 @@ public class SourceQueryPage extends LabKeyPage<SourceQueryPage.ElementCache>
         return this;
     }
 
+    public String getMetadataXml()
+    {
+        viewMetadata();
+        return getCodeEditorValue("metadataText");
+    }
+
     public SourceQueryPage clickSave()
     {
         Ext4Helper.Locators.ext4Button("Save").findElement(getDriver()).click();

--- a/src/org/labkey/test/tests/query/QueryMetadataTest.java
+++ b/src/org/labkey/test/tests/query/QueryMetadataTest.java
@@ -99,7 +99,8 @@ public class QueryMetadataTest extends BaseWebDriverTest
                 "  </table>\n" +
                 "</tables>";
         var queryPage = editPage.clickEditSource();
-        checker().verifyEquals("expect xml to show only the delta for value description",
+        checker().withScreenshot("xml_mismatch")
+                .verifyEquals("expect xml to show only the delta for value description",
                 expectedXml, queryPage.getMetadataXml());
 
         // clean up after
@@ -126,7 +127,8 @@ public class QueryMetadataTest extends BaseWebDriverTest
                 "</tables>";
 
         var queryPage = editPage.clickEditSource();
-        checker().verifyEquals("expect xml to show only the delta for value description",
+        checker().withScreenshot("xml_mismatch")
+                .verifyEquals("expect xml to show only the delta for value description",
                 expectedXml, queryPage.getMetadataXml());
 
         // clean up after
@@ -189,9 +191,6 @@ public class QueryMetadataTest extends BaseWebDriverTest
             .wrapAssertion(()-> assertThat(actualAfterXml)
             .as("expect xml to show only the delta for value description")
             .isEqualTo(expectedAfterXml));
-
-        // clean up after
-        EditMetadataPage.beginAt(this, getProjectName(), "lists", TEST_LIST).resetToDefault();
     }
 
 

--- a/src/org/labkey/test/tests/query/QueryMetadataTest.java
+++ b/src/org/labkey/test/tests/query/QueryMetadataTest.java
@@ -1,0 +1,210 @@
+package org.labkey.test.tests.query;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.pages.query.EditMetadataPage;
+import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.experiment.SampleTypeDefinition;
+import org.labkey.test.params.list.IntListDefinition;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@Category({})
+public class QueryMetadataTest extends BaseWebDriverTest
+{
+    static public String TEST_LIST = "queryMetadataTestList";
+    static public String TEST_SAMPLES = "queryMetadataSamples";
+
+    @Override
+    protected void doCleanup(boolean afterTest)
+    {
+        _containerHelper.deleteProject(getProjectName(), afterTest);
+    }
+
+    @BeforeClass
+    public static void setupProject() throws Exception
+    {
+        QueryMetadataTest init = (QueryMetadataTest) getCurrentTest();
+
+        init.doSetup();
+    }
+
+    private void doSetup() throws Exception
+    {
+        _containerHelper.createProject(getProjectName(), "Collaboration");
+
+        // create a sampleType to look up to
+        List<FieldDefinition> fields = List.of(
+                new FieldDefinition("stringField", FieldDefinition.ColumnType.String),
+        new FieldDefinition("boolField", FieldDefinition.ColumnType.Boolean),
+        new FieldDefinition("decimalField", FieldDefinition.ColumnType.Decimal));
+        var samplesDgen = new SampleTypeDefinition(TEST_SAMPLES)
+                .setFields(fields)
+                .create(createDefaultConnection(), getProjectName())
+                .withGeneratedRows(10);
+        samplesDgen.insertRows();
+        // create a list
+
+        List<FieldDefinition> listColumns = Arrays.asList(
+                new FieldDefinition("name", FieldDefinition.ColumnType.String),
+                new FieldDefinition("value", FieldDefinition.ColumnType.Integer),
+                new FieldDefinition("users", FieldDefinition.ColumnType.User),
+                new FieldDefinition("date", FieldDefinition.ColumnType.DateAndTime),
+                new FieldDefinition("samples", new FieldDefinition.IntLookup(getProjectName(),"exp.materials", TEST_SAMPLES)),
+                new FieldDefinition("selfLookup", new FieldDefinition.IntLookup(getProjectName(),"lists", TEST_LIST)));
+        var dgen = new IntListDefinition(TEST_LIST, "Key").setFields(listColumns)
+                .create(createDefaultConnection(), getProjectName());
+    }
+
+    @Test
+    public void testUpdateLookupFields()
+    {
+        var editPage = EditMetadataPage.beginAt(this, getProjectName(), "lists", TEST_LIST);
+        editPage.fieldsPanel()
+                .getField("selfLookup")
+                .setLabel("SelfLookup")
+                .setLookupValidatorEnabled(true)     // is a change, but does not appear in metadata view
+                .setLookup(new FieldDefinition.IntLookup(null, "lists", TEST_LIST)) // non-change
+                .setDescription("has new description");
+        editPage.fieldsPanel()
+                .getField("samples")
+                .setLabel("SamplesLookup")
+                .setLookup(new FieldDefinition.IntLookup(getProjectName(), "samples", TEST_SAMPLES))
+                .setLookupValidatorEnabled(true);   // is a change but does not appear in metadata view
+        editPage.clickSave();
+
+        String expectedXml = "<tables xmlns=\"http://labkey.org/data/xml\">\n" +
+                "  <table tableName=\"queryMetadataTestList\" tableDbType=\"NOT_IN_DB\">\n" +
+                "    <columns>\n" +
+                "      <column columnName=\"samples\">\n" +
+                "        <columnTitle>SamplesLookup</columnTitle>\n" +
+                "        <fk>\n" +
+                "          <fkDbSchema>samples</fkDbSchema>\n" +
+                "          <fkTable>queryMetadataSamples</fkTable>\n" +
+                "          <fkColumnName>RowId</fkColumnName>\n" +
+                "          <fkFolderPath>/QueryMetadataTest Project</fkFolderPath>\n" +
+                "        </fk>\n" +
+                "      </column>\n" +
+                "      <column columnName=\"selfLookup\">\n" +
+                "        <description>has new description</description>\n" +
+                "        <columnTitle>SelfLookup</columnTitle>\n" +
+                "      </column>\n" +
+                "    </columns>\n" +
+                "  </table>\n" +
+                "</tables>";
+        var queryPage = editPage.clickEditSource();
+        checker().verifyEquals("expect xml to show only the delta for value description",
+                expectedXml, queryPage.getMetadataXml());
+
+        // clean up after
+        EditMetadataPage.beginAt(this, getProjectName(), "lists", TEST_LIST).resetToDefault();
+    }
+
+    @Test
+    public void testSaveDescriptionUpdate()
+    {
+        var editPage = EditMetadataPage.beginAt(this, getProjectName(), "lists", TEST_LIST);
+        editPage.fieldsPanel()
+                .getField("value")
+                .setDescription("has new description");
+        editPage.clickSave();
+
+        String expectedXml = "<tables xmlns=\"http://labkey.org/data/xml\">\n" +
+                "  <table tableName=\"queryMetadataTestList\" tableDbType=\"NOT_IN_DB\">\n" +
+                "    <columns>\n" +
+                "      <column columnName=\"value\">\n" +
+                "        <description>has new description</description>\n" +
+                "      </column>\n" +
+                "    </columns>\n" +
+                "  </table>\n" +
+                "</tables>";
+
+        var queryPage = editPage.clickEditSource();
+        checker().verifyEquals("expect xml to show only the delta for value description",
+                expectedXml, queryPage.getMetadataXml());
+
+        // clean up after
+        EditMetadataPage.beginAt(this, getProjectName(), "lists", TEST_LIST).resetToDefault();
+    }
+
+    /*
+        EditMetadataPage allows you to edit multiple field properties
+        ensure that 'reset to default' from the editMetadataPage
+     */
+    @Test
+    public void testResetToDefault()
+    {
+        var editPage = EditMetadataPage.beginAt(this, getProjectName(), "lists", TEST_LIST);
+        editPage.fieldsPanel()
+                .getField("date")
+                .setDescription("has new description");
+        editPage.fieldsPanel()
+                .getField("value")
+                .setLabel("ValueLabel");
+        editPage.clickSave();
+        // verify/confirm success
+        editPage.waitForSuccess();
+        var queryPage = editPage.clickEditSource();
+        String expectedXml = "<tables xmlns=\"http://labkey.org/data/xml\">\n" +
+                "  <table tableName=\"queryMetadataTestList\" tableDbType=\"NOT_IN_DB\">\n" +
+                "    <columns>\n" +
+                "      <column columnName=\"value\">\n" +
+                "        <columnTitle>ValueLabel</columnTitle>\n" +
+                "      </column>\n" +
+                "      <column columnName=\"date\">\n" +
+                "        <description>has new description</description>\n" +
+                "      </column>\n" +
+                "    </columns>\n" +
+                "  </table>\n" +
+                "</tables>";
+        var actualXml = queryPage.getMetadataXml();
+        checker().withScreenshot("initial_edits")
+            .wrapAssertion(()-> assertThat(actualXml)
+            .as("expect xml to show only the delta for value description")
+            .isEqualTo(expectedXml));
+        queryPage.clickSave();
+        queryPage.goBack();
+
+        editPage = new EditMetadataPage(getDriver());
+
+        // now ensure that 'reset to default' clears the xml delta
+        editPage.resetToDefault();
+        queryPage = editPage.clickEditSource();
+
+        String expectedAfterXml =
+                "<tables xmlns=\"http://labkey.org/data/xml\">\n" +
+                        "  <table tableName=\"queryMetadataTestList\" tableDbType=\"NOT_IN_DB\">\n" +
+                        "    <columns>\n" +
+                        "    </columns>\n" +
+                        "  </table>\n" +
+                        "</tables>\n";
+        var actualAfterXml = queryPage.getMetadataXml();
+        checker().withScreenshot("after_edits")
+            .wrapAssertion(()-> assertThat(actualAfterXml)
+            .as("expect xml to show only the delta for value description")
+            .isEqualTo(expectedAfterXml));
+
+        // clean up after
+        EditMetadataPage.beginAt(this, getProjectName(), "lists", TEST_LIST).resetToDefault();
+    }
+
+
+
+    @Override
+    protected String getProjectName()
+    {
+        return "QueryMetadataTest Project";
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Arrays.asList();
+    }
+}

--- a/src/org/labkey/test/tests/query/QueryMetadataTest.java
+++ b/src/org/labkey/test/tests/query/QueryMetadataTest.java
@@ -1,5 +1,6 @@
 package org.labkey.test.tests.query;
 
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -62,6 +63,16 @@ public class QueryMetadataTest extends BaseWebDriverTest
                 .create(createDefaultConnection(), getProjectName());
     }
 
+    @Before
+    public void resetToDefault()
+    {
+        // visit the metadata edit page for the test list, clear whatever open edits it might have
+        EditMetadataPage.beginAt(this, getProjectName(), "lists", TEST_LIST).resetToDefault();
+    }
+
+    /*
+        Coverage for Issue 47487, Issue 47495
+     */
     @Test
     public void testUpdateLookupFields()
     {
@@ -102,9 +113,6 @@ public class QueryMetadataTest extends BaseWebDriverTest
         checker().withScreenshot("xml_mismatch")
                 .verifyEquals("expect xml to show only the delta for value description",
                 expectedXml, queryPage.getMetadataXml());
-
-        // clean up after
-        EditMetadataPage.beginAt(this, getProjectName(), "lists", TEST_LIST).resetToDefault();
     }
 
     @Test
@@ -130,9 +138,6 @@ public class QueryMetadataTest extends BaseWebDriverTest
         checker().withScreenshot("xml_mismatch")
                 .verifyEquals("expect xml to show only the delta for value description",
                 expectedXml, queryPage.getMetadataXml());
-
-        // clean up after
-        EditMetadataPage.beginAt(this, getProjectName(), "lists", TEST_LIST).resetToDefault();
     }
 
     /*


### PR DESCRIPTION
#### Rationale
[Issue 47495](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47495) addresses customer confusion regarding the way metadata edits to a domain can be inadvertently saved, thus producing unintended updates to domain lookups

While testing this, I found what appears to be a related issue: unless the user resets to default, subsequent metadata edits appear to carry previous changes forward
For now the tests work around this by explicitly resetting to default after running

#### Related Pull Requests
n/a

#### Changes

- [x] New test class, QueryMetadataTest
- Updates to EditMetadataPage
     - [x] implement beginAt for this page/action
     - [x] clickViewSource now returns a sourceQueryPage
- Update to SourceQueryPage
     - [x] page now surfaces a way to get queryXml
