### PR TITLE
Some test helper adjustments for configuring FileWatchers

### DIFF
--- a/src/org/labkey/test/components/pipeline/PipelineTriggerWizard.java
+++ b/src/org/labkey/test/components/pipeline/PipelineTriggerWizard.java
@@ -252,17 +252,18 @@ public class PipelineTriggerWizard extends WebDriverComponent<PipelineTriggerWiz
         getWrapper().clickAndWait(elementCache().saveButton);
     }
 
-    public void saveAndExpectError(String error)
+    public PipelineTriggerWizard saveAndExpectError(String error)
     {
         goToConfiguration();
-        elementCache().saveButton.click();
+        doAndWaitForElementToRefresh(() -> elementCache().saveButton.click(), Locator.tagWithClass("div", "alert-danger"), 10);
         assertTrue("Pipeline Trigger Wizard did not produce an error as expected", elementCache().error.getText().contains(error));
+        return this;
     }
 
     public void cancelEditing()
     {
         goToConfiguration();
-        getWrapper().clickAndWait(elementCache().cancelButton);
+        getWrapper().doAndAcceptUnloadAlert(() -> elementCache().cancelButton.click());
     }
 
     @Override

--- a/src/org/labkey/test/components/pipeline/PipelineTriggerWizard.java
+++ b/src/org/labkey/test/components/pipeline/PipelineTriggerWizard.java
@@ -24,6 +24,7 @@ import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.html.OptionSelect;
+import org.openqa.selenium.Alert;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -263,7 +264,13 @@ public class PipelineTriggerWizard extends WebDriverComponent<PipelineTriggerWiz
     public void cancelEditing()
     {
         goToConfiguration();
-        getWrapper().doAndAcceptUnloadAlert(() -> elementCache().cancelButton.click());
+        elementCache().cancelButton.click();
+
+        // Depending on browser there may or may not be a dirty page alert
+        Alert alert = getWrapper().getAlertIfPresent();
+        if (alert != null) {
+            alert.accept();
+        }
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Adjusting test helpers to handle Cancel button and not saving FileWatcher configuration.
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44895 

#### Related Pull Requests
* Original Fix -- https://github.com/LabKey/premium/pull/318
* Issue Fix -- https://github.com/LabKey/premium/pull/415

#### Changes
* Added wait for Error message to appear after save attempt
* Add Not Saved browser alert check when canceling
