### PR TITLE
Refactor waitForLoaded into waitForReady on BaseReactSelect

### DIFF
--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -36,8 +36,8 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
     private static final String LOADING_TEXT = "loading...";
     protected static final String SELECTOR_CLASS = "select-input-container";
 
-    protected int READY_TIMEOUT = WAIT_FOR_JAVASCRIPT;
-    protected int OPEN_TIMEOUT = 4_000;
+    protected int _readyTimeout = WAIT_FOR_JAVASCRIPT;
+    protected int _openTimeout = 4_000;
 
 
     public BaseReactSelect(WebElement selectOrParent, WebDriver driver)
@@ -57,7 +57,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
      */
     public T setReadyTimeout(int msec)
     {
-        READY_TIMEOUT = msec;
+        _readyTimeout = msec;
         return getThis();
     }
 
@@ -70,7 +70,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
      */
     public T setOpenTimeout(int msec)
     {
-        OPEN_TIMEOUT = msec;
+        _openTimeout = msec;
         return getThis();
     }
 
@@ -197,7 +197,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
     protected void waitForReady()
     {
         waitFor(() -> getComponentElement().isDisplayed() && !isLoading(),
-                "Took too long to become ready", READY_TIMEOUT);
+                "Took too long to become ready", _readyTimeout);
     }
 
     protected T waitForInteractive()
@@ -241,7 +241,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
             getWrapper().fireEvent(elementCache().arrow, WebDriverWrapper.SeleniumEvent.click);
         }
 
-        waitFor(this::isExpanded, "Select didn't expand.", OPEN_TIMEOUT);
+        waitFor(this::isExpanded, "Select didn't expand.", _openTimeout);
         getWrapper().fireEvent(getComponentElement(), WebDriverWrapper.SeleniumEvent.blur);
         return getThis();
     }

--- a/src/org/labkey/test/components/react/FilteringReactSelect.java
+++ b/src/org/labkey/test/components/react/FilteringReactSelect.java
@@ -49,7 +49,7 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
 
     public FilteringReactSelect typeAheadSelect(String value, String optionText, String selectedOptionLabel)
     {
-        waitForLoaded();
+        waitForReady();
         scrollIntoView();
         open();
 
@@ -119,7 +119,7 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
        unless type-ahead filter information is keyed in first */
     public FilteringReactSelect filterSelect(String value, Locator elementToWaitFor)
     {
-        waitForLoaded();
+        waitForReady();
         scrollIntoView();
         WebElement success = null;
         int tryCount = 0;

--- a/src/org/labkey/test/components/react/ReactSelect.java
+++ b/src/org/labkey/test/components/react/ReactSelect.java
@@ -55,7 +55,7 @@ public class ReactSelect extends BaseReactSelect<ReactSelect>
 
     public void select(String option)
     {
-        waitForLoaded();
+        waitForReady();
         scrollIntoView();
         open();
         clickOption(option);
@@ -64,11 +64,11 @@ public class ReactSelect extends BaseReactSelect<ReactSelect>
 
     public void typeOptionThenSelect(String option)
     {
-        waitForLoaded();
+        waitForReady();
         scrollIntoView();
         open();
         enterValueInTextbox(option);
-        waitForLoaded();
+        waitForReady();
 
         waitFor(()->getOptions().contains(option), String.format("Option '%s' is not in the list of options.", option), 1_000);
 


### PR DESCRIPTION
#### Rationale
This change seeks to implement `waitForReady `on `BaseReactSelect`, by refactoring `waitForLoaded `to that method. Most methods on reactSelect defensively call waitForLoaded, but not all do.

Out of caution, I replaced old calls to `waitForLoaded `with new calls to `waitForReady` (which does the same thing, but is also run at instantiation time).  These old calls may not be necessary but I don't think it'll hurt to keep them there.

**Context:**
CrossFolderRegistryTest.testRegistryFilters has been [failing ](https://teamcity.labkey.org/viewLog.html?buildId=2567485&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_LimsStarter_LimsStarterPostgres&fromSakuraUI=true#testNameId8049891800230736841)intermittently for some time because the test attempts to get filtered options from a reactSelect and it's been failing because it didn't open within 4 seconds.

(the test calls into setFilter, which does not wait for ready before calling `open`, so it's likely that open() doesn't happen because the control is not ready?) This change, which implements `waitForReady `on BaseReactSelect, ensures that all reactSelects will wait for ready when they are instantiated.

I think it's likely that overriding `waitForReady `on `BaseReactSelect `will address the above failure, but against the possibility that it doesn't I've taken the liberty to add fields for `READY_TIMEOUT `and `OPEN_TIMEOUT`, with matching setters for those fields. I've also updated `waitForReady `to respect `READY_TIMEOUT`, and open to respect `OPEN_TIMEOUT`

The idea here might be for pages backed by long queries to then be able to specify appropriate timeouts for their selects, like:

` FilteringReactSelect.finder(getDriver()).waitFor().setReadyTimeout(custom_timeout_msec)`

#### Related Pull Requests
n/a

#### Changes

- [x] Make `READY_TIMEOUT` settable, cause `waitForReady()` to respect it
- [x] Make `OPEN_TIMEOUT` settable, cause `open()` to respect it
- [x] refactor `waitForLoaded `into `waitForReady`, replace usages
