### PR TITLE
Automation test for Wiki search results show HTML source when document includes a comma

### DIFF
--- a/src/org/labkey/test/tests/wiki/WikiTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiTest.java
@@ -214,14 +214,14 @@ public class WikiTest extends BaseWebDriverTest
         log("Creating the wiki " + wikiTitle);
         WikiHelper wikiHelper = new WikiHelper(this);
         wikiHelper.createNewWikiPage("HTML");
-        numberOfWikiCreated++;
         setFormElement(Locator.name("name"), wikiName);
         setFormElement(Locator.name("title"), wikiTitle);
         wikiHelper.setWikiBody("<p>" + wikiContent + "</p>");
         wikiHelper.saveWikiPage();
+        numberOfWikiCreated++;
 
 
-        searchFor(PROJECT_NAME, "commas", numberOfWikiCreated, wikiTitle);
+        searchFor(PROJECT_NAME, "commas", 1, wikiTitle);
         Assert.assertEquals("Incorrect result with comma", Arrays.asList(wikiTitle + "\n/" + getProjectName() + "\n" + wikiContent), getTexts(new SearchResultsPage(getDriver()).getResults()));
     }
 

--- a/src/org/labkey/test/tests/wiki/WikiTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiTest.java
@@ -220,8 +220,7 @@ public class WikiTest extends BaseWebDriverTest
         wikiHelper.saveWikiPage();
         numberOfWikiCreated++;
 
-
-        searchFor(PROJECT_NAME, "commas", 1, wikiTitle);
+        searchFor(PROJECT_NAME, "commas", 1, null);
         Assert.assertEquals("Incorrect result with comma", Arrays.asList(wikiTitle + "\n/" + getProjectName() + "\n" + wikiContent), getTexts(new SearchResultsPage(getDriver()).getResults()));
     }
 

--- a/src/org/labkey/test/tests/wiki/WikiTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiTest.java
@@ -28,10 +28,8 @@ import org.labkey.test.pages.search.SearchResultsPage;
 import org.labkey.test.pages.wiki.EditPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PortalHelper;
-import org.labkey.test.util.SearchHelper;
 import org.labkey.test.util.WikiHelper;
 import org.labkey.test.util.search.SearchAdminAPIHelper;
-import org.labkey.test.util.search.SearchResultsQueue;
 
 import java.io.File;
 import java.util.Arrays;
@@ -42,8 +40,6 @@ import java.util.List;
 public class WikiTest extends BaseWebDriverTest
 {
     private static final String PROJECT_NAME = TRICKY_CHARACTERS_FOR_PROJECT_NAMES + "WikiVerifyProject";
-    private static final SearchResultsQueue SEARCH_RESULTS_QUEUE = new SearchResultsQueue();
-    private final SearchHelper _searchHelper = new SearchHelper(this, SEARCH_RESULTS_QUEUE).setMaxTries(6);
     private static final String WIKI_PAGE_ALTTITLE = "PageBBB has HTML";
     private static final String WIKI_PAGE_WEBPART_ID = "qwp999";
     private static final String WIKI_PAGE_TITLE = "_Test Wiki " + BaseWebDriverTest.INJECT_CHARS_1;
@@ -221,10 +217,11 @@ public class WikiTest extends BaseWebDriverTest
         numberOfWikiCreated++;
         setFormElement(Locator.name("name"), wikiName);
         setFormElement(Locator.name("title"), wikiTitle);
-        wikiHelper.setWikiBody(wikiContent);
+        wikiHelper.setWikiBody("<p>" + wikiContent + "</p>");
         wikiHelper.saveWikiPage();
 
-        _searchHelper.searchFor("commas");
+
+        searchFor(PROJECT_NAME, "commas", numberOfWikiCreated, wikiTitle);
         Assert.assertEquals("Incorrect result with comma", Arrays.asList(wikiTitle + "\n/" + getProjectName() + "\n" + wikiContent), getTexts(new SearchResultsPage(getDriver()).getResults()));
     }
 

--- a/src/org/labkey/test/tests/wiki/WikiTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiTest.java
@@ -204,7 +204,7 @@ public class WikiTest extends BaseWebDriverTest
 
     /*
         Regression coverage for
-         :https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=48019
+        https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=48019
 
      */
     @Test
@@ -225,7 +225,7 @@ public class WikiTest extends BaseWebDriverTest
         wikiHelper.saveWikiPage();
 
         _searchHelper.searchFor("commas");
-        Assert.assertEquals("Incorrect result with comma", Arrays.asList(wikiTitle + "\n/" + getProjectName() + "\n" + wikiContent),getTexts(new SearchResultsPage(getDriver()).getResults()));
+        Assert.assertEquals("Incorrect result with comma", Arrays.asList(wikiTitle + "\n/" + getProjectName() + "\n" + wikiContent), getTexts(new SearchResultsPage(getDriver()).getResults()));
     }
 
     protected void verifyWikiPagePresent()

--- a/src/org/labkey/test/tests/wiki/WikiTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiTest.java
@@ -24,11 +24,14 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Wiki;
+import org.labkey.test.pages.search.SearchResultsPage;
 import org.labkey.test.pages.wiki.EditPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PortalHelper;
+import org.labkey.test.util.SearchHelper;
 import org.labkey.test.util.WikiHelper;
 import org.labkey.test.util.search.SearchAdminAPIHelper;
+import org.labkey.test.util.search.SearchResultsQueue;
 
 import java.io.File;
 import java.util.Arrays;
@@ -39,7 +42,8 @@ import java.util.List;
 public class WikiTest extends BaseWebDriverTest
 {
     private static final String PROJECT_NAME = TRICKY_CHARACTERS_FOR_PROJECT_NAMES + "WikiVerifyProject";
-
+    private static final SearchResultsQueue SEARCH_RESULTS_QUEUE = new SearchResultsQueue();
+    private final SearchHelper _searchHelper = new SearchHelper(this, SEARCH_RESULTS_QUEUE).setMaxTries(6);
     private static final String WIKI_PAGE_ALTTITLE = "PageBBB has HTML";
     private static final String WIKI_PAGE_WEBPART_ID = "qwp999";
     private static final String WIKI_PAGE_TITLE = "_Test Wiki " + BaseWebDriverTest.INJECT_CHARS_1;
@@ -196,6 +200,32 @@ public class WikiTest extends BaseWebDriverTest
         EditPage editWikiPage = wikiHelper.editWikiPage();
         editWikiPage.clickShowPageTree();
         assertElementPresent(Locator.id("wiki-toc-tree").append(Locator.linkContainingText(WIKI_PAGE_TITLE + " (" + WIKI_PAGE_NAME + ")")));
+    }
+
+    /*
+        Regression coverage for
+         :https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=48019
+
+     */
+    @Test
+    public void testWikiWithComma()
+    {
+        String wikiName = "Wiki with comma's";
+        String wikiTitle = "Comma in the content";
+        String wikiContent = "This is my HTML, with commas";
+
+        goToProjectHome();
+        log("Creating the wiki " + wikiTitle);
+        WikiHelper wikiHelper = new WikiHelper(this);
+        wikiHelper.createNewWikiPage("HTML");
+        numberOfWikiCreated++;
+        setFormElement(Locator.name("name"), wikiName);
+        setFormElement(Locator.name("title"), wikiTitle);
+        wikiHelper.setWikiBody(wikiContent);
+        wikiHelper.saveWikiPage();
+
+        _searchHelper.searchFor("commas");
+        Assert.assertEquals("Incorrect result with comma", Arrays.asList(wikiTitle + "\n/" + getProjectName() + "\n" + wikiContent),getTexts(new SearchResultsPage(getDriver()).getResults()));
     }
 
     protected void verifyWikiPagePresent()


### PR DESCRIPTION
#### Rationale
Automation test for Wiki search results show HTML source when document includes a comma

Repro:

- Create an HTML wiki page with text "This is my HTML, with commas" on labkey.org (e.g., in the Staff project).
- Save
- Search for "commas" in the current folder
- Search result should not show HTML tags

https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47814

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
