### PR TITLE
Wait for page loads in alert and tab operations

### DIFF
--- a/src/org/labkey/test/components/labkey/LabKeyAlert.java
+++ b/src/org/labkey/test/components/labkey/LabKeyAlert.java
@@ -85,7 +85,9 @@ public class LabKeyAlert extends ModalDialog implements Alert
 
     public void clickButton(String buttonText)
     {
-        getWrapper().clickAndWait(Locator.linkWithText(buttonText).findElement(this));
+        WebElement button = Locator.linkWithText(buttonText).findElement(this);
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(button));
+        getWrapper().clickAndWait(button);
     }
 
     @Override

--- a/src/org/labkey/test/components/labkey/PortalTab.java
+++ b/src/org/labkey/test/components/labkey/PortalTab.java
@@ -147,7 +147,7 @@ public class PortalTab extends WebDriverComponent<PortalTab.ElementCache>
     {
         getWrapper().log("Attempting to show tab [" + getName() + "]");
         String text = getText();
-        getMenu().clickSubMenu(false,"Show");
+        getMenu().clickSubMenu(true,"Show");
         return PortalTab.find(text, getDriver());
     }
 
@@ -155,7 +155,7 @@ public class PortalTab extends WebDriverComponent<PortalTab.ElementCache>
     {
         getWrapper().log("Attempting to hide tab [" + getName() + "]");
         String text = getText();
-        getMenu().clickSubMenu(false,"Hide");
+        getMenu().clickSubMenu(true,"Hide");
         return PortalTab.find(text, getDriver());
     }
 
@@ -163,7 +163,7 @@ public class PortalTab extends WebDriverComponent<PortalTab.ElementCache>
     {
         getWrapper().log("Attempting to delete tab [" + getName() + "]");
         String text = getText();
-        getMenu().clickSubMenu(false,"Delete");
+        getMenu().clickSubMenu(true,"Delete");
     }
 
     /* clicking 'rename' will pop a form to take the name */
@@ -203,7 +203,7 @@ public class PortalTab extends WebDriverComponent<PortalTab.ElementCache>
         return new ElementCache();
     }
 
-    protected class ElementCache extends Component.ElementCache
+    protected class ElementCache extends Component<?>.ElementCache
     {
         WebElement anchor = Locator.xpath("./a").findElement(getComponentElement());
     }

--- a/src/org/labkey/test/tests/TabTest.java
+++ b/src/org/labkey/test/tests/TabTest.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.tests;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
@@ -49,7 +50,7 @@ public class TabTest extends SimpleModuleTest
     }
 
     @Override
-    @Test
+    @Ignore
     public void testModuleProperties()
     {
         //do nothing


### PR DESCRIPTION
#### Rationale
Fixing a couple of timing errors that popped up with a recent JavaScript refactor.

`TabTest` isn't waiting for page loads after deleting a tab.
```
org.openqa.selenium.StaleElementReferenceException: The element reference of <div id="webpart_282" name="webpart"> is stale; either the element is no longer attached to the DOM, it is not in the current frame context, or the document has been refreshed
[...]
  at app//org.labkey.test.selenium.RefindingWebElement.<init>(RefindingWebElement.java:43)
  at app//org.labkey.test.components.WebPart.<init>(WebPart.java:46)
  at app//org.labkey.test.components.WebPart.<init>(WebPart.java:41)
  at app//org.labkey.test.components.BodyWebPart.<init>(BodyWebPart.java:26)
  at app//org.labkey.test.util.PortalHelper.getBodyWebParts(PortalHelper.java:228)
  at app//org.labkey.test.tests.TabTest.lambda$0(TabTest.java:118)
  at app//org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2185)
  at app//org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2217)
  at app//org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2212)
  at app//org.labkey.test.tests.TabTest.doTabManagementTests(TabTest.java:118)
  at app//org.labkey.test.tests.TabTest.doVerifySteps(TabTest.java:46)
  at app//org.labkey.test.tests.SimpleModuleTest.testSteps(SimpleModuleTest.java:247)
```

`NabAssayTest` is attempting to accept a confirmation dialog but the component helper doesn't wait for the dialog to be fully visible:
```
org.openqa.selenium.ElementNotInteractableException: Element <a id="confirmSubmitBtn" class="btn btn-default"> could not be scrolled into view
[...]
  at app//org.labkey.test.components.labkey.LabKeyAlert.clickButton(LabKeyAlert.java:88)
  at app//org.labkey.test.tests.nab.NabAssayTest.lambda$0(NabAssayTest.java:246)
  at app//org.labkey.test.WebDriverWrapper.lambda$22(WebDriverWrapper.java:1958)
  at app//org.labkey.test.WebDriverWrapper.doAndMaybeWaitForPageToLoad(WebDriverWrapper.java:1986)
  at app//org.labkey.test.WebDriverWrapper.doAndWaitForPageToLoad(WebDriverWrapper.java:1959)
  at app//org.labkey.test.WebDriverWrapper.doAndWaitForPageToLoad(WebDriverWrapper.java:1953)
  at app//org.labkey.test.tests.nab.NabAssayTest.runUITests(NabAssayTest.java:241)
```

#### Related Pull Requests
* N/A

#### Changes
* Wait for buttons to be clickable in LabKeyAlert
* Wait for page loads when adding or removing portal tabs