### PR TITLE
Issue 48598: already saved query metadata XML is overridden / removed on a second save

### DIFF
--- a/src/org/labkey/test/tests/experiment/SampleTypeLookupDisplayColumnTest.java
+++ b/src/org/labkey/test/tests/experiment/SampleTypeLookupDisplayColumnTest.java
@@ -7,6 +7,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.query.SourceQueryPage;
 import org.labkey.test.pages.query.UpdateQueryRowPage;
 import org.labkey.test.params.FieldDefinition;
@@ -22,7 +23,7 @@ import java.util.Map;
 
 import static org.junit.Assert.*;
 
-@Category({})
+@Category({Daily.class})
 public class SampleTypeLookupDisplayColumnTest extends BaseWebDriverTest
 {
     private final String TEST_LOOKUP_SAMPLETYPE = "lookupsampletype";

--- a/src/org/labkey/test/tests/issues/IssueAPITest.java
+++ b/src/org/labkey/test/tests/issues/IssueAPITest.java
@@ -13,6 +13,8 @@ import org.labkey.remoteapi.issues.IssueResponseModel;
 import org.labkey.remoteapi.issues.IssuesCommand;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.TestFileUtils;
+import org.labkey.test.categories.Daily;
+import org.labkey.test.categories.Issues;
 import org.labkey.test.util.APIUserHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.IssuesHelper;
@@ -31,7 +33,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.labkey.test.util.PasswordUtil.getUsername;
 
-@Category({})
+@Category({Issues.class, Daily.class})
 public class IssueAPITest extends BaseWebDriverTest
 {
     IssuesHelper _issuesHelper = new IssuesHelper(this);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48598

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4767

#### Changes
* add test case for issue to QueryMetadataTest
* add Daily test category for a couple of other tests that were not running on TC
