### PR TITLE
Collect more information when domain save fails

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -854,6 +854,15 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         {
             try
             {
+                dumpConsoleLogs();
+            }
+            catch (WebDriverException e)
+            {
+                log("Unable to dump console log");
+                TestLogger.error(e.getMessage(), e);
+            }
+            try
+            {
                 if (isTestRunningOnTeamCity())
                 {
                     getArtifactCollector().addArtifactLocation(new File(TestFileUtils.getLabKeyRoot(), "build/deploy/files"));
@@ -1053,6 +1062,37 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             }
         }
         return null;
+    }
+
+    private void dumpConsoleLogs()
+    {
+        List<?> logEntries = executeScript("return console.everything;", List.class);
+        if (logEntries != null)
+        {
+            if (logEntries.isEmpty())
+            {
+                log("No JavaScript console logs to dump");
+            }
+            else
+            {
+                StringBuilder logStr = new StringBuilder();
+                logStr.append("Dumping JavaScript console log\n");
+                for (Object logEntry : logEntries)
+                {
+                    Map entry = (Map) logEntry;
+
+                    logStr.append("    console.")
+                            .append(StringUtils.rightPad((String) entry.get("type"), 6))
+                            .append(entry.get("datetime")).append("  ")
+                            .append(entry.get("value")).append("\n");
+                }
+                log(logStr.toString());
+            }
+        }
+        else
+        {
+            log("Unable to dump JavaScript console");
+        }
     }
 
     protected void disablePageUnloadEvents()

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1897,6 +1897,32 @@ public abstract class WebDriverWrapper implements WrapsDriver
                 .withMessage("waiting for document to be ready")
                 .until(wd -> Objects.equals(executeScript("return document.readyState;"), "complete"));
         Locators.documentRoot.waitForElement(getDriver(), (int) timer.timeRemaining().toMillis());
+        executeScript("""
+                if (console.everything === undefined)
+                {
+                    console.everything = [];
+
+                    console.defaultLog = console.log.bind(console);
+                    console.log = function(){
+                        console.everything.push({"type":"log", "datetime":Date().toLocaleString(), "value":Array.from(arguments)});
+                        console.defaultLog.apply(console, arguments);
+                    }
+                    console.defaultError = console.error.bind(console);
+                    console.error = function(){
+                        console.everything.push({"type":"error", "datetime":Date().toLocaleString(), "value":Array.from(arguments)});
+                        console.defaultError.apply(console, arguments);
+                    }
+                    console.defaultWarn = console.warn.bind(console);
+                    console.warn = function(){
+                        console.everything.push({"type":"warn", "datetime":Date().toLocaleString(), "value":Array.from(arguments)});
+                        console.defaultWarn.apply(console, arguments);
+                    }
+                    console.defaultDebug = console.debug.bind(console);
+                    console.debug = function(){
+                        console.everything.push({"type":"debug", "datetime":Date().toLocaleString(), "value":Array.from(arguments)});
+                        console.defaultDebug.apply(console, arguments);
+                    }
+                }""");
         waitForOnReady("jQuery");
         waitForOnReady("Ext");
         waitForOnReady("Ext4");

--- a/src/org/labkey/test/components/QueryMetadataEditorPage.java
+++ b/src/org/labkey/test/components/QueryMetadataEditorPage.java
@@ -58,7 +58,7 @@ public class QueryMetadataEditorPage extends DomainDesigner<QueryMetadataEditorP
         return new QueryMetadataEditorPage.ElementCache();
     }
 
-    public class ElementCache extends DomainDesigner.ElementCache
+    public class ElementCache extends DomainDesigner<?>.ElementCache
     {
         private final WebElement resetButton = Locator.button("Reset To Default")
                 .findWhenNeeded(buttonPanel).withTimeout(WAIT_FOR_JAVASCRIPT);

--- a/src/org/labkey/test/components/domain/DomainDesigner.java
+++ b/src/org/labkey/test/components/domain/DomainDesigner.java
@@ -1,5 +1,8 @@
 package org.labkey.test.components.domain;
 
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.TestTimeoutException;
+import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.WebDriver;
 
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
@@ -7,7 +10,7 @@ import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 /**
  * A simple domain designer with a properties panel and a single field panel.
  */
-public abstract class DomainDesigner<EC extends DomainDesigner.ElementCache> extends BaseDomainDesigner<EC>
+public abstract class DomainDesigner<EC extends DomainDesigner<?>.ElementCache> extends BaseDomainDesigner<EC>
 {
     public DomainDesigner(WebDriver driver)
     {
@@ -24,9 +27,25 @@ public abstract class DomainDesigner<EC extends DomainDesigner.ElementCache> ext
         return elementCache().fieldsPanel.expand();
     }
 
-    public class ElementCache extends BaseDomainDesigner.ElementCache
+    @Override
+    public Object clickSave()
     {
-        protected final DomainPanel propertiesPanel = new DomainPanel.DomainPanelFinder(getDriver()).index(0)
+        try
+        {
+            return super.clickSave();
+        }
+        catch (TestTimeoutException ex)
+        {
+            BaseWebDriverTest.getCurrentTest().getArtifactCollector().dumpPageSnapshot("domainSave");
+            TestLogger.log("Failed to save domain. Opening properties panel for screenshot.");
+            expandPropertiesPanel();
+            throw ex;
+        }
+    }
+
+    public class ElementCache extends BaseDomainDesigner<?>.ElementCache
+    {
+        protected final DomainPanel<?, ?> propertiesPanel = new DomainPanel.DomainPanelFinder(getDriver()).index(0)
                 .timeout(WAIT_FOR_JAVASCRIPT).findWhenNeeded(this);
         protected final DomainFormPanel fieldsPanel = new DomainFormPanel.DomainFormPanelFinder(getDriver())
                 .index(getFieldPanelIndex()).timeout(1000).findWhenNeeded();

--- a/src/org/labkey/test/pages/issues/IssuesAdminPage.java
+++ b/src/org/labkey/test/pages/issues/IssuesAdminPage.java
@@ -153,8 +153,8 @@ public class IssuesAdminPage extends DomainDesigner<IssuesAdminPage.ElementCache
         OldestFirst("ASC", "Oldest first"),
         NewestFirst("DESC", "Newest first");
 
-        private String _value;
-        private String _text;
+        private final String _value;
+        private final String _text;
 
         SortDirection(String value, String text)
         {
@@ -175,7 +175,7 @@ public class IssuesAdminPage extends DomainDesigner<IssuesAdminPage.ElementCache
         }
     }
 
-    protected class ElementCache extends DomainDesigner.ElementCache
+    protected class ElementCache extends DomainDesigner<?>.ElementCache
     {
         Input singularNameInput = new Input(Locator.inputById("singularItemName").findWhenNeeded(propertiesPanel), getDriver());
         Input pluralNameInput = new Input(Locator.inputById("pluralItemName").findWhenNeeded(propertiesPanel), getDriver());

--- a/src/org/labkey/test/pages/study/DatasetDesignerPage.java
+++ b/src/org/labkey/test/pages/study/DatasetDesignerPage.java
@@ -4,11 +4,11 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.domain.DomainDesigner;
-import org.labkey.test.components.react.FilteringReactSelect;
-import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.html.RadioButton;
+import org.labkey.test.components.react.FilteringReactSelect;
+import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.components.react.ToggleButton;
 import org.labkey.test.components.study.AdvancedDatasetSettingsDialog;
 import org.labkey.test.pages.DatasetPropertiesPage;
@@ -266,7 +266,7 @@ public class DatasetDesignerPage extends DomainDesigner<DatasetDesignerPage.Elem
         return new ElementCache();
     }
 
-    protected class ElementCache extends DomainDesigner.ElementCache
+    protected class ElementCache extends DomainDesigner<?>.ElementCache
     {
         public WebElement advancedSettingsButton = Locator.tagWithText("button", "Advanced Settings")
                 .findWhenNeeded(propertiesPanel);


### PR DESCRIPTION
#### Rationale
`DomainDesigner.clickSave` fails regularly on Windows on TeamCity. The UI indicates that the error is in the properties panel, which is closed in the screenshots. We can detect some of these failures and open the properties panel to take a look.

#### Related Pull Requests
* N/A

#### Changes
* Take screenshot of domain designer properties panel when saving fails
