### PR TITLE
BootstrapMenu: support dropup version

### DIFF
--- a/src/org/labkey/test/components/html/BootstrapMenu.java
+++ b/src/org/labkey/test/components/html/BootstrapMenu.java
@@ -196,40 +196,26 @@ public class BootstrapMenu extends BaseBootstrapMenu
             return dropdownMenu(dropdownToggle());
         }
 
-        private static Locator.XPathLocator dropdownMenu(Locator.XPathLocator toggleLoc, boolean isDropup)
-        {
-
-            return Locator.byClass(isDropup ? "dropup" : "dropdown")
-                    .withChild(toggleLoc)
-                    .withChild(Locator.tag("ul"));
-        }
-
         private static Locator.XPathLocator dropdownMenu(Locator.XPathLocator toggleLoc)
         {
-            return dropdownMenu(toggleLoc, false);
+
+            return Locator.XPathLocator.union(Locator.byClass("dropup"), Locator.byClass("dropdown")).withChild(toggleLoc)
+                    .withChild(Locator.tag("ul"));
         }
     }
 
     public static class BootstrapMenuFinder extends WebDriverComponentFinder<BootstrapMenu, BootstrapMenu.BootstrapMenuFinder>
     {
         private Locator _locator = Locators.dropdownMenu();
-        private boolean _isDropup = false;
 
         public BootstrapMenuFinder(WebDriver driver)
         {
             super(driver);
         }
 
-        public BootstrapMenuFinder(WebDriver driver, boolean isDropup)
-        {
-            super(driver);
-            _isDropup = isDropup;
-            _locator = Locators.dropdownMenu(Locators.dropdownToggle(), _isDropup);
-        }
-
         public BootstrapMenuFinder withToggleId(String id)
         {
-            _locator = Locators.dropdownMenu(Locators.dropdownToggle().withAttribute("id", id), _isDropup);
+            _locator = Locators.dropdownMenu(Locators.dropdownToggle().withAttribute("id", id));
             return this;
         }
 

--- a/src/org/labkey/test/components/html/BootstrapMenu.java
+++ b/src/org/labkey/test/components/html/BootstrapMenu.java
@@ -196,26 +196,40 @@ public class BootstrapMenu extends BaseBootstrapMenu
             return dropdownMenu(dropdownToggle());
         }
 
-        private static Locator.XPathLocator dropdownMenu(Locator.XPathLocator toggleLoc)
+        private static Locator.XPathLocator dropdownMenu(Locator.XPathLocator toggleLoc, boolean isDropup)
         {
-            return Locator.byClass("dropdown")
+
+            return Locator.byClass(isDropup ? "dropup" : "dropdown")
                     .withChild(toggleLoc)
                     .withChild(Locator.tag("ul"));
+        }
+
+        private static Locator.XPathLocator dropdownMenu(Locator.XPathLocator toggleLoc)
+        {
+            return dropdownMenu(toggleLoc, false);
         }
     }
 
     public static class BootstrapMenuFinder extends WebDriverComponentFinder<BootstrapMenu, BootstrapMenu.BootstrapMenuFinder>
     {
         private Locator _locator = Locators.dropdownMenu();
+        private boolean _isDropup = false;
 
         public BootstrapMenuFinder(WebDriver driver)
         {
             super(driver);
         }
 
+        public BootstrapMenuFinder(WebDriver driver, boolean isDropup)
+        {
+            super(driver);
+            _isDropup = isDropup;
+            _locator = Locators.dropdownMenu(Locators.dropdownToggle(), _isDropup);
+        }
+
         public BootstrapMenuFinder withToggleId(String id)
         {
-            _locator = Locators.dropdownMenu(Locators.dropdownToggle().withAttribute("id", id));
+            _locator = Locators.dropdownMenu(Locators.dropdownToggle().withAttribute("id", id), _isDropup);
             return this;
         }
 


### PR DESCRIPTION
#### Rationale
This PR updates BootstrapMenu to make it compatible with the "dropup" variant, which is needed by our new sticky form buttons.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1303
- https://github.com/LabKey/labkey-ui-premium/pull/206
- https://github.com/LabKey/biologics/pull/2408
- https://github.com/LabKey/inventory/pull/1044
- https://github.com/LabKey/sampleManagement/pull/2132
- https://github.com/LabKey/platform/pull/4803
- https://github.com/LabKey/testAutomation/pull/1667

#### Changes
* BootstrapMenu: Add option to find dropup version

