### PR TITLE
align table cell text helper to new UI

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -159,6 +159,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
     public final static int WAIT_FOR_JAVASCRIPT = 10000;
     public final static int WAIT_FOR_PAGE = 60000;
 
+    @lombok.Getter
     public int defaultWaitForPage = WAIT_FOR_PAGE;
     public int longWaitForPage = defaultWaitForPage * 5;
 
@@ -1474,8 +1475,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
      */
     public void fireEvent(WebElement el, SeleniumEvent event)
     {
-        executeScript("" +
-                "var element = arguments[0];" +
+        executeScript("var element = arguments[0];" +
                 "var eventType = arguments[1];" +
                 "var myEvent = document.createEvent('UIEvent');" +
                 "myEvent.initEvent(" +
@@ -1819,7 +1819,10 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
     public String getTextInNonDataRegionTable(String title, int row, int column)
     {
-        return getTableCellText(Locator.xpath("//div/h3/a/span[text()='" + title + "']/../../../../div/table"), row, column);
+        Locator.XPathLocator tableLoc = Locator.tagWithAttribute("div", "name", "webpart")
+                .withDescendant(Locator.tagWithClass("span", "labkey-wp-title-text").withText(title))
+                .descendant(Locator.tagWithClass("table", "labkey-data-region-legacy"));
+        return getTableCellText(tableLoc, row, column);
     }
 
     public void assertTableRowInNonDataRegionTable(String title, String textToCheck, int row, int column)
@@ -1943,8 +1946,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
     private void waitForDocument()
     {
-        waitFor(() -> null != executeScript("" +
-                "try {return document.documentElement;}" +
+        waitFor(() -> null != executeScript("try {return document.documentElement;}" +
                 "catch(e) {return null;}"), "Document did not load", getDefaultWaitForPage());
     }
 
@@ -3930,11 +3932,6 @@ public abstract class WebDriverWrapper implements WrapsDriver
     public String getAttribute(Locator locator, String attributeName)
     {
         return locator.findElement(getDriver()).getAttribute(attributeName);
-    }
-
-    public int getDefaultWaitForPage()
-    {
-        return defaultWaitForPage;
     }
 
     public void setDefaultWaitForPage(int defaultWaitForPage)

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -159,7 +159,6 @@ public abstract class WebDriverWrapper implements WrapsDriver
     public final static int WAIT_FOR_JAVASCRIPT = 10000;
     public final static int WAIT_FOR_PAGE = 60000;
 
-    @lombok.Getter
     public int defaultWaitForPage = WAIT_FOR_PAGE;
     public int longWaitForPage = defaultWaitForPage * 5;
 
@@ -3932,6 +3931,11 @@ public abstract class WebDriverWrapper implements WrapsDriver
     public String getAttribute(Locator locator, String attributeName)
     {
         return locator.findElement(getDriver()).getAttribute(attributeName);
+    }
+
+    public int getDefaultWaitForPage()
+    {
+        return defaultWaitForPage;
     }
 
     public void setDefaultWaitForPage(int defaultWaitForPage)


### PR DESCRIPTION
#### Rationale
Recent changes to remove inline markup elements caused the finder for a non-dataregion table to [fail ](https://teamcity.labkey.org/viewLog.html?tab=queuedBuildOverviewTab&buildId=2599345&buildTypeId=LabkeyTrunk_DailyPostgres_2&fromSakuraUI=true#testNameId-5979966853213322683) because the locator looking for it expected its dataregion title element to be wrapped in a //div/h3/a/span, but is now in a //div/h3/span/span.  I've taken the liberty to make the locator a little more robust to UI changes like this in the future

#### Related Pull Requests
n/a

#### Changes

- [x] Fixed locator
