### PR TITLE
Add to Storage From Grid - sample position editable grid

### DIFF
--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -848,7 +848,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
     public static class EditableGridFinder extends WebDriverComponent.WebDriverComponentFinder<EditableGrid, EditableGridFinder>
     {
-        private final Locator _locator = Locator.byClass("table-cellular");
+        private final Locator _locator = Locator.byClass("editable-grid__container").descendant(Locator.byClass("table-cellular"));
 
         public EditableGridFinder(WebDriver driver)
         {


### PR DESCRIPTION
#### Rationale
This is the next story in the "Improve Freezer View during Add to Storage" epic. This set of PRs adds a 2nd step to the Add to Storage modal which shows the editable grid for the selected storage location(s) to allow setting the location properties (amount, units, F/T count).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1249
- https://github.com/LabKey/labkey-ui-premium/pull/146
- https://github.com/LabKey/inventory/pull/945
- https://github.com/LabKey/sampleManagement/pull/1991
- https://github.com/LabKey/biologics/pull/2266

#### Changes
- Update/fix locator for EditableGrid finder to be more specific when there might be two `<Grid>` components on the page
