### PR TITLE
QueryModel: save settings between page visits

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -75,6 +75,7 @@ import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.html5.WebStorage;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.remote.UnreachableBrowserException;
 import org.openqa.selenium.remote.service.DriverService;
@@ -701,6 +702,18 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                 };
             }
 
+            private void clearLocalStorage()
+            {
+                // Clears browser localStorage. Needed in order to reset some state such as grid filters/sorts/etc.
+                // which are sticky, but can interfere with what tests expect.
+                WebDriver driver = getDriver();
+
+                if (driver instanceof WebStorage webStorage)
+                {
+                    webStorage.getLocalStorage().clear();
+                }
+            }
+
             @Override
             protected void starting(Description description)
             {
@@ -712,6 +725,8 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
                 setUp(); // Instantiate new WebDriver if needed
                 ensureSignedInAsPrimaryTestUser();
+                clearLocalStorage();
+
                 if (_testFailed)
                     resetErrors(); // Clear errors from a previously failed test
                 _testFailed = false;

--- a/src/org/labkey/test/components/ui/grids/GridBar.java
+++ b/src/org/labkey/test/components/ui/grids/GridBar.java
@@ -432,13 +432,18 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
 
     public GridBar clearSearch()
     {
-        if(!elementCache().searchBox.get().isEmpty())
+        if (elementCache().clearSearchButton.isDisplayed())
         {
-            _queryGrid.doAndWaitForUpdate(()->
+            _queryGrid.doAndWaitForUpdate(() ->
             {
-                elementCache().searchBox.set("");
-                elementCache().searchBox.getComponentElement().sendKeys(Keys.ENTER);
+                elementCache().clearSearchButton.click();
             });
+        }
+        else if (!elementCache().searchBox.get().isEmpty())
+        {
+            // Sometimes the search box has something in it, but the filter isn't set, so the clear button isn't visible
+            // This happens when we use beginAt to navigate to the page we're already on.
+            elementCache().searchBox.set("");
         }
         return this;
     }
@@ -476,6 +481,7 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
                 Locator.tagWithAttributeContaining("button", "id", "aliquotviewselector").parent()).findWhenNeeded(this);
 
         protected final Input searchBox = Input.Input(Locator.tagWithClass("input", "grid-panel__search-input"), getDriver()).findWhenNeeded(this);
+        protected final WebElement clearSearchButton = Locator.byClass("fa-remove").findWhenNeeded(this);
     }
 
     protected static abstract class Locators

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -659,7 +659,9 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
             manageViews().revertDefaultView().dismiss();
         }
 
-        selectView("Default");
+        // If the panelHeader is visible then we probably have a non-default view
+        if (elementCache().panelHeader().isDisplayed())
+            selectView("Default");
 
         // If after selecting the 'Default' view there is still a 'Undo' button visible it means the current view is the
         // default view that has been modified but not saved.

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -249,7 +249,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
     {
         String currentSearchExp = getGridBar().getSearchExpression();
         if (!currentSearchExp.isBlank())
-            doAndWaitForUpdate(()-> getGridBar().clearSearch());
+            getGridBar().clearSearch();
 
         return this;
     }


### PR DESCRIPTION
#### Rationale
See rationale in ui-components

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1287
- https://github.com/LabKey/labkey-ui-premium/pull/185
- https://github.com/LabKey/biologics/pull/2365
- https://github.com/LabKey/inventory/pull/1016
- https://github.com/LabKey/sampleManagement/pull/2095

#### Changes
* Update tests clear local storage after login
* Fix issue with clearSearch on grids
* Fix issue with selecting default view on grids
