### PR TITLE
QueryWebPart support for async loading of total rows count in grid pagination header

### DIFF
--- a/src/org/labkey/test/tests/DataRegionTest.java
+++ b/src/org/labkey/test/tests/DataRegionTest.java
@@ -71,6 +71,7 @@ public class DataRegionTest extends AbstractQWPTest
                     Pair.of("Collapse filter clauses", "testMultiClausesFilter"),
                     Pair.of("Filter field case insensitive", "testCaseInsensitiveFilterField"),
                     Pair.of("Hide Paging Count", "testHidePagingCount"),
+                    Pair.of("Async Total Rows Count", "testAsyncTotalRowsCount"),
                     Pair.of("Show All Rows", "testShowAllTotalRows"),
                     Pair.of("Use getBaseFilters", "testGetBaseFilters"),
                     Pair.of("Filter on \"Sort\" column", "testFilterOnSortColumn"),


### PR DESCRIPTION
#### Rationale
See platform PR for rationale

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4558

#### Changes
* DataRegionTest - add simple test case for showPaginationCountAsync prop of QueryWebPart
