### PR TITLE
Allow MultiMenu to wait for menu items

### DIFF
--- a/src/org/labkey/test/components/react/MultiMenu.java
+++ b/src/org/labkey/test/components/react/MultiMenu.java
@@ -22,9 +22,17 @@ import java.util.Optional;
 
 public class MultiMenu extends BootstrapMenu
 {
+    private int _menuWaitTmeout = 500;
+
     protected MultiMenu(WebElement element, WebDriver driver)
     {
         super(driver, element);
+    }
+
+    public MultiMenu setMenuWait(int menuWait)
+    {
+        _menuWaitTmeout = menuWait;
+        return this;
     }
 
     private WebElement getMenuList()
@@ -35,7 +43,7 @@ public class MultiMenu extends BootstrapMenu
     public WebElement getMenuItem(String text)
     {
         return Locator.tag("li").withChild(Locator.tagWithAttribute("a", "role", "menuitem")
-                .withText(text)).findElement(getMenuList());
+                    .withText(text)).waitForElement(getMenuList(), _menuWaitTmeout);
     }
 
     public boolean isMenuItemDisabled(String text)


### PR DESCRIPTION
#### Rationale
Recently, [BiologicsSampleTimelineTest.testStorageTimelineEvents](https://teamcity.labkey.org/viewLog.html?tab=queuedBuildOverviewTab&buildId=2657683&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsPostgres&fromSakuraUI=true#testNameId-8170939845070100064) has failed because it couldn't find the "Add to Storage" menu item despite it being visible in the after-failure screenshot.

This change enables MultiMenu to wait for a settable duration for menuItems to be present before failing.  (I've taken the liberty of setting the default at a half-second)

#### Related Pull Requests
 https://github.com/LabKey/biologics/pull/2391

#### Changes

- [x] cause multiMenu to wait for menu items to be present
