### PR TITLE
Add test helpers that default to using standard password

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -358,6 +358,11 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         WebTestHelper.saveSession(email, getDriver());
     }
 
+    public void attemptSignIn()
+    {
+        attemptSignIn(PasswordUtil.getUsername());
+    }
+
     public void attemptSignIn(String email)
     {
         attemptSignIn(email, PasswordUtil.getPassword());
@@ -409,7 +414,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         return setInitialPassword(user, PasswordUtil.getPassword());
     }
 
-    // Don't call this unless you're actually testing password-related functionality
+    // Don't call this unless you're actually testing authentication functionality
     protected String setInitialPassword(String user, String password)
     {
         beginAt(WebTestHelper.buildURL("security", "showRegistrationEmail", Map.of("email", user)));

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -344,12 +344,23 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         assertEquals("Signed in as wrong user.", PasswordUtil.getUsername(), getCurrentUser());
     }
 
+    // Use default password
+    public void signIn(String email)
+    {
+        signIn(email, PasswordUtil.getPassword());
+    }
+
     // Just sign in & verify -- don't check for startup, upgrade, admin mode, etc.
     public void signIn(String email, String password)
     {
         attemptSignIn(email, password);
         Assert.assertEquals("Logged in as wrong user", email, getCurrentUser());
         WebTestHelper.saveSession(email, getDriver());
+    }
+
+    public void attemptSignIn(String email)
+    {
+        attemptSignIn(email, PasswordUtil.getPassword());
     }
 
     public void attemptSignIn(String email, String password)
@@ -393,7 +404,13 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         assertTrue(String.format("Wrong errors.\nExpected: ['%s']\nActual: '%s'", String.join("',\n'", expectedMessages), errorText), missingErrors.isEmpty());
     }
 
-    protected void setInitialPassword(String user, String password)
+    protected String setInitialPassword(String user)
+    {
+        return setInitialPassword(user, PasswordUtil.getPassword());
+    }
+
+    // Don't call this unless you're actually testing password-related functionality
+    protected String setInitialPassword(String user, String password)
     {
         beginAt(WebTestHelper.buildURL("security", "showRegistrationEmail", Map.of("email", user)));
         // Get setPassword URL from notification email.
@@ -405,6 +422,8 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         setFormElement(Locator.id("password2"), password);
 
         clickButton("Set Password");
+
+        return password;
     }
 
     protected String getPasswordResetUrl(String username)

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -44,7 +44,6 @@ import static org.junit.Assert.assertTrue;
 public class AdminConsoleTest extends BaseWebDriverTest
 {
     protected static final String APP_ADMIN_USER = "app_admin_test_user@adminconsole.test";
-    protected static final String APP_ADMIN_USER_PASS = PasswordUtil.getPassword();
 
     @Override
     public String getProjectName()
@@ -110,9 +109,9 @@ public class AdminConsoleTest extends BaseWebDriverTest
         
         // log out as siteAdmin, log in as appAdmin
         signOut();
-        signIn(APP_ADMIN_USER, APP_ADMIN_USER_PASS);
+        signIn(APP_ADMIN_USER);
 
-        // verify that all of the following links are visible to AppAdmin:
+        // verify that all the following links are visible to AppAdmin:
         goToAdminConsole().goToSettingsSection();
         List<String> expectedLinkTexts = new ArrayList<>(Arrays.asList("change user properties",
                 "folder types",
@@ -271,7 +270,7 @@ public class AdminConsoleTest extends BaseWebDriverTest
     private void createTestUser()
     {
         _userHelper.createUser(APP_ADMIN_USER, true, false);
-        setInitialPassword(APP_ADMIN_USER, APP_ADMIN_USER_PASS);
+        setInitialPassword(APP_ADMIN_USER);
 
         ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
         apiPermissionsHelper.addMemberToRole(APP_ADMIN_USER, "Application Admin", PermissionsHelper.MemberType.user, "/");

--- a/src/org/labkey/test/tests/ProjectTermsOfUseTest.java
+++ b/src/org/labkey/test/tests/ProjectTermsOfUseTest.java
@@ -59,7 +59,7 @@ public class ProjectTermsOfUseTest extends BaseTermsOfUseTest
         // simulate a session expiration and make sure you can still log in to a project with terms.
         signOut();
         beginAt(WebTestHelper.buildURL("login", "login", Maps.of("returnUrl", WebTestHelper.getContextPath() + "/" + PUBLIC_TERMS_PROJECT_NAME + "/project-begin.view")));
-        attemptSignIn(PasswordUtil.getUsername(), PasswordUtil.getPassword());
+        attemptSignIn();
         waitForElement(Locators.labkeyError.containing("you must log in and approve the terms of use"));
         assertTextPresent(PROJECT_TERMS_SNIPPET);
         checkCheckbox(Locators.termsOfUseCheckbox().findElement(getDriver()));

--- a/src/org/labkey/test/tests/SecurityApiTest.java
+++ b/src/org/labkey/test/tests/SecurityApiTest.java
@@ -41,7 +41,6 @@ public class SecurityApiTest extends BaseWebDriverTest
     private static final String GROUP_1 = "testgroup1";
     private static final String GROUP_2 = "testgroup2";
     private static final String ADMIN_USER = "security-api@clientapi.test";
-    private static final String ADMIN_USER_PWD = PasswordUtil.getPassword();
     private static final String USER_CREATED_BY_API = "api-created-user@securityapi.test"; // This email value is found in the security-api.xml file for the "create new user" test.
 
     protected File[] getTestFiles()
@@ -83,7 +82,7 @@ public class SecurityApiTest extends BaseWebDriverTest
 
         // Create the admin user that will be used to call the APIs.
         _userHelper.createUserAndNotify(ADMIN_USER);
-        setInitialPassword(ADMIN_USER, ADMIN_USER_PWD);
+        setInitialPassword(ADMIN_USER);
         apiPermissionsHelper.addUserToSiteGroup(ADMIN_USER, "Site Administrators");
 
     }
@@ -148,7 +147,7 @@ public class SecurityApiTest extends BaseWebDriverTest
         APITestHelper apiTester = new APITestHelper(this);
         apiTester.setTestFiles(getTestFiles());
         apiTester.setIgnoredElements(getIgnoredElements());
-        apiTester.runApiTests(ADMIN_USER, ADMIN_USER_PWD);
+        apiTester.runApiTests(ADMIN_USER);
     }
 
     @Override
@@ -156,5 +155,4 @@ public class SecurityApiTest extends BaseWebDriverTest
     {
         return Arrays.asList("query");
     }
-
 }

--- a/src/org/labkey/test/tests/SecurityLDAPTest.java
+++ b/src/org/labkey/test/tests/SecurityLDAPTest.java
@@ -99,7 +99,7 @@ public class SecurityLDAPTest extends BaseWebDriverTest
         }
         signOut();
 
-        // test: attempt login via ladap and confirm message displayed on login screen
+        // test: attempt login via LDAP and confirm message displayed on login screen
         attemptSignIn(LDAP_USER, LDAP_USER_PASSWORD);
         assertTitleEquals("Sign In");
         assertTextPresent("to have your account created.");

--- a/src/org/labkey/test/tests/UserDetailsPermissionTest.java
+++ b/src/org/labkey/test/tests/UserDetailsPermissionTest.java
@@ -99,9 +99,9 @@ public class UserDetailsPermissionTest extends BaseWebDriverTest
         _userHelper.createUser(USER_INFO_VIEWER, true, true);
         _userHelper.createUser(IMPERSONATED_USER, true, true);
         _userHelper.createUser(CHECKED_USER, true, true);
-        setInitialPassword(ADMIN_USER, PasswordUtil.getPassword());
-        setInitialPassword(USER_INFO_VIEWER, PasswordUtil.getPassword());
-        setInitialPassword(IMPERSONATED_USER, PasswordUtil.getPassword());
+        setInitialPassword(ADMIN_USER);
+        setInitialPassword(USER_INFO_VIEWER);
+        setInitialPassword(IMPERSONATED_USER);
 
         _containerHelper.createProject(getProjectName(), null);
 

--- a/src/org/labkey/test/tests/UserTest.java
+++ b/src/org/labkey/test/tests/UserTest.java
@@ -57,7 +57,6 @@ import static org.junit.Assert.assertTrue;
 public class UserTest extends BaseWebDriverTest
 {
     private static final String[] REQUIRED_FIELDS = {"FirstName", "LastName", "Phone", "Mobile"};
-    private static final String TEST_PASSWORD = PasswordUtil.getPassword();
 
     /**copied from LoginController.EMAIL_PASSWORDMISMATCH_ERROR, but needs to be broken into multiple separate sentences,
      *  the search function can't handle the line breaks
@@ -166,7 +165,7 @@ public class UserTest extends BaseWebDriverTest
     public void testChangeUserEmail()
     {
         new UIUserHelper(this).cloneUser(CHANGE_EMAIL_USER, NORMAL_USER);
-        setInitialPassword(CHANGE_EMAIL_USER, TEST_PASSWORD);
+        setInitialPassword(CHANGE_EMAIL_USER);
 
         //change their email address
         changeUserEmail(CHANGE_EMAIL_USER, CHANGE_EMAIL_USER_ALTERNATE);
@@ -174,12 +173,12 @@ public class UserTest extends BaseWebDriverTest
         signOut();
 
         //verify can log in with new address
-        signIn(CHANGE_EMAIL_USER_ALTERNATE, TEST_PASSWORD);
+        signIn(CHANGE_EMAIL_USER_ALTERNATE);
 
         signOut();
 
         //verify can't log in with old address
-        signInShouldFail(CHANGE_EMAIL_USER, TEST_PASSWORD, EMAIL_PASSWORD_MISMATCH_ERROR);
+        signInShouldFail(CHANGE_EMAIL_USER, PasswordUtil.getPassword(), EMAIL_PASSWORD_MISMATCH_ERROR);
 
         simpleSignIn();
 
@@ -200,7 +199,7 @@ public class UserTest extends BaseWebDriverTest
 
         log("Create a new user.");
         _userHelper.createUser(SELF_SERVICE_EMAIL_USER, true, true);
-        setInitialPassword(SELF_SERVICE_EMAIL_USER, TEST_PASSWORD);
+        setInitialPassword(SELF_SERVICE_EMAIL_USER);
 
         goToHome();
 
@@ -208,7 +207,7 @@ public class UserTest extends BaseWebDriverTest
         impersonate(SELF_SERVICE_EMAIL_USER);
 
         log("Goto the account maintenance page and change the email address.");
-        changeEmailAddress(SELF_SERVICE_EMAIL_USER, SELF_SERVICE_EMAIL_USER_CHANGED, TEST_PASSWORD);
+        changeEmailAddress(SELF_SERVICE_EMAIL_USER, SELF_SERVICE_EMAIL_USER_CHANGED);
 
         goToHome();
 
@@ -264,7 +263,7 @@ public class UserTest extends BaseWebDriverTest
     public void testCustomFieldLogin()
     {
         String customFieldValue = "loginCredentials";
-        setInitialPassword(NORMAL_USER, TEST_PASSWORD);
+        setInitialPassword(NORMAL_USER);
 
         goToSiteUsers();
         DataRegionTable table = new DataRegionTable("Users", getDriver());
@@ -286,11 +285,11 @@ public class UserTest extends BaseWebDriverTest
         signOut();
 
         log("Sign in using custom field value");
-        attemptSignIn(customFieldValue, TEST_PASSWORD);
+        attemptSignIn(customFieldValue);
         Assert.assertEquals("Logged in as wrong user", NORMAL_USER, getCurrentUser());
     }
 
-    private void changeEmailAddress(String currentEmail, String newEmail, String password)
+    private void changeEmailAddress(String currentEmail, String newEmail)
     {
         goToMyAccount();
 
@@ -301,7 +300,7 @@ public class UserTest extends BaseWebDriverTest
 
         assertTextPresent(currentEmail);
 
-        setFormElement(Locator.css("#password"), password);
+        setFormElement(Locator.css("#password"), PasswordUtil.getPassword());
         clickButton("Submit");
     }
 
@@ -415,7 +414,7 @@ public class UserTest extends BaseWebDriverTest
             ensureRequiredFieldsSet();
 
             _userHelper.createUserAndNotify(BLANK_USER);
-            setInitialPassword(BLANK_USER, TEST_PASSWORD);
+            setInitialPassword(BLANK_USER);
 
             DomainDesignerPage domainDesignerPage = goToSiteUsers().clickChangeUserProperties();
             DomainFormPanel domainFormPanel = domainDesignerPage.fieldsPanel();
@@ -441,7 +440,7 @@ public class UserTest extends BaseWebDriverTest
             domainDesignerPage.clickFinish();
 
             signOut();
-            attemptSignIn(BLANK_USER, TEST_PASSWORD);
+            attemptSignIn(BLANK_USER);
             waitForElement(Locator.name("quf_FirstName"));
 
             clickButton("Submit");

--- a/src/org/labkey/test/tests/core/security/AppAdminRoleTest.java
+++ b/src/org/labkey/test/tests/core/security/AppAdminRoleTest.java
@@ -58,7 +58,7 @@ public class AppAdminRoleTest extends BaseWebDriverTest
     {
         _userHelper.createUser(USER);
         _userHelper.createUserAndNotify(APP_ADMIN, true);
-        setInitialPassword(APP_ADMIN, PasswordUtil.getPassword());
+        setInitialPassword(APP_ADMIN);
 
         new ApiPermissionsHelper(this).addUserAsAppAdmin(APP_ADMIN);
     }

--- a/src/org/labkey/test/util/APITestHelper.java
+++ b/src/org/labkey/test/util/APITestHelper.java
@@ -65,7 +65,12 @@ public class APITestHelper
 
     public void runApiTests() throws Exception
     {
-        runApiTests(PasswordUtil.getUsername(), PasswordUtil.getPassword());
+        runApiTests(PasswordUtil.getUsername());
+    }
+
+    public void runApiTests(String username) throws Exception
+    {
+        runApiTests(username, PasswordUtil.getPassword());
     }
 
     public void runApiTests(String username, String password) throws Exception


### PR DESCRIPTION
#### Rationale
Most tests should set and use the standard password to ensure they're adhering to the current password rules. Add and migrate to `setInitialPassword()`, `signIn()`, `attemptSignIn()`, and `runApiTests()` variants that default to the standard password.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4707