### PR TITLE
Fix inappropriate inheritance in `QueryMetadataEditorPage`

### DIFF
--- a/src/org/labkey/test/components/QueryMetadataEditorPage.java
+++ b/src/org/labkey/test/components/QueryMetadataEditorPage.java
@@ -76,6 +76,12 @@ public class QueryMetadataEditorPage extends DomainDesigner<QueryMetadataEditorP
         }
 
         @Override
+        protected Locator.XPathLocator saveButtonLocator()
+        {
+            return Locator.byClass("btn-primary");
+        }
+
+        @Override
         protected Locator.XPathLocator buttonPanelLocator()
         {
             return Locator.byClass("query-metadata-editor-buttons");

--- a/src/org/labkey/test/components/QueryMetadataEditorPage.java
+++ b/src/org/labkey/test/components/QueryMetadataEditorPage.java
@@ -2,7 +2,7 @@ package org.labkey.test.components;
 
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
-import org.labkey.test.components.domain.DomainDesigner;
+import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.query.AliasFieldDialog;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -12,11 +12,32 @@ import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 /**
  * Automates the platform component defined in: query/src/client/QueryMetadataEditor/QueryMetadataEditor.tsx
  */
-public class QueryMetadataEditorPage extends DomainDesigner<QueryMetadataEditorPage.ElementCache>
+public class QueryMetadataEditorPage extends WebDriverComponent<QueryMetadataEditorPage.ElementCache>
 {
+    private final WebElement el;
+    private final WebDriver driver;
+
     public QueryMetadataEditorPage(WebDriver driver)
     {
-        super(driver);
+        this.driver = driver;
+        el = Locator.id("app").findElement(this.driver); // Full page component
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return driver;
+    }
+
+    public DomainFormPanel getFieldsPanel()
+    {
+        return elementCache().fieldsPanel.expand();
     }
 
     public void resetToDefault()
@@ -42,7 +63,6 @@ public class QueryMetadataEditorPage extends DomainDesigner<QueryMetadataEditorP
         return new AliasFieldDialog(this);
     }
 
-    @Override
     public QueryMetadataEditorPage clickSave()
     {
         elementCache().saveButton.click();
@@ -53,13 +73,18 @@ public class QueryMetadataEditorPage extends DomainDesigner<QueryMetadataEditorP
     }
 
     @Override
-    protected QueryMetadataEditorPage.ElementCache newElementCache()
+    protected ElementCache newElementCache()
     {
-        return new QueryMetadataEditorPage.ElementCache();
+        return new ElementCache();
     }
 
-    public class ElementCache extends DomainDesigner.ElementCache
+    public class ElementCache extends Component<?>.ElementCache
     {
+        protected final DomainFormPanel fieldsPanel = new DomainFormPanel.DomainFormPanelFinder(getDriver())
+                .timeout(1000).findWhenNeeded();
+
+        protected final WebElement buttonPanel = Locator.byClass("query-metadata-editor-buttons").findWhenNeeded(this);
+
         private final WebElement resetButton = Locator.button("Reset To Default")
                 .findWhenNeeded(buttonPanel).withTimeout(WAIT_FOR_JAVASCRIPT);
         private final WebElement aliasFieldButton = Locator.button("Alias Field")
@@ -68,23 +93,8 @@ public class QueryMetadataEditorPage extends DomainDesigner<QueryMetadataEditorP
                 .findWhenNeeded(buttonPanel).withTimeout(WAIT_FOR_JAVASCRIPT);
         private final WebElement editSourceButton = Locator.button("Edit Source")
                 .findWhenNeeded(buttonPanel).withTimeout(WAIT_FOR_JAVASCRIPT);
+        public final WebElement saveButton = Locator.byClass("save-button")
+                .findWhenNeeded(buttonPanel).withTimeout(WAIT_FOR_JAVASCRIPT);
 
-        @Override
-        protected int getFieldPanelIndex()
-        {
-            return 0;
-        }
-
-        @Override
-        protected Locator.XPathLocator saveButtonLocator()
-        {
-            return Locator.byClass("btn-primary");
-        }
-
-        @Override
-        protected Locator.XPathLocator buttonPanelLocator()
-        {
-            return Locator.byClass("query-metadata-editor-buttons");
-        }
     }
 }

--- a/src/org/labkey/test/components/domain/BaseDomainDesigner.java
+++ b/src/org/labkey/test/components/domain/BaseDomainDesigner.java
@@ -83,18 +83,8 @@ public abstract class BaseDomainDesigner<EC extends BaseDomainDesigner.ElementCa
 
     public abstract class ElementCache extends Component<EC>.ElementCache
     {
-        protected final WebElement buttonPanel = buttonPanelLocator().findWhenNeeded(this);
+        protected final WebElement buttonPanel = Locator.byClass("form-buttons").findWhenNeeded(this);
         public final WebElement cancelButton = Locator.byClass("cancel-button").findWhenNeeded(buttonPanel);
-        public final WebElement saveButton = saveButtonLocator().findWhenNeeded(buttonPanel);
-
-        protected Locator.XPathLocator saveButtonLocator()
-        {
-            return Locator.byClass("save-button");
-        }
-
-        protected Locator.XPathLocator buttonPanelLocator()
-        {
-            return Locator.byClass("form-buttons");
-        }
+        public final WebElement saveButton = Locator.byClass("save-button").findWhenNeeded(buttonPanel);
     }
 }

--- a/src/org/labkey/test/components/domain/BaseDomainDesigner.java
+++ b/src/org/labkey/test/components/domain/BaseDomainDesigner.java
@@ -85,7 +85,12 @@ public abstract class BaseDomainDesigner<EC extends BaseDomainDesigner.ElementCa
     {
         protected final WebElement buttonPanel = buttonPanelLocator().findWhenNeeded(this);
         public final WebElement cancelButton = Locator.byClass("cancel-button").findWhenNeeded(buttonPanel);
-        public final WebElement saveButton = Locator.byClass("save-button").findWhenNeeded(buttonPanel);
+        public final WebElement saveButton = saveButtonLocator().findWhenNeeded(buttonPanel);
+
+        protected Locator.XPathLocator saveButtonLocator()
+        {
+            return Locator.byClass("save-button");
+        }
 
         protected Locator.XPathLocator buttonPanelLocator()
         {


### PR DESCRIPTION
#### Rationale
`QueryMetadataEditorPage` isn't actually a domain designer and doesn't get much utility out of extending `DomainDesigner`. The recent change to the domain designer button bar broke tests that use the QueryMetadataEditorPage.

#### Related Pull Requests
* #1652

#### Changes
* Fix inappropriate inheritance by `QueryMetadataEditorPage`
