### PR TITLE
Add support for source (data class) parents in our apps

### DIFF
--- a/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
@@ -62,87 +62,6 @@ public abstract class SampleTypeDesigner<T extends SampleTypeDesigner<T>> extend
         return getThis();
     }
 
-    public int getParentAliasIndex(String parentAlias)
-    {
-        List<Input> inputs = elementCache().parentAliases();
-        for (int i = 0; i < inputs.size(); i++)
-        {
-            if (inputs.get(i).get().equals(parentAlias))
-            {
-                return i;
-            }
-        }
-        throw new NotFoundException("No such parent alias: " + parentAlias);
-    }
-
-    public List<String> getParentAliasOptions(int index)
-    {
-        expandPropertiesPanel();
-        return elementCache().parentAliasSelect(index).getOptions();
-    }
-
-    public T removeParentAlias(String parentAlias)
-    {
-        expandPropertiesPanel();
-        int aliasIndex = getParentAliasIndex(parentAlias);
-        return removeParentAlias(aliasIndex);
-    }
-
-    public T removeParentAlias(int index)
-    {
-        expandPropertiesPanel();
-        elementCache().removeParentAliasIcon(index).click();
-        return getThis();
-    }
-
-    protected T setParentAlias(int index, @Nullable String alias, @Nullable String optionDisplayText)
-    {
-        expandPropertiesPanel();
-        elementCache().parentAlias(index).setValue(alias);
-        if (optionDisplayText != null)
-        {
-            elementCache().parentAliasSelect(index).select(optionDisplayText);
-        }
-        return getThis();
-    }
-
-    public T setParentAlias(String alias, String optionDisplayText)
-    {
-        expandPropertiesPanel();
-        int index = getParentAliasIndex(alias);
-        elementCache().parentAliasSelect(index).select(optionDisplayText);
-        return getThis();
-    }
-
-    public String getParentAlias(int index)
-    {
-        expandPropertiesPanel();
-        return elementCache().parentAlias(index).get();
-    }
-
-    public String getParentAliasSelectText(int index)
-    {
-        expandPropertiesPanel();
-        return elementCache().parentAliasSelect(index).getSelections().get(0);
-    }
-
-    protected int findEmptyAlias()
-    {
-        List<Input> aliases = elementCache().parentAliases();
-        int index = -1;
-        for(int i = 0; i < aliases.size(); i++)
-        {
-            if(aliases.get(i).getValue().isEmpty())
-            {
-                index = i;
-                break;
-            }
-        }
-
-        return index;
-
-    }
-
     public boolean hasUniqueIdAlert()
     {
         return elementCache().uniqueIdAlert.isDisplayed();
@@ -186,27 +105,5 @@ public abstract class SampleTypeDesigner<T extends SampleTypeDesigner<T>> extend
                 .append(Locator.tagWithClassContaining("i", "domain-panel-status-icon-green")).refindWhenNeeded(this);
 
         protected final WebElement addAliasButton = Locator.tagWithClass("i","container--addition-icon").findWhenNeeded(this);
-
-        public List<Input> parentAliases()
-        {
-            return Input.Input(Locator.name("alias"), getDriver()).findAll(propertiesPanel);
-        }
-
-        Input parentAlias(int index)
-        {
-            return parentAliases().get(index);
-        }
-
-        ReactSelect parentAliasSelect(int index)
-        {
-            return ReactSelect.finder(getDriver())
-                    .withInputClass("sampleset-insert--parent-select")
-                    .index(index).find(propertiesPanel);
-        }
-
-        WebElement removeParentAliasIcon(int index)
-        {
-            return Locator.tagWithClass("i","container--removal-icon").findElements(propertiesPanel).get(index);
-        }
     }
 }

--- a/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
@@ -3,14 +3,10 @@ package org.labkey.test.components.ui.domainproperties.samples;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
-import org.labkey.test.components.html.Input;
-import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.components.ui.domainproperties.EntityTypeDesigner;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-
-import java.util.List;
 
 /**
  * Automates the LabKey ui component defined in: packages/components/src/components/domainproperties/samples/SampleTypeDesigner.tsx

--- a/src/org/labkey/test/components/ui/grids/CustomizeGridViewDialog.java
+++ b/src/org/labkey/test/components/ui/grids/CustomizeGridViewDialog.java
@@ -67,8 +67,8 @@ public class CustomizeGridViewDialog extends ModalDialog
     }
 
     /**
-     * Get the list of visible fields from the 'Available Fields' panel. Children of an expanded filed only have the name
-     * in the list, this des not include the path.
+     * Get the list of visible fields from the 'Available Fields' panel. Children of an expanded field only have the name
+     * in the list, this does not include the path.
      *
      * @return The list of field names.
      */

--- a/src/org/labkey/test/util/DataClassHelper.java
+++ b/src/org/labkey/test/util/DataClassHelper.java
@@ -53,11 +53,6 @@ public class DataClassHelper extends WebDriverWrapper
         Locked
     }
 
-    public DataClassHelper(WebDriverWrapper driverWrapper)
-    {
-        this(driverWrapper.getDriver());
-    }
-
     public DataClassHelper(WebDriver driver)
     {
         _driver = driver;
@@ -93,18 +88,6 @@ public class DataClassHelper extends WebDriverWrapper
 
         createPage.addFields(props.getFields());
         createPage.clickSave();
-    }
-
-    public void createDataClass(DataClassDefinition definition, File dataFile)
-    {
-        createDataClass(definition);
-        goToDataClass(definition.getName()).bulkImport(dataFile);
-    }
-
-    public void createDataClass(DataClassDefinition definition, String data)
-    {
-        createDataClass(definition);
-        goToDataClass(definition.getName()).bulkImport(data);
     }
 
     public void createDataClass(DataClassDefinition definition, List<Map<String, String>> data)
@@ -196,34 +179,16 @@ public class DataClassHelper extends WebDriverWrapper
                 .submit();
     }
 
-    public void mergeImport(String tsvData)
-    {
-        startTsvImport(tsvData, DataClassHelper.MERGE_OPTION)
-                .submit();
-    }
-
     public void bulkImport(List<Map<String, String>> data)
     {
         startTsvImport(data, IMPORT_OPTION)
                 .submit();
     }
 
-    public void bulkImportExpectingError(List<Map<String, String>> data, String importOption)
-    {
-        startTsvImport(data, importOption)
-                .submitExpectingError();
-    }
-
     public void mergeImport(List<Map<String, String>> data)
     {
         startTsvImport(data, DataClassHelper.MERGE_OPTION)
                 .submit();
-    }
-
-    public void mergeImportExpectingError(List<Map<String, String>> data)
-    {
-        startTsvImport(data, DataClassHelper.MERGE_OPTION)
-                .submitExpectingError();
     }
 
     private ImportDataPage startTsvImport(String tsv, String importOption)
@@ -245,42 +210,5 @@ public class DataClassHelper extends WebDriverWrapper
             throw new IllegalArgumentException("No data provided");
         }
         return startTsvImport(DataClassAPIHelper.convertMapToTsv(data), importOption);
-    }
-
-    public void deleteDataObjects(DataRegionTable dataClassTable, String expectedTitle)
-    {
-        doAndWaitForPageToLoad(() -> {
-            dataClassTable.clickHeaderButton("Delete");
-            Window.Window(getDriver()).withTitle(expectedTitle).waitFor()
-                    .clickButton("Yes, Delete", false);
-            Window.Window(getDriver()).withTitleContaining("Delete data").waitFor();
-            _ext4Helper.waitForMaskToDisappear();
-        });
-    }
-
-    private void verifyDataRow(Map<String, String> expectedData, int index, DataRegionTable drt)
-    {
-        Map<String, String> actualData = drt.getRowDataAsMap(index);
-
-        for (Map.Entry<String, String> field : expectedData.entrySet())
-        {
-            assertEquals(field.getKey() + " not as expected at index " + index, field.getValue().trim(), actualData.get(field.getKey()));
-        }
-    }
-
-    public void verifyDataValues(List<Map<String, String>> data)
-    {
-        DataRegionTable drt = getDataClassDataRegionTable();
-        for (Map<String, String> expectedRow : data)
-        {
-            int index = drt.getRowIndex("Name", expectedRow.get("Name").trim());
-            verifyDataRow(expectedRow, index, drt);
-        }
-    }
-
-    public String getDetailsFieldValue(String label)
-    {
-        Locator loc = Locator.tag("td").withClass("lk-form-label").withText(label + ":").followingSibling("td");
-        return loc.findElement(getDriver()).getText();
     }
 }

--- a/src/org/labkey/test/util/DataClassHelper.java
+++ b/src/org/labkey/test/util/DataClassHelper.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.test.util;
+
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.components.ext4.Window;
+import org.labkey.test.pages.ImportDataPage;
+import org.labkey.test.pages.experiment.CreateDataClassPage;
+import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.experiment.DataClassDefinition;
+import org.labkey.test.util.exp.DataClassAPIHelper;
+import org.openqa.selenium.WebDriver;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.labkey.test.util.exp.DataClassAPIHelper.DATA_CLASS_DATA_REGION_NAME;
+
+/**
+ * Helper methods for creating Data Classes and importing data into them through standard LabKey Server UI
+ */
+public class DataClassHelper extends WebDriverWrapper
+{
+    public static final String IMPORT_OPTION = "IMPORT";
+    public static final String MERGE_OPTION = "MERGE";
+    public static final String UPDATE_OPTION = "UPDATE";
+    private final WebDriver _driver;
+
+    public enum StatusType {
+        Available,
+        Consumed,
+        Locked
+    }
+
+    public DataClassHelper(WebDriverWrapper driverWrapper)
+    {
+        this(driverWrapper.getDriver());
+    }
+
+    public DataClassHelper(WebDriver driver)
+    {
+        _driver = driver;
+    }
+
+    public static DataClassHelper beginAtDataClassesList(WebDriverWrapper dWrapper, String containerPath)
+    {
+        dWrapper.beginAt(WebTestHelper.buildURL("experiment", containerPath, "listDataClass"));
+        return new DataClassHelper(dWrapper.getDriver());
+    }
+    
+
+    @Override
+    public WebDriver getWrappedDriver()
+    {
+        return _driver;
+    }
+
+    public void createDataClass(DataClassDefinition props)
+    {
+        CreateDataClassPage createPage = goToCreateNewDataClass();
+
+        createPage.setName(props.getName());
+
+        if (props.getNameExpression() != null)
+        {
+            createPage.setNameExpression(props.getNameExpression());
+        }
+        if (props.getDescription() != null)
+        {
+            createPage.setDescription(props.getDescription());
+        }
+
+        createPage.addFields(props.getFields());
+        createPage.clickSave();
+    }
+
+    public void createDataClass(DataClassDefinition definition, File dataFile)
+    {
+        createDataClass(definition);
+        goToDataClass(definition.getName()).bulkImport(dataFile);
+    }
+
+    public void createDataClass(DataClassDefinition definition, String data)
+    {
+        createDataClass(definition);
+        goToDataClass(definition.getName()).bulkImport(data);
+    }
+
+    public void createDataClass(DataClassDefinition definition, List<Map<String, String>> data)
+    {
+        createDataClass(definition);
+        goToDataClass(definition.getName()).bulkImport(data);
+    }
+
+    public CreateDataClassPage goToCreateNewDataClass()
+    {
+        getDataClassesList().clickHeaderButtonAndWait("New Data Class");
+        return new CreateDataClassPage(getDriver());
+    }
+
+    public DataClassHelper goToDataClass(String name)
+    {
+        TestLogger.log("Go to the data class '" + name + "'");
+        clickAndWait(Locator.linkWithText(name));
+        return this;
+    }
+
+    public void verifyFields(List<FieldDefinition> _fields)
+    {
+        TestLogger.log("Verify that the fields for the data class are as expected");
+        Set<String> actualNames = new HashSet<>(getDataClassFields());
+        Set<String> expectedNames = _fields.stream().map(FieldDefinition::getName).collect(Collectors.toSet());
+        expectedNames.add("Name");
+        expectedNames.add("Description");
+        assertEquals("Fields in data class not as expected.", expectedNames, actualNames);
+    }
+
+    public DataRegionTable getDataClassesList()
+    {
+        return new DataRegionTable.DataRegionFinder(getDriver()).withName(DATA_CLASS_DATA_REGION_NAME).find();
+    }
+
+    public DataRegionTable getDataClassDataRegionTable()
+    {
+        return new DataRegionTable.DataRegionFinder(getDriver()).withName("query").find();
+    }
+
+    public int getDataCount()
+    {
+        return getDataClassDataRegionTable().getDataRowCount();
+    }
+
+    private List<String> getDataClassFields()
+    {
+        return getDataClassDataRegionTable().getColumnNames();
+    }
+
+    public void insertRow(Map<String, String> fieldValues)
+    {
+        getDataClassDataRegionTable()
+                .clickInsertNewRow();
+        for (Map.Entry<String, String> fieldValue : fieldValues.entrySet())
+        {
+            setFormElement(Locator.name("quf_" + fieldValue.getKey()), fieldValue.getValue());
+        }
+        clickButton("Submit");
+    }
+
+    public void bulkImport(File dataFile)
+    {
+        fileImport(dataFile, IMPORT_OPTION);
+    }
+
+    public void mergeImport(File dataFile)
+    {
+        fileImport(dataFile, MERGE_OPTION);
+    }
+
+    private void fileImport(File dataFile, String importOption)
+    {
+        DataRegionTable drt = getDataClassDataRegionTable();
+        TestLogger.log("Adding data from file");
+        ImportDataPage importDataPage = drt.clickImportBulkData();
+        importDataPage.setFile(dataFile);
+        if (MERGE_OPTION.equals(importOption))
+            importDataPage.setFileMerge(true);
+        else if (UPDATE_OPTION.equals(importOption))
+            importDataPage.setFileInsertOption(true);
+        importDataPage.submit();
+    }
+
+    public void bulkImport(String tsvData)
+    {
+        startTsvImport(tsvData, IMPORT_OPTION)
+                .submit();
+    }
+
+    public void mergeImport(String tsvData)
+    {
+        startTsvImport(tsvData, DataClassHelper.MERGE_OPTION)
+                .submit();
+    }
+
+    public void bulkImport(List<Map<String, String>> data)
+    {
+        startTsvImport(data, IMPORT_OPTION)
+                .submit();
+    }
+
+    public void bulkImportExpectingError(List<Map<String, String>> data, String importOption)
+    {
+        startTsvImport(data, importOption)
+                .submitExpectingError();
+    }
+
+    public void mergeImport(List<Map<String, String>> data)
+    {
+        startTsvImport(data, DataClassHelper.MERGE_OPTION)
+                .submit();
+    }
+
+    public void mergeImportExpectingError(List<Map<String, String>> data)
+    {
+        startTsvImport(data, DataClassHelper.MERGE_OPTION)
+                .submitExpectingError();
+    }
+
+    private ImportDataPage startTsvImport(String tsv, String importOption)
+    {
+        DataRegionTable drt = getDataClassDataRegionTable();
+        ImportDataPage importDataPage = drt.clickImportBulkData();
+        if (MERGE_OPTION.equals(importOption))
+            importDataPage.setCopyPasteMerge(true);
+        else if (UPDATE_OPTION.equals(importOption))
+            importDataPage.setCopyPasteInsertOption(true);
+        importDataPage.setText(tsv);
+        return importDataPage;
+    }
+
+    private ImportDataPage startTsvImport(List<Map<String, String>> data, String importOption)
+    {
+        if (data == null || data.isEmpty())
+        {
+            throw new IllegalArgumentException("No data provided");
+        }
+        return startTsvImport(DataClassAPIHelper.convertMapToTsv(data), importOption);
+    }
+
+    public void deleteDataObjects(DataRegionTable dataClassTable, String expectedTitle)
+    {
+        doAndWaitForPageToLoad(() -> {
+            dataClassTable.clickHeaderButton("Delete");
+            Window.Window(getDriver()).withTitle(expectedTitle).waitFor()
+                    .clickButton("Yes, Delete", false);
+            Window.Window(getDriver()).withTitleContaining("Delete data").waitFor();
+            _ext4Helper.waitForMaskToDisappear();
+        });
+    }
+
+    private void verifyDataRow(Map<String, String> expectedData, int index, DataRegionTable drt)
+    {
+        Map<String, String> actualData = drt.getRowDataAsMap(index);
+
+        for (Map.Entry<String, String> field : expectedData.entrySet())
+        {
+            assertEquals(field.getKey() + " not as expected at index " + index, field.getValue().trim(), actualData.get(field.getKey()));
+        }
+    }
+
+    public void verifyDataValues(List<Map<String, String>> data)
+    {
+        DataRegionTable drt = getDataClassDataRegionTable();
+        for (Map<String, String> expectedRow : data)
+        {
+            int index = drt.getRowIndex("Name", expectedRow.get("Name").trim());
+            verifyDataRow(expectedRow, index, drt);
+        }
+    }
+
+    public String getDetailsFieldValue(String label)
+    {
+        Locator loc = Locator.tag("td").withClass("lk-form-label").withText(label + ":").followingSibling("td");
+        return loc.findElement(getDriver()).getText();
+    }
+}

--- a/src/org/labkey/test/util/exp/DataClassAPIHelper.java
+++ b/src/org/labkey/test/util/exp/DataClassAPIHelper.java
@@ -1,5 +1,6 @@
 package org.labkey.test.util.exp;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
@@ -13,6 +14,7 @@ import org.labkey.test.util.DomainUtils;
 import org.labkey.test.util.TestDataGenerator;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -23,6 +25,7 @@ public class DataClassAPIHelper
 {
 
     public static final String SCHEMA_NAME = "exp.data";
+    public static final String DATA_CLASS_DATA_REGION_NAME = "DataClass";
 
     /**
      * Create a dataclass in the specified container with the fields provided.
@@ -93,6 +96,23 @@ public class DataClassAPIHelper
                 new HashSet<>(sourceNames), rowIds.keySet());
 
         return rowIds;
+    }
+
+    @NotNull
+    public static String convertMapToTsv(@NotNull List<Map<String, String>> data)
+    {
+        // first the header
+        List<String> rows = new ArrayList<>();
+        rows.add(String.join("\t", data.get(0).keySet()));
+        data.forEach(dataMap -> {
+            StringBuilder row = new StringBuilder();
+            data.get(0).keySet().forEach(key -> {
+                row.append(dataMap.get(key));
+                row.append("\t");
+            });
+            rows.add(row.substring(0, row.lastIndexOf("\t")));
+        });
+        return String.join("\n", rows);
     }
 
 }


### PR DESCRIPTION
#### Rationale
We are now supporting adding data class parents to data classes in our applications, so there's an opportunity for code sharing to support testing this functionality.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/138
- https://github.com/LabKey/platform/pull/4597
- https://github.com/LabKey/sampleManagement/pull/1970
- https://github.com/LabKey/biologics/pull/2240
- https://github.com/LabKey/labkey-ui-components/pull/1236

#### Changes
* Move alias handling methods and element cache objects to `EntityTypeDesigner` base class.
* Add `DataClassHelper` akin to `SampleTypeHelper`
* Update `DataClassApiHelper` with utility method
