### PR TITLE
Fix page load detection on Firefox 115

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1882,10 +1882,14 @@ public abstract class WebDriverWrapper implements WrapsDriver
     {
         try
         {
+            toBeStale.isEnabled();
             new WebDriverWait(getDriver(), timer.timeRemaining())
-                    .ignoring(NullPointerException.class)
                     .withMessage("waiting for browser to navigate")
                     .until(ExpectedConditions.stalenessOf(toBeStale));
+        }
+        catch (StaleElementReferenceException | NoSuchElementException | NullPointerException ignore)
+        {
+            // `ExpectedConditions.stalenessOf(toBeStale)` sometimes chokes when coming from a blank page (about:blank)
         }
         catch (TimeoutException ex)
         {


### PR DESCRIPTION
#### Rationale
`TestScrubber.cleanSiteSettings` fails on Firefox 115. `WebDriverWrapper.doAndWaitForPageToLoad` waits for the `:root` element to go stale to ensure navigation has occurred. The mechanism used to do this fails when navigating from a blank page (`about:blank`).
Note: Normal test initialization doesn't fail this way because it follows a different code path that doesn't use `doAndWaitForPageToLoad` for the initial navigation to LabKey.
<details>
<summary>Stacktrace</summary>

```
org.openqa.selenium.TimeoutException: Expected condition failed: waiting for browser to navigate (tried for 59 second(s) with 500 milliseconds interval)

	at org.labkey.test.WebDriverWrapper.waitForPageToLoad(WebDriverWrapper.java:1892)
	at org.labkey.test.WebDriverWrapper.doAndMaybeWaitForPageToLoad(WebDriverWrapper.java:2019)
	at org.labkey.test.WebDriverWrapper.doAndWaitForPageToLoad(WebDriverWrapper.java:1988)
	at org.labkey.test.WebDriverWrapper.beginAt(WebDriverWrapper.java:1137)
	at org.labkey.test.WebDriverWrapper.beginAt(WebDriverWrapper.java:1116)
	at org.labkey.test.LabKeySiteWrapper.simpleSignIn(LabKeySiteWrapper.java:135)
	at org.labkey.test.TestScrubber.cleanSiteSettings(TestScrubber.java:51)
	at org.labkey.test.BaseWebDriverTest$2.finished(BaseWebDriverTest.java:447)
	at org.labkey.junit.rules.TestWatcher.finishedQuietly(TestWatcher.java:80)
	at org.labkey.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:36)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:833)

Caused by: org.openqa.selenium.NoSuchElementException: The element with the reference 86c58d90-ea6d-4b21-80b3-8584a550f57f is not known in the current browsing context
For documentation on this error, please visit: https://selenium.dev/exceptions/#no_such_element
Build info: version: '4.8.3', revision: 'e5e76298c3'
System info: os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '11.5', java.version: '17.0.1'
Driver info: org.openqa.selenium.firefox.FirefoxDriver
Command: [50c62ddc-42a8-418d-aada-0e7cd9ec10ce, isElementEnabled {id=86c58d90-ea6d-4b21-80b3-8584a550f57f}]
Capabilities {acceptInsecureCerts: true, browserName: firefox, browserVersion: 115.1.0, moz:accessibilityChecks: false, moz:buildID: 20230724124053, moz:debuggerAddress: 127.0.0.1:5777, moz:geckodriverVersion: 0.33.0, moz:headless: false, moz:platformVersion: 21.6.0, moz:processID: 59814, moz:profile: /var/folders/7n/h66fn8f9087..., moz:shutdownTimeout: 60000, moz:useNonSpecCompliantPointerOrigin: false, moz:webdriverClick: true, moz:windowless: false, pageLoadStrategy: normal, platformName: MAC, proxy: Proxy(), se:cdp: ws://127.0.0.1:5777/devtool..., se:cdpVersion: 85.0, setWindowRect: true, strictFileInteractability: false, timeouts: {implicit: 0, pageLoad: 300000, script: 30000}, unhandledPromptBehavior: dismiss and notify}
Element: [[FirefoxDriver: firefox on MAC (50c62ddc-42a8-418d-aada-0e7cd9ec10ce)] -> css selector: :root]
Session ID: 50c62ddc-42a8-418d-aada-0e7cd9ec10ce
	at jdk.internal.reflect.GeneratedConstructorAccessor20.newInstance(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	at org.openqa.selenium.remote.codec.w3c.W3CHttpResponseCodec.createException(W3CHttpResponseCodec.java:200)
	at org.openqa.selenium.remote.codec.w3c.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:133)
	at org.openqa.selenium.remote.codec.w3c.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:53)
	at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:193)
	at org.openqa.selenium.remote.service.DriverCommandExecutor.invokeExecute(DriverCommandExecutor.java:183)
	at org.openqa.selenium.remote.service.DriverCommandExecutor.execute(DriverCommandExecutor.java:158)
	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:543)
	at org.openqa.selenium.remote.RemoteWebElement.execute(RemoteWebElement.java:257)
	at org.openqa.selenium.remote.RemoteWebElement.isEnabled(RemoteWebElement.java:196)
	at org.labkey.test.selenium.WebElementWrapper.isEnabled(WebElementWrapper.java:79)
	at org.openqa.selenium.support.ui.ExpectedConditions$24.apply(ExpectedConditions.java:690)
	at org.openqa.selenium.support.ui.ExpectedConditions$24.apply(ExpectedConditions.java:685)
	at org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:208)
	... 14 more
```
</details>

#### Related Pull Requests
* N/A

#### Changes
* Fix page load detection on Firefox 115
