### PR TITLE
47818: Ability to export folder archives with only metadata

### DIFF
--- a/src/org/labkey/test/pages/admin/ExportFolderPage.java
+++ b/src/org/labkey/test/pages/admin/ExportFolderPage.java
@@ -38,7 +38,8 @@ public class ExportFolderPage extends LabKeyPage<ExportFolderPage.ElementCache>
     public static final String STUDY = "Study";
     public static final String FILES = "Files";
     public static final String ETLS = "ETL Definitions";
-    public static final String SAMPLE_TYPES_AND_DATA_CLASSES = "Sample Types and Data Classes";
+    public static final String SAMPLE_TYPE_DATA = "Sample Type Data";
+    public static final String DATA_CLASS_DATA = "Data Class Data";
     public static final String QC_STATE_SETTINGS = "QC State Settings";
 
     public ExportFolderPage(WebDriver driver)
@@ -83,9 +84,15 @@ public class ExportFolderPage extends LabKeyPage<ExportFolderPage.ElementCache>
         return this;
     }
 
-    public ExportFolderPage includeSampleTypeAndDataClasses(boolean checked)
+    public ExportFolderPage includeSampleTypeData(boolean checked)
     {
-        elementCache().sampleTypeAndDataClasses.set(checked);
+        elementCache().sampleTypeData.set(checked);
+        return this;
+    }
+
+    public ExportFolderPage includeDataClassData(boolean checked)
+    {
+        elementCache().dataClassData.set(checked);
         return this;
     }
 
@@ -200,7 +207,8 @@ public class ExportFolderPage extends LabKeyPage<ExportFolderPage.ElementCache>
 
         public final Checkbox roleAssighmentsCheckbox = exportItemCheckbox(ROLE_ASSIGNMENTS);
 
-        public final Checkbox sampleTypeAndDataClasses = exportItemCheckbox(SAMPLE_TYPES_AND_DATA_CLASSES);
+        public final Checkbox sampleTypeData = exportItemCheckbox(SAMPLE_TYPE_DATA);
+        public final Checkbox dataClassData = exportItemCheckbox(DATA_CLASS_DATA);
 
         public final Checkbox includeFilesCheckbox = exportItemCheckbox(FILES);
 

--- a/src/org/labkey/test/tests/ProjectCreatorUserTest.java
+++ b/src/org/labkey/test/tests/ProjectCreatorUserTest.java
@@ -151,7 +151,7 @@ public class ProjectCreatorUserTest extends BaseWebDriverTest
             .setFolderType("Template")
             .setTemplateSourceId(containerId)
             .setTemplateIncludeSubfolders(true)
-            .setTemplateWriterTypes("Lists");
+            .setTemplateWriterTypes("List Data");
         createProject(command);
         stopImpersonating();
 

--- a/src/org/labkey/test/tests/SampleTypeLinkedStudyExportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkedStudyExportTest.java
@@ -107,7 +107,8 @@ public class SampleTypeLinkedStudyExportTest extends BaseWebDriverTest
         goToFolderManagement()
                 .goToExportTab();
         File exportArchive = new ExportFolderPage(getDriver())
-                .includeSampleTypeAndDataClasses(true)
+                .includeSampleTypeData(true)
+                .includeDataClassData(true)
                 .exportToBrowserAsZipFile();
 
         log("Navigate into the destination folder and import there");


### PR DESCRIPTION
#### Rationale
Sample types and data classes have been split out to be their own top level options as well as having options to separately choose between the design and data for either data type.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/4468
