### PR TITLE
Add regression test for updating issues

### DIFF
--- a/src/org/labkey/test/pages/issues/BaseUpdatePage.java
+++ b/src/org/labkey/test/pages/issues/BaseUpdatePage.java
@@ -60,9 +60,9 @@ public abstract class BaseUpdatePage<EC extends BaseUpdatePage.ElementCache> ext
     }
 
     @Override
-    public OptionSelect related()
+    public Input related()
     {
-        return (OptionSelect) super.related();
+        return (Input) super.related();
     }
 
     @Override

--- a/src/org/labkey/test/tests/issues/IssuesTest.java
+++ b/src/org/labkey/test/tests/issues/IssuesTest.java
@@ -388,7 +388,8 @@ public class IssuesTest extends BaseWebDriverTest
 
     /**
      * Test that issues update form displays existing values correctly and saves new values without error.
-     * Issue 48068: Add test coverage for issue notify lists
+     * Issue 48059: Cannot update tickets or issues in issue tracker on labkey.org
+     * Issue 47912: When updating or resolving an issue, fields are changed to default values
      */
     @Test
     public void testIssueUpdate()


### PR DESCRIPTION
#### Rationale
There have been a couple of bugs with updating issues in recent month ([48059](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48059) and [47912](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47912)). Adding a regression test for these sorts of scenarios.

#### Related Pull Requests
* labkey/platform#4441
* labkey/platform#4500

#### Changes
* Add regression tests for recent issue tracker bugs
