### PR TITLE
Update UI for sample and source creation

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -50,6 +50,11 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
         return _driver;
     }
 
+    public boolean hasTargetEntityTypeSelect()
+    {
+        return Locator.tagWithName("input", "targetEntityType").existsIn(this);
+    }
+
     public ReactSelect targetEntityTypeSelect()
     {
         // Which tabs are available and selected can vary so try finding the visible react select

--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -437,14 +437,12 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
             waitForLoaded();
         }
 
-        Locator tabContainerLoc = Locator.tagWithClassContaining("ul", "list-group");
         Locator deleteRowsBtnLoc = Locator.XPathLocator.union(
                 Locator.button("Delete rows"),
                 Locator.buttonContainingText("Remove"));
         Locator bulkInsertBtnLoc = Locator.button("Bulk Insert");
         Locator bulkUpdateBtnLoc = Locator.button("Bulk Update");
 
-        WebElement tabContainer = tabContainerLoc.findWhenNeeded(this);
         WebElement bulkInsertBtn = bulkInsertBtnLoc.findWhenNeeded(this).withTimeout(2000);
         WebElement bulkUpdateBtn = bulkUpdateBtnLoc.findWhenNeeded(this).withTimeout(2000);
         WebElement deleteRowsBtn = deleteRowsBtnLoc.findWhenNeeded(this).withTimeout(2000);

--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -289,8 +289,16 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
                 isElementVisible(elementCache().deleteRowsBtn);
     }
 
+    public boolean hasTabs()
+    {
+        return Locator.tagWithClassContaining("ul", "list-group").existsIn(this);
+    }
+
     public boolean isFileUploadVisible()
     {
+        if (!hasTabs())
+            return optionalFileUploadPanel().isPresent();
+
         return modeSelectListItem("from File").withClass("active").findOptionalElement(this).isPresent() &&
                 optionalFileUploadPanel().isPresent() &&
                 isElementVisible(fileUploadPanel().getComponentElement());
@@ -369,6 +377,9 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     public EntityInsertPanel showFileUpload()
     {
+        if (!hasTabs())
+            return this;
+
         if (!isFileUploadVisible())
         {
             var toggle = getFileUploadTab();
@@ -426,12 +437,14 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
             waitForLoaded();
         }
 
+        Locator tabContainerLoc = Locator.tagWithClassContaining("ul", "list-group");
         Locator deleteRowsBtnLoc = Locator.XPathLocator.union(
                 Locator.button("Delete rows"),
                 Locator.buttonContainingText("Remove"));
         Locator bulkInsertBtnLoc = Locator.button("Bulk Insert");
         Locator bulkUpdateBtnLoc = Locator.button("Bulk Update");
 
+        WebElement tabContainer = tabContainerLoc.findWhenNeeded(this);
         WebElement bulkInsertBtn = bulkInsertBtnLoc.findWhenNeeded(this).withTimeout(2000);
         WebElement bulkUpdateBtn = bulkUpdateBtnLoc.findWhenNeeded(this).withTimeout(2000);
         WebElement deleteRowsBtn = deleteRowsBtnLoc.findWhenNeeded(this).withTimeout(2000);


### PR DESCRIPTION
#### Rationale
We are in the process of simplifying the sample creation experience along the way to adding more options when creating samples. The simplification implemented in this PR and its relatives adjusts the entity creation page to not be a tabbed page for sample or source creation and to simplify the header on that page to remove the icon and subtitle.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/115
- https://github.com/LabKey/biologics/pull/2190
- https://github.com/LabKey/inventory/pull/899
- https://github.com/LabKey/labkey-ui-components/pull/1214
- https://github.com/LabKey/sampleManagement/pull/1910

#### Changes
* Add method for checking if a target selector exists
* Add method for checking if the EntityInsertPanel has tabs or not
