### PR TITLE
Issue 47750: LKSM auto-link to study ignores aliquots

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeLinkedStudyExportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkedStudyExportTest.java
@@ -95,6 +95,13 @@ public class SampleTypeLinkedStudyExportTest extends BaseWebDriverTest
                 "Date", now,
                 "ParticipantID", "P1"));
 
+        samplesTable = DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
+        samplesTable.clickImportBulkData();
+        String header = "AliquotedFrom\n";
+        String aliquotRow =  "Blood\n";
+        setFormElement(Locator.name("text"), header + aliquotRow);
+        clickButton("Submit");
+
         log("Export the Sample type folder");
         goToProjectHome(SAMPLE_TYPE_PROJECT);
         goToFolderManagement()


### PR DESCRIPTION
#### Rationale
Add test coverage for 
- auto-link aliquots to study
- Issue 45238 as manifested during folder import with derivatives present

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4345
* https://github.com/LabKey/testAutomation/pull/1493
* https://github.com/LabKey/platform/pull/4332

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
