### PR TITLE
Make `BaseWebDriverTest.getCurrentTestClass` private

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -244,7 +244,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         return currentTest;
     }
 
-    public static Class<? extends BaseWebDriverTest> getCurrentTestClass()
+    private static Class<? extends BaseWebDriverTest> getCurrentTestClass()
     {
         return getCurrentTest() != null ? getCurrentTest().getClass() : null;
     }

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -153,6 +153,7 @@ import static org.labkey.test.WebTestHelper.makeRelativeUrl;
 import static org.labkey.test.components.html.RadioButton.RadioButton;
 import static org.openqa.selenium.chrome.ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY;
 import static org.openqa.selenium.chrome.ChromeDriverService.CHROME_DRIVER_VERBOSE_LOG_PROPERTY;
+import static org.openqa.selenium.firefox.GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY;
 
 public abstract class WebDriverWrapper implements WrapsDriver
 {
@@ -435,7 +436,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
                 String logFileName = new SimpleDateFormat("'geckodriver_'HHmmss'.log'").format(new Date());
                 final String logPath = new File(downloadDir.getParentFile(), logFileName).getAbsolutePath();
                 log("Saving geckodriver log to: " + logPath);
-                System.setProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE, logPath);
+                System.setProperty(GECKO_DRIVER_LOG_PROPERTY, logPath);
                 return;
             }
             else
@@ -443,7 +444,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
                 log("Failed to create directory for geckodriver log: " + downloadDir.getParentFile().getAbsolutePath());
             }
         }
-        System.setProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE, "/dev/null");
+        System.setProperty(GECKO_DRIVER_LOG_PROPERTY, "/dev/null");
     }
 
     public boolean isFirefox()

--- a/src/org/labkey/test/tests/AttachmentFieldTest.java
+++ b/src/org/labkey/test/tests/AttachmentFieldTest.java
@@ -40,7 +40,7 @@ public class AttachmentFieldTest extends BaseWebDriverTest
     @Override
     protected @Nullable String getProjectName()
     {
-        return getCurrentTestClass().getSimpleName() + " Project";
+        return getClass().getSimpleName() + " Project";
     }
 
     @Override

--- a/src/org/labkey/test/tests/ExportOptionsMetadataOnlyTest.java
+++ b/src/org/labkey/test/tests/ExportOptionsMetadataOnlyTest.java
@@ -38,7 +38,7 @@ public class ExportOptionsMetadataOnlyTest extends BaseWebDriverTest
     @Override
     protected @Nullable String getProjectName()
     {
-        return getCurrentTestClass().getSimpleName() + " Project";
+        return getClass().getSimpleName() + " Project";
     }
 
     @BeforeClass


### PR DESCRIPTION
#### Rationale
`BaseWebDriverTest.getCurrentTestClass` is a convenience method to prevent tests from stepping on each other's toes when JUnit multi-threading leaves a stalled test running while starting another test.

#### Related Pull Requests
* N/A

#### Changes
* Make `BaseWebDriverTest.getCurrentTestClass` private and refactor usages
* Remove usage of deprecated `FirefoxDriver.SystemProperty.BROWSER_LOGFILE`