### PR TITLE
Automated tests for editable grid improvements

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -29,8 +29,10 @@ import static org.labkey.test.WebDriverWrapper.sleep;
  */
 public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.ElementCache>
 {
-    private WebDriver _driver;
+    private final WebDriver _driver;
     private final WebElement _editingDiv;
+
+    private int _readyTimeout = WAIT_FOR_JAVASCRIPT;
 
     public EntityInsertPanel(WebElement element, WebDriver driver)
     {
@@ -330,7 +332,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
             modeSelectListItem("from Grid")
                     .waitForElement(this, 2000).click();
             clearElementCache();
-            WebDriverWrapper.waitFor(() -> isGridVisible(),
+            WebDriverWrapper.waitFor(this::isGridVisible,
                     "the grid did bot become visible", 2000);
         }
         elementCache().grid.waitForLoaded();
@@ -371,11 +373,17 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
             
             newPanel.clearElementCache();
             newPanel.waitForReady();
-            WebDriverWrapper.waitFor(() -> newPanel.isFileUploadVisible(),
+            WebDriverWrapper.waitFor(newPanel::isFileUploadVisible,
                     "the file upload panel did bot become visible", 2000);
 
             return newPanel;
         }
+        return this;
+    }
+
+    public EntityInsertPanel setReadyTimeout(int readyTimeout)
+    {
+        _readyTimeout = readyTimeout;
         return this;
     }
 
@@ -392,7 +400,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
             {
                 return false;
             }
-        }, "The insert panel did not become loaded", WAIT_FOR_JAVASCRIPT);
+        }, "The insert panel did not become loaded", _readyTimeout);
     }
 
     /**

--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -136,8 +136,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
     public EntityInsertPanel addRecords(List<Map<String, Object>> records)
     {
         showGrid();
-        getWrapper().setFormElement(elementCache().addRowsTxtBox, Integer.toString(records.size()));
-        elementCache().addRowsButton.click();
+        elementCache().grid.addRows(records.size());
 
         List<Integer> rowIndices = elementCache().grid.getEditableRowIndices();
 
@@ -239,60 +238,34 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
     public EntityInsertPanel setAddRows(int numOfRows)
     {
         showGrid();
-        getWrapper().setFormElement(elementCache().addRowsTxtBox, Integer.toString(numOfRows));
+        elementCache().grid.setAddRows(numOfRows);
         return this;
     }
 
-    public EntityInsertPanel clickAddRows()
+    public EntityInsertPanel addRows(int count)
     {
         showGrid();
-        elementCache().addRowsButton.click();
+        elementCache().grid.addRows(count);
         return this;
     }
 
     public EntityInsertPanel clickRemove()
     {
         showGrid();
-        getEditableGrid().doAndWaitForUpdate(()->
-                elementCache().deleteRowsBtn.click());
+        elementCache().grid.clickRemove();
         return this;
     }
 
     public EntityBulkInsertDialog clickBulkInsert()
     {
         showGrid();
-        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().bulkInsertBtn));
-        elementCache().bulkInsertBtn.click();
-        return new EntityBulkInsertDialog(getDriver());
-    }
-
-    public boolean isBulkInsertVisible()
-    {
-        return modeSelectListItem("from Grid").withClass("active").findOptionalElement(this).isPresent() &&
-                elementCache().bulkInsertBtnLoc.existsIn(this) &&
-                isElementVisible(elementCache().bulkInsertBtn);
+        return elementCache().grid.clickBulkInsert();
     }
 
     public EntityBulkUpdateDialog clickBulkUpdate()
     {
         showGrid();
-        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().bulkUpdateBtn));
-        elementCache().bulkUpdateBtn.click();
-        return new EntityBulkUpdateDialog(getDriver());
-    }
-
-    public boolean isBulkUpdateVisible()
-    {
-        return modeSelectListItem("from Grid").withClass("active").findOptionalElement(this).isPresent() &&
-                elementCache().bulkUpdateBtnLoc.existsIn(this) &&
-                isElementVisible(elementCache().bulkUpdateBtn);
-    }
-
-    public boolean isDeleteRowsVisible()
-    {
-        return modeSelectListItem("from Grid").withClass("active").findOptionalElement(this).isPresent() &&
-                elementCache().deleteRowsBtnLoc.existsIn(this) &&
-                isElementVisible(elementCache().deleteRowsBtn);
+        return elementCache().grid.clickBulkUpdate();
     }
 
     public boolean hasTabs()
@@ -397,7 +370,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
             var newPanel = new EntityInsertPanel.EntityInsertPanelFinder(getDriver()).findWhenNeeded(getDriver());
             
             newPanel.clearElementCache();
-            newPanel.waitForLoaded();
+            newPanel.waitForReady();
             WebDriverWrapper.waitFor(() -> newPanel.isFileUploadVisible(),
                     "the file upload panel did bot become visible", 2000);
 
@@ -406,7 +379,8 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
         return this;
     }
 
-    private void waitForLoaded()
+    @Override
+    protected void waitForReady()
     {
         WebDriverWrapper.waitFor(()-> {
             try
@@ -439,24 +413,6 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     protected class ElementCache extends Component<?>.ElementCache
     {
-        public ElementCache()
-        {
-            waitForLoaded();
-        }
-
-        Locator deleteRowsBtnLoc = Locator.XPathLocator.union(
-                Locator.button("Delete rows"),
-                Locator.buttonContainingText("Remove"));
-        Locator bulkInsertBtnLoc = Locator.button("Bulk Insert");
-        Locator bulkUpdateBtnLoc = Locator.button("Bulk Update");
-
-        WebElement bulkInsertBtn = bulkInsertBtnLoc.findWhenNeeded(this).withTimeout(2000);
-        WebElement bulkUpdateBtn = bulkUpdateBtnLoc.findWhenNeeded(this).withTimeout(2000);
-        WebElement deleteRowsBtn = deleteRowsBtnLoc.findWhenNeeded(this).withTimeout(2000);
-
-        WebElement addRowsTxtBox = Locator.tagWithName("input", "addCount").findWhenNeeded(this);
-        WebElement addRowsButton = Locator.buttonContainingText("Add").findWhenNeeded(this);
-
         WebElement addParent = Locator.tagWithClass("span", "container--action-button")
                 .containing("Parent").findWhenNeeded(getDriver());
 

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -6,8 +6,11 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.Input;
 import org.labkey.test.components.react.ReactDatePicker;
 import org.labkey.test.components.react.ReactSelect;
+import org.labkey.test.components.ui.entities.EntityBulkInsertDialog;
+import org.labkey.test.components.ui.entities.EntityBulkUpdateDialog;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
@@ -79,6 +82,32 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         Locators.spinner.waitForElementToDisappear(this, 30000);
     }
 
+    public void clickRemove()
+    {
+        doAndWaitForUpdate(() -> elementCache().deleteRowsBtn.click());
+    }
+
+    public EntityBulkInsertDialog clickBulkInsert()
+    {
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().bulkInsertBtn));
+        elementCache().bulkInsertBtn.click();
+
+        return new EntityBulkInsertDialog(getDriver());
+    }
+
+    public EntityBulkUpdateDialog clickBulkUpdate()
+    {
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().bulkUpdateBtn));
+        elementCache().bulkUpdateBtn.click();
+
+        return new EntityBulkUpdateDialog(getDriver());
+    }
+
+    public ExportMenu getExportMenu()
+    {
+        return elementCache().exportMenu;
+    }
+
     public List<String> getColumnNames()
     {
         return elementCache().getColumnNames();
@@ -130,7 +159,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
     private List<WebElement> getRows()
     {
         waitForLoaded();
-        return Locators.rows.findElements(getComponentElement());
+        return Locators.rows.findElements(elementCache().table);
     }
 
     public List<Map<String, String>> getGridData(String... columns)
@@ -753,16 +782,26 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         }
     }
 
-    public void doAndWaitForUpdate(Runnable func)
+    public void setAddRows(int count)
     {
-        func.run();
-        waitForUpdate();
+        elementCache().addCountInput.set(String.valueOf(count));
     }
 
-    private void waitForUpdate()
+    public void addRows(int count)
     {
-        waitForLoaded();
-        clearElementCache();
+        setAddRows(count);
+        doAndWaitForUpdate(() -> {
+            elementCache().addRowsButton.click();
+        });
+    }
+
+    private void doAndWaitForUpdate(Runnable func)
+    {
+        int initialCount = getRowCount();
+
+        func.run();
+
+        waitFor(() -> getRowCount() != initialCount, "Failed to add/remove rows", 5_000);
     }
 
     @Override
@@ -773,7 +812,18 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
     protected class ElementCache extends Component<?>.ElementCache
     {
-        private final WebElement selectColumn = Locator.xpath("//th/input[@type='checkbox']").findWhenNeeded(getComponentElement());
+        final WebElement topControls = Locator.byClass("QueryGrid-bottom-spacing").findWhenNeeded(this);
+
+        final WebElement bulkInsertBtn = Locator.button("Bulk Insert").findWhenNeeded(topControls);
+        final WebElement bulkUpdateBtn = Locator.button("Bulk Update").findWhenNeeded(topControls);
+        final WebElement deleteRowsBtn =  Locator.XPathLocator
+                .union(Locator.button("Delete rows"), Locator.buttonContainingText("Remove"))
+                .findWhenNeeded(topControls);
+        final ExportMenu exportMenu = ExportMenu.finder(getDriver()).findWhenNeeded(topControls);
+
+        final WebElement table = Locator.byClass("table-cellular").findWhenNeeded(this);
+
+        private final WebElement selectColumn = Locator.xpath("//th/input[@type='checkbox']").findWhenNeeded(table);
 
         private final List<String> columnNames = new ArrayList<>();
 
@@ -781,7 +831,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         {
             if (columnNames.isEmpty())
             {
-                List<WebElement> headerCells = Locators.headerCells.waitForElements(getComponentElement(), WAIT_FOR_JAVASCRIPT);
+                List<WebElement> headerCells = Locators.headerCells.waitForElements(table, WAIT_FOR_JAVASCRIPT);
 
                 for (WebElement el : headerCells)
                 {
@@ -812,22 +862,25 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
         public WebElement inputCell()
         {
-            return Locators.inputCell.findElement(getComponentElement());
+            return Locators.inputCell.findElement(table);
         }
 
         public ReactSelect lookupSelect(WebElement cell)
         {
             Locator.byClass("cell-menu-selector").findOptionalElement(cell).ifPresent(WebElement::click);
-            ReactSelect lookupSelect = ReactSelect.finder(getDriver()).timeout(2_000).find(getComponentElement());
+            ReactSelect lookupSelect = ReactSelect.finder(getDriver()).timeout(2_000).find(table);
             waitFor(()->lookupSelect.isInteractive() && !lookupSelect.isLoading(), "Select control is not ready.", 1_000);
             return lookupSelect;
         }
 
         public ReactDatePicker datePicker()
         {
-            return new ReactDatePicker.ReactDateInputFinder(getDriver()).withClassName("date-input-cell").find(getComponentElement());
+            return new ReactDatePicker.ReactDateInputFinder(getDriver()).withClassName("date-input-cell").find(table);
         }
 
+        final WebElement addRowsPanel = Locator.byClass("editable-grid__controls").findWhenNeeded(this);
+        final Input addCountInput = Input.Input(Locator.name("addCount"), getDriver()).findWhenNeeded(addRowsPanel);
+        final WebElement addRowsButton = Locator.byClass("btn-primary").findWhenNeeded(addRowsPanel);
     }
 
     protected abstract static class Locators
@@ -848,7 +901,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
     public static class EditableGridFinder extends WebDriverComponent.WebDriverComponentFinder<EditableGrid, EditableGridFinder>
     {
-        private final Locator _locator = Locator.byClass("editable-grid__container").descendant(Locator.byClass("table-cellular"));
+        private final Locator _locator = Locator.byClass("editable-grid__container").parent();
 
         public EditableGridFinder(WebDriver driver)
         {

--- a/src/org/labkey/test/components/ui/grids/ExportMenu.java
+++ b/src/org/labkey/test/components/ui/grids/ExportMenu.java
@@ -1,0 +1,64 @@
+package org.labkey.test.components.ui.grids;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.BootstrapMenu;
+import org.labkey.test.components.react.MultiMenu;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.io.File;
+
+/**
+ * Wraps `packages/components/src/public/QueryModel/ExportMenu.tsx`
+ */
+public class ExportMenu extends WebDriverComponent<Component.ElementCache>
+{
+    private final BootstrapMenu _menu;
+    private final WebDriver _driver;
+
+    protected ExportMenu(BootstrapMenu menu, WebDriver driver)
+    {
+        _menu = menu;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _menu.getComponentElement();
+    }
+
+    @Override
+    protected WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    public static SimpleWebDriverComponentFinder<ExportMenu> finder(WebDriver driver)
+    {
+        return new MultiMenu.MultiMenuFinder(driver).withButtonIcon("fa-download")
+                .wrap((el, wd) -> new ExportMenu(new BootstrapMenu(wd, el), driver));
+    }
+
+    public File exportData(GridBar.ExportType exportType)
+    {
+        WebElement exportButton = getExportMenuItem(exportType);
+        return getWrapper().doAndWaitForDownload(exportButton::click);
+    }
+
+    public TabSelectionExportDialog openExcelTabsModal()
+    {
+        WebElement exportButton = getExportMenuItem(GridBar.ExportType.EXCEL);
+        exportButton.click();
+
+        return new TabSelectionExportDialog(this.getDriver());
+    }
+
+    private WebElement getExportMenuItem(GridBar.ExportType exportType)
+    {
+        _menu.expand();
+        return Locator.css("span.export-menu-icon").withClass(exportType.buttonCssClass()).findElement(this);
+    }
+}

--- a/src/org/labkey/test/components/ui/grids/GridBar.java
+++ b/src/org/labkey/test/components/ui/grids/GridBar.java
@@ -14,7 +14,6 @@ import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.react.MultiMenu;
 import org.labkey.test.components.ui.Pager;
-import org.openqa.selenium.ElementNotInteractableException;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
@@ -60,28 +59,12 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
 
     public File exportData(ExportType exportType)
     {
-        WebElement exportButton = getExportButton(exportType);
-        return getWrapper().doAndWaitForDownload(exportButton::click);
-    }
-
-    private WebElement getExportButton(ExportType exportType)
-    {
-        WebElement downloadBtn = Locator.tagWithClass("span", "fa-download").findElement(this);
-
-        if(!downloadBtn.isDisplayed())
-            throw new ElementNotInteractableException("File export button is not visible.");
-
-        downloadBtn.click();
-
-        return Locator.css("span.export-menu-icon").withClass(exportType.buttonCssClass()).findElement(this);
+        return elementCache().exportMenu.exportData(exportType);
     }
 
     public TabSelectionExportDialog openExcelTabsModal()
     {
-        WebElement exportButton = getExportButton(ExportType.EXCEL);
-        exportButton.click();
-
-        return new TabSelectionExportDialog(this.getDriver());
+        return elementCache().exportMenu.openExcelTabsModal();
     }
 
     /**
@@ -467,6 +450,7 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
 
     protected class ElementCache extends Component<?>.ElementCache
     {
+        private final ExportMenu exportMenu = ExportMenu.finder(getDriver()).findWhenNeeded(this);
 
         private final Map<String, MultiMenu> menus = new HashMap<>();
         protected MultiMenu findMenu(String buttonText)

--- a/src/org/labkey/test/tests/component/EditableGridTest.java
+++ b/src/org/labkey/test/tests/component/EditableGridTest.java
@@ -53,11 +53,11 @@ public class EditableGridTest extends BaseWebDriverTest
         EditableGrid testGrid = testPage.getEditableGrid("exp", "Data");
         String wideShape = "Too wide\tACME\tthing\tanother\televen\toff the map\tMoar columns\n";
 
-        clickButton("Add Row", 0);
+        testGrid.addRows(1);
         testGrid.pasteFromCell(0, "Description", wideShape);
-        assertThat("Expect cell error to explain that paste cannot add columns",
-                testGrid.getCellPopoverText(0, "Description"),
-                is("Unable to paste. Cannot paste columns beyond the columns found in the grid."));
+        assertEquals("Expect cell error to explain that paste cannot add columns",
+                "Unable to paste. Cannot paste columns beyond the columns found in the grid.",
+                testGrid.getCellPopoverText(0, "Description"));
         assertThat("Expect failed paste to leave data unchanged",
                 testGrid.getColumnData("Name"), everyItem(is("")));
     }
@@ -67,19 +67,20 @@ public class EditableGridTest extends BaseWebDriverTest
     {
         CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
         EditableGrid testGrid = testPage.getEditableGrid("exp", "Data");
-        String tallShape = "42\n" +
-                "41\n" +
-                "40\n" +
-                "39\n" +
-                "38";
+        String tallShape = """
+                42
+                41
+                40
+                39
+                38""";
 
-        assertThat(testGrid.getRowCount(), is(0));
-        clickButton("Add Row", 0);
+        assertEquals("Initial editable grid row count", 0, testGrid.getRowCount());
+        testGrid.addRows(1);
         testGrid.pasteFromCell(0, "Description", tallShape);
         List<String> pastedColData = testGrid.getColumnData("Description");
         List<String> unpastedColData = testGrid.getColumnData("Name");
 
-        assertThat(testGrid.getRowCount(), is(5));
+        assertEquals("Editable grid row count after paste", 5, testGrid.getRowCount());
         assertEquals("Didn't get correct values", List.of("42", "41", "40", "39", "38"), pastedColData);
         assertThat("expect other column to remain empty",
                 unpastedColData, everyItem(is("")));

--- a/src/org/labkey/test/tests/component/EditableGridTest.java
+++ b/src/org/labkey/test/tests/component/EditableGridTest.java
@@ -9,6 +9,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.ui.grids.EditableGrid;
 import org.labkey.test.pages.test.CoreComponentsTestPage;
+import org.openqa.selenium.WebElement;
 
 import java.util.Arrays;
 import java.util.List;
@@ -84,6 +85,24 @@ public class EditableGridTest extends BaseWebDriverTest
         assertEquals("Didn't get correct values", List.of("42", "41", "40", "39", "38"), pastedColData);
         assertThat("expect other column to remain empty",
                 unpastedColData, everyItem(is("")));
+    }
+
+    @Test
+    public void testDragFillIncrementingIntegers()
+    {
+        CoreComponentsTestPage testPage = CoreComponentsTestPage.beginAt(this, getProjectName());
+        EditableGrid testGrid = testPage.getEditableGrid("exp", "Data");
+
+        testGrid.addRows(6);
+        WebElement cell1 = testGrid.setCellValue(0, "Description", "2");
+        WebElement cell2 = testGrid.setCellValue(1, "Description", "4");
+        WebElement cell3 = testGrid.getCell(4, "Description");
+
+        testGrid.selectCellRange(cell1, cell2);
+        testGrid.dragFill(cell2, cell3);
+
+        List<String> actualValues = testGrid.getColumnData("Description");
+        assertEquals("Drag-fill should have extrapolated values", List.of("2", "4", "6", "8", "10", ""), actualValues);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Adding functionality to enable automated tests for recent editable grid improvements (specifically drag-fill). The scope of some editable grid operations was not included in the editable grid test component (adding and removing rows); this change also moves that functionality into the test components.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/2465
* https://github.com/LabKey/sampleManagement/pull/2184

#### Changes
* Add drag-fill operations to `EditableGrid`
* Move row add/remove operations to `EditableGrid`
* Add drag-fill test to `EditableGridTest`
* Update `EditableGrid` to wait for updates correctly
