### PR TITLE
Don't ping healthcheck in a tight loop during bootstrap

### DIFF
--- a/src/org/labkey/test/util/QuickBootstrapPseudoTest.java
+++ b/src/org/labkey/test/util/QuickBootstrapPseudoTest.java
@@ -84,6 +84,7 @@ public class QuickBootstrapPseudoTest extends BaseWebDriverTest
             {
                 lastException = e;
             }
+            sleep(500);
         } while (!timer.isTimedOut());
 
         throw new RuntimeException("Server not done starting up.", lastException);


### PR DESCRIPTION
#### Rationale
When bootstrapping a server via this test, the access log starts with 10MB+ of calls to check whether the server is ready yet. We can probably ease up.

#### Related Pull Requests
* N/A

#### Changes
* Add sleep to avoid hammering healthcheck during bootstrap
