### PR TITLE
Update reference to renamed module

### DIFF
--- a/buildTestModules/starterArtifacts/build.gradle
+++ b/buildTestModules/starterArtifacts/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     modules ("org.labkey.module:dataintegration:${labkeyVersion}@module") {
         transitive = true
     }
-    modules ("org.labkey.module:duo:${labkeyVersion}@module") {
+    modules ("org.labkey.module:mfa:${labkeyVersion}@module") {
         transitive = true
     }
     modules ("org.labkey.module:ldap:${labkeyVersion}@module") {


### PR DESCRIPTION
#### Rationale
This should have been updated when the Duo module was generalized to `mfa`

#### Related Pull Requests
* https://github.com/LabKey/distributions/pull/401

#### Changes
* Update dependency on renamed module `duo` -> `mfa`
