### PR TITLE
wait for link element to exist

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailTable.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTable.java
@@ -1,7 +1,6 @@
 package org.labkey.test.components.ui.grids;
 
 import org.labkey.test.Locator;
-import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
 import org.openqa.selenium.By;
@@ -123,7 +122,7 @@ public class DetailTable extends WebDriverComponent<DetailTable.ElementCache>
     {
         // Should not click the container, it could be a td which would miss the clickable element.
         // Maybe this shouldn't assume an anchor but should be a generic(*)?
-        Locator.tag("a").findElement(getField(fieldCaption)).click();
+        Locator.tag("a").waitForElement(getField(fieldCaption), 1500).click();
     }
 
     /**


### PR DESCRIPTION
#### Rationale
Recently, BiologicsTest.testProteinRegistrationWithTrickyCharacters [failed ](https://teamcity.labkey.org/viewLog.html?buildId=2558950&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_LimsStarter_LimsStarterPostgres&fromSakuraUI=true#testNameId718259160189762974) because its call to DetailTable.clickField could't find the css=a tag in the Nuc Sequences field- the link is there in the screencap image post-failure, but is absent from the html page artifact.  This suggests that DetailTable.clickField should await the presence of the tag.

#### Related Pull Requests
n/a

#### Changes

- [x] wait for css=a tag, for up to 1500msec 
