### PR TITLE
Allow test to specify delete timeout

### DIFF
--- a/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
+++ b/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
@@ -54,13 +54,23 @@ public class DeleteConfirmationDialog<SourcePage extends WebDriverWrapper, Confi
 
     public ConfirmPage confirmDelete()
     {
-        this.dismiss("Yes, Delete");
+        return confirmDelete(10);
+    }
+
+    public ConfirmPage confirmDelete(Integer waitSeconds)
+    {
+        this.dismiss("Yes, Delete", waitSeconds);
         return _confirmPageSupplier.get();
     }
 
     public ConfirmPage confirmPermanentlyDelete()
     {
-        this.dismiss("Yes, Permanently Delete");
+        return confirmPermanentlyDelete(10);
+    }
+
+    public ConfirmPage confirmPermanentlyDelete(Integer waitSeconds)
+    {
+        this.dismiss("Yes, Permanently Delete", waitSeconds);
         return _confirmPageSupplier.get();
     }
 


### PR DESCRIPTION
#### Rationale
Recently, [BiologicsProjectAdminTest.testDeleteProjectWithOwnData](https://teamcity.labkey.org/viewLog.html?buildId=2676264&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsPostgres&fromSakuraUI=true#testNameId-4832435743203914329) failed because it took longer than the default 10-second timeout for the test to delete a project with data in it.

This change modifies DeleteConfirmationDialog to allow calling code to specify an appropriate timeout for the delete operation to take.

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/2426

#### Changes

- [x] provide overloads to dismiss methods that accept timeout values
