### PR TITLE
New Line Support for Multi Value Filters 

### DIFF
--- a/src/org/labkey/test/tests/FilterTest.java
+++ b/src/org/labkey/test/tests/FilterTest.java
@@ -422,11 +422,11 @@ public class FilterTest extends BaseWebDriverTest
         assertEquals("ModifiedBy: Contains '~me~'",
                 List.of(name0, name0), list.getColumnDataAsText(userColumn));
 
-        list.setFilter("ModifiedBy", "Does Not Equal Any Of (example usage: a;b;c)", "~me~");
+        list.setFilter("ModifiedBy", "Does Not Equal Any Of", "~me~");
         assertEquals("ModifiedBy: Does Not Equal Any Of (~me~)",
                 List.of(name1, name2), list.getColumnDataAsText(userColumn));
 
-        list.setFilter("ModifiedBy", "Equals One Of (example usage: a;b;c)", "~me~;" + name1);
+        list.setFilter("ModifiedBy", "Equals One Of", "~me~;" + name1);
         assertEquals("ModifiedBy: Equals One Of (~me~;editor1)",
                 List.of(name0, name1, name0), list.getColumnDataAsText(userColumn));
     }
@@ -540,13 +540,13 @@ public class FilterTest extends BaseWebDriverTest
             return Arrays.asList(
                     //String columnName, String filter1Type, String filter1, String filter2Type, String filter2, String[] textPresentAfterFilter, String[] textNotPresentAfterFilter,
                     //Issue 12197
-                    createFilterArgs(_listCol4, "Equals One Of (example usage: a;b;c)", TEST_DATA[4][3] + ";" + TEST_DATA[4][2], null, null, new String[]{TEST_DATA[1][2], TEST_DATA[1][3]}, new String[]{TEST_DATA[1][0], TEST_DATA[1][1]}),
+                    createFilterArgs(_listCol4, "Equals One Of", TEST_DATA[4][3] + ";" + TEST_DATA[4][2], null, null, new String[]{TEST_DATA[1][2], TEST_DATA[1][3]}, new String[]{TEST_DATA[1][0], TEST_DATA[1][1]}),
                     createFilterArgs(_listCol1, "Equals", TEST_DATA[1][0], null, null, new String[]{TEST_DATA[1][0]}, new String[]{TEST_DATA[1][2], TEST_DATA[1][1], TEST_DATA[1][3]}),
                     createFilterArgs(_listCol1, "Starts With", "Z", null, null, new String[]{TEST_DATA[1][3]}, new String[]{TEST_DATA[1][0], TEST_DATA[1][1], TEST_DATA[1][2]}),
                     createFilterArgs(_listCol1, "Does Not Start With", "Z", null, null, new String[]{TEST_DATA[1][2], TEST_DATA[1][1], TEST_DATA[1][0]}, new String[]{TEST_DATA[1][3]}),
                     //can't check for the absence of thing you're excluding, since it will be present in the filter text
                     createFilterArgs(_listCol1, "Does Not Equal", TEST_DATA[1][0], null, null, new String[]{TEST_DATA[1][2], TEST_DATA[1][1], TEST_DATA[1][3]}, new String[]{TEST_DATA[5][0]}),
-                    createFilterArgs(_listCol1, "Does Not Equal Any Of (example usage: a;b;c)", TEST_DATA[1][0] + ";" + TEST_DATA[1][1], null, null, new String[]{TEST_DATA[1][2], TEST_DATA[1][3]}, new String[]{TEST_DATA[5][0], TEST_DATA[5][1]}),
+                    createFilterArgs(_listCol1, "Does Not Equal Any Of", TEST_DATA[1][0] + ";" + TEST_DATA[1][1], null, null, new String[]{TEST_DATA[1][2], TEST_DATA[1][3]}, new String[]{TEST_DATA[5][0], TEST_DATA[5][1]}),
                     createFilterArgs(_listCol3, "Equals", "true", null, null, new String[]{TEST_DATA[1][0], TEST_DATA[1][2]}, new String[]{TEST_DATA[1][1], TEST_DATA[1][3]}),
                     createFilterArgs(_listCol3, "Does Not Equal", "false", null, null, new String[]{TEST_DATA[1][0], TEST_DATA[1][2]}, new String[]{TEST_DATA[1][1], TEST_DATA[1][3]}),
                     //filter is case insensitive
@@ -555,8 +555,8 @@ public class FilterTest extends BaseWebDriverTest
                     createFilterArgs(_listCol4, "Is Greater Than", "9", null, null, new String[]{TEST_DATA[1][0]}, new String[]{TEST_DATA[1][2], TEST_DATA[1][3], TEST_DATA[1][1]}),
                     createFilterArgs(_listCol4, "Is Blank", null, null, null, new String[]{}, new String[]{TEST_DATA[1][2], TEST_DATA[1][3], TEST_DATA[1][1], TEST_DATA[1][0]}),
                     //new filters for faceted filtering
-                    createFilterArgs(_listCol6, "Contains One Of (example usage: a;b;c)", TEST_DATA[5][1] + ";" + TEST_DATA[5][3], null, null, new String[]{TEST_DATA[5][1]}, new String[]{TEST_DATA[1][0], TEST_DATA[1][2]}),
-                    createFilterArgs(_listCol1, "Does Not Contain Any Of (example usage: a;b;c)", TEST_DATA[1][3] + ";" + TEST_DATA[1][1], null, null, new String[]{TEST_DATA[1][0], TEST_DATA[1][2]}, new String[]{TEST_DATA[0][1], TEST_DATA[0][3]}),
+                    createFilterArgs(_listCol6, "Contains One Of", TEST_DATA[5][1] + ";" + TEST_DATA[5][3], null, null, new String[]{TEST_DATA[5][1]}, new String[]{TEST_DATA[1][0], TEST_DATA[1][2]}),
+                    createFilterArgs(_listCol1, "Does Not Contain Any Of", TEST_DATA[1][3] + ";" + TEST_DATA[1][1], null, null, new String[]{TEST_DATA[1][0], TEST_DATA[1][2]}, new String[]{TEST_DATA[0][1], TEST_DATA[0][3]}),
                     createFilterArgs(_listCol6, "Is Blank", null, null, null, new String[]{TEST_DATA[1][3]}, new String[]{TEST_DATA[1][1], TEST_DATA[1][2], TEST_DATA[1][0]}),
                     createFilterArgs(_listCol6, "Is Not Blank", null, null, null, new String[]{TEST_DATA[1][1], TEST_DATA[1][2], TEST_DATA[1][0]}, new String[]{TEST_DATA[1][3]})
             );
@@ -606,7 +606,8 @@ public class FilterTest extends BaseWebDriverTest
             region = new DataRegionTable(TABLE_NAME, this);
             region.openFilterDialog(fieldKey);
             _extHelper.clickExtTab("Choose Filters");
-            shortWait().until(ExpectedConditions.visibilityOf(Locator.id("value_1").findElement(getDriver())));
+            String id = (filter1Type.matches("Contains One Of|Does Not Contain Any Of|Equals One Of|Does Not Equal Any Of")) ? "value_1-1" : "value_1";
+            shortWait().until(ExpectedConditions.visibilityOf(Locator.id(id).findElement(getDriver())));
 
             if (filter1 != null)
             {
@@ -624,12 +625,12 @@ public class FilterTest extends BaseWebDriverTest
                     // so the filter is inverted again from "Not In" to "Does Not Equal Any Of" and "Light" is selected.
                     waitForFormElementToEqual(Locator.name("value_1"), "Light");
                 }
-                else if (filter1Type.equals("Does Not Equal Any Of (example usage: a;b;c)") && "Light;Mellow".equals(filter1))
+                else if (filter1Type.equals("Does Not Equal Any Of") && "Light;Mellow".equals(filter1))
                 {
                     // In this test case, "Does Not Equal Any Of" and "Light;Mellow" are the initial filter type and value.
                     // When showing the dialog, "Does Not Equal Any Of" is inverted to "In" and "Robust;ZanzibarMasinginiTanzaniaAfrica" are selected.
                     // When switching tabs, nothing changes.
-                    waitForFormElementToEqual(Locator.name("value_1"), "Light;Mellow");
+                    waitForFormElementToEqual(Locator.name("value_1-1"), "Light\nMellow");
                 }
                 else if (filter1Type.equals("Does Not Equal") && "false".equals(filter1))
                 {
@@ -643,7 +644,7 @@ public class FilterTest extends BaseWebDriverTest
                 }
                 else
                 {
-                    assertEquals(filter1, getFormElement(Locator.id("value_1")));
+                    assertEquals(filter1.replaceAll(";", "\n"), getFormElement(Locator.id(id)));
                 }
             }
 

--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -939,7 +939,7 @@ public class GridPanelTest extends GridPanelBaseTest
                 1, filterValues.size());
 
         checker().verifyEquals("The filter value is not as expected.",
-                String.format("%s;%s", firstFilterValue, secondFilterValue), getFormElement(filterValues.get(0)));
+                String.format("%s\n%s", firstFilterValue, secondFilterValue), getFormElement(filterValues.get(0)));
 
         checker().screenShotIfNewError("Updated_Filter_Error");
 
@@ -1213,7 +1213,7 @@ public class GridPanelTest extends GridPanelBaseTest
         filterValues = Locator.tagWithClass("textarea", "filter-expression__textarea").findElement(panelElement);
 
         checker().verifyEquals(String.format("The filter value for '%s' is not as expected.", FILTER_STRING_COL),
-                oneOfFilter, getFormElement(filterValues));
+                oneOfFilter.replaceAll(";", "\n"), getFormElement(filterValues));
 
         checker().screenShotIfNewError("Populated_Filter_Int_Field_Error");
 

--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -194,7 +194,7 @@ public class GridPanelTest extends GridPanelBaseTest
         cv.saveCustomView(VIEW_FEWER_COLUMNS);
 
         log(String.format("Finally create a view named '%s' for '%s' that only has a filter.", VIEW_FILTERED_COLUMN, SMALL_SAMPLE_TYPE));
-        drtSamples.setFilter(FILTER_STRING_COL, "Contains One Of (example usage: a;b;c)", String.format("%1$s;%1$s%2$s", stringSetMembers.get(0), stringSetMembers.get(1)));
+        drtSamples.setFilter(FILTER_STRING_COL, "Contains One Of", String.format("%1$s;%1$s%2$s", stringSetMembers.get(0), stringSetMembers.get(1)));
         cv = drtSamples.openCustomizeGrid();
         cv.saveCustomView(VIEW_FILTERED_COLUMN);
 

--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -933,7 +933,7 @@ public class GridPanelTest extends GridPanelBaseTest
         checker().verifyTrue("The second filter expression should be empty.",
                 filterTypes.get(1).getValue().isEmpty());
 
-        List<WebElement> filterValues = Locator.tagWithClass("input", "filter-expression__input").findElements(panelElement);
+        List<WebElement> filterValues = Locator.tagWithClass("textarea", "filter-expression__textarea").findElements(panelElement);
 
         checker().verifyEquals("There should only be one filter value text box.",
                 1, filterValues.size());
@@ -1210,7 +1210,7 @@ public class GridPanelTest extends GridPanelBaseTest
         checker().verifyEquals(String.format("Filter expression for '%s' is not as expected.", FILTER_STRING_COL),
                 "Contains One Of", filterTypes.get(0).getValue());
 
-        filterValues = Locator.tagWithClass("input", "filter-expression__input").findElement(panelElement);
+        filterValues = Locator.tagWithClass("textarea", "filter-expression__textarea").findElement(panelElement);
 
         checker().verifyEquals(String.format("The filter value for '%s' is not as expected.", FILTER_STRING_COL),
                 oneOfFilter, getFormElement(filterValues));

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -1038,7 +1038,8 @@ public class DataRegionTable extends DataRegion
         WebElement filterDialogElement = getWrapper().waitForElement(filterDialog);
 
         WebDriverWrapper.waitFor(() -> getWrapper().isElementPresent(filterDialog.append(Locator.linkWithText("[All]")).notHidden()) ||
-                        getWrapper().isElementPresent(filterDialog.append(Locator.tagWithId("input", "value_1").notHidden())),
+                        getWrapper().isElementPresent(filterDialog.append(Locator.tagWithId("input", "value_1").notHidden())) ||
+                        getWrapper().isElementPresent(filterDialog.append(Locator.tagWithId("textarea", "value_1-1").notHidden())),
                 "Filter Dialog", WAIT_FOR_JAVASCRIPT);
         getWrapper()._extHelper.waitForLoadingMaskToDisappear(WAIT_FOR_JAVASCRIPT);
 

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -1112,7 +1112,8 @@ public class DataRegionTable extends DataRegion
 
         if (filter1 != null && !filter1Type.contains("Blank"))
         {
-            getWrapper().setFormElement(Locator.id("value_1"), filter1);
+            String id = (filter1Type.matches("Contains One Of|Does Not Contain Any Of|Equals One Of|Does Not Equal Any Of")) ? "value_1-1" : "value_1";
+            getWrapper().setFormElement(Locator.id(id), filter1);
         }
 
         if (filter2Type != null && !filter2Type.contains("Blank"))


### PR DESCRIPTION
#### Rationale
Whereas previously it was necessary to use a semicolon delimited list of values with multi-value filters such as 'Contains One Of', with these changes it is possible to use a newline as a delimiter. As such, filter value inputs for relevant multi-value filters have been changed from field inputs to textarea inputs. See [spec](https://docs.google.com/document/d/1148zLiMiyYkYbZd2mODGhH2kQK7XIdZGsK3lktnpWh0/edit?usp=sharing) for more details.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/156
* https://github.com/LabKey/labkey-ui-premium/pull/140
* https://github.com/LabKey/labkey-ui-components/pull/1239
* https://github.com/LabKey/platform/pull/4608
* https://github.com/LabKey/sampleManagement/pull/1976
* https://github.com/LabKey/biologics/pull/2244
* https://github.com/LabKey/inventory/pull/931
* https://github.com/LabKey/testAutomation/pull/1578

#### Changes
* Update string
