### PR TITLE
QueryGrid: Add showChart and closeChart

### DIFF
--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -675,7 +675,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
     public WebElement showChart(String chartName)
     {
         elementCache().chartsMenu.clickSubMenu(false, chartName);
-        return elementCache().svgChart;
+        return elementCache().svgChart();
     }
 
     public void closeChart()
@@ -736,9 +736,10 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
 
         final WebElement chartPanel = Locator.byClass("chart-panel").refindWhenNeeded(this);
 
-        final WebElement svgChart = Locator.byClass("svg-chart")
-                .refindWhenNeeded(chartPanel)
-                .withTimeout(WAIT_FOR_JAVASCRIPT);
+        public WebElement svgChart()
+        {
+            return Locator.byClass("svg-chart").waitForElement(elementCache().chartPanel, WAIT_FOR_JAVASCRIPT);
+        }
 
         final WebElement closeButton = Locator.tagContainingText("button", "Close").refindWhenNeeded(chartPanel);
 

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -672,6 +672,17 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         return this;
     }
 
+    public WebElement showChart(String chartName)
+    {
+        elementCache().chartsMenu.clickSubMenu(false, chartName);
+        return elementCache().svgChart;
+    }
+
+    public void closeChart()
+    {
+        elementCache().closeButton.click();
+    }
+
     /**
      * possible this is either a GridPanel, or a QueryGridPanel (QGP is to be deprecated).
      * use this to test which one so we can fork behavior until QGP is gone
@@ -720,6 +731,16 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         {
             return Locator.xpath("preceding-sibling::div[contains(@class,'panel-heading')]").findWhenNeeded(this);
         }
+
+        final BootstrapMenu chartsMenu = new MultiMenu.MultiMenuFinder(getDriver()).withText("Charts").findWhenNeeded(this);
+
+        final WebElement chartPanel = Locator.byClass("chart-panel").refindWhenNeeded(this);
+
+        final WebElement svgChart = Locator.byClass("svg-chart")
+                .refindWhenNeeded(chartPanel)
+                .withTimeout(WAIT_FOR_JAVASCRIPT);
+
+        final WebElement closeButton = Locator.tagContainingText("button", "Close").refindWhenNeeded(chartPanel);
 
     }
 


### PR DESCRIPTION
#### Rationale
Add showChart and closeChart methods to QueryGrid so our tests can more easily open and close charts.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/1619
- https://github.com/LabKey/biologics/pull/2323

#### Changes
* QueryGrid: Add showChart and closeChart
