### PR TITLE
Fix missing value tests

### DIFF
--- a/src/org/labkey/test/tests/MissingValueIndicatorsTest.java
+++ b/src/org/labkey/test/tests/MissingValueIndicatorsTest.java
@@ -33,6 +33,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -40,7 +41,7 @@ import static org.labkey.test.util.DataRegionTable.DataRegion;
 
 public abstract class MissingValueIndicatorsTest extends BaseWebDriverTest
 {
-    public static final Locator.XPathLocator MV_LOCATOR = Locator.tagWithClass("td", "labkey-mv-indicator");
+    private static final String MV_LOCATOR_CLASS = "labkey-mv-indicator";
 
     @LogMethod
     protected void setupMVIndicators()
@@ -66,32 +67,61 @@ public abstract class MissingValueIndicatorsTest extends BaseWebDriverTest
         clickButton("Save");
     }
 
-    protected void validateSingleColumnData()
+    protected void checkDataregionData(DataRegionTable dataRegion, Map<String, List<String>> expectedValues)
     {
-        assertNoLabKeyErrors();
-        assertMvIndicatorPresent();
-        assertTextPresent("Ted", "Alice", "Bob", "Q", "N", "male", "female", "17");
+        for(Map.Entry<String, List<String>> entry : expectedValues.entrySet())
+        {
+            List<String> actualValues = dataRegion.getColumnDataAsText(entry.getKey());
+            checker().verifyEquals(String.format("Values in column '%s' not as expected.", entry.getKey()),
+                    entry.getValue(), actualValues);
+        }
+        checker().screenShotIfNewError(getProjectName()+ "_DataRegion_Data_Error");
     }
 
-    protected void validateTwoColumnData(String dataRegionName, String columnName)
+    protected void checkMvIndicatorPresent(DataRegionTable dataRegion, Map<String, List<Integer>> expectedMVCells)
     {
-        assertNoLabKeyErrors();
-        assertMvIndicatorPresent();
-        assertTextPresent("Franny", "Zoe", "J.D.", "Q", "N", "male", "female", "50");
-        assertTextNotPresent("'25'");
-        DataRegionTable dataRegion = new DataRegionTable(dataRegionName, this);
-        dataRegion.setFilter(columnName, "Equals", "Zoe");
-        assertTextNotPresent("'25'");
-        assertTextPresent("Zoe", "female");
-        assertMvIndicatorPresent();
-        click(MV_LOCATOR.append("/font/a"));
-        assertTextPresent("'25'");
-        dataRegion.clearAllFilters(columnName);
+
+        int numOfRows = dataRegion.getDataRowCount();
+
+        for(Map.Entry<String, List<Integer>> entry : expectedMVCells.entrySet())
+        {
+            List<Integer> actualMVCells = new ArrayList<>();
+            for(int row = 0; row < numOfRows; row++)
+            {
+                WebElement cell = dataRegion.findCell(row, entry.getKey());
+                if(cell.getAttribute("class").equals(MV_LOCATOR_CLASS))
+                {
+                    actualMVCells.add(row);
+                }
+            }
+
+            checker().verifyEquals(String.format("Rows with MV indicator in column '%s' not as expected.", entry.getKey()),
+                    entry.getValue(), actualMVCells);
+        }
+
+        checker().screenShotIfNewError(getProjectName()+ "_MV_Indicator_Error");
+
     }
 
-    protected void assertMvIndicatorPresent()
+    protected void checkOriginalValuePopup(DataRegionTable dataRegion, String column, int row, String expectedValue)
     {
-        assertElementPresent(MV_LOCATOR);
+        WebElement origValueMsg = Locator.tagWithId("span", "helpDivBody").findWhenNeeded(getDriver());
+
+        WebElement cell = dataRegion.findCell(row, column);
+
+        WebElement popupLink = Locator.tagWithClass("a", "_helpPopup").findWhenNeeded(cell);
+
+        popupLink.click();
+
+        if(checker().verifyTrue("'Original Value' popup did not show.",
+                waitFor(origValueMsg::isDisplayed, 1_000)))
+        {
+            checker().verifyEquals("'Original Value' message not as expected.",
+                    String.format("The value as originally entered was: '%s'.", expectedValue), origValueMsg.getText());
+        }
+
+        checker().screenShotIfNewError(getProjectName()+ "_MV_Popup_Error");
+
     }
 
     @LogMethod

--- a/src/org/labkey/test/tests/list/ListMissingValuesTest.java
+++ b/src/org/labkey/test/tests/list/ListMissingValuesTest.java
@@ -13,7 +13,9 @@ import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.LogMethod;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.labkey.test.util.DataRegionTable.DataRegion;
 
@@ -85,7 +87,22 @@ public class ListMissingValuesTest extends MissingValueIndicatorsTest
 
         importDataPage.setText(TEST_DATA_SINGLE_COLUMN_LIST);
         importDataPage.submit();
-        validateSingleColumnData();
+        assertNoLabKeyErrors();
+
+        DataRegionTable dataRegion = new DataRegionTable("query", this);
+
+        Map<String, List<String>> expectedData = new HashMap<>();
+        expectedData.put("Name", List.of("Ted", "Alice", "Bob"));
+        expectedData.put("Age with space", List.of("N", "17", "Q"));
+        expectedData.put("Sex", List.of("male", "female", "N"));
+
+        Map<String, List<Integer>> expectedMVIndicators = new HashMap<>();
+        expectedMVIndicators.put("Age with space", List.of(0, 2));
+        expectedMVIndicators.put("Sex", List.of(2));
+
+        checkDataregionData(dataRegion, expectedData);
+        checkMvIndicatorPresent(dataRegion, expectedMVIndicators);
+
         testMvFiltering(List.of("age with space", "sex"));
 
         deleteListData();
@@ -108,7 +125,23 @@ public class ListMissingValuesTest extends MissingValueIndicatorsTest
 
         importDataPage.setText(TEST_DATA_TWO_COLUMN_LIST);
         importDataPage.submit();
-        validateTwoColumnData("query", "name");
+        assertNoLabKeyErrors();
+
+        dataRegion = new DataRegionTable("query", this);
+
+        expectedData = new HashMap<>();
+        expectedData.put("Name", List.of("Franny", "Zoe", "J.D."));
+        expectedData.put("Age with space", List.of("N", "Q", "50"));
+        expectedData.put("Sex", List.of("male", "female", "Q"));
+
+        expectedMVIndicators = new HashMap<>();
+        expectedMVIndicators.put("Age with space", List.of(0, 1));
+        expectedMVIndicators.put("Sex", List.of(2));
+
+        checkDataregionData(dataRegion, expectedData);
+        checkMvIndicatorPresent(dataRegion, expectedMVIndicators);
+        checkOriginalValuePopup(dataRegion, "sex", 2, "male");
+
         testMvFiltering(List.of("age with space", "sex"));
     }
 

--- a/src/org/labkey/test/tests/study/StudyMissingValuesTest.java
+++ b/src/org/labkey/test/tests/study/StudyMissingValuesTest.java
@@ -18,7 +18,10 @@ import org.labkey.test.util.PortalHelper;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.labkey.test.util.DataRegionTable.DataRegion;
 
@@ -113,7 +116,22 @@ public class StudyMissingValuesTest extends MissingValueIndicatorsTest
         importDataPage.setText(TEST_DATA_SINGLE_COLUMN_DATASET)
                 .submit();
 
-        validateSingleColumnData();
+        assertNoLabKeyErrors();
+
+        DataRegionTable dataRegion = new DataRegionTable("Dataset", this);
+
+        Map<String, List<String>> expectedData = new HashMap<>();
+        expectedData.put("Participant ID", List.of("Alice", "Bob", "Ted"));
+        expectedData.put("Age with space", List.of("17", "Q", "N"));
+        expectedData.put("Sex", List.of("female", "N", "male"));
+
+        Map<String, List<Integer>> expectedMVIndicators = new HashMap<>();
+        expectedMVIndicators.put("Age with space", List.of(1, 2));
+        expectedMVIndicators.put("Sex", List.of(1));
+
+        checkDataregionData(dataRegion, expectedData);
+        checkMvIndicatorPresent(dataRegion, expectedMVIndicators);
+
         testMvFiltering(List.of("Age with space", "Sex"));
 
         deleteDatasetData(3);
@@ -138,8 +156,23 @@ public class StudyMissingValuesTest extends MissingValueIndicatorsTest
 
         importDataPage.setText(TEST_DATA_TWO_COLUMN_DATASET);
         importDataPage.submit();
+        assertNoLabKeyErrors();
 
-        validateTwoColumnData("Dataset", "ParticipantId");
+        dataRegion = new DataRegionTable("Dataset", this);
+
+        expectedData = new HashMap<>();
+        expectedData.put("Participant ID", List.of("Franny", "J.D.", "Zoe"));
+        expectedData.put("Age with space", List.of("N", "50", "Q"));
+        expectedData.put("Sex", List.of("male", "Q", "female"));
+
+        expectedMVIndicators = new HashMap<>();
+        expectedMVIndicators.put("Age with space", List.of(0, 2));
+        expectedMVIndicators.put("Sex", List.of(1));
+
+        checkDataregionData(dataRegion, expectedData);
+        checkMvIndicatorPresent(dataRegion, expectedMVIndicators);
+        checkOriginalValuePopup(dataRegion, "Age with space", 2, "25");
+
         testMvFiltering(List.of("Age with space", "Sex"));
 
         log("19874: Regression test for reshow of missing value indicators when submitting default forms with errors");
@@ -188,7 +221,23 @@ public class StudyMissingValuesTest extends MissingValueIndicatorsTest
         clickButton("Next");
 
         clickButton("Link to Study");
-        validateSingleColumnData();
+        assertNoLabKeyErrors();
+
+        DataRegionTable dataRegion = new DataRegionTable("Dataset", this);
+
+        Map<String, List<String>> expectedData = new HashMap<>();
+        expectedData.put("Participant ID", List.of("Alice", "Bob", "Ted"));
+        expectedData.put("Age", List.of("17", "Q", "N"));
+        expectedData.put("Sex", List.of("female", "N", "male"));
+        expectedData.put("Assay ID", Collections.nCopies(3, ASSAY_RUN_SINGLE_COLUMN));
+
+        Map<String, List<Integer>> expectedMVIndicators = new HashMap<>();
+        expectedMVIndicators.put("Age", List.of(1, 2));
+        expectedMVIndicators.put("Sex", List.of(1));
+
+        checkDataregionData(dataRegion, expectedData);
+        checkMvIndicatorPresent(dataRegion, expectedMVIndicators);
+
     }
 
     private void deleteDatasetData(int rowCount)


### PR DESCRIPTION
#### Rationale
The missing values test started failing because the previous value for a field is present in a tooltip that is not visible. The helper code for these tests was old and was only doing a basic check for text on the page (it didn't care if it was visible or not). The helper code was also not validating that the missing value indicator was shown in the correct field, it was only checking if an indicator was present. Finally the helper code had hard coded values for the data to look for. This made maintenance difficult with the test cases.

This fix made the helper code more explicit in the checks that it runs, and has the tests passing in the expected data to the helper code.

The tests now pass on TeamCity
[Postgres](https://teamcity.labkey.org/buildConfiguration/bt20?branch=fixMissingValueIndicatorsTest&buildTypeTab=overview&mode=builds)
[MSSQL](https://teamcity.labkey.org/buildConfiguration/bt21?branch=fixMissingValueIndicatorsTest&buildTypeTab=overview&mode=builds)

#### Related Pull Requests
* None.

#### Changes
* Update  MissingValueIndicatorsTest to be more explicit in the checks it runs.
* Replace helper methods with distinct methods.
* Update tests to pass in expected values.
