### PR TITLE
Clear selection explicitly before exporting list archive

### DIFF
--- a/src/org/labkey/test/tests/ListArchiveExportTest.java
+++ b/src/org/labkey/test/tests/ListArchiveExportTest.java
@@ -8,7 +8,6 @@ import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
-import org.labkey.test.Locators;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Hosting;
 import org.labkey.test.components.list.ManageListsGrid;
@@ -112,6 +111,7 @@ public class ListArchiveExportTest extends BaseWebDriverTest
         goBack();
 
         listsGrid = new ManageListsGrid(getDriver());
+        listsGrid.uncheckAllOnPage();
         listsGrid.clearAllFilters();
         listsGrid.setFilter("Container", "Equals One Of", LIST_FOLDER_A + ";" + getProjectName());
         Assert.assertEquals("Incorrect list after container filter", Arrays.asList(LIST_A, LIST_B), listsGrid.getColumnDataAsText("Name"));


### PR DESCRIPTION
#### Rationale
List selection doesn't seem to be getting cleared after attempting to export lists with matching names:
```
org.openqa.selenium.TimeoutException: File(s) did not appear in download dir:
  at app//org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2245)
  at app//org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2238)
  at app//org.labkey.test.WebDriverWrapper.getNewFiles(WebDriverWrapper.java:2316)
  at app//org.labkey.test.WebDriverWrapper.doAndWaitForDownload(WebDriverWrapper.java:2292)
  at app//org.labkey.test.WebDriverWrapper.doAndWaitForDownload(WebDriverWrapper.java:2271)
  at app//org.labkey.test.components.list.ManageListsGrid.exportSelectedLists(ManageListsGrid.java:50)
  at app//org.labkey.test.tests.ListArchiveExportTest.testExportListArchive(ListArchiveExportTest.java:119)
```
![image](https://github.com/LabKey/testAutomation/assets/5263798/944cefda-e539-4781-9c75-9d100337cee4)

#### Related Pull Requests
* N/A

#### Changes
* Clear selection explicitly before exporting list archive
