### PR TITLE
Add flag to dump browser console logs

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -854,7 +854,10 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         {
             try
             {
-                dumpConsoleLogs();
+                if (TestProperties.isDumpBrowserConsole())
+                {
+                    dumpBrowserConsole();
+                }
             }
             catch (WebDriverException e)
             {
@@ -1064,7 +1067,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         return null;
     }
 
-    private void dumpConsoleLogs()
+    private void dumpBrowserConsole()
     {
         List<?> logEntries = executeScript("return console.everything;", List.class);
         if (logEntries != null)

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -152,6 +152,11 @@ public abstract class TestProperties
         return "true".equals(System.getProperty("webtest.webdriver.headless"));
     }
 
+    public static boolean isDumpBrowserConsole()
+    {
+        return "true".equals(System.getProperty("webtest.dump.browser.console"));
+    }
+
     public static double getTimeoutMultiplier()
     {
         try

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1897,32 +1897,35 @@ public abstract class WebDriverWrapper implements WrapsDriver
                 .withMessage("waiting for document to be ready")
                 .until(wd -> Objects.equals(executeScript("return document.readyState;"), "complete"));
         Locators.documentRoot.waitForElement(getDriver(), (int) timer.timeRemaining().toMillis());
-        executeScript("""
-                if (console.everything === undefined)
-                {
-                    console.everything = [];
+        if (TestProperties.isDumpBrowserConsole())
+        {
+            executeScript("""
+                    if (console.everything === undefined)
+                    {
+                        console.everything = [];
 
-                    console.defaultLog = console.log.bind(console);
-                    console.log = function(){
-                        console.everything.push({"type":"log", "datetime":Date().toLocaleString(), "value":Array.from(arguments)});
-                        console.defaultLog.apply(console, arguments);
-                    }
-                    console.defaultError = console.error.bind(console);
-                    console.error = function(){
-                        console.everything.push({"type":"error", "datetime":Date().toLocaleString(), "value":Array.from(arguments)});
-                        console.defaultError.apply(console, arguments);
-                    }
-                    console.defaultWarn = console.warn.bind(console);
-                    console.warn = function(){
-                        console.everything.push({"type":"warn", "datetime":Date().toLocaleString(), "value":Array.from(arguments)});
-                        console.defaultWarn.apply(console, arguments);
-                    }
-                    console.defaultDebug = console.debug.bind(console);
-                    console.debug = function(){
-                        console.everything.push({"type":"debug", "datetime":Date().toLocaleString(), "value":Array.from(arguments)});
-                        console.defaultDebug.apply(console, arguments);
-                    }
-                }""");
+                        console.defaultLog = console.log.bind(console);
+                        console.log = function(){
+                            console.everything.push({"type":"log", "datetime":Date().toLocaleString(), "value":Array.from(arguments)});
+                            console.defaultLog.apply(console, arguments);
+                        }
+                        console.defaultError = console.error.bind(console);
+                        console.error = function(){
+                            console.everything.push({"type":"error", "datetime":Date().toLocaleString(), "value":Array.from(arguments)});
+                            console.defaultError.apply(console, arguments);
+                        }
+                        console.defaultWarn = console.warn.bind(console);
+                        console.warn = function(){
+                            console.everything.push({"type":"warn", "datetime":Date().toLocaleString(), "value":Array.from(arguments)});
+                            console.defaultWarn.apply(console, arguments);
+                        }
+                        console.defaultDebug = console.debug.bind(console);
+                        console.debug = function(){
+                            console.everything.push({"type":"debug", "datetime":Date().toLocaleString(), "value":Array.from(arguments)});
+                            console.defaultDebug.apply(console, arguments);
+                        }
+                    }""");
+        }
         waitForOnReady("jQuery");
         waitForOnReady("Ext");
         waitForOnReady("Ext4");


### PR DESCRIPTION
#### Rationale
I'm worried that running this extra JavaScript on every page load is causing us to see more intermittent failures. I haven't seen much useful information dumped from the browser console so I'd like to hide the feature behind a flag.

#### Related Pull Requests
* #1650 

#### Changes
* Add flag (`webtest.dump.browser.console`) to dump browser console logs
