### PR TITLE
Regression coverage for Issue 47659

### DIFF
--- a/src/org/labkey/test/pages/query/EditMetadataPage.java
+++ b/src/org/labkey/test/pages/query/EditMetadataPage.java
@@ -88,11 +88,13 @@ public class EditMetadataPage extends BaseDomainDesigner<EditMetadataPage.Elemen
 
     protected class ElementCache extends BaseDomainDesigner<EditMetadataPage.ElementCache>.ElementCache
     {
-        protected final WebElement buttonPanel = queryMetadataButtonPanelLocator().findWhenNeeded(this);
-        protected final WebElement aliasFieldBtn = Locator.button("Alias Field").findWhenNeeded(buttonPanel);
-        protected final WebElement editSourceBtn = Locator.button("Edit Source").findWhenNeeded(buttonPanel);
-        protected final WebElement saveBtn = Locator.button("Save").findWhenNeeded(getDriver());
-        protected final WebElement resetToDefaultBtn = Locator.button("Reset To Default").findWhenNeeded(buttonPanel);
+        protected final WebElement buttonPanel = queryMetadataButtonPanelLocator().findWhenNeeded(this)
+                .withTimeout(WAIT_FOR_JAVASCRIPT);
+        protected final WebElement aliasFieldBtn = Locator.button("Alias Field").findWhenNeeded(buttonPanel).withTimeout(WAIT_FOR_JAVASCRIPT);
+        protected final WebElement editSourceBtn = Locator.button("Edit Source").findWhenNeeded(buttonPanel).withTimeout(WAIT_FOR_JAVASCRIPT);
+        protected final WebElement saveBtn = Locator.button("Save").findWhenNeeded(getDriver()).withTimeout(WAIT_FOR_JAVASCRIPT);
+        protected final WebElement resetToDefaultBtn = Locator.button("Reset To Default").findWhenNeeded(buttonPanel)
+                .withTimeout(WAIT_FOR_JAVASCRIPT);
         DomainFormPanel firstDomainFormPanel = new DomainFormPanel.DomainFormPanelFinder(getDriver())   // for situations where there's only one on the page
                 .timeout(WAIT_FOR_JAVASCRIPT)
                 .findWhenNeeded(this);

--- a/src/org/labkey/test/tests/query/QueryMetadataTest.java
+++ b/src/org/labkey/test/tests/query/QueryMetadataTest.java
@@ -198,7 +198,30 @@ public class QueryMetadataTest extends BaseWebDriverTest
             .isEqualTo(expectedAfterXml));
     }
 
+    /*
+        Regression coverage for Issue 47659
+     */
+    @Test
+    public void testEnsureOnlyModifiedColumnAppearsInMetadataXML()
+    {
+        var editPage = EditMetadataPage.beginAt(this, getProjectName(), "lists", TEST_LIST);
+        editPage.fieldsPanel().getField("Created")
+                .setDateFormat("Date");
+        editPage.clickSave();
 
+        var queryXmlPage = editPage.clickEditSource();
+        var actualXml = queryXmlPage.getMetadataXml();
+        String expectedColumnPart = "<table tableName=\"queryMetadataTestList\" tableDbType=\"NOT_IN_DB\">\n" +
+                "    <columns>\n" +
+                "      <column columnName=\"Created\">\n" +
+                "        <formatString>Date</formatString>\n" +
+                "      </column>\n" +
+                "    </columns>\n" +
+                "  </table>";
+        assertThat(actualXml)
+                .as("expect only the field edited in this test to appear in the query xml")
+                .contains(expectedColumnPart);
+    }
 
     @Override
     protected String getProjectName()


### PR DESCRIPTION
#### Rationale
This adds regression coverage for Issue 47659, which describes the case where Query XML metadata overwrites unmodified columns.  

#### Related Pull Requests
n/a

#### Changes

- [x] New test case to explicitly cover this particular scenario (there are others adjacent, or which implicitly cover it)
- [x] Added defensive timeouts for finding page elements
