### PR TITLE
try to prevent stale reference to textarea

### DIFF
--- a/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
+++ b/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
@@ -41,7 +41,6 @@ public class DeleteConfirmationDialog<SourcePage extends WebDriverWrapper, Confi
     protected void waitForReady()
     {
         WebDriverWrapper.waitFor(()-> elementCache().body.isDisplayed() &&
-                        Locator.tagWithClass("textarea", "form-control").existsIn(this) &&
                         !BootstrapLocators.loadingSpinner.existsIn(this),
                 "The 'Choose Samples to Add' dialog did not display.", 1_000);
     }

--- a/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
+++ b/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
@@ -5,8 +5,8 @@ import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.bootstrap.ModalDialog;
+import org.labkey.test.components.html.Input;
 import org.labkey.test.pages.LabKeyPage;
-import org.openqa.selenium.WebElement;
 
 import java.util.function.Supplier;
 
@@ -41,6 +41,7 @@ public class DeleteConfirmationDialog<SourcePage extends WebDriverWrapper, Confi
     protected void waitForReady()
     {
         WebDriverWrapper.waitFor(()-> elementCache().body.isDisplayed() &&
+                        Locator.tagWithClass("textarea", "form-control").existsIn(this) &&
                         !BootstrapLocators.loadingSpinner.existsIn(this),
                 "The 'Choose Samples to Add' dialog did not display.", 1_000);
     }
@@ -71,9 +72,9 @@ public class DeleteConfirmationDialog<SourcePage extends WebDriverWrapper, Confi
 
     public DeleteConfirmationDialog setUserComment(String comment)
     {
-        WebElement commentInput = Locator.tag("textarea").waitForElement(this, 1000);
-        commentInput.click();
-        commentInput.sendKeys(comment);
+        var commentInput = Input.Input(Locator.tagWithClass("textarea", "form-control"), getDriver()).timeout(2000)
+                .refindWhenNeeded(this);
+        commentInput.set(comment);
         return this;
     }
 }


### PR DESCRIPTION
#### Rationale
Recently,  BiologicsAdminTest.testDeleteEmptyProject began [failing ](https://teamcity.labkey.org/viewLog.html?tab=queuedBuildOverviewTab&buildId=2600117&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_LimsStarter_LimsStarterPostgres&fromSakuraUI=true#testNameId-3845714979850337579)on lims_starter with an error saying that the user-comment textArea was stale.

I've recently observed modal dialog-derived components failing in the same way and it seems that awaiting the component to be ready is helpful- it's possible that the component's lifecycle requires us to wait more rigorously, or to just use refindingElements within it.

#### Related Pull Requests
n/a

#### Changes

- [x] wait for the textArea to be present
- [x] use refindingWebElement for textArea
