### PR TITLE
Issue 47289: Export List Archive - Auto test update

### DIFF
--- a/src/org/labkey/test/tests/ListArchiveExportTest.java
+++ b/src/org/labkey/test/tests/ListArchiveExportTest.java
@@ -96,10 +96,9 @@ public class ListArchiveExportTest extends BaseWebDriverTest
         listsGrid.setFilter("Container", "Equals One Of (example usage: a;b;c)", LIST_FOLDER_A + ";" + getProjectName());
         listsGrid.checkAllOnPage();
         listsGrid.clickHeaderButton("Export List Archive");
-        waitForElement(Locators.labkeyErrorHeading);
-        Assert.assertEquals("Incorrect permission error message",
-                "You do not have the permission to export List '" + LIST_B + "' from Folder '/" + getProjectName() + "'.",
-                Locators.labkeyErrorSubHeading.findElement(getDriver()).getText());
+        Assert.assertEquals("Invalid error message", "List archive export is only supported for Lists in folders where you are an administrator. Try filtering to select only Lists in the local folder.",
+                Locator.tagWithClass("div", "labkey-error").findElement(getDriver()).getText());
+        goBack();
         stopImpersonating();
 
         goToProjectHome();


### PR DESCRIPTION
#### Rationale
Issue [47289](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47289): Export List Archive if the user is an Admin of the folders of the selected Lists, else show a simple error

Update auto test based on the changes in the Related PR.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4434

#### Changes
* Update test to use labkey-error, and change error text.