### PR TITLE
Wait for grid update when saving view

### DIFF
--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -435,7 +435,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
                 dialog.setMakeAvailable(false);
         }
 
-        dialog.saveView();
+        doAndWaitForUpdate(()-> dialog.saveView());
     }
 
     /**

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -435,7 +435,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
                 dialog.setMakeAvailable(false);
         }
 
-        doAndWaitForUpdate(()-> dialog.saveView());
+        dialog.saveView();
     }
 
     /**

--- a/src/org/labkey/test/components/ui/grids/SaveViewDialog.java
+++ b/src/org/labkey/test/components/ui/grids/SaveViewDialog.java
@@ -142,7 +142,7 @@ public class SaveViewDialog extends ModalDialog
      */
     public void saveView()
     {
-        dismiss("Save", 1);
+        grid.doAndWaitForUpdate(()-> dismiss("Save", 1));
     }
 
     /**


### PR DESCRIPTION
#### Rationale
BiologicsComponentTest.testGridViewAcrossFolders has been intermittently [failing ](https://teamcity.labkey.org/viewLog.html?tab=queuedBuildOverviewTab&buildId=2630679&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_LimsStarter_LimsStarterPostgres&fromSakuraUI=true#testNameId6418676379570466375)because The element reference of <span class="alert-info view-edit-alert"> is stale.

In the test's context, the test has just saved a view on the queryGrid of a Samples page, and is attempting to immediately select the default view.  To select any view, the component checks to see if the selection is also the current view, and it seems likely that the call to getEditAlertText() falls in the shuffle of whatever update occurs following the saving of the prior view.

#### Related Pull Requests
n/a

#### Changes

- [x] cause saveView to wait for update (hope there isn't a condition where it shouldn't expect that)
