### PR TITLE
Add awaiting method to DeferredErrorCollector

### DIFF
--- a/src/org/labkey/test/util/DeferredErrorCollector.java
+++ b/src/org/labkey/test/util/DeferredErrorCollector.java
@@ -1,6 +1,7 @@
 package org.labkey.test.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.awaitility.core.ConditionTimeoutException;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +26,7 @@ import java.util.Set;
 public class DeferredErrorCollector
 {
     private static final Set<Class<? extends Throwable>> defaultRecordableErrorTypes =
-            Set.of(AssertionError.class);
+            Set.of(AssertionError.class, ConditionTimeoutException.class);
 
     private final ArtifactCollector artifactCollector;
     private final List<DeferredError> allErrors = new ArrayList<>();


### PR DESCRIPTION
#### Rationale
Integrating basing awaitility assertion functionality into DeferredErrorCollector.
The previous pattern of creating a bunch of subclasses doesn't work when we might want to mix functionality of several of them (awaiting + screenshot for example)

#### Related Pull Requests
* #1617 

#### Changes
* Add `checker().await(Duration)` method
* Combine `DeferredErrorCollectorWrapper` subclasses into a single class
