### PR TITLE
Pause before setting name in sample type designer

### DIFF
--- a/src/org/labkey/test/components/Component.java
+++ b/src/org/labkey/test/components/Component.java
@@ -45,13 +45,13 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
     @Override
     public WebElement findElement(By by)
     {
-        return elementCache().findElement(by);
+        return getComponentElement().findElement(by);
     }
 
     @Override
     public List<WebElement> findElements(By by)
     {
-        return elementCache().findElements(by);
+        return getComponentElement().findElements(by);
     }
 
     private EC _elementCache;

--- a/src/org/labkey/test/components/Component.java
+++ b/src/org/labkey/test/components/Component.java
@@ -45,13 +45,13 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
     @Override
     public WebElement findElement(By by)
     {
-        return getComponentElement().findElement(by);
+        return elementCache().findElement(by);
     }
 
     @Override
     public List<WebElement> findElements(By by)
     {
-        return getComponentElement().findElements(by);
+        return elementCache().findElements(by);
     }
 
     private EC _elementCache;

--- a/src/org/labkey/test/components/domain/DomainPanel.java
+++ b/src/org/labkey/test/components/domain/DomainPanel.java
@@ -1,7 +1,6 @@
 package org.labkey.test.components.domain;
 
 import org.labkey.test.Locator;
-import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.util.LabKeyExpectedConditions;
@@ -99,12 +98,6 @@ public abstract class DomainPanel<EC extends DomainPanel<EC, T>.ElementCache, T 
 
     public abstract class ElementCache extends Component<EC>.ElementCache
     {
-        public ElementCache()
-        {
-            // Add a little speed bump to prevent form initialization from clearing out entered values
-            WebDriverWrapper.sleep(500);
-        }
-
         protected final WebElement expandToggle = Locator.css(".domain-form-expand-btn, .domain-form-collapse-btn")
                 .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
         protected final WebElement headerStatusIcon = Locator.css(".domain-panel-status-icon > svg").findWhenNeeded(this);

--- a/src/org/labkey/test/components/domain/DomainPanel.java
+++ b/src/org/labkey/test/components/domain/DomainPanel.java
@@ -1,6 +1,7 @@
 package org.labkey.test.components.domain;
 
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.util.LabKeyExpectedConditions;
@@ -96,6 +97,12 @@ public abstract class DomainPanel<EC extends DomainPanel<EC, T>.ElementCache, T 
 
     public abstract class ElementCache extends Component<EC>.ElementCache
     {
+        public ElementCache()
+        {
+            // Add a little speed bump to prevent form initialization from clearing out entered values
+            WebDriverWrapper.sleep(250);
+        }
+
         protected final WebElement expandToggle = Locator.css(".domain-form-expand-btn, .domain-form-collapse-btn")
                 .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
         protected final WebElement headerStatusIcon = Locator.css(".domain-panel-status-icon > svg").findWhenNeeded(this);

--- a/src/org/labkey/test/components/domain/DomainPanel.java
+++ b/src/org/labkey/test/components/domain/DomainPanel.java
@@ -100,7 +100,7 @@ public abstract class DomainPanel<EC extends DomainPanel<EC, T>.ElementCache, T 
         public ElementCache()
         {
             // Add a little speed bump to prevent form initialization from clearing out entered values
-            WebDriverWrapper.sleep(250);
+            WebDriverWrapper.sleep(500);
         }
 
         protected final WebElement expandToggle = Locator.css(".domain-form-expand-btn, .domain-form-collapse-btn")

--- a/src/org/labkey/test/components/domain/DomainPanel.java
+++ b/src/org/labkey/test/components/domain/DomainPanel.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.WebElement;
 import java.util.Optional;
 
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+import static org.labkey.test.WebDriverWrapper.waitFor;
 
 /**
  * Wraps the functionality of the LabKey ui component defined in domainproperties/CollapsiblePanelHeader.tsx
@@ -61,8 +62,9 @@ public abstract class DomainPanel<EC extends DomainPanel<EC, T>.ElementCache, T 
         if (isExpanded() != expand)
         {
             elementCache().expandToggle.click();
+            waitFor(() -> isExpanded() == expand, "Panel failed to " + (expand ? "expand" : "collapse"), 2_000);
             getWrapper().shortWait()
-                    .until(LabKeyExpectedConditions.animationIsDone(getComponentElement())); // wait for transition to happen
+                    .until(LabKeyExpectedConditions.animationIsDone(elementCache().panelBody)); // wait for transition to happen
         }
         return getThis();
     }

--- a/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
@@ -272,13 +272,14 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
 
     protected class ElementCache extends DomainDesigner<?>.ElementCache
     {
-        protected final Input nameInput = new ValidatingInput(Locator.id("entity-name").findWhenNeeded(this), getDriver());
-        protected final Input nameExpressionInput = new ValidatingInput(Locator.id("entity-nameExpression").findWhenNeeded(this), getDriver());
-        protected final Input descriptionInput = new ValidatingInput(Locator.id("entity-description").findWhenNeeded(this), getDriver());
+        protected final Input nameInput = new ValidatingInput(Locator.id("entity-name").findWhenNeeded(propertiesPanel), getDriver());
+        protected final Input nameExpressionInput = new ValidatingInput(Locator.id("entity-nameExpression").findWhenNeeded(propertiesPanel), getDriver());
+        protected final Input descriptionInput = new ValidatingInput(Locator.id("entity-description").findWhenNeeded(propertiesPanel), getDriver());
 
         protected final Select autoLinkDataToStudy = SelectWrapper.Select(Locator.id("entity-autoLinkTargetContainerId"))
-                .findWhenNeeded(this);
-        protected final Input linkedDatasetCategory = new ValidatingInput(Locator.id("entity-autoLinkCategory").findWhenNeeded(this), getDriver());
+                .findWhenNeeded(propertiesPanel);
+        protected final Input linkedDatasetCategory = new ValidatingInput(Locator.id("entity-autoLinkCategory")
+                .findWhenNeeded(propertiesPanel), getDriver());
 
         Optional<WebElement> optionalWarningAlert()
         {

--- a/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
@@ -272,6 +272,12 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
 
     protected class ElementCache extends DomainDesigner<?>.ElementCache
     {
+        public ElementCache()
+        {
+            // Add a little speed bump to prevent form initialization from clearing out entered values
+            WebDriverWrapper.sleep(500);
+        }
+
         protected final Input nameInput = new ValidatingInput(Locator.id("entity-name").findWhenNeeded(propertiesPanel), getDriver());
         protected final Input nameExpressionInput = new ValidatingInput(Locator.id("entity-nameExpression").findWhenNeeded(propertiesPanel), getDriver());
         protected final Input descriptionInput = new ValidatingInput(Locator.id("entity-description").findWhenNeeded(propertiesPanel), getDriver());

--- a/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
@@ -178,14 +178,14 @@ public abstract class SampleTypeDesigner<T extends SampleTypeDesigner<T>> extend
 
     protected class ElementCache extends EntityTypeDesigner<T>.ElementCache
     {
-        protected final WebElement uniqueIdAlert = Locator.tagWithClassContaining("div","uniqueid-alert").refindWhenNeeded(this);
+        protected final WebElement uniqueIdAlert = Locator.tagWithClassContaining("div","uniqueid-alert").refindWhenNeeded(propertiesPanel);
         protected final WebElement uniqueIdAlertAddButton = Locator.tagWithClassContaining("div","uniqueid-alert")
-                .append(Locator.tag("button")).refindWhenNeeded(this);
-        protected final WebElement uniqueIdMsg = Locator.tagWithClass("div","uniqueid-msg").refindWhenNeeded(this);
+                .append(Locator.tag("button")).refindWhenNeeded(propertiesPanel);
+        protected final WebElement uniqueIdMsg = Locator.tagWithClass("div","uniqueid-msg").refindWhenNeeded(propertiesPanel);
         protected final WebElement uniqueIdMsgCheckIcon = Locator.tagWithClass("div","uniqueid-msg")
-                .append(Locator.tagWithClassContaining("i", "domain-panel-status-icon-green")).refindWhenNeeded(this);
+                .append(Locator.tagWithClassContaining("i", "domain-panel-status-icon-green")).refindWhenNeeded(propertiesPanel);
 
-        protected final WebElement addAliasButton = Locator.tagWithClass("i","container--addition-icon").findWhenNeeded(this);
+        protected final WebElement addAliasButton = Locator.tagWithClass("i","container--addition-icon").findWhenNeeded(propertiesPanel);
 
         public List<Input> parentAliases()
         {

--- a/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
@@ -178,12 +178,12 @@ public abstract class SampleTypeDesigner<T extends SampleTypeDesigner<T>> extend
 
     protected class ElementCache extends EntityTypeDesigner<T>.ElementCache
     {
-        protected final WebElement uniqueIdAlert = Locator.tagWithClassContaining("div","uniqueid-alert").refindWhenNeeded(propertiesPanel);
+        protected final WebElement uniqueIdAlert = Locator.tagWithClassContaining("div","uniqueid-alert").refindWhenNeeded(getDriver());
         protected final WebElement uniqueIdAlertAddButton = Locator.tagWithClassContaining("div","uniqueid-alert")
-                .append(Locator.tag("button")).refindWhenNeeded(propertiesPanel);
-        protected final WebElement uniqueIdMsg = Locator.tagWithClass("div","uniqueid-msg").refindWhenNeeded(propertiesPanel);
+                .append(Locator.tag("button")).refindWhenNeeded(getDriver());
+        protected final WebElement uniqueIdMsg = Locator.tagWithClass("div","uniqueid-msg").refindWhenNeeded(getDriver());
         protected final WebElement uniqueIdMsgCheckIcon = Locator.tagWithClass("div","uniqueid-msg")
-                .append(Locator.tagWithClassContaining("i", "domain-panel-status-icon-green")).refindWhenNeeded(propertiesPanel);
+                .append(Locator.tagWithClassContaining("i", "domain-panel-status-icon-green")).refindWhenNeeded(getDriver());
 
         protected final WebElement addAliasButton = Locator.tagWithClass("i","container--addition-icon").findWhenNeeded(propertiesPanel);
 

--- a/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
@@ -178,12 +178,12 @@ public abstract class SampleTypeDesigner<T extends SampleTypeDesigner<T>> extend
 
     protected class ElementCache extends EntityTypeDesigner<T>.ElementCache
     {
-        protected final WebElement uniqueIdAlert = Locator.tagWithClassContaining("div","uniqueid-alert").refindWhenNeeded(getDriver());
+        protected final WebElement uniqueIdAlert = Locator.tagWithClassContaining("div","uniqueid-alert").refindWhenNeeded(this);
         protected final WebElement uniqueIdAlertAddButton = Locator.tagWithClassContaining("div","uniqueid-alert")
-                .append(Locator.tag("button")).refindWhenNeeded(getDriver());
-        protected final WebElement uniqueIdMsg = Locator.tagWithClass("div","uniqueid-msg").refindWhenNeeded(getDriver());
+                .append(Locator.tag("button")).refindWhenNeeded(this);
+        protected final WebElement uniqueIdMsg = Locator.tagWithClass("div","uniqueid-msg").refindWhenNeeded(this);
         protected final WebElement uniqueIdMsgCheckIcon = Locator.tagWithClass("div","uniqueid-msg")
-                .append(Locator.tagWithClassContaining("i", "domain-panel-status-icon-green")).refindWhenNeeded(getDriver());
+                .append(Locator.tagWithClassContaining("i", "domain-panel-status-icon-green")).refindWhenNeeded(this);
 
         protected final WebElement addAliasButton = Locator.tagWithClass("i","container--addition-icon").findWhenNeeded(propertiesPanel);
 


### PR DESCRIPTION
#### Rationale
Sample type creation through the UI fails regularly at automation speed. The name seems to be cleared out after the value is set.

#### Related Pull Requests
* N/A

#### Changes
* Sleep briefly before interacting with entity type designer
* Narrow scoping of various designer sub-components
