### PR TITLE
give menu toggles a moment to become interactable before clicking

### DIFF
--- a/src/org/labkey/test/components/react/BaseBootstrapMenu.java
+++ b/src/org/labkey/test/components/react/BaseBootstrapMenu.java
@@ -7,6 +7,10 @@ import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
 
 /**
  * Wraps basic open/close functionality of 'Dropdown' and 'DropdownButton' components from '@types/react-bootstrap'
@@ -54,6 +58,8 @@ public abstract class BaseBootstrapMenu extends WebDriverComponent<BaseBootstrap
         if (!isExpanded())
         {
             getWrapper().scrollIntoView(elementCache().toggleAnchor);
+            new WebDriverWait(getDriver(), Duration.ofSeconds(2))
+                    .until(ExpectedConditions.elementToBeClickable(elementCache().toggleAnchor));
             for (int retry = 0; retry < _expandRetryCount; retry++)
             {
                 elementCache().toggleAnchor.click();
@@ -73,7 +79,11 @@ public abstract class BaseBootstrapMenu extends WebDriverComponent<BaseBootstrap
     public void collapse()
     {
         if (isExpanded())
+        {
+            new WebDriverWait(getDriver(), Duration.ofSeconds(2))
+                    .until(ExpectedConditions.elementToBeClickable(elementCache().toggleAnchor));
             elementCache().toggleAnchor.click();
+        }
         WebDriverWrapper.waitFor(()-> !isExpanded(), "Menu did not collapse as expected", WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
     }
 


### PR DESCRIPTION
#### Rationale
Recently, testGridViewAcrossFolders (in BiologicsComponentTest) began [failing ]([BiologicsComponentTest.testGridViewAcrossFolders](https://teamcity.labkey.org/viewLog.html?buildId=2567485&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_LimsStarter_LimsStarterPostgres&fromSakuraUI=true#testNameId6418676379570466375)) due to the view selection menu not expanding after 10 seconds.

This failure defies ready local repro, so this change tests the theory that the menu toggle wasn't interactable when the test tried clicking it (in context, the test just dismissed the 'save view' dialog) by causing the expand and collapse menus to wait for up to 2 seconds for the toggle to become clickable before clicking.

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/2274

#### Changes
wait for toggle to be interactable before clicking it
