### PR TITLE
Remove react-bootstrap-toggle dependency and replace ReactBootstrapToggle usages

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -406,7 +406,7 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
     {
         if (!getMode().equalsIgnoreCase(name))
         {
-            boolean isSummary = elementCache().customFieldsViewToggle.isEnabled();
+            boolean isSummary = elementCache().customFieldsViewToggle.isOn();
             elementCache().customFieldsViewToggle.set(!isSummary);
         }
         WebDriverWrapper.waitFor(()-> getMode().equalsIgnoreCase(name),

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -394,11 +394,11 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
      */
     public String getMode()
     {
-        return elementCache().customFieldsViewToggle.getSelectedStatus(); // will be either "Summary mode" or "Detail mode"
+        return elementCache().customFieldsViewToggle.getSelectedStatus(); // will be either "Summary" or "Detail"
     }
 
     /**
-     * Selects the desired mode.  Possible values are "Detail mode" and "Summary mode"
+     * Selects the desired mode.  Possible values are "Summary" and "Detail"
      * @param name The name of the desired mode, or the text to appear in the toggle in its desired state
      * @return an instance of the current DomainFormPanel
      */
@@ -406,9 +406,8 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
     {
         if (!getMode().equalsIgnoreCase(name))
         {
-            // get the current mode (on/off), assume the opposite state is desired
-            Boolean modeState = elementCache().customFieldsViewToggle.get();
-            elementCache().customFieldsViewToggle.set(!modeState);
+            boolean isSummary = elementCache().customFieldsViewToggle.isEnabled();
+            elementCache().customFieldsViewToggle.set(!isSummary);
         }
         WebDriverWrapper.waitFor(()-> getMode().equalsIgnoreCase(name),
                 "the mode select toggle did not become [" +name+ "] as expected", 2000);
@@ -421,7 +420,7 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
     */
     public boolean isSummaryMode()
     {
-        return getMode().equalsIgnoreCase("Summary Mode");
+        return getMode().equalsIgnoreCase("Summary");
     }
 
     /*
@@ -429,7 +428,7 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
      */
     public ResponsiveGrid getSummaryModeGrid()
     {
-        switchMode("Summary mode");
+        switchMode("Summary");
         return new ResponsiveGrid.ResponsiveGridFinder(getDriver())
                 .locatedBy(Locator.tagWithClass("div", "domain-field-toolbar").followingSibling("div").followingSibling("div"))
                 .waitFor(this);
@@ -459,7 +458,7 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
      */
     public boolean isDetailMode()
     {
-        return getMode().equalsIgnoreCase("Detail Mode");   
+        return getMode().equalsIgnoreCase("Detail");
     }
 
     /*
@@ -467,7 +466,7 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
      */
     public int getRowcountInSummaryMode()
     {
-        switchMode("Summary Mode");
+        switchMode("Summary");
 
         return getSummaryModeGrid().getRows().size();
     }
@@ -564,7 +563,7 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
         public final WebElement toggleButton = Locator.tagWithAttributeContaining("div", "id", "domain-toggle-summary").
                 findWhenNeeded(this);
         public final ToggleButton customFieldsViewToggle = new ToggleButton.ToggleButtonFinder(getDriver())
-                .withState("Detail mode").timeout(5000).findWhenNeeded(this);
+                .withState("Detail").timeout(5000).findWhenNeeded(this);
 
         protected WebElement addFieldButton = new WebElementWrapper()
         {

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -392,7 +392,7 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
         in 'Summary mode', fields are shown in a grid, with columns representing field attributes like 'name', 'range uri', etc
         in 'Detail mode', fields appear as editable, in FieldRows
      */
-    public String getMode()
+    private String getMode()
     {
         return elementCache().customFieldsViewToggle.getSelectedStatus(); // will be either "Summary" or "Detail"
     }
@@ -402,7 +402,7 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
      * @param name The name of the desired mode, or the text to appear in the toggle in its desired state
      * @return an instance of the current DomainFormPanel
      */
-    public DomainFormPanel switchMode(String name)
+    private DomainFormPanel switchMode(String name)
     {
         if (!getMode().equalsIgnoreCase(name))
         {
@@ -423,12 +423,17 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
         return getMode().equalsIgnoreCase("Summary");
     }
 
+    public DomainFormPanel selectSummaryMode()
+    {
+        return switchMode("Summary");
+    }
+
     /*
         gets the grid containing row data/metadata in summary view
      */
     public ResponsiveGrid getSummaryModeGrid()
     {
-        switchMode("Summary");
+        selectSummaryMode();
         return new ResponsiveGrid.ResponsiveGridFinder(getDriver())
                 .locatedBy(Locator.tagWithClass("div", "domain-field-toolbar").followingSibling("div").followingSibling("div"))
                 .waitFor(this);
@@ -461,13 +466,17 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
         return getMode().equalsIgnoreCase("Detail");
     }
 
+    public DomainFormPanel selectDetailMode()
+    {
+        return switchMode("Detail");
+    }
+
     /*
         Summary mode shows a table containing a row per field, with columns representing field attributes
      */
     public int getRowcountInSummaryMode()
     {
-        switchMode("Summary");
-
+        selectSummaryMode();
         return getSummaryModeGrid().getRows().size();
     }
 

--- a/src/org/labkey/test/components/react/ToggleButton.java
+++ b/src/org/labkey/test/components/react/ToggleButton.java
@@ -32,29 +32,28 @@ public class ToggleButton extends WebDriverComponent<WebDriverComponent<?>.Eleme
     public ToggleButton set(boolean enabled)
     {
         String desiredState = enabled ? "enabled" : "disabled";
-        if (enabled && isDisabled())
+        if (enabled && !isOn())
         {
             if (hasButtons()) selectFirst();
             else getComponentElement().click();
         }
-        else if (!enabled && isEnabled())
+        else if (!enabled && isOn())
         {
             if (hasButtons()) selectSecond();
             else getComponentElement().click();
         }
-        WebDriverWrapper.waitFor(()-> isEnabled() == enabled,
+        else
+        {
+            throw new IllegalStateException("Unable to determine toggle state: " + getComponentElement());
+        }
+        WebDriverWrapper.waitFor(()-> isOn() == enabled,
                 "the toggle button did not become " + desiredState, 2000);
         return this;
     }
 
-    public boolean isEnabled()
+    public boolean isOn()
     {
         return getComponentElement().getAttribute("class").contains("toggle-on");
-    }
-
-    public boolean isDisabled()
-    {
-        return getComponentElement().getAttribute("class").contains("toggle-off");
     }
 
     /*
@@ -62,27 +61,30 @@ public class ToggleButton extends WebDriverComponent<WebDriverComponent<?>.Eleme
      */
     public String getSelectedStatus()
     {
-        if (isEnabled())
+        if (isOn())
             return Locator.tag("button").index(0).findElement(this).getText();
         else
             return Locator.tag("button").index(1).findElement(this).getText();
     }
 
-    public ToggleButton selectFirst()
+    private ToggleButton selectFirst()
     {
         Locator.tag("button").index(0).findElement(this).click();
         return this;
     }
 
-    public ToggleButton selectSecond()
+    private ToggleButton selectSecond()
     {
         Locator.tag("button").index(1).findElement(this).click();
         return this;
     }
 
+    private Boolean hasButtons = null;
     private boolean hasButtons()
     {
-        return Locator.tag("button").findElementOrNull(this) != null;
+        if (hasButtons == null)
+            hasButtons = Locator.tag("button").existsIn(this);
+        return hasButtons;
     }
 
     public static class ToggleButtonFinder extends WebDriverComponentFinder<ToggleButton, ToggleButtonFinder>

--- a/src/org/labkey/test/components/react/ToggleButton.java
+++ b/src/org/labkey/test/components/react/ToggleButton.java
@@ -32,31 +32,57 @@ public class ToggleButton extends WebDriverComponent<WebDriverComponent<?>.Eleme
     public ToggleButton set(boolean enabled)
     {
         String desiredState = enabled ? "enabled" : "disabled";
-        if (get() != enabled)
-            getComponentElement().click();
-        WebDriverWrapper.waitFor(()-> get() == enabled,
+        if (enabled && isDisabled())
+        {
+            if (hasButtons()) selectFirst();
+            else getComponentElement().click();
+        }
+        else if (!enabled && isEnabled())
+        {
+            if (hasButtons()) selectSecond();
+            else getComponentElement().click();
+        }
+        WebDriverWrapper.waitFor(()-> isEnabled() == enabled,
                 "the toggle button did not become " + desiredState, 2000);
         return this;
     }
 
-    /*
-        The componentElement will get the 'off' class when the slider is grayed out.
-     */
-    public boolean get()
+    public boolean isEnabled()
     {
-        return !getComponentElement().getAttribute("class").contains("off");
+        return getComponentElement().getAttribute("class").contains("toggle-on");
+    }
+
+    public boolean isDisabled()
+    {
+        return getComponentElement().getAttribute("class").contains("toggle-off");
     }
 
     /*
-        the 'off' status causes the child span with 'toggle-off' class to be shown; otherwise,
-        the one with 'toggle-on' is shown.
+        the 'off' status causes the 2nd button to be active; otherwise, the one 1st button is active
      */
     public String getSelectedStatus()
     {
-        if (get())
-            return Locator.tagWithClass("span", "toggle-on").findElement(this).getText();
+        if (isEnabled())
+            return Locator.tag("button").index(0).findElement(this).getText();
         else
-            return Locator.tagWithClass("span", "toggle-off").findElement(this).getText();
+            return Locator.tag("button").index(1).findElement(this).getText();
+    }
+
+    public ToggleButton selectFirst()
+    {
+        Locator.tag("button").index(0).findElement(this).click();
+        return this;
+    }
+
+    public ToggleButton selectSecond()
+    {
+        Locator.tag("button").index(1).findElement(this).click();
+        return this;
+    }
+
+    private boolean hasButtons()
+    {
+        return Locator.tag("button").findElementOrNull(this) != null;
     }
 
     public static class ToggleButtonFinder extends WebDriverComponentFinder<ToggleButton, ToggleButtonFinder>
@@ -98,7 +124,7 @@ public class ToggleButton extends WebDriverComponent<WebDriverComponent<?>.Eleme
             }
             if (_state != null)
             {
-                locator = locator.withDescendant(Locator.tagWithText("span", _state));
+                locator = locator.withDescendant(Locator.tagWithText("button", _state));
             }
 
             return locator;

--- a/src/org/labkey/test/components/react/ToggleButton.java
+++ b/src/org/labkey/test/components/react/ToggleButton.java
@@ -44,7 +44,7 @@ public class ToggleButton extends WebDriverComponent<WebDriverComponent<?>.Eleme
         }
         else
         {
-            throw new IllegalStateException("Unable to determine toggle state: " + getComponentElement());
+            throw new IllegalStateException("Unable to toggle state to " + desiredState + ". It may already be in that state.");
         }
         WebDriverWrapper.waitFor(()-> isOn() == enabled,
                 "the toggle button did not become " + desiredState, 2000);

--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -43,7 +43,7 @@ public class EntityBulkUpdateDialog extends ModalDialog
 
     public boolean isFieldEnabled(String columnTitle)
     {
-        return elementCache().getToggle(columnTitle).get();
+        return elementCache().getToggle(columnTitle).isEnabled();
     }
 
     public EntityBulkUpdateDialog setEditableState(String columnTitle, boolean enable)

--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -43,7 +43,7 @@ public class EntityBulkUpdateDialog extends ModalDialog
 
     public boolean isFieldEnabled(String columnTitle)
     {
-        return elementCache().getToggle(columnTitle).isEnabled();
+        return elementCache().getToggle(columnTitle).isOn();
     }
 
     public EntityBulkUpdateDialog setEditableState(String columnTitle, boolean enable)

--- a/src/org/labkey/test/pages/core/login/AuthDialogBase.java
+++ b/src/org/labkey/test/pages/core/login/AuthDialogBase.java
@@ -58,7 +58,7 @@ public abstract class AuthDialogBase<T extends AuthDialogBase<T>> extends ModalD
 
     public boolean isEnabled()
     {
-        return elementCache().enableToggle.get();
+        return elementCache().enableToggle.isEnabled();
     }
 
     public T clickApplyExpectingError()

--- a/src/org/labkey/test/pages/core/login/AuthDialogBase.java
+++ b/src/org/labkey/test/pages/core/login/AuthDialogBase.java
@@ -58,7 +58,7 @@ public abstract class AuthDialogBase<T extends AuthDialogBase<T>> extends ModalD
 
     public boolean isEnabled()
     {
-        return elementCache().enableToggle.isEnabled();
+        return elementCache().enableToggle.isOn();
     }
 
     public T clickApplyExpectingError()

--- a/src/org/labkey/test/pages/list/EditListDefinitionPage.java
+++ b/src/org/labkey/test/pages/list/EditListDefinitionPage.java
@@ -189,7 +189,7 @@ public class EditListDefinitionPage extends DomainDesigner<EditListDefinitionPag
 
         protected ToggleButton autoImportSlider()
         {
-            return new ToggleButton.ToggleButtonFinder(getDriver()).withState("Import Data").find(fieldsPanel);
+            return new ToggleButton.ToggleButtonFinder(getDriver()).withState("Yes").find(fieldsPanel);
         }
     }
 }

--- a/src/org/labkey/test/pages/list/EditListDefinitionPage.java
+++ b/src/org/labkey/test/pages/list/EditListDefinitionPage.java
@@ -141,7 +141,7 @@ public class EditListDefinitionPage extends DomainDesigner<EditListDefinitionPag
 
     public boolean getAutoImport()
     {
-        return elementCache().autoImportSlider().isEnabled();
+        return elementCache().autoImportSlider().isOn();
     }
 
     public void setColumnPhiLevel(String name, FieldDefinition.PhiSelectType phiLevel)

--- a/src/org/labkey/test/pages/list/EditListDefinitionPage.java
+++ b/src/org/labkey/test/pages/list/EditListDefinitionPage.java
@@ -141,7 +141,7 @@ public class EditListDefinitionPage extends DomainDesigner<EditListDefinitionPag
 
     public boolean getAutoImport()
     {
-        return elementCache().autoImportSlider().get();
+        return elementCache().autoImportSlider().isEnabled();
     }
 
     public void setColumnPhiLevel(String name, FieldDefinition.PhiSelectType phiLevel)

--- a/src/org/labkey/test/pages/study/DatasetDesignerPage.java
+++ b/src/org/labkey/test/pages/study/DatasetDesignerPage.java
@@ -243,7 +243,7 @@ public class DatasetDesignerPage extends DomainDesigner<DatasetDesignerPage.Elem
 
     public boolean getAutoImport()
     {
-        return elementCache().autoImportToggle().get();
+        return elementCache().autoImportToggle().isEnabled();
     }
 
     public DatasetDesignerPage setPreviewMappedColumn(String columnLabel, String value)

--- a/src/org/labkey/test/pages/study/DatasetDesignerPage.java
+++ b/src/org/labkey/test/pages/study/DatasetDesignerPage.java
@@ -307,7 +307,7 @@ public class DatasetDesignerPage extends DomainDesigner<DatasetDesignerPage.Elem
         // this is only shown when inferring fields from a file
         protected ToggleButton autoImportToggle()
         {
-            return new ToggleButton.ToggleButtonFinder(getDriver()).withState("Import Data").waitFor(fieldsPanel);
+            return new ToggleButton.ToggleButtonFinder(getDriver()).withState("Yes").waitFor(fieldsPanel);
         }
 
         protected FilteringReactSelect columnMapSelect(String labelText)

--- a/src/org/labkey/test/pages/study/DatasetDesignerPage.java
+++ b/src/org/labkey/test/pages/study/DatasetDesignerPage.java
@@ -243,7 +243,7 @@ public class DatasetDesignerPage extends DomainDesigner<DatasetDesignerPage.Elem
 
     public boolean getAutoImport()
     {
-        return elementCache().autoImportToggle().isEnabled();
+        return elementCache().autoImportToggle().isOn();
     }
 
     public DatasetDesignerPage setPreviewMappedColumn(String columnLabel, String value)

--- a/src/org/labkey/test/tests/FieldEditorRowSelectionActionTest.java
+++ b/src/org/labkey/test/tests/FieldEditorRowSelectionActionTest.java
@@ -96,7 +96,7 @@ public class FieldEditorRowSelectionActionTest extends BaseWebDriverTest
         log("Verifying the toggle between summary view and detail view list domain");
         checker().verifyTrue("Incorrect default display mode", domainFormPanel.isDetailMode());
 
-        domainFormPanel.switchMode("Summary");
+        domainFormPanel.selectSummaryMode();
         checker().verifyTrue("Did not switch to Summary Mode", domainFormPanel.isSummaryMode());
         checker().wrapAssertion(()-> assertThat(domainFormPanel.getSummaryModeColumns())
                 .as("Incorrect header values in summary mode in list domain")
@@ -134,7 +134,7 @@ public class FieldEditorRowSelectionActionTest extends BaseWebDriverTest
         log("Verifying the toggle between summary view and detail view");
         checker().verifyTrue("Incorrect default display mode", domainFormPanel.isDetailMode());
 
-        domainFormPanel.switchMode("Summary");
+        domainFormPanel.selectSummaryMode();
         checker().verifyTrue("Did not switch to Summary Mode", domainFormPanel.isSummaryMode());
         checker().wrapAssertion(()-> assertThat(domainFormPanel.getSummaryModeColumns())
                         .as("Incorrect columns in summary mode")
@@ -210,7 +210,7 @@ public class FieldEditorRowSelectionActionTest extends BaseWebDriverTest
         log("Verifying the toggle between summary view and detail view for Results domain");
         checker().verifyTrue("Incorrect default display mode for result domain", domainFormPanel.isDetailMode());
 
-        domainFormPanel.switchMode("Summary");
+        domainFormPanel.selectSummaryMode();
         checker().verifyTrue("Did not switch to Summary Mode", domainFormPanel.isSummaryMode());
         List<String> actualHeaders = domainFormPanel.getSummaryModeColumns();
         checker().wrapAssertion(()-> assertThat(actualHeaders)

--- a/src/org/labkey/test/tests/FieldEditorRowSelectionActionTest.java
+++ b/src/org/labkey/test/tests/FieldEditorRowSelectionActionTest.java
@@ -96,7 +96,7 @@ public class FieldEditorRowSelectionActionTest extends BaseWebDriverTest
         log("Verifying the toggle between summary view and detail view list domain");
         checker().verifyTrue("Incorrect default display mode", domainFormPanel.isDetailMode());
 
-        domainFormPanel.switchMode("Summary Mode");
+        domainFormPanel.switchMode("Summary");
         checker().verifyTrue("Did not switch to Summary Mode", domainFormPanel.isSummaryMode());
         checker().wrapAssertion(()-> assertThat(domainFormPanel.getSummaryModeColumns())
                 .as("Incorrect header values in summary mode in list domain")
@@ -134,7 +134,7 @@ public class FieldEditorRowSelectionActionTest extends BaseWebDriverTest
         log("Verifying the toggle between summary view and detail view");
         checker().verifyTrue("Incorrect default display mode", domainFormPanel.isDetailMode());
 
-        domainFormPanel.switchMode("Summary Mode");
+        domainFormPanel.switchMode("Summary");
         checker().verifyTrue("Did not switch to Summary Mode", domainFormPanel.isSummaryMode());
         checker().wrapAssertion(()-> assertThat(domainFormPanel.getSummaryModeColumns())
                         .as("Incorrect columns in summary mode")
@@ -210,7 +210,7 @@ public class FieldEditorRowSelectionActionTest extends BaseWebDriverTest
         log("Verifying the toggle between summary view and detail view for Results domain");
         checker().verifyTrue("Incorrect default display mode for result domain", domainFormPanel.isDetailMode());
 
-        domainFormPanel.switchMode("Summary Mode");
+        domainFormPanel.switchMode("Summary");
         checker().verifyTrue("Did not switch to Summary Mode", domainFormPanel.isSummaryMode());
         List<String> actualHeaders = domainFormPanel.getSummaryModeColumns();
         checker().wrapAssertion(()-> assertThat(actualHeaders)


### PR DESCRIPTION
#### Rationale
Selenium test update for ToggleButton conversion from ReactBootstrapToggle to ToggleButtons/ToggleIcon

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1326

#### Changes
- update ToggleButton to account for button or icon version of ToggleButtons.tsx component
