### PR TITLE
Wait for the 'clear' element to be clickable before clicking

### DIFF
--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -270,6 +270,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
         if (hasSelection())
         {
             var clear = Locators.clear.waitForElement(getComponentElement(), 1_500);
+            getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(clear));
             clear.click();
             getWrapper().shortWait().until(ExpectedConditions.stalenessOf(clear));
         }


### PR DESCRIPTION
#### Rationale
Recently, [BiologicsAutoPopulateAssayJobSamplesTest.testAssociateTaskToExistingAssayRun](https://teamcity.labkey.org/viewLog.html?buildId=2667795&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsPostgres&fromSakuraUI=true#testNameId-3261285293786488283) has failed because the test was supposed to clear a value in an editingDetailTable
![image](https://github.com/LabKey/testAutomation/assets/16809856/6e528bb5-0dff-491e-8d5a-c984af0d5d08)

The test fails because the Workflow Task selection has not been cleared and therefore the 'Save Run Details' button is not clickable/enabled.  The theory of this fix is that the test clicked the 'clear' element before it was ready.  (of course, that doesn't explain why the following line, which waits for the 'clear' element to become stale, didn't hold up the works)

#### Related Pull Requests
n/a

#### Changes

- [x] wait for the 'clear' element to be clickable
