### PR TITLE
Workaround intermittent connection errors when rendering R reports

### DIFF
--- a/src/org/labkey/test/pages/reports/ScriptReportPage.java
+++ b/src/org/labkey/test/pages/reports/ScriptReportPage.java
@@ -6,18 +6,18 @@ import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.components.core.ProjectMenu;
 import org.labkey.test.components.ext4.Checkbox;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.util.CodeMirrorHelper;
 import org.labkey.test.util.Ext4Helper;
-import org.labkey.test.util.PortalHelper;
+import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static org.labkey.test.components.ext4.Checkbox.Ext4Checkbox;
 import static org.labkey.test.components.ext4.RadioButton.RadioButton;
@@ -174,8 +174,10 @@ public class ScriptReportPage extends LabKeyPage<ScriptReportPage.ElementCache>
     {
         _clickReportTab();
         // Handle occasional problem where Firefox terminates requests with an HTTP status of 0
-        if (Locators.labkeyError.containing("Status:  (0)").existsIn(getDriver()))
+        Optional<WebElement> errorEl = Locators.labkeyError.containing("Failed to retrieve report results").findOptionalElement(getDriver());
+        if (errorEl.isPresent())
         {
+            TestLogger.warn(errorEl.get().getText());
             clickSourceTab();
             String oldValue = getEditor().getCodeMirrorValue();
             getEditor().setCodeMirrorValue(oldValue + " "); // Force report to run again

--- a/src/org/labkey/test/pages/reports/ScriptReportPage.java
+++ b/src/org/labkey/test/pages/reports/ScriptReportPage.java
@@ -174,7 +174,7 @@ public class ScriptReportPage extends LabKeyPage<ScriptReportPage.ElementCache>
     {
         _clickReportTab();
         // Handle occasional problem where Firefox terminates requests with an HTTP status of 0
-        if (false && Locators.labkeyError.containing("Status:  (0)").existsIn(getDriver()))
+        if (Locators.labkeyError.containing("Status:  (0)").existsIn(getDriver()))
         {
             clickSourceTab();
             String oldValue = getEditor().getCodeMirrorValue();

--- a/src/org/labkey/test/pages/reports/ScriptReportPage.java
+++ b/src/org/labkey/test/pages/reports/ScriptReportPage.java
@@ -3,13 +3,16 @@ package org.labkey.test.pages.reports;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.Locators;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
+import org.labkey.test.components.core.ProjectMenu;
 import org.labkey.test.components.ext4.Checkbox;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.util.CodeMirrorHelper;
 import org.labkey.test.util.Ext4Helper;
+import org.labkey.test.util.PortalHelper;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -169,12 +172,26 @@ public class ScriptReportPage extends LabKeyPage<ScriptReportPage.ElementCache>
 
     public ScriptReportPage clickReportTab()
     {
+        _clickReportTab();
+        // Handle occasional problem where Firefox terminates requests with an HTTP status of 0
+        if (false && Locators.labkeyError.containing("Status:  (0)").existsIn(getDriver()))
+        {
+            clickSourceTab();
+            String oldValue = getEditor().getCodeMirrorValue();
+            getEditor().setCodeMirrorValue(oldValue + " "); // Force report to run again
+            _clickReportTab();
+        }
+        return this;
+    }
+
+    private void _clickReportTab()
+    {
+        scrollToTop(); // Clicking report tab can scroll such that the cursor hovers over and opens the project menu
         waitAndClick(Ext4Helper.Locators.tab("Report"));
         // Report view should appear quickly
         shortWait().until(ExpectedConditions.visibilityOfElementLocated(Locator.tagWithClass("div", "reportView")));
         // Actual report might take a while to load
         _ext4Helper.waitForMaskToDisappear(BaseWebDriverTest.WAIT_FOR_PAGE);
-        return this;
     }
 
     public WebElement findReportElement()


### PR DESCRIPTION
#### Rationale
Ajax requests from the script report designer regularly get terminated by Firefox for some reason, resulting in an error that looks like this:
![image](https://github.com/LabKey/testAutomation/assets/5263798/d8375f5f-e2d7-4270-ad73-f1dfd48d8239)

We've spent a lot of time investigating these errors and we haven't received any reports of them happening outside of test environments.
The test helper can make a trivial modification to the report to cause the report designer to request a fresh render.

#### Related Pull Requests
* N/A

#### Changes
* Force a rerender of R reports for certain errors
* Avoid mousing over the project menu when activating the report tab
