### PR TITLE
Improve reliability of audit log tests

### DIFF
--- a/src/org/labkey/test/tests/core/security/TroubleshooterRoleTest.java
+++ b/src/org/labkey/test/tests/core/security/TroubleshooterRoleTest.java
@@ -11,6 +11,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Git;
 import org.labkey.test.pages.core.admin.ShowAdminPage;
 import org.labkey.test.pages.core.admin.ShowAuditLogPage;
+import org.labkey.test.params.list.IntListDefinition;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PermissionsHelper;
@@ -39,6 +40,7 @@ public class TroubleshooterRoleTest extends BaseWebDriverTest
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
         _userHelper.deleteUsers(false, TROUBLESHOOTER);
+        _containerHelper.deleteProject(getProjectName(), afterTest);
     }
 
     private void doSetup()
@@ -46,11 +48,15 @@ public class TroubleshooterRoleTest extends BaseWebDriverTest
         _userHelper.createUser(TROUBLESHOOTER);
         ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
         apiPermissionsHelper.addMemberToRole(TROUBLESHOOTER,"Troubleshooter", PermissionsHelper.MemberType.user,"/");
+        _containerHelper.createProject(getProjectName());
     }
 
     @Test
-    public void testAuditLogsIsAccessible() throws IOException
+    public void testAuditLogsIsAccessible() throws Exception
     {
+        // Ensure that there is at least on event to see
+        new IntListDefinition("AuditList", "id").create(createDefaultConnection(), getProjectName());
+
         impersonate(TROUBLESHOOTER);
         ShowAdminPage showAdminPage = goToAdminConsole().goToSettingsSection();
 
@@ -60,7 +66,7 @@ public class TroubleshooterRoleTest extends BaseWebDriverTest
 
         log("Verify the export file is non empty");
         ShowAuditLogPage auditLogPage = showAdminPage.clickAuditLog();
-        auditLogPage.selectView("Domain events"); // Pick something that will have some rows.
+        auditLogPage.selectView("Domain events");
         DataRegionTable logTable = auditLogPage.getLogTable();
         assertTrue("Troubleshooter should see audit entries", logTable.getDataRowCount() > 0);
         File exportedFile = logTable.expandExportPanel().exportText();

--- a/src/org/labkey/test/tests/core/security/TroubleshooterRoleTest.java
+++ b/src/org/labkey/test/tests/core/security/TroubleshooterRoleTest.java
@@ -17,7 +17,6 @@ import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PermissionsHelper;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 


### PR DESCRIPTION
#### Rationale
`TroubleshooterRoleTest` incorrectly assumed that there would be domain audit entries. `AuditLogMaintenanceTest` deletes audit table entries and can cause this test to fail.

#### Related Pull Requests
* N/A

#### Changes
* Create a list before checking audit table permissions
