### PR TITLE
Wait for QC state options to load

### DIFF
--- a/src/org/labkey/test/pages/assay/UpdateQCStatePage.java
+++ b/src/org/labkey/test/pages/assay/UpdateQCStatePage.java
@@ -6,6 +6,8 @@ import org.labkey.test.util.DataRegionTable;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
+import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfNestedElementLocatedBy;
+
 
 public class UpdateQCStatePage extends LabKeyPage<UpdateQCStatePage.ElementCache>
 {
@@ -22,7 +24,8 @@ public class UpdateQCStatePage extends LabKeyPage<UpdateQCStatePage.ElementCache
 
     public UpdateQCStatePage selectState(String state)
     {
-        setFormElement(elementCache().stateInput, state);
+        shortWait().until(presenceOfNestedElementLocatedBy(elementCache().stateSelect, Locator.tagWithAttribute("option", "value")));
+        selectOptionByText(elementCache().stateSelect, state);
         return this;
     }
 
@@ -52,8 +55,7 @@ public class UpdateQCStatePage extends LabKeyPage<UpdateQCStatePage.ElementCache
 
     protected class ElementCache extends LabKeyPage.ElementCache
     {
-
-        WebElement stateInput = Locator.id("stateInput").findWhenNeeded(this);
+        WebElement stateSelect = Locator.id("stateInput").findWhenNeeded(this);
         WebElement commentInput = Locator.textarea("comment").findWhenNeeded(this);
     }
 }


### PR DESCRIPTION
#### Rationale
Failure artifacts show that the desired option exists. Hopefully the helper just needs to wait for options to load.
```
org.openqa.selenium.NoSuchElementException: Cannot locate option with value: What is this
  at app//org.openqa.selenium.support.ui.Select.findOptionsByValue(Select.java:291)
  at app//org.openqa.selenium.support.ui.Select.selectByValue(Select.java:194)
  at app//org.labkey.test.WebDriverWrapper.selectOptionByValue(WebDriverWrapper.java:3783)
  at app//org.labkey.test.WebDriverWrapper.selectOption(WebDriverWrapper.java:3770)
  at app//org.labkey.test.WebDriverWrapper.setFormElement(WebDriverWrapper.java:3313)
  at app//org.labkey.test.pages.assay.UpdateQCStatePage.selectState(UpdateQCStatePage.java:25)
  at app//org.labkey.test.pages.assay.AssayRunsPage.setRowQcStatus(AssayRunsPage.java:95)
  at app//org.labkey.test.tests.premium.AssayQCTest.setQCStates(AssayQCTest.java:496)
  at app//org.labkey.test.tests.premium.AssayQCTest.testQCStateVisibility(AssayQCTest.java:154)
```

#### Related Pull Requests
* N/A

#### Changes
* Wait for QC state options to load
