### PR TITLE
include awaitility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ project.dependencies {
     api("junit:junit:${junitVersion}")
     api("org.seleniumhq.selenium:selenium-api:${seleniumVersion}")
     api("org.assertj:assertj-core:${assertjVersion}")
+    implementation("org.awaitility:awaitility:${awaitilityVersion}")
     implementation("commons-io:commons-io:${commonsIoVersion}")
     implementation("com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}")
     implementation("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 aspectjVersion=1.9.19
 assertjVersion=3.23.1
+awaitilityVersion=4.2.0
 commonsTextVersion=1.10.0
 reflectionsVersion=0.9.10
 hamcrestCoreVersion=1.3


### PR DESCRIPTION
#### Rationale
This change imports support for `awaitility`, which gets us support for awaiting asserts

One of the Biologics tests in 23.7 failed recently while asserting a condition that was fulfilled by the time the failure screenshot was taken; this change is intended to allow that test to await the fulfillment of the assert (see related pull request)

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/2443

#### Changes

- [x] include `awaitility`
- [x] backport awaiting support to `DeferredErrorCollector`
- [x] (CR feedback) undo changes to `DeferredErrorCollector`
