### PR TITLE
Fix some test UI race conditions

### DIFF
--- a/src/org/labkey/test/components/ChartTypeDialog.java
+++ b/src/org/labkey/test/components/ChartTypeDialog.java
@@ -177,24 +177,15 @@ public class ChartTypeDialog extends ChartWizardDialog<ChartTypeDialog.ElementCa
     public ChartTypeDialog setYAxisSide(int measureIndex, YAxisSide side)
     {
         WebElement measureEl = elementCache().Y_FIELD_DISPLAY.index(measureIndex).findElement(this);
-        if (!measureEl.getAttribute("class").contains("selected"))
+        WebElement arrow = Locator.tagWithClass("i", "fa-arrow-circle-" + side.name().toLowerCase()).waitForElement(measureEl, 5_000);
+        if (!arrow.isDisplayed())
         {
             Locator.byClass("field-selection-text").findElement(measureEl).click();
+            getWrapper().shortWait().until(ExpectedConditions.visibilityOf(arrow));
         }
+        arrow.click();
+        getWrapper().shortWait().until(ExpectedConditions.stalenessOf(arrow));
 
-        switch(side)
-        {
-            case Left:
-                final WebElement leftArrow = elementCache().Y_FIELD_SIDE_LEFT.index(measureIndex).findElement(this);
-                leftArrow.click();
-                getWrapper().shortWait().until(ExpectedConditions.stalenessOf(leftArrow));
-                break;
-            case Right:
-                final WebElement rightArrow = elementCache().Y_FIELD_SIDE_RIGHT.index(measureIndex).findElement(this);
-                rightArrow.click();
-                getWrapper().shortWait().until(ExpectedConditions.stalenessOf(rightArrow));
-                break;
-        }
         return this;
     }
 
@@ -529,8 +520,6 @@ public class ChartTypeDialog extends ChartWizardDialog<ChartTypeDialog.ElementCa
         public final String DROP_TEXT = "/following-sibling::div[contains(@class, 'field-area-drop-text ')]";
         public final String REMOVE_ICON = FIELD_DISPLAY + "//div[contains(@class, 'field-selection-remove')]";
         public Locator Y_FIELD_DISPLAY = Locator.xpath(YAXIS_CONTAINER + FIELD_AREA + FIELD_DISPLAY);
-        public Locator Y_FIELD_SIDE_LEFT = Locator.xpath(YAXIS_CONTAINER + FIELD_AREA + FIELD_DISPLAY + "//i[contains(@class, 'fa-arrow-circle-left')]");
-        public Locator Y_FIELD_SIDE_RIGHT = Locator.xpath(YAXIS_CONTAINER + FIELD_AREA + FIELD_DISPLAY + "//i[contains(@class, 'fa-arrow-circle-right')]");
         public WebElement typeTitle = new LazyWebElement(Locator.xpath("//div[contains(@class, 'type-title')]"), this);
 
         public final String SERIES_CONTAINER = "//div[contains(@class, 'field-title')][contains(text(), 'Series')]";

--- a/src/org/labkey/test/components/ChartWizardDialog.java
+++ b/src/org/labkey/test/components/ChartWizardDialog.java
@@ -40,7 +40,7 @@ public abstract class ChartWizardDialog<EC extends ChartWizardDialog.ElementCach
         clickButton("Cancel", true);
     }
 
-    class ElementCache extends Window.ElementCache
+    class ElementCache extends Window<?>.ElementCache
     {
         public ElementCache()
         {

--- a/src/org/labkey/test/components/ui/notifications/ServerNotificationMenu.java
+++ b/src/org/labkey/test/components/ui/notifications/ServerNotificationMenu.java
@@ -118,6 +118,8 @@ public class ServerNotificationMenu extends BaseBootstrapMenu
     public ImportsPage clickViewAll()
     {
         expand();
+        WebDriverWrapper.waitFor(elementCache().viewAllLink::isDisplayed,
+                "View all link did not become visible.", 2_500);
         elementCache().viewAllLink.click();
         return new ImportsPage(getWrapper());
     }

--- a/src/org/labkey/test/pages/query/EditMetadataPage.java
+++ b/src/org/labkey/test/pages/query/EditMetadataPage.java
@@ -70,11 +70,13 @@ public class EditMetadataPage extends BaseDomainDesigner<EditMetadataPage.Elemen
 
     protected class ElementCache extends BaseDomainDesigner<EditMetadataPage.ElementCache>.ElementCache
     {
-        protected final WebElement buttonPanel = queryMetadataButtonPanelLocator().findWhenNeeded(this);
-        protected final WebElement aliasFieldBtn = Locator.button("Alias Field").findWhenNeeded(buttonPanel);
-        protected final WebElement editSourceBtn = Locator.button("Edit Source").findWhenNeeded(buttonPanel);
-        protected final WebElement saveBtn = Locator.button("Save").findWhenNeeded(getDriver());
-        protected final WebElement resetToDefaultBtn = Locator.button("Reset To Default").findWhenNeeded(buttonPanel);
+        protected final WebElement buttonPanel = queryMetadataButtonPanelLocator().findWhenNeeded(this)
+                .withTimeout(WAIT_FOR_JAVASCRIPT);
+        protected final WebElement aliasFieldBtn = Locator.button("Alias Field").findWhenNeeded(buttonPanel).withTimeout(WAIT_FOR_JAVASCRIPT);
+        protected final WebElement editSourceBtn = Locator.button("Edit Source").findWhenNeeded(buttonPanel).withTimeout(WAIT_FOR_JAVASCRIPT);
+        protected final WebElement saveBtn = Locator.button("Save").findWhenNeeded(getDriver()).withTimeout(WAIT_FOR_JAVASCRIPT);
+        protected final WebElement resetToDefaultBtn = Locator.button("Reset To Default").findWhenNeeded(buttonPanel)
+                .withTimeout(WAIT_FOR_JAVASCRIPT);
         DomainFormPanel firstDomainFormPanel = new DomainFormPanel.DomainFormPanelFinder(getDriver())   // for situations where there's only one on the page
                 .timeout(WAIT_FOR_JAVASCRIPT)
                 .findWhenNeeded(this);

--- a/src/org/labkey/test/tests/ParticipantReportTest.java
+++ b/src/org/labkey/test/tests/ParticipantReportTest.java
@@ -335,7 +335,6 @@ public class ParticipantReportTest extends ReportTest
 
         //Deselect All
         expandReportFilterWindow();
-        waitForElement(Locator.css(".initSelectionComplete"));
         _ext4Helper.deselectAllParticipantFilter();
         click(Locator.xpath("//a[./span[@title = 'Edit']]"));
         waitForElement(Locator.xpath("id('participant-report-panel-1-body')/div[contains(@style, 'display: none')]"), WAIT_FOR_JAVASCRIPT); // Edit panel should be hidden
@@ -406,7 +405,6 @@ public class ParticipantReportTest extends ReportTest
 
         //Deselect All
         expandReportFilterWindow();
-        waitForElement(Locator.css(".initSelectionComplete"));
         _ext4Helper.deselectAllParticipantFilter();
         waitForElement(Locator.css("table.x4-toolbar-item").withText("Showing 0 Results"));
 
@@ -587,6 +585,7 @@ public class ParticipantReportTest extends ReportTest
                 .elementToBeClickable(Locator.css(".report-filter-window .x4-tool-expand-right")));
         expander.click();
         waitForElement(Locator.css(".report-filter-window .x4-tool-collapse-left"));
+        waitForElement(Locator.css(".initSelectionComplete"));
         assertElementNotPresent(Locator.css(".report-filter-window.x4-collapsed"));
     }
 

--- a/src/org/labkey/test/tests/filecontent/FileContentDownloadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentDownloadTest.java
@@ -168,7 +168,7 @@ public class FileContentDownloadTest extends BaseWebDriverTest
         doubleClick(FileBrowserHelper.Locators.gridRow(textFile.getName()));
 
         switchToWindow(1);
-        assertTextPresent("Sample text file");
+        waitForText("Sample text file");
         getDriver().close();
         switchToMainWindow();
     }

--- a/src/org/labkey/test/util/Ext4Helper.java
+++ b/src/org/labkey/test/util/Ext4Helper.java
@@ -573,7 +573,7 @@ public class Ext4Helper
      */
     public void deselectAllParticipantFilter()
     {
-        checkGridRowCheckbox("All");
+        selectAllParticipantFilter();
         uncheckGridRowCheckbox("All");
     }
 
@@ -582,6 +582,7 @@ public class Ext4Helper
      */
     public void selectAllParticipantFilter()
     {
+        _test.waitForElement(Locator.xpath("//*[contains(@class, 'lk-filter-panel-label') and text()='All']"));
         checkGridRowCheckbox("All");
     }
 

--- a/src/org/labkey/test/util/UIPermissionsHelper.java
+++ b/src/org/labkey/test/util/UIPermissionsHelper.java
@@ -21,9 +21,11 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.pages.PermissionsEditor;
 import org.labkey.test.util.ext4cmp.Ext4CmpRef;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.Date;
 import java.util.List;
@@ -56,6 +58,8 @@ public class UIPermissionsHelper extends PermissionsHelper
     {
         _driver.goToHome();
         _driver.goToSiteGroups();
+        WebElement groupNameInput = _driver.shortWait().until(ExpectedConditions.elementToBeClickable(Locator.input("sitegroupsname")));
+
         if (_driver.isElementPresent(Locator.tagWithText("div", groupName)))
         {
             if (failIfAlreadyExists)
@@ -64,11 +68,8 @@ public class UIPermissionsHelper extends PermissionsHelper
                 return;
         }
 
-        Locator l = Locator.xpath("//input[contains(@name, 'sitegroupsname')]");
-        _driver.waitForElement(l, _driver.defaultWaitForPage);
-
-        _driver.setFormElement(l, groupName);
-        _driver.pressEnter(l);
+        _driver.setFormElement(groupNameInput, groupName);
+        groupNameInput.sendKeys(Keys.ENTER);
         _driver._extHelper.waitForExtDialog(groupName + " Information");
     }
 


### PR DESCRIPTION
#### Rationale
Address intermittent failure in `GroupTest`:
```
org.openqa.selenium.ElementNotInteractableException: Element <input id="textfield-1020-inputEl" class="x4-form-field x4-form-empty-field x4-form-text" name="sitegroupsname" type="text"> could not be scrolled into view
[...]
  at app//org.labkey.test.util.UIPermissionsHelper.startCreateGlobalPermissionsGroup(UIPermissionsHelper.java:70)
  at app//org.labkey.test.util.UIPermissionsHelper.createGlobalPermissionsGroup(UIPermissionsHelper.java:78)
  at app//org.labkey.test.util.UIPermissionsHelper.createGlobalPermissionsGroup(UIPermissionsHelper.java:51)
  at app//org.labkey.test.tests.GroupTest.testSteps(GroupTest.java:111)
```

Address intermittent failure in `ChartTypeDialog.setYAxisSide`:
```
org.openqa.selenium.ElementNotInteractableException: Click failed; try clicking a child element. Firefox doesn't like clicking certain wrapping elements
Element <i class="fa fa-arrow-circle-right unselected"> could not be scrolled into view
  at app//org.labkey.test.selenium.ReclickingWebElement.click(ReclickingWebElement.java:105)
  at app//org.labkey.test.components.ChartTypeDialog.setYAxisSide(ChartTypeDialog.java:194)
  at app//org.labkey.test.tests.TimeChartDateBasedTest.multiAxisTimeChartTest(TimeChartDateBasedTest.java:646)
  at app//org.labkey.test.tests.TimeChartDateBasedTest.doVerifySteps(TimeChartDateBasedTest.java:114)
  at app//org.labkey.test.tests.StudyBaseTest.runUITests(StudyBaseTest.java:138)
  at app//org.labkey.test.tests.StudyBaseTest.testSteps(StudyBaseTest.java:348)
```

#### Related Pull Requests
* Stale PR: https://github.com/LabKey/testAutomation/pull/1238

#### Changes
* Wait for chart dialog button to be visible
* Wait for group name input to be visible
