### PR TITLE
Update test helper to match database auth dialog change

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -611,8 +611,8 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
             verifyInitialUserError(email, null, null, "You must enter a password.");
             verifyInitialUserError(email, "LongEnough", null, "You must enter a password.");
             verifyInitialUserError(email, null, "LongEnough", "You must enter a password.");
-            verifyInitialUserError(email, "short", "short", "Your password must be at least six characters and cannot contain spaces.");
-            verifyInitialUserError(email, email, email, "Your password must not match your email address.");
+            verifyInitialUserError(email, "short", "short", "Your password is not complex enough.");
+            verifyInitialUserError(email, email, email, "Your password is not complex enough.");
             verifyInitialUserError(email, "LongEnough", "ButDontMatch", "Your password entries didn't match.");
 
             log("Register the first user");

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -37,7 +37,6 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
@@ -170,7 +169,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                 String errors = StringUtils.join(getTexts(Locator.css(".labkey-error").findElements(getDriver())), "\n");
 
                 // If we get redirected here the message is not indicated as an error
-                if (errors.length() == 0 && null != getUrlParam("message", true))
+                if (errors.isEmpty() && null != getUrlParam("message", true))
                     errors = getUrlParam("message", true);
 
                 if (errors.contains("The email address and password you entered did not match any accounts on file."))
@@ -759,7 +758,15 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         clickAndWait(Locator.linkWithText("Next"), 90000); // Initial user creation blocks during upgrade script execution
 
         if (null != expectedError)
+        {
             assertEquals("Wrong error message.", expectedError, Locator.css(".labkey-error").findElement(getDriver()).getText());
+        }
+        else
+        {
+            WebElement element = Locator.css(".labkey-error").findElementOrNull(getDriver());
+            if (null != element)
+                fail("Unexpected error: " + element.getText());
+        }
     }
 
     private void verifyInitialUserRedirects()

--- a/src/org/labkey/test/pages/core/login/DatabaseAuthConfigureDialog.java
+++ b/src/org/labkey/test/pages/core/login/DatabaseAuthConfigureDialog.java
@@ -82,7 +82,7 @@ public class DatabaseAuthConfigureDialog extends AuthDialogBase<DatabaseAuthConf
         {
             JSONObject params = new JSONObject();
             params.put("expiration", oldExpiration != null ? oldExpiration.name() : PasswordExpiration.Never.name());
-            params.put("strength", oldStrength != null ? oldStrength.name() : PasswordStrength.Strong.name());
+            params.put("strength", oldStrength != null ? oldStrength.name() : PasswordStrength.Good.name());
             SimplePostCommand postCommand = new SimplePostCommand("login", "SaveDbLoginProperties");
             postCommand.setJsonObject(params);
             try
@@ -100,8 +100,7 @@ public class DatabaseAuthConfigureDialog extends AuthDialogBase<DatabaseAuthConf
 
     public enum PasswordStrength implements OptionSelect.SelectOption
     {
-        Weak,
-        Strong;
+        Weak, Good, Strong;
 
         @Override
         public String getValue()

--- a/src/org/labkey/test/pages/core/login/DatabaseAuthConfigureDialog.java
+++ b/src/org/labkey/test/pages/core/login/DatabaseAuthConfigureDialog.java
@@ -10,7 +10,6 @@ import org.labkey.test.components.html.OptionSelect;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 
 import java.io.IOException;
 
@@ -32,9 +31,7 @@ public class DatabaseAuthConfigureDialog extends AuthDialogBase<DatabaseAuthConf
     // get password strength
     public PasswordStrength getPasswordStrength()
     {
-        if (elementCache().weakButton.getAttribute("class").contains("active"))
-            return PasswordStrength.Weak;
-        else return PasswordStrength.Strong;
+        return PasswordStrength.valueOf(elementCache().passwordStrengthSelect.getSelection().getValue());
     }
 
     public DatabaseAuthConfigureDialog setPasswordStrength(PasswordStrength newStrength)
@@ -42,13 +39,10 @@ public class DatabaseAuthConfigureDialog extends AuthDialogBase<DatabaseAuthConf
         if (getPasswordStrength().equals(newStrength))
             return this;
 
-        if (newStrength.equals(PasswordStrength.Strong))
-            elementCache().strongButton.click();
-        else
-            elementCache().weakButton.click();
-
+        elementCache().passwordStrengthSelect.selectOption(newStrength);
         WebDriverWrapper.waitFor(()-> getPasswordStrength().equals(newStrength),
-                "the password strength was not set to desired state ["+newStrength.toString()+"] in time", 1000);
+                "the password strength was not set to desired state ["+ newStrength +"] in time", 1000);
+
         return this;
     }
 
@@ -60,7 +54,7 @@ public class DatabaseAuthConfigureDialog extends AuthDialogBase<DatabaseAuthConf
 
     public PasswordExpiration getPasswordExpiration()
     {
-        return  PasswordExpiration.valueOf(elementCache().passwordExpirationSelect.getSelection().getValue());
+        return PasswordExpiration.valueOf(elementCache().passwordExpirationSelect.getSelection().getValue());
     }
 
     @Override
@@ -104,7 +98,18 @@ public class DatabaseAuthConfigureDialog extends AuthDialogBase<DatabaseAuthConf
         }
     }
 
-    public enum PasswordStrength {Weak, Strong}
+    public enum PasswordStrength implements OptionSelect.SelectOption
+    {
+        Weak,
+        Strong;
+
+        @Override
+        public String getValue()
+        {
+            return name();
+        }
+    }
+
     public enum PasswordExpiration implements OptionSelect.SelectOption
     {
         Never, FiveSeconds, ThreeMonths, SixMonths, OneYear;
@@ -140,11 +145,9 @@ public class DatabaseAuthConfigureDialog extends AuthDialogBase<DatabaseAuthConf
     protected class ElementCache extends AuthDialogBase.ElementCache
     {
         OptionSelect<PasswordExpiration> passwordExpirationSelect = new OptionSelect<>(Locator.tagWithName("select", "expiration")
-                .findWhenNeeded(this).withTimeout(2000));
+            .findWhenNeeded(this).withTimeout(2000));
 
-        WebElement strongButton = Locator.button("Strong").refindWhenNeeded(this).withTimeout(4000);
-        WebElement weakButton = Locator.button("Weak").refindWhenNeeded(this).withTimeout(4000);
+        OptionSelect<PasswordStrength> passwordStrengthSelect = new OptionSelect<>(Locator.tagWithName("select", "strength")
+            .findWhenNeeded(this).withTimeout(2000));
     }
-
-
 }

--- a/src/org/labkey/test/tests/SecurityApiTest.java
+++ b/src/org/labkey/test/tests/SecurityApiTest.java
@@ -24,6 +24,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.util.APITestHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
+import org.labkey.test.util.PasswordUtil;
 
 import java.io.File;
 import java.util.Arrays;
@@ -40,7 +41,7 @@ public class SecurityApiTest extends BaseWebDriverTest
     private static final String GROUP_1 = "testgroup1";
     private static final String GROUP_2 = "testgroup2";
     private static final String ADMIN_USER = "security-api@clientapi.test";
-    private static final String ADMIN_USER_PWD = "Pa$$w0rd";
+    private static final String ADMIN_USER_PWD = PasswordUtil.getPassword();
     private static final String USER_CREATED_BY_API = "api-created-user@securityapi.test"; // This email value is found in the security-api.xml file for the "create new user" test.
 
     protected File[] getTestFiles()

--- a/src/org/labkey/test/tests/SecurityTest.java
+++ b/src/org/labkey/test/tests/SecurityTest.java
@@ -793,9 +793,9 @@ public class SecurityTest extends BaseWebDriverTest
         configurePage
                 .getPrimaryConfigurationRow("Standard database authentication")
                 .clickEdit(new DatabaseAuthenticationProvider())
-                .setDbLoginConfig(DatabaseAuthConfigureDialog.PasswordStrength.Strong,
+                .setDbLoginConfig(DatabaseAuthConfigureDialog.PasswordStrength.Good,
                                 DatabaseAuthConfigureDialog.PasswordExpiration.Never);
-        // don't click 'Save and Finish' here; setting to strong/never in dbAuth doesn't require a page-level submit
+        // don't click 'Save and Finish' here; setting to good/never in dbAuth doesn't require a page-level submit
 
         setInitialPassword(NORMAL_USER, simplePassword);
         assertTextPresent("Your password must contain three of the following"); // fail, too simple

--- a/src/org/labkey/test/tests/UserTest.java
+++ b/src/org/labkey/test/tests/UserTest.java
@@ -36,6 +36,7 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.IssuesHelper;
+import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.UIUserHelper;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -56,7 +57,7 @@ import static org.junit.Assert.assertTrue;
 public class UserTest extends BaseWebDriverTest
 {
     private static final String[] REQUIRED_FIELDS = {"FirstName", "LastName", "Phone", "Mobile"};
-    private static final String TEST_PASSWORD = "0asdfgh!";
+    private static final String TEST_PASSWORD = PasswordUtil.getPassword();
 
     /**copied from LoginController.EMAIL_PASSWORDMISMATCH_ERROR, but needs to be broken into multiple separate sentences,
      *  the search function can't handle the line breaks


### PR DESCRIPTION
#### Rationale
The list of database auth strength options has expanded and the dialog now uses a drop-down list instead of buttons

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4707