### PR TITLE
Avoid unnecessary Gradle task configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ if (!BuildUtils.isIntellij())  {
             }
         }
     }
-    project.tasks.jar {
+    project.tasks.named('jar').configure {
         Jar jar ->
             jar.archiveBaseName.set(apiArtifactName)
             jar.setGroup('org.labkey.api')

--- a/data/qc/build.gradle
+++ b/data/qc/build.gradle
@@ -16,70 +16,65 @@ sourceSets {
   }
 }
 
-project.task('validatorJar',
-        group: "QC",
-        type: Jar,
-        description: "Builds jar for assay validation",
-        {
-            from sourceSets.main.output
-            from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
-            duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-            archiveFileName.set("validator.jar")
-            destinationDirectory = project.projectDir
-            manifest {
-                attributes 'Implementation-Title': 'Assay Validator Jar',
-                        'Implementation-Version': project.version,
-                        'Built-By' : System.getProperty("user.name"),
-                        'Main-Class': 'org.labkey.AssayValidator'
-            }
-        }
-)
+project.tasks.register('validatorJar', Jar) {
+    group = "QC"
+    description = "Builds jar for assay validation"
 
-project.task('transformJar',
-        group: "QC",
-        type: Jar,
-        description: "Builds jar for doing assay transforms",
-
-        {
-            from sourceSets.main.output
-            from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
-            duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-            archiveFileName.set("transform.jar")
-            destinationDirectory = project.projectDir
-            manifest {
-            attributes 'Implementation-Title': 'Assay Validator Jar',
-                    'Implementation-Version': project.version,
-                    'Built-By' : System.getProperty("user.name"),
-                    'Main-Class': 'org.labkey.AssayTransform'
-            }
-        }
-)
-
-project.task('transformWarningJar',
-        group: "QC",
-        type: Jar,
-        description: "Builds jar for doing assay transform warnings",
-        {
-            from sourceSets.main.output
-            from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
-            duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-            archiveFileName.set("transformWarning.jar")
-            destinationDirectory = project.projectDir
-            manifest {
-            attributes 'Implementation-Title': 'Assay Validator Jar',
-                    'Implementation-Version': project.version,
-                    'Built-By' : System.getProperty("user.name"),
-                    'Main-Class': 'org.labkey.AssayTransformWarning'
-            }
-        }
-)
-
-project.tasks.jar.dependsOn(project.tasks.validatorJar)
-project.tasks.jar.dependsOn(project.tasks.transformJar)
-project.tasks.jar.dependsOn(project.tasks.transformWarningJar)
-
-project.tasks.jar.configure { jarTask ->
-    project.project(BuildUtils.getTestProjectPath(project.gradle)).tasks.withType(RunTestSuite).configureEach({ t ->
-        t.dependsOn(jarTask)
-    })
+    from sourceSets.main.output
+    from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    archiveFileName.set("validator.jar")
+    destinationDirectory = project.projectDir
+    manifest {
+        attributes 'Implementation-Title': 'Assay Validator Jar',
+                'Implementation-Version': project.version,
+                'Built-By': System.getProperty("user.name"),
+                'Main-Class': 'org.labkey.AssayValidator'
+    }
 }
+
+project.tasks.register('transformJar', Jar) {
+    group = "QC"
+    description = "Builds jar for doing assay transforms"
+
+    from sourceSets.main.output
+    from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    archiveFileName.set("transform.jar")
+    destinationDirectory = project.projectDir
+    manifest {
+        attributes 'Implementation-Title': 'Assay Validator Jar',
+                'Implementation-Version': project.version,
+                'Built-By': System.getProperty("user.name"),
+                'Main-Class': 'org.labkey.AssayTransform'
+    }
+}
+
+project.tasks.register('transformWarningJar', Jar) {
+    group = "QC"
+    description = "Builds jar for doing assay transform warnings"
+
+    from sourceSets.main.output
+    from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    archiveFileName.set("transformWarning.jar")
+    destinationDirectory = project.projectDir
+    manifest {
+        attributes 'Implementation-Title': 'Assay Validator Jar',
+                'Implementation-Version': project.version,
+                'Built-By': System.getProperty("user.name"),
+                'Main-Class': 'org.labkey.AssayTransformWarning'
+    }
+}
+
+var jarTask = project.tasks.named('jar')
+
+jarTask.configure {
+    dependsOn(project.tasks.validatorJar)
+    dependsOn(project.tasks.transformJar)
+    dependsOn(project.tasks.transformWarningJar)
+}
+
+project.project(BuildUtils.getTestProjectPath(project.gradle)).tasks.withType(RunTestSuite).configureEach({ t ->
+    t.dependsOn(jarTask)
+})

--- a/distributions/teamcity/build.gradle
+++ b/distributions/teamcity/build.gradle
@@ -1,3 +1,4 @@
+import org.labkey.gradle.plugin.Distribution
 import org.labkey.gradle.plugin.FileModule
 import org.labkey.gradle.task.ModuleDistribution
 import org.labkey.gradle.util.BuildUtils

--- a/distributions/teamcity/build.gradle
+++ b/distributions/teamcity/build.gradle
@@ -1,9 +1,8 @@
+import org.labkey.gradle.plugin.FileModule
 import org.labkey.gradle.task.ModuleDistribution
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.ModuleFinder
-import org.labkey.gradle.plugin.Distribution
-import org.labkey.gradle.plugin.FileModule
 
 plugins {
     id 'org.labkey.build.distribution'
@@ -14,19 +13,17 @@ if (!BuildUtils.isOpenSource(project))
 
 dist.description = "Distribution that includes all modules, for use in the continuous integration LabKey Server instance"
 
-project.task(
-        "distribution",
-        group: GroupNames.DISTRIBUTION,
-        description: "Make a LabKey modules distribution for 'test'",
-        type: ModuleDistribution,
-        {ModuleDistribution dist ->
-            dist.subDirName = "test"
-            dist.includeTarGZArchive=true
-            dist.embeddedArchiveType="tar.gz"
-            dist.extraFileIdentifier='-test'
-            dist.versionPrefix='Test'
-        }
-)
+project.tasks.register("distribution", ModuleDistribution) {
+    ModuleDistribution dist ->
+        dist.group = GroupNames.DISTRIBUTION
+        dist.description = "Make a LabKey modules distribution for 'test'"
+
+        dist.subDirName = "test"
+        dist.includeTarGZArchive = true
+        dist.embeddedArchiveType = "tar.gz"
+        dist.extraFileIdentifier = '-test'
+        dist.versionPrefix = 'Test'
+}
 
 
 if (project.hasProperty('inheritedDistPath'))
@@ -51,8 +48,10 @@ if (project.hasProperty('inheritedDistPath'))
 
     def split = inheritedDistPath.split(":")
     String inheritedDistName = split[split.length - 1]
-    tasks.distribution.subDirName = "test/" + inheritedDistName
-    tasks.distribution.versionPrefix = "Test_" + inheritedDistName
+    tasks.named('distribution').configure { task ->
+        task.subDirName = "test/" + inheritedDistName
+        task.versionPrefix = "Test_" + inheritedDistName
+    }
 }
 else
 {

--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -9,30 +9,31 @@ subprojects { Project p ->
     }
 }
 
-task('build', group: 'Build', description: "Build all module files for subprojects",
-    {
-        subprojects.each { Project p ->
-            if (p.getProjectDir().exists())
-                dependsOn(p.tasks.module)
-        }
+tasks.register('build') {
+    group = 'Build'
+    description = "Build all module files for subprojects"
+    subprojects.each { Project p ->
+        if (p.getProjectDir().exists())
+            dependsOn(p.tasks.module)
     }
-)
+}
 
-task('deploy', group: 'Deploy', description: "Deploy all test module files",
-    {
-        subprojects.each { Project p ->
-            if (p.projectDir.exists())
-                dependsOn(p.tasks.deployModule)
-        }
-        dependsOn(project.tasks.build)
-    }
-)
+tasks.register('deploy') {
+    group = 'Deploy'
+    description = "Deploy all test module files"
 
-task('clean', group: 'Clean', description: 'Clean all build directories for subprojects',
-    {
-        subprojects.each { Project p ->
-            if (p.projectDir.exists())
-                dependsOn(p.tasks.clean)
-        }
+    subprojects.each { Project p ->
+        if (p.projectDir.exists())
+            dependsOn(p.tasks.deployModule)
     }
-)
+    dependsOn(project.tasks.build)
+}
+
+tasks.register('clean') {
+    group 'Clean'
+    description 'Clean all build directories for subprojects'
+    subprojects.each { Project p ->
+        if (p.projectDir.exists())
+            dependsOn(p.tasks.clean)
+    }
+}


### PR DESCRIPTION
#### Rationale
Using [task configuration avoidance APIs](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) can make builds more efficient.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/171

#### Changes
* Update gradle task references to avoid unnecessary configuration