### PR TITLE
Test helper to get text from text nodes

### DIFF
--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -12,6 +12,7 @@ import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.components.react.MultiMenu;
 import org.labkey.test.components.react.ReactCheckBox;
 import org.labkey.test.components.ui.FilterStatusValue;
+import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -545,15 +546,11 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         //
         // If this proves to be unreliable it might be easier/safer to return the panel header text and let the test do
         // a .contains() on it to see if it has the expected header.
-        if(elementCache().panelHeader().isDisplayed())
+        WebElement panelHeader = elementCache().panelHeader();
+        if(panelHeader.isDisplayed())
         {
-            String alertText = getEditAlertText();
-            String headerText = elementCache().panelHeader().getText();
-            headerText = headerText.contains(alertText) ? headerText.substring(alertText.length()) : headerText;
-            String buttonText = "Undo\nSave";
-            headerText = headerText.contains(buttonText) ? headerText.substring(0, headerText.indexOf(buttonText)) : headerText;
-            String appButtonText = "UndoSave";
-            viewName = headerText.contains(appButtonText) ? headerText.substring(0, headerText.indexOf(appButtonText)) : headerText;
+            // The view name in the header is not in a separate element.
+            viewName = WebDriverUtils.getTextNodeWithin(panelHeader);
         }
         else
         {

--- a/src/org/labkey/test/components/ui/grids/SaveViewDialog.java
+++ b/src/org/labkey/test/components/ui/grids/SaveViewDialog.java
@@ -122,7 +122,7 @@ public class SaveViewDialog extends ModalDialog
      */
     public void saveView()
     {
-        dismiss("Save", 1);
+        grid.doAndWaitForUpdate(() -> dismiss("Save", 1));
     }
 
     /**

--- a/src/org/labkey/test/util/selenium/WebDriverUtils.java
+++ b/src/org/labkey/test/util/selenium/WebDriverUtils.java
@@ -22,7 +22,9 @@ import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.WrapsElement;
@@ -136,5 +138,68 @@ public abstract class WebDriverUtils
             return (WebDriver) peeling;
         else
             return null;
+    }
+
+    /**
+     * {@link WebElement} cannot represent a text node. JavaScript can though, so we can use it to isolate the text
+     * children of a WebElement and get their text.
+     * Given a WebElement representing the following div:
+     * <pre>{@code
+     * <div>
+     *     <span>A</span>
+     *     B
+     *     <button>C</button>
+     *     D
+     *     <span>D</span>
+     * </div>
+     * }</pre>
+     * This method will return a list containing {@code ("B", "D")}
+     * @param element element to search
+     * @return text from all child text nodes
+     */
+    @SuppressWarnings("unchecked")
+    public static List<String> getTextNodesWithin(WebElement element)
+    {
+        JavascriptExecutor executor = (JavascriptExecutor) extractWrappedDriver(element);
+
+        final String script = """
+                var iterator = document.evaluate("text()", arguments[0]);
+                var texts = [];
+
+                let thisNode = iterator.iterateNext();
+
+                while (thisNode) {
+                    texts.push(thisNode.textContent);
+                    thisNode = iterator.iterateNext();
+                }
+                return texts;
+                """;
+
+        List<Object> nodeTexts;
+        try
+        {
+            nodeTexts = (List<Object>) executor.executeScript(script, element);
+        }
+        catch (WebDriverException retry)
+        {
+            nodeTexts = (List<Object>) executor.executeScript(script, element);
+        }
+
+        return nodeTexts.stream().map(t -> (String) t).toList();
+    }
+
+    /**
+     * Gets text from the first text node under the specified WebElement.
+     *
+     * @see #getTextNodesWithin(WebElement)
+     */
+    public static String getTextNodeWithin(WebElement element)
+    {
+        List<String> textChildren = getTextNodesWithin(element);
+        if (textChildren.isEmpty())
+        {
+            throw new NoSuchElementException("Element does not have any text children: " + element.toString());
+        }
+        return textChildren.get(0);
     }
 }

--- a/src/org/labkey/test/util/selenium/WebDriverUtils.java
+++ b/src/org/labkey/test/util/selenium/WebDriverUtils.java
@@ -182,6 +182,7 @@ public abstract class WebDriverUtils
         }
         catch (WebDriverException retry)
         {
+            // Script might throw if the document tree is modified during iteration. Retry once.
             nodeTexts = (List<Object>) executor.executeScript(script, element);
         }
 


### PR DESCRIPTION
#### Rationale
We occasionally see product DOM that contains text in a way that is difficult for tests to extract just the text it wants (e.g. `<div><span>unwanted</span>wanted</div>`). A `WebElement` cannot represent such a text node but JavaScript can. We can use JavaScript to isolate the text children of a WebElement and get their text.
Given a WebElement representing the following div:
```
<div>
    <span>A</span>
    B
    <button>C</button>
    D
    <span>D</span>
</div>
```
`WebDriverUtils.getTextNodesWithin` will return a list containing `("B", "D")`
`WebDriverUtils.getTextNodeWithin` will return just `"B"`

#### Related Pull Requests
* N/A

#### Changes
* Create test helper to get text from text nodes
* Backport timing fix for `SaveViewDialog` (#1636)
