### PR TITLE
Issue 47845: Multistep ETL stored procedure transform with no source

### DIFF
--- a/modules/ETLtest/resources/ETLs/SProcModifiedSinceNoSourceMultiStep.xml
+++ b/modules/ETLtest/resources/ETLs/SProcModifiedSinceNoSourceMultiStep.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>Stored Proc Modified Since No Source Multi Step</name>
+    <description>Multi Step using Modified Since filter and SP with no SP source</description>
+    <transforms>
+        <transform id="step1" type="org.labkey.di.pipeline.TransformTask">
+            <description>Copy to target</description>
+            <source schemaName="etltest" queryName="source" />
+            <destination schemaName="etltest" queryName="target" bulkLoad="true" targetOption="append">
+                <alternateKeys>
+                    <column name="id"/>
+                </alternateKeys>
+            </destination>
+        </transform>
+        <transform id="step2" type="StoredProcedure">
+            <procedure schemaName="etltest" procedureName="etlTest" useTransaction="false">
+                <parameter name="@testMode" value="1"/>
+                <parameter name="testInOutParam" value="before"/>
+            </procedure>
+        </transform>
+    </transforms>
+    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified" />
+    <schedule>
+        <poll interval="60m" />
+    </schedule>
+</etl>


### PR DESCRIPTION
#### Rationale
Add test ETL for the case when a stored procedure step with no source is in a multistep ETL with a modified since filter.

#### Related Pull Requests
* https://github.com/LabKey/dataintegration/pull/227

#### Changes
* Add SProcModifiedSinceNoSourceMultiStep.xml
