### PR TITLE
Allow `WebDriverWrapper.waitFor` to return non-boolean values

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -2170,22 +2170,24 @@ public abstract class WebDriverWrapper implements WrapsDriver
     }
 
     /**
-     * Wait for Supplier to return true
+     * Wait for Supplier to return non-null non-false value
      * @param wait milliseconds
-     * @return false if Supplier.get() doesn't return true within 'wait' ms
+     * @return final result of Supplier.get()
      */
     @Contract(pure = true)
-    public static boolean waitFor(Supplier<Boolean> checker, int wait)
+    public static <T> T waitFor(Supplier<T> checker, int wait)
     {
         long startTime = System.currentTimeMillis();
+        T result;
         do
         {
-            if( checker.get() )
-                return true;
+            result = checker.get();
+            if (result != null && !Boolean.FALSE.equals(result))
+                break;
             sleep(100);
         } while ((System.currentTimeMillis() - startTime) < wait);
 
-        return checker.get();
+        return result;
     }
 
     public static void waitForEquals(String message, Supplier<?> expected, Supplier<?> actual, int wait)


### PR DESCRIPTION
#### Rationale
This allows us to wait for a thing then have the thing instead of fetching it separately after the wait finishes. This mimics the behavior of Selenium's `FluentWait.until` behavior but this isn't fatal if the wait doesn't succeed.

#### Related Pull Requests
* N/A

#### Changes
* Allow `WebDriverWrapper.waitFor` to return non-boolean values
