### PR TITLE
Attempt to address staleness in delete confirmation dialog

### DIFF
--- a/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
+++ b/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
@@ -41,7 +41,8 @@ public class DeleteConfirmationDialog<SourcePage extends WebDriverWrapper, Confi
     protected void waitForReady()
     {
         WebDriverWrapper.waitFor(()-> elementCache().body.isDisplayed() &&
-                        !BootstrapLocators.loadingSpinner.existsIn(this),
+                !elementCache().title.getText().isEmpty() &&
+                !BootstrapLocators.loadingSpinner.existsIn(this),
                 "The delete confirmation dialog did not become ready.", 1_000);
     }
 

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -15,6 +15,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
 import java.util.Arrays;
@@ -369,6 +370,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     public DetailDataPanel clickSave()
     {
         String title = getSourceTitle();
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().saveButton));
         elementCache().saveButton.click();
 
         // If save causes some update, wait until it is completed.


### PR DESCRIPTION
#### Rationale
Some tests are intermittently [failing ](https://teamcity.labkey.org/viewLog.html?buildId=2624497&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsPostgres&fromSakuraUI=true#testNameId3243660359584709410)in biologics because when trying to set the user comment in DeleteConfirmationDialog, somehow the dialog body element is stale.
DeleteConfirmationDialog is one of the few ModalDialog subclasses that usually doesn't find the dialog by specifying its title, and it's possible that while rendering the component (updating the title) React might re-draw it (?)
I've attempted to address this failure a couple of ways without much success, but this is an attempt to wait until the dialog's title text is not empty (crossing fingers that this works)

#### Related Pull Requests
n/a

#### Changes

- [x] Attempt to improve `DeleteConfirmationDialog.waitforReady`
- [x] Don't click `DetailTableEdit.clickSave` save button until it's clickable
