### PR TITLE
SchemaBrowser: Utilize sub-components for layout

### DIFF
--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -534,7 +534,7 @@ public class LinkedSchemaTest extends BaseWebDriverTest
         _schemaHelper.updateLinkedSchema(getProjectName(), TARGET_FOLDER, STUDY_SCHEMA_NAME, sourceContainerPath, null, null, null, updatedMetaData);
 
         beginAt("/" + PROJECT_NAME + "/" + TARGET_FOLDER + "/query-begin.view?schemaName=CommonData&queryName=Demographics");
-        final WebElement error = Locator.tagWithClass("div", "lk-qd-error").waitForElement(shortWait());
+        final WebElement error = Locator.tagWithClass("div", "lk-vq-warn-message").waitForElement(shortWait());
         MatcherAssert.assertThat("Schema browser error.", error.getText(),
                 CoreMatchers.containsString("Error creating linked schema table 'Demographics': Column Pid2Consent.Study not found in column map."));
 


### PR DESCRIPTION
#### Rationale
Test updates for schema browser changes.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4460

#### Changes
* Updates a locator in the `LinkedSchemaTest.verifyLinkedSchemaWithLookup`
