### PR TITLE
AdminFolderTypeTest fix for timing issue by waiting for Create Project page options to load

### DIFF
--- a/src/org/labkey/test/tests/AdminFolderTypeTest.java
+++ b/src/org/labkey/test/tests/AdminFolderTypeTest.java
@@ -29,6 +29,7 @@ public class AdminFolderTypeTest extends BaseWebDriverTest
 
         log("Verifying the default folder type while project creation");
         goToCreateProject();
+        waitForElement(Locator.tagWithText("label", "Collaboration"));
         checker().fatal().verifyTrue("Incorrect default folder type selected",
                 RadioButton.RadioButton().withLabel(newDefaultFolder).find(getDriver()).isSelected());
 
@@ -47,7 +48,8 @@ public class AdminFolderTypeTest extends BaseWebDriverTest
         checker().fatal().verifyTrue(folderTypeName + " should have been enabled", folderTypePage.isEnabled(folderTypeName));
 
         goToCreateProject();
-        checker().fatal().verifyTrue(folderTypeName + " project is not enabled", isElementPresent(Locator.tagWithText("label",folderTypeName)));
+        waitForElement(Locator.tagWithText("label", "Collaboration"));
+        checker().fatal().verifyTrue(folderTypeName + " project is not visible", isElementPresent(Locator.tagWithText("label",folderTypeName)));
 
         log("Disabling the folder type " + folderTypeName);
         folderTypePage = goToAdminConsole().clickFolderType();
@@ -58,7 +60,8 @@ public class AdminFolderTypeTest extends BaseWebDriverTest
         checker().fatal().verifyFalse(folderTypeName + " should have been disabled", folderTypePage.isEnabled(folderTypeName));
 
         goToCreateProject();
-        checker().fatal().verifyFalse(folderTypeName + " project is not disabled", isElementPresent(Locator.tagWithText("label",folderTypeName)));
+        waitForElement(Locator.tagWithText("label", "Collaboration"));
+        checker().fatal().verifyFalse(folderTypeName + " project is not hidden", isElementPresent(Locator.tagWithText("label",folderTypeName)));
 
         /* Test coverage for Issue 44995: Filter disabled folder types from folder management admin page */
 

--- a/src/org/labkey/test/tests/AdminFolderTypeTest.java
+++ b/src/org/labkey/test/tests/AdminFolderTypeTest.java
@@ -25,11 +25,11 @@ public class AdminFolderTypeTest extends BaseWebDriverTest
         folderTypePage.setDefaultFolderType(newDefaultFolder).clickSave();
 
         folderTypePage = goToAdminConsole().clickFolderType();
-        checker().verifyEquals("Incorrect default Folder type selected", newDefaultFolder, folderTypePage.getDefaultFolderType());
+        checker().fatal().verifyEquals("Incorrect default Folder type selected", newDefaultFolder, folderTypePage.getDefaultFolderType());
 
         log("Verifying the default folder type while project creation");
         goToCreateProject();
-        checker().verifyTrue("Incorrect default folder type selected",
+        checker().fatal().verifyTrue("Incorrect default folder type selected",
                 RadioButton.RadioButton().withLabel(newDefaultFolder).find(getDriver()).isSelected());
 
         log(String.format("Rollback to the old default folder type '%s'.", oldDefaultFolder));
@@ -44,10 +44,10 @@ public class AdminFolderTypeTest extends BaseWebDriverTest
 
         log("Verifying by default folder is enabled");
         FolderTypePages folderTypePage = goToAdminConsole().clickFolderType();
-        checker().verifyTrue(folderTypeName + " should have been enabled", folderTypePage.isEnabled(folderTypeName));
+        checker().fatal().verifyTrue(folderTypeName + " should have been enabled", folderTypePage.isEnabled(folderTypeName));
 
         goToCreateProject();
-        checker().verifyTrue(folderTypeName + " project is not enabled", isElementPresent(Locator.tagWithText("label",folderTypeName)));
+        checker().fatal().verifyTrue(folderTypeName + " project is not enabled", isElementPresent(Locator.tagWithText("label",folderTypeName)));
 
         log("Disabling the folder type " + folderTypeName);
         folderTypePage = goToAdminConsole().clickFolderType();
@@ -55,16 +55,16 @@ public class AdminFolderTypeTest extends BaseWebDriverTest
 
         log("Verifying folder type " + folderTypeName + " is disabled");
         folderTypePage = goToAdminConsole().clickFolderType();
-        checker().verifyFalse(folderTypeName + " should have been disabled", folderTypePage.isEnabled(folderTypeName));
+        checker().fatal().verifyFalse(folderTypeName + " should have been disabled", folderTypePage.isEnabled(folderTypeName));
 
         goToCreateProject();
-        checker().verifyFalse(folderTypeName + " project is not disabled", isElementPresent(Locator.tagWithText("label",folderTypeName)));
+        checker().fatal().verifyFalse(folderTypeName + " project is not disabled", isElementPresent(Locator.tagWithText("label",folderTypeName)));
 
         /* Test coverage for Issue 44995: Filter disabled folder types from folder management admin page */
 
         goToHome();
         goToFolderManagement().goToFolderTypeTab();
-        checker().verifyFalse("Disabled folder " + folderTypeName + " should not be present at Folder Management --> Folder type",
+        checker().fatal().verifyFalse("Disabled folder " + folderTypeName + " should not be present at Folder Management --> Folder type",
                isElementPresent(Locator.radioButtonByNameAndValue("folderType", folderTypeName)));
 
         log("Enabling the folder type " + folderTypeName);

--- a/src/org/labkey/test/tests/AdminFolderTypeTest.java
+++ b/src/org/labkey/test/tests/AdminFolderTypeTest.java
@@ -25,12 +25,12 @@ public class AdminFolderTypeTest extends BaseWebDriverTest
         folderTypePage.setDefaultFolderType(newDefaultFolder).clickSave();
 
         folderTypePage = goToAdminConsole().clickFolderType();
-        checker().fatal().verifyEquals("Incorrect default Folder type selected", newDefaultFolder, folderTypePage.getDefaultFolderType());
+        checker().verifyEquals("Incorrect default Folder type selected", newDefaultFolder, folderTypePage.getDefaultFolderType());
 
         log("Verifying the default folder type while project creation");
         goToCreateProject();
         waitForElement(Locator.tagWithText("label", "Collaboration"));
-        checker().fatal().verifyTrue("Incorrect default folder type selected",
+        checker().verifyTrue("Incorrect default folder type selected",
                 RadioButton.RadioButton().withLabel(newDefaultFolder).find(getDriver()).isSelected());
 
         log(String.format("Rollback to the old default folder type '%s'.", oldDefaultFolder));
@@ -45,11 +45,11 @@ public class AdminFolderTypeTest extends BaseWebDriverTest
 
         log("Verifying by default folder is enabled");
         FolderTypePages folderTypePage = goToAdminConsole().clickFolderType();
-        checker().fatal().verifyTrue(folderTypeName + " should have been enabled", folderTypePage.isEnabled(folderTypeName));
+        checker().verifyTrue(folderTypeName + " should have been enabled", folderTypePage.isEnabled(folderTypeName));
 
         goToCreateProject();
         waitForElement(Locator.tagWithText("label", "Collaboration"));
-        checker().fatal().verifyTrue(folderTypeName + " project is not visible", isElementPresent(Locator.tagWithText("label",folderTypeName)));
+        checker().verifyTrue(folderTypeName + " project is not visible", isElementPresent(Locator.tagWithText("label",folderTypeName)));
 
         log("Disabling the folder type " + folderTypeName);
         folderTypePage = goToAdminConsole().clickFolderType();
@@ -57,17 +57,17 @@ public class AdminFolderTypeTest extends BaseWebDriverTest
 
         log("Verifying folder type " + folderTypeName + " is disabled");
         folderTypePage = goToAdminConsole().clickFolderType();
-        checker().fatal().verifyFalse(folderTypeName + " should have been disabled", folderTypePage.isEnabled(folderTypeName));
+        checker().verifyFalse(folderTypeName + " should have been disabled", folderTypePage.isEnabled(folderTypeName));
 
         goToCreateProject();
         waitForElement(Locator.tagWithText("label", "Collaboration"));
-        checker().fatal().verifyFalse(folderTypeName + " project is not hidden", isElementPresent(Locator.tagWithText("label",folderTypeName)));
+        checker().verifyFalse(folderTypeName + " project is not hidden", isElementPresent(Locator.tagWithText("label",folderTypeName)));
 
         /* Test coverage for Issue 44995: Filter disabled folder types from folder management admin page */
 
         goToHome();
         goToFolderManagement().goToFolderTypeTab();
-        checker().fatal().verifyFalse("Disabled folder " + folderTypeName + " should not be present at Folder Management --> Folder type",
+        checker().verifyFalse("Disabled folder " + folderTypeName + " should not be present at Folder Management --> Folder type",
                isElementPresent(Locator.radioButtonByNameAndValue("folderType", folderTypeName)));
 
         log("Enabling the folder type " + folderTypeName);


### PR DESCRIPTION
#### Rationale
See recent intermittent test failures for AdminFolderTypeTest. It was saying that an expected Create Project option wasn't available, but really it was just still loading.

#### Changes
* Add wait on Create Project page for options before checking for existing option
