### PR TITLE
expand filteringReactSelect before attempting to interact with filter input

### DIFF
--- a/src/org/labkey/test/components/react/FilteringReactSelect.java
+++ b/src/org/labkey/test/components/react/FilteringReactSelect.java
@@ -162,8 +162,7 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
 
     private List<WebElement> setFilter(String value)
     {
-        if (!isOpen())
-            open();
+        open();
         elementCache().input.sendKeys(value);
         long filterStart = System.currentTimeMillis();
         WebDriverWrapper.waitFor(()-> {

--- a/src/org/labkey/test/components/react/FilteringReactSelect.java
+++ b/src/org/labkey/test/components/react/FilteringReactSelect.java
@@ -162,6 +162,8 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
 
     private List<WebElement> setFilter(String value)
     {
+        if (!isOpen())
+            open();
         elementCache().input.sendKeys(value);
         long filterStart = System.currentTimeMillis();
         WebDriverWrapper.waitFor(()-> {


### PR DESCRIPTION
#### Rationale
Recently, tests like [CrossFolderRegistryTest.testRegistryFilters](https://teamcity.labkey.org/viewLog.html?buildId=2522162&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_LimsStarter_LimsStarterPostgres&fromSakuraUI=true#testNameId8049891800230736841) have begun failing because the input on a FilteringReactSelect is not accessible by keyboard.

It turns out that if the reactSelect is expanded, the issue seems not to repro.
Hopefully this is not too invasive an approach

#### Related Pull Requests
n/a

#### Changes

- [x] expand the reactSelect before trying to type a filter expression into it
