### PR TITLE
Address Some Random Failures in LKSM

### DIFF
--- a/src/org/labkey/test/components/bootstrap/ModalDialog.java
+++ b/src/org/labkey/test/components/bootstrap/ModalDialog.java
@@ -141,12 +141,12 @@ public class ModalDialog extends WebDriverComponent<ModalDialog.ElementCache>
 
     protected class ElementCache extends Component<ElementCache>.ElementCache
     {
-        public final WebElement title = Locators.title.findWhenNeeded(getComponentElement());
+        public final WebElement title = Locators.title.refindWhenNeeded(getComponentElement());
         public final WebElement closeButton = Locator.tagWithClass("button", "close")
                 .withAttribute("data-dismiss", "modal")
-                .findWhenNeeded(getComponentElement());
+                .refindWhenNeeded(getComponentElement());
         public final WebElement body = Locators.body
-                .findWhenNeeded(getComponentElement()).withTimeout(WAIT_FOR_JAVASCRIPT);
+                .refindWhenNeeded(getComponentElement()).withTimeout(WAIT_FOR_JAVASCRIPT);
     }
 
     public static class Locators

--- a/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
@@ -2,8 +2,9 @@ package org.labkey.test.components.ui.domainproperties.samples;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.test.Locator;
-import org.labkey.test.components.react.ReactSelect;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.html.Input;
+import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.components.ui.domainproperties.EntityTypeDesigner;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.WebDriver;
@@ -47,6 +48,10 @@ public abstract class SampleTypeDesigner<T extends SampleTypeDesigner<T>> extend
     public T addParentAlias(String alias, @Nullable String optionDisplayText)
     {
         expandPropertiesPanel();
+
+        WebDriverWrapper.waitFor(elementCache().addAliasButton::isDisplayed,
+                "'Add Parent Alias' button is not visible.", 2_500);
+
         elementCache().addAliasButton.click();
         int initialCount = findEmptyAlias();
         if (optionDisplayText == null)


### PR DESCRIPTION
#### Rationale
Fixing some random failures seen in LKSM.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/1972

#### Changes
* Use refind when getting dialog elements. (Dialogs might refresh).
* Wait for Add Parent button in sample type designer before clicking it.
