### PR TITLE
DownloadOutputView: render file names if not empty

### DIFF
--- a/modules/simpletest/resources/reports/schemas/lists/People/Super Cool R Report.r
+++ b/modules/simpletest/resources/reports/schemas/lists/People/Super Cool R Report.r
@@ -13,9 +13,7 @@
         plot(as.factor(labkey.data$name), labkey.data$age, main="Age")
         dev.off()
 
-filename <- paste("do_render", ".gct");
-write.table(labkey.data, file = filename, sep = "\t", qmethod = "double", col.names=NA)
-filename <- paste("dont_render", ".gct");
-write.table(labkey.data, file = filename, sep = "\t", qmethod = "double", col.names=NA)
+write.table(labkey.data, file = "do_render.gct", sep = "\t", qmethod = "double", col.names=NA)
+write.table(labkey.data, file = "dont_render.gct", sep = "\t", qmethod = "double", col.names=NA)
 
 # ${fileout:regex(.*?(do_.*\.gct))}

--- a/src/org/labkey/test/tests/DataReportsTest.java
+++ b/src/org/labkey/test/tests/DataReportsTest.java
@@ -89,7 +89,7 @@ public class DataReportsTest extends ReportTest
     private final static String R_SCRIPT1_TEXT1 = "1965-03-06";
     private final static String R_SCRIPT1_TEXT2 = "1980-08-01";
     private final static String R_SCRIPT1_IMG = "resultImage";
-    private final static String R_SCRIPT1_PDF = "PDF output file (click to download)";
+    private final static String R_SCRIPT1_PDF = "study.pdf";
     private final static String R_FILTERED = "999320565";
     private final static String R_SORT = "DEMsex";
     private final static String R_SORT1 = "Male";

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -1159,7 +1159,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
         assertElementPresent(Locator.xpath("//img[starts-with(@id,'resultImage')]"));
         click(Locator.tagWithAttributeContaining("img", "src", "minus.gif"));
         log("Verify comment based output regex substitution syntax");
-        assertElementPresent(Locator.tagWithText("a", "Text output file (click to download)"));
+        assertElementPresent(Locator.tagWithText("a", "do_render.gct"));
         log("Verify comment based input file substitution syntax");
         assertTextPresent("Adam", "Britt", "Dave");
 


### PR DESCRIPTION
#### Rationale
See the related platform PR for the rationale

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4760

#### Changes
* Update tests to check for specific files names when testing R report file output
