### PR TITLE
test coverage for configurable ELN name settings

### DIFF
--- a/src/org/labkey/test/pages/admin/ElnSettingsPage.java
+++ b/src/org/labkey/test/pages/admin/ElnSettingsPage.java
@@ -1,0 +1,91 @@
+package org.labkey.test.pages.admin;
+
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.components.html.RadioButton;
+import org.labkey.test.pages.LabKeyPage;
+import org.labkey.test.pages.core.admin.ShowAdminPage;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+/*
+    This page is linked from
+ */
+public class ElnSettingsPage extends LabKeyPage<ElnSettingsPage.ElementCache>
+{
+    public ElnSettingsPage(WebDriver driver)
+    {
+        super(driver);
+    }
+
+    public static ElnSettingsPage beginAt(WebDriverWrapper webDriverWrapper)
+    {
+        webDriverWrapper.beginAt(WebTestHelper.buildURL("notebook",  "configuration"));
+        return new ElnSettingsPage(webDriverWrapper.getDriver());
+    }
+
+    public ElnSettingsPage selectCreatedByDateRowId()
+    {
+        elementCache().createdByDateRowIdRadioBtn.set(true);
+        return this;
+    }
+
+    public ElnSettingsPage selectDateRowId()
+    {
+        elementCache().dateRowIdRadioBtn.set(true);
+        return this;
+    }
+
+    public ElnSettingsPage selectRowId()
+    {
+        elementCache().rowIdRadioBtn.set(true);
+        return this;
+    }
+
+    public String getSelectedPattern()
+    {
+        var selectedRadio = Locator.checkedRadioInGroup("nameExpression").findElement(getDriver());
+        return selectedRadio.getAttribute("value");
+    }
+
+    public ShowAdminPage clickCancel()
+    {
+        clickAndWait(elementCache().cancelBtn);
+        return new ShowAdminPage(getDriver());
+    }
+
+    public ShowAdminPage clickSave()
+    {
+        clickAndWait(elementCache().saveBtn);
+
+        return new ShowAdminPage(getDriver());
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return super.elementCache();
+    }
+
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
+    {
+
+        RadioButton createdByDateRowIdRadioBtn = new RadioButton.RadioButtonFinder().withValue("CreatedByDateRowId")
+                .findWhenNeeded(this);
+        RadioButton dateRowIdRadioBtn = new RadioButton.RadioButtonFinder().withValue("DateRowId")
+                .findWhenNeeded(this);
+        RadioButton rowIdRadioBtn = new RadioButton.RadioButtonFinder().withValue("RowId")
+                .findWhenNeeded(this);
+        WebElement saveBtn = Locator.tagWithClass("a", "labkey-button").withText("Save")
+                .findWhenNeeded(this);
+        WebElement cancelBtn = Locator.tagWithClass("a", "labkey-button").withText("Cancel")
+                .findWhenNeeded(this);
+    }
+}

--- a/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
+++ b/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
@@ -21,6 +21,7 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.DomainDesignerPage;
 import org.labkey.test.pages.ConfigureReportsAndScriptsPage;
 import org.labkey.test.pages.LabKeyPage;
+import org.labkey.test.pages.admin.ElnSettingsPage;
 import org.labkey.test.pages.compliance.ComplianceSettingsAccountsPage;
 import org.labkey.test.pages.core.login.LoginConfigurePage;
 import org.openqa.selenium.WebDriver;
@@ -226,6 +227,13 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
         clickAndWait(elementCache().creditsLink);
     }
 
+    public ElnSettingsPage clickNotebookSettings()
+    {
+        goToSettingsSection();
+        clickAndWait(elementCache().notebookSettingsLink);
+        return new ElnSettingsPage(getDriver());
+    }
+
     @Override
     protected ElementCache newElementCache()
     {
@@ -262,6 +270,8 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
         protected WebElement systemPropertiesLink = Locator.linkContainingText("system properties").findWhenNeeded(this);
         protected WebElement viewsAndScriptingLink = Locator.linkWithText("views and scripting").findWhenNeeded(this);
         protected WebElement creditsLink = Locator.linkWithText("credits").findWhenNeeded(this);
+
+        protected WebElement notebookSettingsLink = Locator.linkWithText("Notebook settings").findWhenNeeded(this);
 
         protected List<WebElement> findActiveUsers()
         {


### PR DESCRIPTION
#### Rationale
This adds page class support for a new page class in the admin console, used to select notebookID name expressions.

The associated product change ([spec](https://docs.google.com/document/d/1WR4Ti8s-c_mJABCDFf5dJde-DQS9Pkc3p3IcoxO_Z1c/edit#heading=h.7u5qro28q0oc)) moves selection of notebookID name expressions from being folder-specific to being a global setting

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/2474

#### Changes

- [x] page class to wrap notebook settings in admin console
- [x] link to it from ShowAdminPage
