### PR TITLE
Wait for ready for EntityInsertPanel

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -31,6 +31,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 {
     private final WebDriver _driver;
     private final WebElement _editingDiv;
+    private int _readyTimeout = 10000;
 
     public EntityInsertPanel(WebElement element, WebDriver driver)
     {
@@ -56,13 +57,17 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
         WebDriverWrapper.waitFor(()-> {
             try{
                 return isFileUploadVisible() ||
-                        isGridVisible() ||
-                        hasTabs();
+                        isGridVisible();
             } catch (NoSuchElementException retry)
             {
                 return false;
             }
-        }, 10000);
+        }, "The Insert panel did not become ready in time", _readyTimeout);
+    }
+
+    public void setReadyTimeout(int readyTimeout)
+    {
+        _readyTimeout = readyTimeout;
     }
 
     public boolean hasTargetEntityTypeSelect()

--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -65,9 +65,10 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
         }, "The Insert panel did not become ready in time", _readyTimeout);
     }
 
-    public void setReadyTimeout(int readyTimeout)
+    public EntityInsertPanel setReadyTimeout(int readyTimeout)
     {
         _readyTimeout = readyTimeout;
+        return this;
     }
 
     public boolean hasTargetEntityTypeSelect()

--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -29,7 +29,7 @@ import static org.labkey.test.WebDriverWrapper.sleep;
  */
 public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.ElementCache>
 {
-    private WebDriver _driver;
+    private final WebDriver _driver;
     private final WebElement _editingDiv;
 
     public EntityInsertPanel(WebElement element, WebDriver driver)
@@ -48,6 +48,21 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
     public WebDriver getDriver()
     {
         return _driver;
+    }
+
+    @Override
+    protected void waitForReady()
+    {
+        WebDriverWrapper.waitFor(()-> {
+            try{
+                return isFileUploadVisible() ||
+                        isGridVisible() ||
+                        hasTabs();
+            } catch (NoSuchElementException retry)
+            {
+                return false;
+            }
+        }, 10000);
     }
 
     public boolean hasTargetEntityTypeSelect()
@@ -357,8 +372,8 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
             modeSelectListItem("from Grid")
                     .waitForElement(this, 2000).click();
             clearElementCache();
-            WebDriverWrapper.waitFor(() -> isGridVisible(),
-                    "the grid did bot become visible", 2000);
+            WebDriverWrapper.waitFor(this::isGridVisible,
+                    "the grid did not become visible", 2000);
         }
         elementCache().grid.waitForLoaded();
         return this;


### PR DESCRIPTION
#### Rationale
Recently [BiologicsSampleCreateTest.testDashboardCreateSamples](https://teamcity.labkey.org/viewLog.html?buildId=2704106&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsPostgres&fromSakuraUI=true#testNameId-1930444423740823537) failed because the `EntityInsertPanel.getEditableGrid` method assumes that if the grid isn't already shown, there must be a means to show it present (a la the 'show grid' or 'upload from file' selector).  The screenshot shows the grid is there, and this is an instance where there isn't a mode-selection; what's likely happened here is that the test asked for the grid before `EntityInsertPanel `was ready.

This change implements `waitForReady `on `EntityInsertPanel `by awaiting the file-upload or the grid or mode-selection tabs to be present.

#### Related Pull Requests
n/a

#### Changes

- [ ] await ready, 
