### PR TITLE
fix intermittent knitr test failure

### DIFF
--- a/data/knitr/knitr.lib.xml
+++ b/data/knitr/knitr.lib.xml
@@ -1,8 +1,7 @@
 <libraries xmlns="http://labkey.org/clientLibrary/xml/">
     <library compileInProductionMode="false"/>
     <dependencies>
-        <dependency path="https://ajax.aspnetcdn.com/ajax/jquery/jquery-1.9.0.min.js"/>
-        <dependency path="https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.9.4/jquery.dataTables.min.js"/>
+        <dependency path="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"/>
     </dependencies>
 </libraries>
 

--- a/modules/scriptpad/resources/reports/schemas/kable.report.xml
+++ b/modules/scriptpad/resources/reports/schemas/kable.report.xml
@@ -6,9 +6,8 @@
     <reportType>
         <R>
             <dependencies>
-                <dependency path="https://ajax.aspnetcdn.com/ajax/jquery/jquery-1.9.0.min.js"/>
-                <dependency path="https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.9.4/jquery.dataTables.min.js"/>
-                <dependency path="https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.9.4/css/jquery.dataTables.css"/>
+                <dependency path="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"/>
+                <dependency path="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css"/>
             </dependencies>
         </R>
     </reportType>

--- a/src/org/labkey/test/tests/KnitrReportTest.java
+++ b/src/org/labkey/test/tests/KnitrReportTest.java
@@ -110,10 +110,10 @@ public class KnitrReportTest extends AbstractKnitrReportTest
         {
             deleteLibXml();
         }
-        verifyAdhocReportDependencies("Strings",
-                "https://ajax.aspnetcdn.com/ajax/jquery/jquery-1.9.0.min.js;" +
-                "https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.9.4/jquery.dataTables.min.js;\r\n" +
-                "https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.9.4/css/jquery.dataTables.css"
+
+            verifyAdhocReportDependencies("Strings",
+                "https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js;\r\n" +
+                "https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css"
         );
     }
 


### PR DESCRIPTION
#### Rationale
The `KnitrReportTest.testAdhocReportDependenciesString` would fail intermittently with a javascript error similar to this
```
ERROR AdminController          2023-08-18T22:09:58,440     http-nio-8111-exec-5 : Client exception detected:
http://localhost:8111/labkey/KnitrReportProject/reports-createScriptReport.view?scriptExtension=&tabId=Source&reportType=ReportService.rReport&redirectUrl=%2Flabkey%2FKnitrReportProject%2Freports-manageViews.view
http://localhost:8111/labkey/KnitrReportProject/reports-createScriptReport.view?scriptExtension=&tabId=Source&reportType=ReportService.rReport&redirectUrl=%2Flabkey%2FKnitrReportProject%2Freports-manageViews.view
Mozilla/5.0 (X11; Linux x86_64; rv:102.0) Gecko/20100101 Firefox/102.0
teamcity@labkey.test
TypeError: $(...).dataTable is not a function
  http://localhost:8111/labkey/KnitrReportProject/reports-createScriptReport.view?scriptExtension=&tabId=Source&reportType=ReportService.rReport&redirectUrl=%2Flabkey%2FKnitrReportProject%2Freports-manageViews.view line 129 > injectedScript:3:28
  mightThrow (http://localhost:8111/labkey/internal/jQuery/jquery-3.5.1.js:3762:29)
  Deferred/then/resolve/</process< (http://localhost:8111/labkey/internal/jQuery/jquery-3.5.1.js:3830:12)
```
The root cause was that the `kable` report had dependencies on a `jquery` data table library but also included a specific version of `jquery:1.9.0` this is different from the 3.5.1 version that we include on every page. The LABKEY script/css dependency utilities do not guarantee the order that the browser loads scripts. This introduced a race condition where occasionally the report would get the 3.5.1 version of `jquery`.

I've updated the report to use a more recent version of `dataTable` that is compatible with `jquery:3.5.1` and adjusted the test to expect the newer dependencies.