### PR TITLE
wait for comment text area to exist before interacting

### DIFF
--- a/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
+++ b/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
@@ -1,6 +1,7 @@
 package org.labkey.test.components.ui;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.bootstrap.ModalDialog;
@@ -34,6 +35,14 @@ public class DeleteConfirmationDialog<SourcePage extends WebDriverWrapper, Confi
         super(finder);
         _sourcePage = sourcePage;
         _confirmPageSupplier = confirmPageSupplier;
+    }
+
+    @Override
+    protected void waitForReady()
+    {
+        WebDriverWrapper.waitFor(()-> elementCache().body.isDisplayed() &&
+                        !BootstrapLocators.loadingSpinner.existsIn(this),
+                "The 'Choose Samples to Add' dialog did not display.", 1_000);
     }
 
     public SourcePage cancelDelete()

--- a/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
+++ b/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
@@ -62,7 +62,7 @@ public class DeleteConfirmationDialog<SourcePage extends WebDriverWrapper, Confi
 
     public DeleteConfirmationDialog setUserComment(String comment)
     {
-        WebElement commentInput = Locator.tag("textarea").findWhenNeeded(this);
+        WebElement commentInput = Locator.tag("textarea").waitForElement(this, 1000);
         commentInput.click();
         commentInput.sendKeys(comment);
         return this;


### PR DESCRIPTION
#### Rationale
Recently tests have been observed to [fail ](https://teamcity.labkey.org/viewLog.html?buildId=2548370&buildTypeId=LabKey_237Release_Internal_CloudInfrastructure_TrialLimsIntegrationTest&fromSakuraUI=true#testNameId-3204144024052112041) while interacting with a DeleteConfirmationDialog because framework code assumes the comment textArea element will be present and interactable.  Artifacts show it to be absent, a loading spinner being shown.

This causes DeleteConfirmationDialog to wait for its body element to be displayed, and for the dialog to not contain a loading spinner, and it now waits for up to a second for the comment textarea to be present, hopefully that will prevent test noise/uninteresting failures

#### Related Pull Requests
n/a

#### Changes

- [x] wait for up to a second for the textArea to be present
- [x] implement waitForReady for DeleteConfirmationDialog
