### PR TITLE
Add Optional Getter for Empty Grid Message

### DIFF
--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -672,6 +672,19 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
         return elementCache().getColumnHeaderCell(columnText).getAttribute("title");
     }
 
+    public Optional<String> getGridEmptyMessage()
+    {
+        Optional<String> msg = Optional.empty();
+
+        WebElement tr = Locator.tagWithClass("tr", "grid-empty").refindWhenNeeded(this);
+        if(tr.isDisplayed())
+        {
+            msg = Optional.of(Locator.tag("td").findElement(tr).getText());
+        }
+
+        return msg;
+    }
+
     /**
      * supports chaining between base and derived instances
      * @return  magic


### PR DESCRIPTION
#### Rationale
The message shown when the grid is empty can vary depending on what page is showing the grid. This adds a getter that returns an optional string for the empty grid message (if present).

Example:
<img width="1644" alt="Screenshot 2023-07-12 at 3 07 46 PM" src="https://github.com/LabKey/testAutomation/assets/12738200/f30312a7-8b03-4733-adc4-523ada597c3e">


#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/1959

#### Changes
* Add a getter for empty grid message.
