### PR TITLE
use awaitility to get a more-expressive wait

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ project.dependencies {
     api("junit:junit:${junitVersion}")
     api("org.seleniumhq.selenium:selenium-api:${seleniumVersion}")
     api("org.assertj:assertj-core:${assertjVersion}")
+    implementation("org.awaitility:awaitility:${awaitilityVersion}")
     implementation("commons-io:commons-io:${commonsIoVersion}")
     implementation("com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}")
     implementation("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 aspectjVersion=1.9.19
 assertjVersion=3.23.1
+awaitilityVersion=4.2.0
 commonsTextVersion=1.10.0
 reflectionsVersion=0.9.10
 hamcrestCoreVersion=1.3


### PR DESCRIPTION
#### Rationale
This change introduces [Awaitility](https://github.com/awaitility/awaitility/wiki/Usage), a library with support for awaiting assert conditions (whether hamcrest or assertj).

I haven't come up with a way to use this with checker (the ability to defer test-ending assert failures and capture screenshots would be nice) and there seems to be a lot of use patterns we could benefit from


#### Related Pull Requests
https://github.com/LabKey/biologics/pull/2314

#### Changes

- [x] pull in awaitility
