### PR TITLE
await expected conditions after tab delete

### DIFF
--- a/src/org/labkey/test/tests/TabTest.java
+++ b/src/org/labkey/test/tests/TabTest.java
@@ -19,8 +19,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.components.BodyWebPart;
 import org.labkey.test.components.labkey.PortalTab;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LabKeyExpectedConditions;
@@ -30,6 +30,7 @@ import org.labkey.test.util.PortalHelper;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -114,14 +115,23 @@ public class TabTest extends SimpleModuleTest
         String tab2Delete = "RENAMED TAB 1";
         portalHelper.activateTab(tab2Delete);
         portalHelper.deleteTab("Test Tab 2");
-        List<BodyWebPart> bodyparts = portalHelper.getBodyWebParts();
-        assertTrue("Webparts failed to load after tab delete while on page", bodyparts != null && bodyparts.size() > 0);
-        assertEquals("Wrong tab selected after tab deletion", tab2Delete, getText(PortalHelper.Locators.activeTab().containing(tab2Delete)).replace(Locator.NBSP, " ").trim());
+        WebDriverWrapper.waitFor(()-> portalHelper.getBodyWebParts().size() > 0,
+                "Webparts failed to load after tab delete while on page", 2000);
+        WebDriverWrapper.waitFor(()-> {
+                    try
+                    {
+                        return getText(PortalHelper.Locators.activeTab())
+                                .replace(Locator.NBSP, " ").equals(tab2Delete);
+                    }catch (NoSuchElementException retry)
+                    {
+                        return false;
+                    }
+                }, "Wrong tab selected after tab deletion", 2000);
 
         //Delete tab while on the Tab
         portalHelper.deleteTab(tab2Delete);
-        bodyparts = portalHelper.getBodyWebParts();
-        assertTrue("Webparts failed to load after tab delete", bodyparts != null && bodyparts.size() > 0);
+        WebDriverWrapper.waitFor(()-> portalHelper.getBodyWebParts().size() > 0,
+                "Webparts failed to load after tab delete while on page", 2000);
     }
 
     @LogMethod


### PR DESCRIPTION
#### Rationale
Recently TabTest has been failing because asserts intended to verify the count of body webparts after deleting a tab seem to either be happening more quickly than before, or the re-rendering of the page after deleting a tab is taking longer than it did.

Also, this change awaits the expected active tab after deleting a tab, versus failing if it's not instantly present

#### Related Pull Requests
n/a

#### Changes

- [x] await non-zero body webpart count after deleting a tab, vs. asserting without waiting
- [x] await expected active tab, vs. asserting it to be instantly present
