### PR TITLE
Issue 47509: If the lookup was defined with an explicit container, verify that the sample is in that container before mapping its value

### DIFF
--- a/src/org/labkey/test/tests/LookupToSampleIDTest.java
+++ b/src/org/labkey/test/tests/LookupToSampleIDTest.java
@@ -105,7 +105,7 @@ public class LookupToSampleIDTest extends BaseWebDriverTest
 
         createAssay(assayName, SAMPLE_TYPE_NAME, "Integer", sampleTypeFolder);
         importDataInAssay(assayName, ASSAY_IMPORT_SPLIT); //import data into assay
-        waitForText("Failed to convert 'SampleID': Could not translate value: ID_123456");
+        waitForText("Could not convert value 'ID_123456' (String) for Integer field 'SampleID'");
 
         goToProjectHome();
         clickFolder(FOLDER_NAME);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47509

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4316
* https://github.com/LabKey/platform/pull/4341

#### Changes
* LookupToSampleIDTest update to expected error text
