### PR TITLE
Verify setting entity type name

### DIFF
--- a/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
@@ -8,6 +8,7 @@ import org.labkey.test.components.domain.DomainDesigner;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.html.SelectWrapper;
+import org.labkey.test.components.html.ValidatingInput;
 import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.params.FieldDefinition;
 import org.openqa.selenium.WebDriver;
@@ -271,13 +272,13 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
 
     protected class ElementCache extends DomainDesigner<?>.ElementCache
     {
-        protected final Input nameInput = Input.Input(Locator.id("entity-name"), getDriver()).findWhenNeeded(this);
-        protected final Input nameExpressionInput = Input.Input(Locator.id("entity-nameExpression"), getDriver()).waitFor(this);
-        protected final Input descriptionInput = Input.Input(Locator.id("entity-description"), getDriver()).findWhenNeeded(this);
+        protected final Input nameInput = new ValidatingInput(Locator.id("entity-name").findWhenNeeded(this), getDriver());
+        protected final Input nameExpressionInput = new ValidatingInput(Locator.id("entity-nameExpression").findWhenNeeded(this), getDriver());
+        protected final Input descriptionInput = new ValidatingInput(Locator.id("entity-description").findWhenNeeded(this), getDriver());
 
         protected final Select autoLinkDataToStudy = SelectWrapper.Select(Locator.id("entity-autoLinkTargetContainerId"))
                 .findWhenNeeded(this);
-        protected final Input linkedDatasetCategory = Input.Input(Locator.id("entity-autoLinkCategory"), getDriver()).findWhenNeeded(this);
+        protected final Input linkedDatasetCategory = new ValidatingInput(Locator.id("entity-autoLinkCategory").findWhenNeeded(this), getDriver());
 
         Optional<WebElement> optionalWarningAlert()
         {


### PR DESCRIPTION
#### Rationale
Sample type creation sometimes fails because the test fails to set the name. `ValidatingInput` will attempt to retry when this happens.

`Failed to set input: [[[[FirefoxDriver: firefox on LINUX (854ed86c-ae24-442c-9909-60bae90d4abb)] -> id: app]] -> id: entity-name]`

```
org.labkey.test.TestTimeoutException: org.openqa.selenium.TimeoutException: Expected condition failed: waiting for browser to navigate (tried for 59 second(s) with 500 milliseconds interval)
[...]
  at app//org.labkey.test.WebDriverWrapper.waitForPageToLoad(WebDriverWrapper.java:1892)
  at app//org.labkey.test.WebDriverWrapper.doAndMaybeWaitForPageToLoad(WebDriverWrapper.java:1990)
  at app//org.labkey.test.WebDriverWrapper.doAndWaitForPageToLoad(WebDriverWrapper.java:1959)
  at app//org.labkey.test.WebDriverWrapper.clickAndWait(WebDriverWrapper.java:2792)
  at app//org.labkey.test.WebDriverWrapper.clickAndWait(WebDriverWrapper.java:2787)
  at app//org.labkey.test.components.domain.BaseDomainDesigner.clickSave(BaseDomainDesigner.java:69)
  at app//org.labkey.test.util.SampleTypeHelper.createSampleType(SampleTypeHelper.java:131)
  at app//org.labkey.test.util.SampleTypeHelper.createSampleType(SampleTypeHelper.java:142)
```

![image](https://github.com/LabKey/testAutomation/assets/5263798/c9ca6b6f-21a1-4061-9596-fb2476b5389c)

#### Related Pull Requests
* N/A

#### Changes
* Use `ValidatingInput` for entity type name input
