### PR TITLE
Add regression test for roundtripping flow folder archive

### DIFF
--- a/src/org/labkey/test/Locators.java
+++ b/src/org/labkey/test/Locators.java
@@ -27,6 +27,7 @@ public abstract class Locators
     public static final Locator signInLink = Locator.tagWithAttributeContaining("a", "href", "login.view");
     public static final Locator.XPathLocator folderTab = Locator.tagWithClass("div", "lk-nav-tabs-ct").append(Locator.tagWithClass("ul", "lk-nav-tabs")).childTag("li");
     public static final Locator.XPathLocator panelWebpartTitle = Locator.byClass("labkey-wp-title-text");
+    public static final Locator.XPathLocator folderTitle = Locator.tagWithClass("a", "lk-body-title-folder");
 
     public static Locator.XPathLocator headerContainer()
     {

--- a/src/org/labkey/test/pages/admin/ExportFolderPage.java
+++ b/src/org/labkey/test/pages/admin/ExportFolderPage.java
@@ -161,11 +161,19 @@ public class ExportFolderPage extends LabKeyPage<ExportFolderPage.ElementCache>
         new FileBrowserHelper(this).waitForFileGridReady();
     }
 
-    public void exportToPipelineAsZip()
+    public FileBrowserHelper exportToPipelineAsZip()
+    {
+        int timeout = getDefaultWaitForPage();
+        return exportToPipelineAsZip(timeout);
+    }
+
+    public FileBrowserHelper exportToPipelineAsZip(int timeout)
     {
         selectExportLocation(ExportLocation.pipelineAsZip);
-        clickAndWait(elementCache().exportBtn);
-        new FileBrowserHelper(this).waitForFileGridReady();
+        clickAndWait(elementCache().exportBtn, timeout);
+        FileBrowserHelper fileBrowserHelper = new FileBrowserHelper(this);
+        fileBrowserHelper.waitForFileGridReady();
+        return fileBrowserHelper;
     }
 
     public File exportToBrowserAsZipFile()

--- a/src/org/labkey/test/tests/flow/FlowFolderReimportTest.java
+++ b/src/org/labkey/test/tests/flow/FlowFolderReimportTest.java
@@ -52,7 +52,7 @@ public class FlowFolderReimportTest extends BaseWebDriverTest
         _containerHelper.createProject(getProjectName(), "Flow");
         setupFlowWorkspace();
 
-        testReimport(false);
+        testReimport(false, false);
     }
 
     @Test
@@ -62,7 +62,7 @@ public class FlowFolderReimportTest extends BaseWebDriverTest
         _containerHelper.createSubfolder(getProjectName(), "Flow subfolder", "Flow");
         setupFlowWorkspace();
 
-        testReimport(true);
+        testReimport(true, false);
     }
 
     @Test
@@ -73,10 +73,10 @@ public class FlowFolderReimportTest extends BaseWebDriverTest
         _containerHelper.createSubfolder(getProjectName(), "Flow subfolder", "Flow");
         setupFlowWorkspace();
 
-        testReimport(true);
+        testReimport(true, true);
     }
 
-    private void testReimport(boolean hasSubfolders)
+    private void testReimport(boolean hasSubfolders, boolean expectError)
     {
         ExportFolderPage exportFolderPage = ExportFolderPage.beginAt(this, getProjectName());
         exportFolderPage.includeSubfolders(hasSubfolders);
@@ -96,7 +96,7 @@ public class FlowFolderReimportTest extends BaseWebDriverTest
         }
 
         goToProjectHome(OTHER_PROJECT);
-        importFolderFromZip(file, false, 1, false, 600_000);
+        importFolderFromZip(file, false, 1, expectError, 600_000);
     }
 
     private void setupFlowWorkspace()
@@ -126,7 +126,7 @@ public class FlowFolderReimportTest extends BaseWebDriverTest
 
             clickAndWait(Locators.folderTitle);
             clickAndWait(Locator.linkWithText("Upload Sample Descriptions"));
-            clickAndWait(Locator.button("Save")); // Domain designer
+            waitAndClickAndWait(Locator.button("Save")); // Domain designer
 
             clickAndWait(Locators.folderTitle);
             clickAndWait(Locator.linkWithText("Upload More Samples"));

--- a/src/org/labkey/test/tests/flow/FlowFolderReimportTest.java
+++ b/src/org/labkey/test/tests/flow/FlowFolderReimportTest.java
@@ -146,6 +146,11 @@ public class FlowFolderReimportTest extends BaseWebDriverTest
         }
 
         clickAndWait(Locators.folderTitle);
+        clickAndWait(Locator.linkWithText("Create a new Analysis script"));
+        setFormElement(Locator.name("ff_name"), "Unused Script");
+        clickAndWait(Locator.lkButton("Create Analysis Script"));
+
+        clickAndWait(Locators.folderTitle);
         clickAndWait(Locator.linkWithText("Define sample description join fields"));
         selectOptionByValue(Locator.name("ff_samplePropertyURI"), "Name");
         selectOptionByValue(Locator.name("ff_dataField"), "Name");
@@ -157,13 +162,15 @@ public class FlowFolderReimportTest extends BaseWebDriverTest
         goToProjectHome(containerPath);
 
         // Flow Summary Webpart
-        assertElementPresent(Locator.linkWithText("FCS Analyses (1 run)"));
+        //assertElementPresent(Locator.linkWithText("FCS Analyses (1 run)"));
+        //assertElementPresent(Locator.linkWithText("Unused Script (0 runs)"));
         assertElementPresent(Locator.linkWithText("Samples (72)"));
-        assertElementPresent(Locator.linkWithText("Analysis (1 run)"));
+        //assertElementPresent(Locator.linkWithText("Analysis (1 run)"));
 
         // Flow Experiment Webpart
-        assertElementPresent(Locator.linkWithText("72 FCS files"));
-        assertElementPresent(Locator.linkWithText("72 sample descriptions in this folder."));
+        //assertElementPresent(Locator.linkWithText("72 FCS files"));
+        assertElementPresent(Locator.linkWithText("72 sample descriptions"));
+        assertElementPresent(Locator.linkWithText("Modify sample description join fields"));
     }
 
     @Override

--- a/src/org/labkey/test/tests/flow/FlowFolderReimportTest.java
+++ b/src/org/labkey/test/tests/flow/FlowFolderReimportTest.java
@@ -52,7 +52,7 @@ public class FlowFolderReimportTest extends BaseWebDriverTest
         _containerHelper.createProject(getProjectName(), "Flow");
         setupFlowWorkspace();
 
-        testReimport();
+        testReimport(false);
     }
 
     @Test
@@ -62,7 +62,7 @@ public class FlowFolderReimportTest extends BaseWebDriverTest
         _containerHelper.createSubfolder(getProjectName(), "Flow subfolder", "Flow");
         setupFlowWorkspace();
 
-        testReimport();
+        testReimport(true);
     }
 
     @Test
@@ -73,13 +73,13 @@ public class FlowFolderReimportTest extends BaseWebDriverTest
         _containerHelper.createSubfolder(getProjectName(), "Flow subfolder", "Flow");
         setupFlowWorkspace();
 
-        testReimport();
+        testReimport(true);
     }
 
-    private void testReimport()
+    private void testReimport(boolean hasSubfolders)
     {
         ExportFolderPage exportFolderPage = ExportFolderPage.beginAt(this, getProjectName());
-        exportFolderPage.includeSubfolders(true);
+        exportFolderPage.includeSubfolders(hasSubfolders);
         FileBrowserHelper fileBrowserHelper = exportFolderPage.exportToPipelineAsZip(600_000);
 
         File file;

--- a/src/org/labkey/test/tests/flow/FlowFolderReimportTest.java
+++ b/src/org/labkey/test/tests/flow/FlowFolderReimportTest.java
@@ -1,0 +1,154 @@
+package org.labkey.test.tests.flow;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
+import org.labkey.test.Locators;
+import org.labkey.test.TestFileUtils;
+import org.labkey.test.TestProperties;
+import org.labkey.test.categories.Daily;
+import org.labkey.test.pages.ImportDataPage;
+import org.labkey.test.pages.admin.ExportFolderPage;
+import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
+import org.labkey.test.util.AbstractDataRegionExportOrSignHelper;
+import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.FileBrowserHelper;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Issue 47873: Folder archive with xar and samples fails to import
+ */
+@Category({Daily.class})
+public class FlowFolderReimportTest extends BaseWebDriverTest
+{
+    private static final String OTHER_PROJECT = "FlowFolderReimportTest Target";
+    private static final File FLOW_WORKSPACE = TestFileUtils.getSampleData("flow/versions/v10.8.wsp");
+
+    File flowSamples = null;
+
+    @Override
+    protected void doCleanup(boolean afterTest)
+    {
+        _containerHelper.deleteProject(getProjectName(), false);
+        _containerHelper.deleteProject(OTHER_PROJECT, false);
+    }
+
+    @Before
+    public void preTest()
+    {
+        doCleanup(false); // Delete projects
+
+        _containerHelper.createProject(OTHER_PROJECT); // Create target project
+    }
+
+    @Test
+    public void testReimportProject()
+    {
+        _containerHelper.createProject(getProjectName(), "Flow");
+        setupFlowWorkspace();
+
+        testReimport();
+    }
+
+    @Test
+    public void testReimportSubfolder()
+    {
+        _containerHelper.createProject(getProjectName(), "Flow");
+        _containerHelper.createSubfolder(getProjectName(), "Flow subfolder", "Flow");
+        setupFlowWorkspace();
+
+        testReimport();
+    }
+
+    @Test
+    public void testReimportNestedWorkspaceFolder()
+    {
+        _containerHelper.createProject(getProjectName(), "Flow");
+        setupFlowWorkspace();
+        _containerHelper.createSubfolder(getProjectName(), "Flow subfolder", "Flow");
+        setupFlowWorkspace();
+
+        testReimport();
+    }
+
+    private void testReimport()
+    {
+        ExportFolderPage exportFolderPage = ExportFolderPage.beginAt(this, getProjectName());
+        exportFolderPage.includeSubfolders(true);
+        FileBrowserHelper fileBrowserHelper = exportFolderPage.exportToPipelineAsZip(600_000);
+
+        File file;
+        if (TestProperties.isServerRemote())
+        {
+            List<String> fileList = fileBrowserHelper.getFileList();
+            fileBrowserHelper.selectFileBrowserItem(fileList.get(0));
+            file = fileBrowserHelper.downloadSelectedFiles();
+        }
+        else
+        {
+            File exportDir = new File(TestFileUtils.getDefaultFileRoot(getProjectName()), "export");
+            file = exportDir.listFiles()[0];
+        }
+
+        goToProjectHome(OTHER_PROJECT);
+        importFolderFromZip(file, false, 1, false, 600_000);
+    }
+
+    private void setupFlowWorkspace()
+    {
+        clickAndWait(Locator.linkWithText("Import FlowJo Workspace Analysis"));
+        // 1. Select Workspace
+        setFormElement(Locator.id("workspace.file"), FLOW_WORKSPACE);
+        clickAndWait(Locator.lkButton("Next"));
+        // 2. Select FCS Files
+        clickAndWait(Locator.lkButton("Next"));
+        // 3. Review Samples
+        clickAndWait(Locator.lkButton("Next"));
+        // 4. Analysis Folder
+        clickAndWait(Locator.lkButton("Next"));
+        // 5. Confirm
+        clickAndWait(Locator.lkButton("Finish"));
+        // Wait for import
+        new PipelineStatusDetailsPage(getDriver()).waitForComplete();
+
+        if (flowSamples == null)
+        {
+            // Pipeline status should redirect to sample list.
+            DataRegionTable drt = new DataRegionTable.DataRegionFinder(getDriver()).waitFor();
+            drt.checkAllOnPage();
+            flowSamples = drt.expandExportPanel()
+                    .exportExcel(AbstractDataRegionExportOrSignHelper.ExcelFileType.XLSX);
+
+            clickAndWait(Locators.folderTitle);
+            clickAndWait(Locator.linkWithText("Upload Sample Descriptions"));
+            clickAndWait(Locator.button("Save")); // Domain designer
+
+            clickAndWait(Locators.folderTitle);
+            clickAndWait(Locator.linkWithText("Upload More Samples"));
+            new ImportDataPage(getDriver()).setFile(flowSamples).submit();
+        }
+
+        clickAndWait(Locators.folderTitle);
+        clickAndWait(Locator.linkWithText("Define sample description join fields"));
+        selectOptionByValue(Locator.name("ff_samplePropertyURI"), "Name");
+        selectOptionByValue(Locator.name("ff_dataField"), "Name");
+        clickAndWait(Locator.lkButton("update"));
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return "FlowFolderReimportTest Project";
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Arrays.asList("flow", "experiment");
+    }
+}

--- a/src/org/labkey/test/tests/flow/FlowFolderReimportTest.java
+++ b/src/org/labkey/test/tests/flow/FlowFolderReimportTest.java
@@ -51,32 +51,44 @@ public class FlowFolderReimportTest extends BaseWebDriverTest
     {
         _containerHelper.createProject(getProjectName(), "Flow");
         setupFlowWorkspace();
+        verifyFlowDashboard(getProjectName());
 
-        testReimport(false, false);
+        exportThenImport(false, false);
+        verifyFlowDashboard(OTHER_PROJECT);
     }
 
     @Test
     public void testReimportSubfolder()
     {
-        _containerHelper.createProject(getProjectName(), "Flow");
-        _containerHelper.createSubfolder(getProjectName(), "Flow subfolder", "Flow");
-        setupFlowWorkspace();
+        String subfolder = "Flow subfolder";
 
-        testReimport(true, false);
+        _containerHelper.createProject(getProjectName(), "Flow");
+        _containerHelper.createSubfolder(getProjectName(), subfolder, "Flow");
+        setupFlowWorkspace();
+        verifyFlowDashboard(getProjectName() + "/" + subfolder);
+
+        exportThenImport(true, false);
+        verifyFlowDashboard(OTHER_PROJECT + "/" + subfolder);
     }
 
     @Test
     public void testReimportNestedWorkspaceFolder()
     {
+        final String subfolder = "Flow subfolder";
+
         _containerHelper.createProject(getProjectName(), "Flow");
         setupFlowWorkspace();
-        _containerHelper.createSubfolder(getProjectName(), "Flow subfolder", "Flow");
+        _containerHelper.createSubfolder(getProjectName(), subfolder, "Flow");
         setupFlowWorkspace();
 
-        testReimport(true, true);
+        exportThenImport(true, true);
+
+        // TODO: enable once import is successful
+        verifyFlowDashboard(OTHER_PROJECT);
+        verifyFlowDashboard(OTHER_PROJECT + "/" + subfolder);
     }
 
-    private void testReimport(boolean hasSubfolders, boolean expectError)
+    private void exportThenImport(boolean hasSubfolders, boolean expectError)
     {
         ExportFolderPage exportFolderPage = ExportFolderPage.beginAt(this, getProjectName());
         exportFolderPage.includeSubfolders(hasSubfolders);
@@ -138,6 +150,20 @@ public class FlowFolderReimportTest extends BaseWebDriverTest
         selectOptionByValue(Locator.name("ff_samplePropertyURI"), "Name");
         selectOptionByValue(Locator.name("ff_dataField"), "Name");
         clickAndWait(Locator.lkButton("update"));
+    }
+
+    private void verifyFlowDashboard(String containerPath)
+    {
+        goToProjectHome(containerPath);
+
+        // Flow Summary Webpart
+        assertElementPresent(Locator.linkWithText("FCS Analyses (1 run)"));
+        assertElementPresent(Locator.linkWithText("Samples (72)"));
+        assertElementPresent(Locator.linkWithText("Analysis (1 run)"));
+
+        // Flow Experiment Webpart
+        assertElementPresent(Locator.linkWithText("72 FCS files"));
+        assertElementPresent(Locator.linkWithText("72 sample descriptions in this folder."));
     }
 
     @Override

--- a/src/org/labkey/test/tests/flow/FlowJoQueryTest.java
+++ b/src/org/labkey/test/tests/flow/FlowJoQueryTest.java
@@ -138,8 +138,9 @@ public class FlowJoQueryTest extends BaseFlowTest
         new DataRegionTable("query", getDriver()).clickHeaderMenu("Analysis Folder", "All Analysis Folders");
         assertTextNotPresent("No data to show");
         DataRegionTable region = new DataRegionTable("query", this);
-        region.setFilter("AbsDifference", "Is Greater Than or Equal To", "2", longWaitForPage);
-        region.setFilter("PercentDifference", "Is Greater Than or Equal To", "2.5", longWaitForPage);
+        region.setUpdateTimeout(longWaitForPage);
+        region.setFilter("AbsDifference", "Is Greater Than or Equal To", "2");
+        region.setFilter("PercentDifference", "Is Greater Than or Equal To", "2.5");
 
         // NOTE: see https://github.com/LabKey/commonAssays/pull/476
         // As part of this PR there were various places we removed range constraints on data values to improve plot consistency.


### PR DESCRIPTION
#### Rationale
We were unable to import certain folder archives: [Issue 47873: Folder archive with xar and samples fails to import](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47873)
Adding some regression testing to test this scenario.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4463

#### Changes
* Create `FlowFolderReimportTest`
