### PR TITLE
Remove obsolete references to issues API jar

### DIFF
--- a/buildTestModules/communityArtifacts/build.gradle
+++ b/buildTestModules/communityArtifacts/build.gradle
@@ -61,7 +61,6 @@ dependencies {
     // add dependencies on all community API artifacts
     implementation "org.labkey.api:core:${labkeyVersion}"
     implementation "org.labkey.api:assay:${labkeyVersion}"
-    implementation "org.labkey.api:issues:${labkeyVersion}"
     implementation "org.labkey.api:ms2:${labkeyVersion}"
     implementation "org.labkey.api:targetedms:${labkeyVersion}"
 

--- a/buildTestModules/starterArtifacts/build.gradle
+++ b/buildTestModules/starterArtifacts/build.gradle
@@ -85,7 +85,6 @@ dependencies {
     // add dependencies on all starter API artifacts
     implementation "org.labkey.api:core:${labkeyVersion}"
     implementation "org.labkey.api:assay:${labkeyVersion}"
-    implementation "org.labkey.api:issues:${labkeyVersion}"
     implementation "org.labkey.api:ms2:${labkeyVersion}"
     implementation "org.labkey.api:targetedms:${labkeyVersion}"
     implementation "org.labkey.api:dataintegration:${labkeyVersion}"


### PR DESCRIPTION
#### Rationale
The separate issues API jar was removed. These references started failing in develop once the version was bumped to 23.6-SNAPSHOT. They will also start failing when TeamCity attempt to test for 23.5.0.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4329

#### Changes
* Remove dependencies on issues API
