### PR TITLE
Issue 43420: Swap jTidy --> jSoup

### DIFF
--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -240,17 +240,6 @@ public class WikiLongTest extends BaseWebDriverTest
         _wikiHelper.saveWikiPage();
         assertTextNotPresent("New Page");  // Should not be an error, so should have left the editor
 
-        log("test fixup for unsafe _blank targets, see #33356");
-        _wikiHelper.createNewWikiPage();
-        setFormElement(Locator.name("name"), WIKI_PAGE9_NAME);
-        _wikiHelper.setWikiBody(WIKI_PAGE9_CONTENT);
-        _wikiHelper.saveWikiPage();
-        assertTextNotPresent("New Page");  // Should not be an error, so should have left the editor
-
-        String renderedPage9 = getHtmlSource();
-        assertTrue("Fixed up link not present", renderedPage9.contains("<a href=\"http://labkey.com\" rel=\"noopener noreferrer\" target=\"_blank\">Fixup</a>"));
-        assertTrue("Safe link mangled", renderedPage9.contains("<a href=\"http://labkey.com\">Safe</a>"));
-
         log("test create new html page with a webpart");
         _wikiHelper.createNewWikiPage("HTML");
 
@@ -518,6 +507,18 @@ public class WikiLongTest extends BaseWebDriverTest
         clickTab("Wiki");
         portalHelper.clickWebpartMenuItem("Pages", true, "Copy");
         assertElementPresent(Locator.linkWithText(PROJECT_NAME));
+
+        log("test fixup for unsafe _blank targets, see #33356");
+        _wikiHelper.createNewWikiPage();
+        setFormElement(Locator.name("name"), WIKI_PAGE9_NAME);
+        _wikiHelper.setWikiBody(WIKI_PAGE9_CONTENT);
+        _wikiHelper.saveWikiPage();
+        assertTextNotPresent("New Page");  // Should not be an error, so should have left the editor
+
+        String renderedPage9 = getHtmlSource();
+        assertTrue("Fixed up link not present", renderedPage9.contains("<a href=\"http://labkey.com\" rel=\"noopener noreferrer\" target=\"_blank\">Fixup</a>"));
+        assertTrue("Safe link mangled", renderedPage9.contains("<a href=\"http://labkey.com\">Safe</a>"));
+
         stopImpersonating();
 
         log("delete wiki web part");

--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -521,10 +521,13 @@ public class WikiLongTest extends BaseWebDriverTest
 
         log("Ensure non-developer can't save script");
         _wikiHelper.createNewWikiPage();
-        setFormElement(Locator.name("name"), WIKI_PAGE5_NAME);
+        setFormElement(Locator.name("name"), "Unsaveable");
         _wikiHelper.setWikiBody(WIKI_PAGE5_CONTENT);
         _wikiHelper.saveWikiPage(false);
         waitForText("There was a problem while saving: Illegal element");
+        _wikiHelper.setWikiBody("<a onclick=\"alert('test');\">test</a>");
+        _wikiHelper.saveWikiPage(false);
+        waitForText("There was a problem while saving: Illegal attribute 'onclick' on element");
 
         stopImpersonating();
 

--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -524,10 +524,10 @@ public class WikiLongTest extends BaseWebDriverTest
         setFormElement(Locator.name("name"), "Unsaveable");
         _wikiHelper.setWikiBody(WIKI_PAGE5_CONTENT);
         _wikiHelper.saveWikiPage(false);
-        waitForText("There was a problem while saving: Illegal element");
+        waitForText("There was a problem while saving: Illegal element <script>. For permissions to use this element, contact your system administrator.");
         _wikiHelper.setWikiBody("<a onclick=\"alert('test');\">test</a>");
         _wikiHelper.saveWikiPage(false);
-        waitForText("There was a problem while saving: Illegal attribute 'onclick' on element");
+        waitForText("There was a problem while saving: Illegal attribute 'onclick' on element <a>");
 
         stopImpersonating();
 

--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @Category({Daily.class, Wiki.class})
@@ -121,11 +122,10 @@ public class WikiLongTest extends BaseWebDriverTest
                     ## Subtitle MD
                     *italic text MD*
                     """;
-    private static final String WIKI_PAGE9_CONTENT =
-            """
-            <a href="http://labkey.com" target="_blank">Fixup</a>
-            <a href="http://labkey.com">Safe link</a>
-            """;
+
+    private static final String SAFE_LINK_HTML = "<a href=\"http://labkey.com\">Safe link</a>";
+    private static final String FIXUP_LINK_HTML = "<a href=\"http://labkey.com\" target=\"_blank\">Fixup</a>";
+    private static final String WIKI_PAGE9_CONTENT = SAFE_LINK_HTML + "\n" + FIXUP_LINK_HTML;
 
     private static final String NAVBAR1_CONTENT =
             "{labkey:tree|name=core.currentProject}";
@@ -516,8 +516,9 @@ public class WikiLongTest extends BaseWebDriverTest
         assertTextNotPresent("New Page");  // Should not be an error, so should have left the editor
 
         String renderedPage9 = getHtmlSource();
+        assertFalse("Link needing fixup wasn't fixed up", renderedPage9.contains(FIXUP_LINK_HTML));
         assertTrue("Fixed up link not present", renderedPage9.contains("<a href=\"http://labkey.com\" rel=\"noopener noreferrer\" target=\"_blank\">Fixup</a>"));
-        assertTrue("Safe link mangled", renderedPage9.contains("<a href=\"http://labkey.com\">Safe link</a>"));
+        assertTrue("Safe link mangled", renderedPage9.contains(SAFE_LINK_HTML));
 
         log("Ensure non-developer can't save script");
         _wikiHelper.createNewWikiPage();

--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -517,7 +517,14 @@ public class WikiLongTest extends BaseWebDriverTest
 
         String renderedPage9 = getHtmlSource();
         assertTrue("Fixed up link not present", renderedPage9.contains("<a href=\"http://labkey.com\" rel=\"noopener noreferrer\" target=\"_blank\">Fixup</a>"));
-        assertTrue("Safe link mangled", renderedPage9.contains("<a href=\"http://labkey.com\">Safe</a>"));
+        assertTrue("Safe link mangled", renderedPage9.contains("<a href=\"http://labkey.com\">Safe link</a>"));
+
+        log("Ensure non-developer can't save script");
+        _wikiHelper.createNewWikiPage();
+        setFormElement(Locator.name("name"), WIKI_PAGE5_NAME);
+        _wikiHelper.setWikiBody(WIKI_PAGE5_CONTENT);
+        _wikiHelper.saveWikiPage(false);
+        waitForText("There was a problem while saving: Illegal element");
 
         stopImpersonating();
 

--- a/src/org/labkey/test/util/WikiHelper.java
+++ b/src/org/labkey/test/util/WikiHelper.java
@@ -134,10 +134,14 @@ public class WikiHelper
     {
         String title = Locator.id("wiki-input-title").findElement(_test.getDriver()).getText();
         if (title.equals("")) title = Locator.id("wiki-input-name").findElement(_test.getDriver()).getText();
-        _test.clickButton("Save & Close");
         if (expectSuccess)
         {
+            _test.clickButton("Save & Close");
             _test.waitForElement(Locator.linkWithText(title));
+        }
+        else
+        {
+            _test.clickButton("Save & Close", 0);
         }
     }
 

--- a/src/org/labkey/test/util/WikiHelper.java
+++ b/src/org/labkey/test/util/WikiHelper.java
@@ -127,10 +127,18 @@ public class WikiHelper
 
     public void saveWikiPage()
     {
+        saveWikiPage(true);
+    }
+
+    public void saveWikiPage(boolean expectSuccess)
+    {
         String title = Locator.id("wiki-input-title").findElement(_test.getDriver()).getText();
         if (title.equals("")) title = Locator.id("wiki-input-name").findElement(_test.getDriver()).getText();
         _test.clickButton("Save & Close");
-        _test.waitForElement(Locator.linkWithText(title));
+        if (expectSuccess)
+        {
+            _test.waitForElement(Locator.linkWithText(title));
+        }
     }
 
     /**


### PR DESCRIPTION
#### Rationale
jTidy appears abandoned and doesn't support common HTML5 tag elements

[Issue #43420: Replace jTidy with jSoup...or similar](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43420)

### Related
* https://github.com/LabKey/platform/pull/4542

#### Changes
* Swapped jSoup library in place of jTidy
* Add test coverage for script detection