### PR TITLE
Another attempt to fix intermittent lineage graph test errors

### DIFF
--- a/src/org/labkey/test/components/ui/lineage/NodeDetail.java
+++ b/src/org/labkey/test/components/ui/lineage/NodeDetail.java
@@ -3,6 +3,7 @@ package org.labkey.test.components.ui.lineage;
 import org.labkey.test.Locator;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.util.LabKeyExpectedConditions;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -31,7 +32,7 @@ public class NodeDetail extends WebDriverComponent<NodeDetail.ElementCache>
     @Override
     protected void waitForReady()
     {
-        getWrapper().shortWait().until(ExpectedConditions.visibilityOf(getComponentElement()));
+        getWrapper().shortWait().until(LabKeyExpectedConditions.animationIsDone(getComponentElement()));
     }
 
     public String getName()
@@ -51,8 +52,10 @@ public class NodeDetail extends WebDriverComponent<NodeDetail.ElementCache>
 
     private void clickHiddenLink(WebElement link, boolean wait)
     {
-        getWrapper().mouseOver(getComponentElement());
-        new WebDriverWait(getDriver(), Duration.ofSeconds(2)).until(ExpectedConditions.elementToBeClickable(link));
+        new WebDriverWait(getDriver(), Duration.ofSeconds(2)).until(wd -> {
+            getWrapper().mouseOver(getComponentElement());
+            return ExpectedConditions.elementToBeClickable(link).apply(wd);
+        });
         if (wait)
             getWrapper().clickAndWait(link);
         else


### PR DESCRIPTION
#### Rationale
ExpTest is still having problems
```
org.openqa.selenium.TimeoutException: Expected condition failed: waiting for element to be clickable: [[[[[[[[[[FirefoxDriver: firefox on WINDOWS (4a31a184-84b0-434e-87dd-90cf7a21aa3a)] -> xpath: //div[contains(concat(' ',normalize-space(@class),' '), " row ")][div[contains(concat(' ',normalize-space(@class),' '), " col-md-8 ")][div[contains(concat(' ',normalize-space(@class),' '), " lineage-visgraph-ct ")]]]]] -> css selector: div.lineage-node-detail-container]] -> xpath: .//details[summary[contains(concat(' ',normalize-space(@class),' '), " lineage-name ")]][summary[h6[contains(text(), "Data Parents")]]]]] -> css selector: li > div.lineage-name[title="Data: CAexample_mini.mzXML"]]] -> xpath: .//a[contains(concat(' ',normalize-space(@class),' '), " lineage-data-link--text ")][normalize-space()="Overview"]] (tried for 2 second(s) with 500 milliseconds interval)
	at app//org.openqa.selenium.support.ui.WebDriverWait.timeoutException(WebDriverWait.java:87)
	at app//org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:231)
	at app//org.labkey.test.components.ui.lineage.NodeDetail.clickHiddenLink(NodeDetail.java:55)
	at app//org.labkey.test.components.ui.lineage.NodeDetail.clickOverViewLink(NodeDetail.java:44)
	at app//org.labkey.test.tests.ExpTest.testSteps(ExpTest.java:104)
```

#### Related Pull Requests
* #1335 

#### Changes
* Add retry to `NodeDetail.clickHiddenLink`
