### PR TITLE
Add synchronization to more FileBrowserHelper methods

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3590,34 +3590,6 @@ public abstract class WebDriverWrapper implements WrapsDriver
         el.sendKeys(fileNames);
     }
 
-    /**
-     * @deprecated Use {@link org.labkey.test.util.FileBrowserHelper#dragAndDropFileInDropZone(File)} or
-     * {@link org.labkey.test.util.FileBrowserHelper#dragDropUpload(File)}
-     */
-    @Deprecated
-    public void dragAndDropFileInDropZone(File fileName)
-    {
-        //Offsets for the drop zone
-        int offsetX = 0;
-        int offsetY = 0;
-
-        //Min version of the JS script - creates the dataTransfer object
-        String JS_DROP_FILES = "var c=arguments,b=c[0],k=c[1];c=c[2];for(var d=b.ownerDocument||document,l=0;;){var e=b.getBoundingClientRect(),g=e.left+(k||e.width/2),h=e.top+(c||e.height/2),f=d.elementFromPoint(g,h);if(f&&b.contains(f))break;if(1<++l)throw b=Error('Element not interactable'),b.code=15,b;}var a=d.createElement('INPUT');a.setAttribute('type','file');a.setAttribute('multiple','');a.setAttribute('style','position:fixed;z-index:2147483647;left:0;top:0;');a.onchange=function(b){a.parentElement.removeChild(a);b.stopPropagation();var c={constructor:DataTransfer,effectAllowed:'all',dropEffect:'none',types:['Files'],files:a.files,setData:function(){},getData:function(){},clearData:function(){},setDragImage:function(){}};window.DataTransferItemList&&(c.items=Object.setPrototypeOf(Array.prototype.map.call(a.files,function(a){return{constructor:DataTransferItem,kind:'file',type:a.type,getAsFile:function(){return a},getAsString:function(b){var c=new FileReader;c.onload=function(a){b(a.target.result)};c.readAsText(a)}}}),{constructor:DataTransferItemList,add:function(){},clear:function(){},remove:function(){}}));['dragenter','dragover','drop'].forEach(function(a){var b=d.createEvent('DragEvent');b.initMouseEvent(a,!0,!0,d.defaultView,0,0,0,g,h,!1,!1,!1,!1,0,null);Object.setPrototypeOf(b,null);b.dataTransfer=c;Object.setPrototypeOf(b,DragEvent.prototype);f.dispatchEvent(b)})};d.documentElement.appendChild(a);a.getBoundingClientRect();return a;";
-
-         //Execute the script to make the drop zone visible.
-        executeScript("LABKEY.internal.FileDrop.showDropzones()");
-
-        //Locator to the drop zone
-        WebElement element = Locator.tagWithClassContaining("div","dropzone").findElement(getDriver());
-        WebElement input = (WebElement)executeScript(JS_DROP_FILES,element,offsetX,offsetY);
-        log("Web element returned " + input);
-
-        //setting the input
-        input.sendKeys(fileName.getAbsolutePath());
-
-        executeScript("LABKEY.internal.FileDrop.hideDropzones()");
-    }
-
     public void setFormElement(Locator loc, File file)
     {
         WebElement el = loc.waitForElement(new WebDriverWait(getDriver(), Duration.ofSeconds(5)));

--- a/src/org/labkey/test/tests/FolderExportTest.java
+++ b/src/org/labkey/test/tests/FolderExportTest.java
@@ -73,6 +73,10 @@ public class FolderExportTest extends BaseWebDriverTest
     private static final String folderFromTemplate = "4 Folder From Template";
     private static final String folderWithPermissions = "5 Folder From Zip With Permissions";
     private static final String folderInheritingPermissions = "6 Inheriting";
+
+    private static final String exportImportSourceProject = "Source_Folder~,!@#$%%++_)(&+=[{";
+    private static final String exportImportTargetProject = "Target_Folder~!@#$%%++_)(&+=]},";
+
     private static final String folderArchive = "SampleWithSubfolders.folder";
     private static final String folderZip = folderArchive + ".zip";
     private static final String projectPermsZip = "ProjectWithPerms.folder.zip";
@@ -158,18 +162,16 @@ public class FolderExportTest extends BaseWebDriverTest
     @Test
     public void testExportImportWithSpecialCharactersInFileName()
     {
-        String sourceFolder = "Source_Folder~,!@#$%%++_)(&+=[{";
-        String targetFolder = "Target_Folder~!@#$%%++_)(&+=]},";
         String dir = "test~!@#$%(%)+-_=+_[]{}";
         String uploadFileName = "pdf_sample_with+%$@+%%+#-+=.pdf";
 
         goToHome();
 
-        log("Creating " + sourceFolder);
-        _containerHelper.createProject(sourceFolder, "Collaboration");
+        log("Creating " + exportImportSourceProject);
+        _containerHelper.createProject(exportImportSourceProject, "Collaboration");
 
         log("Creating dir " + dir + " in Files webpart");
-        goToProjectHome(sourceFolder);
+        goToProjectHome(exportImportSourceProject);
         goToModule("FileContent");
         _fileBrowserHelper.createFolder(dir);
 
@@ -177,16 +179,16 @@ public class FolderExportTest extends BaseWebDriverTest
         _fileBrowserHelper.selectFileBrowserItem("/" + dir + "/");
         _fileBrowserHelper.uploadFile(TestFileUtils.getSampleData("fileTypes/" + uploadFileName));
 
-        goToProjectHome(sourceFolder);
+        goToProjectHome(exportImportSourceProject);
 
-        log("Exporting " + sourceFolder);
-        File sourceZip = exportFolderAsZip(sourceFolder, false, false, false, true);
+        log("Exporting " + exportImportSourceProject);
+        File sourceZip = exportFolderAsZip(exportImportSourceProject, false, false, false, true);
 
-        log("Creating " + targetFolder);
-        _containerHelper.createProject(targetFolder, "Collaboration");
+        log("Creating " + exportImportTargetProject);
+        _containerHelper.createProject(exportImportTargetProject, "Collaboration");
 
-        log("Importing " + sourceZip.getName() + " to " + targetFolder);
-        goToProjectHome(targetFolder);
+        log("Importing " + sourceZip.getName() + " to " + exportImportTargetProject);
+        goToProjectHome(exportImportTargetProject);
         importFolderFromZip(sourceZip, false, 1);
 
         log("Verify presence of " + uploadFileName);
@@ -196,7 +198,7 @@ public class FolderExportTest extends BaseWebDriverTest
         assertEquals("Expected file '" + uploadFileName + "' did not get downloaded", uploadFileName, downloadedFile.getName());
 
         log("Test Drag and Drop zip folder '" + sourceZip.getName() + "'");
-        _fileBrowserHelper.dragAndDropFileInDropZone(sourceZip);
+        _fileBrowserHelper.dragDropUpload(sourceZip);
     }
 
     @Test
@@ -679,6 +681,8 @@ public class FolderExportTest extends BaseWebDriverTest
         {
             _containerHelper.deleteProject(importProject, false);
         }
+        _containerHelper.deleteProject(exportImportSourceProject, false);
+        _containerHelper.deleteProject(exportImportTargetProject, false);
         _userHelper.deleteUsers(false, testUsers);
     }
 

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -389,6 +389,7 @@ public class FileBrowserHelper extends WebDriverWrapper
             setFormElement(Locator.name("Flag/Comment"), description);
             propWindow.clickButton("Save", true);
             _ext4Helper.waitForMaskToDisappear();
+            Locators.gridRow(fileName).childTag("td").withText(description).waitForElement(getDriver(), 5_000);
         });
     }
 

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -157,7 +157,7 @@ public class FileBrowserHelper extends WebDriverWrapper
         WebElement sortMenuLink = Locator.tagWithClass("a", "x4-menu-item-link")
                 .withDescendant(Locator.tagWithClass("span", "x4-menu-item-text").withText(sortText))
                 .waitForElement(getDriver(), 1500);
-        doAndWaitForFileListRefresh(()-> sortMenuLink.click());
+        doAndWaitForFileListRefresh(sortMenuLink::click);
 
         assertThat("Did not get expected sort for column ["+columnText+"]",
                 getSortDirection(headerLoc), is(sortDirection));
@@ -294,24 +294,28 @@ public class FileBrowserHelper extends WebDriverWrapper
     public void renameFile(String currentName, String newName)
     {
         selectFileBrowserItem(currentName);
-        clickFileBrowserButton(BrowserAction.RENAME);
-        Window renameWindow = Window(getDriver()).withTitle("Rename").waitFor();
-        setFormElement(Locator.name("renameText-inputEl").findElement(renameWindow), newName);
-        renameWindow.clickButton("Rename", WAIT_FOR_EXT_MASK_TO_DISSAPEAR);
+        doAndWaitForFileListRefresh(() -> {
+            clickFileBrowserButton(BrowserAction.RENAME);
+            Window renameWindow = Window(getDriver()).withTitle("Rename").waitFor();
+            setFormElement(Locator.name("renameText-inputEl").findElement(renameWindow), newName);
+            renameWindow.clickButton("Rename", WAIT_FOR_EXT_MASK_TO_DISSAPEAR);
+        });
         waitForElement(fileGridCell.withText(newName));
     }
 
     public void moveFile(String fileName, String destinationPath)
     {
         selectFileBrowserItem(fileName);
-        clickFileBrowserButton(BrowserAction.MOVE);
-        Window moveWindow = Window(getDriver()).withTitle("Choose Destination").waitFor();
-        //NOTE:  this doesn't yet support nested folders
-        WebElement folder = Locator.tagWithClass("span", "x4-tree-node-text").withText(destinationPath).waitForElement(moveWindow, 1000);
-        shortWait().until(LabKeyExpectedConditions.animationIsDone(folder));
-        sleep(500);
-        folder.click();
-        moveWindow.clickButton("Move", WAIT_FOR_EXT_MASK_TO_DISSAPEAR);
+        doAndWaitForFileListRefresh(() -> {
+            clickFileBrowserButton(BrowserAction.MOVE);
+            Window moveWindow = Window(getDriver()).withTitle("Choose Destination").waitFor();
+            //NOTE:  this doesn't yet support nested folders
+            WebElement folder = Locator.tagWithClass("span", "x4-tree-node-text").withText(destinationPath).waitForElement(moveWindow, 1000);
+            shortWait().until(LabKeyExpectedConditions.animationIsDone(folder));
+            sleep(500);
+            folder.click();
+            moveWindow.clickButton("Move", WAIT_FOR_EXT_MASK_TO_DISSAPEAR);
+        });
 
         waitForElementToDisappear(fileGridCell.withText(fileName));
     }
@@ -319,9 +323,11 @@ public class FileBrowserHelper extends WebDriverWrapper
     public void deleteFile(String fileName)
     {
         selectFileBrowserItem(fileName);
-        clickFileBrowserButton(BrowserAction.DELETE);
-        Window(getDriver()).withTitle("Delete Files").waitFor()
-                .clickButton("Yes", WAIT_FOR_EXT_MASK_TO_DISSAPEAR);
+        doAndWaitForFileListRefresh(() -> {
+            clickFileBrowserButton(BrowserAction.DELETE);
+            Window(getDriver()).withTitle("Delete Files").waitFor()
+                    .clickButton("Yes", WAIT_FOR_EXT_MASK_TO_DISSAPEAR);
+        });
         waitForElementToDisappear(fileGridCell.withText(fileName));
     }
 
@@ -368,18 +374,22 @@ public class FileBrowserHelper extends WebDriverWrapper
 
     public void createFolder(String folderName)
     {
-        clickFileBrowserButton(BrowserAction.NEW_FOLDER);
-        setFormElement(Locator.name("folderName"), folderName);
-        clickButton("Submit", WAIT_FOR_EXT_MASK_TO_DISSAPEAR);
+        doAndWaitForFileListRefresh(() -> {
+            clickFileBrowserButton(BrowserAction.NEW_FOLDER);
+            setFormElement(Locator.name("folderName"), folderName);
+            clickButton("Submit", WAIT_FOR_EXT_MASK_TO_DISSAPEAR);
+        });
         waitForElement(fileGridCell.withText(folderName));
     }
 
     public void setDescription(String fileName, String description)
     {
-        Window propWindow = editProperty(fileName);
-        setFormElement(Locator.name("Flag/Comment"), description);
-        propWindow.clickButton("Save", true);
-        _ext4Helper.waitForMaskToDisappear();
+        doAndWaitForFileListRefresh(() -> {
+            Window propWindow = editProperty(fileName);
+            setFormElement(Locator.name("Flag/Comment"), description);
+            propWindow.clickButton("Save", true);
+            _ext4Helper.waitForMaskToDisappear();
+        });
     }
 
     public String getFileDescription(String fileName)
@@ -569,16 +579,8 @@ public class FileBrowserHelper extends WebDriverWrapper
         assertEquals("Description didn't clear after upload", "", getFormElement(Locator.name("description")));
     }
 
-    /**
-     *
-     * @param file
-     */
-    @Override
-    @LogMethod
-    public void dragAndDropFileInDropZone(@LoggedParam File file)
+    private void dragAndDropFileInDropZone(File file)
     {
-        waitForFileGridReady();
-
         //Offsets for the drop zone
         int offsetX = 0;
         int offsetY = 0;
@@ -690,10 +692,10 @@ public class FileBrowserHelper extends WebDriverWrapper
         ADMIN("cog", "Admin", "customize"),
         CREATE_RUN("sitemap", "Create Run", "createRun");
 
-        private String _iconName;
-        private String _buttonText;
-        private String _extId; // from Browser.js
-        private boolean _triggersPageLoad;
+        private final String _iconName;
+        private final String _buttonText;
+        private final String _extId; // from Browser.js
+        private final boolean _triggersPageLoad;
 
         BrowserAction(String iconName, String buttonText, String extId, boolean triggersPageLoad)
         {


### PR DESCRIPTION
#### Rationale
S3 tests hit intermittent failures because of the slightly longer delay for many file browser operations. `FileBrowserHelper` assumes that many of these operations will finish immediately. `doAndWaitForFileListRefresh` should make sure the file list has updated before allowing tests to continue.

#### Related Pull Requests
* N/A

#### Changes
* Remove redundant `dragAndDropFileInDropZone` method
* Clean up extra test projects created by `FolderExportTest`
* Wrap more file browser operations in `doAndWaitForFileListRefresh`