### PR TITLE
ToggleButton test component fix for allowing set() to be called on current state without error

### DIFF
--- a/src/org/labkey/test/components/react/ToggleButton.java
+++ b/src/org/labkey/test/components/react/ToggleButton.java
@@ -31,6 +31,10 @@ public class ToggleButton extends WebDriverComponent<WebDriverComponent<?>.Eleme
 
     public ToggleButton set(boolean enabled)
     {
+        // if we can't determine the current state of the toggle, then throw without proceeding
+        if (!isOn() && !isOff())
+            throw new IllegalStateException("Unable to determine the current state of the toggle.");
+
         String desiredState = enabled ? "enabled" : "disabled";
         if (enabled && !isOn())
         {
@@ -42,10 +46,6 @@ public class ToggleButton extends WebDriverComponent<WebDriverComponent<?>.Eleme
             if (hasButtons()) selectSecond();
             else getComponentElement().click();
         }
-        else
-        {
-            throw new IllegalStateException("Unable to toggle state to " + desiredState + ". It may already be in that state.");
-        }
         WebDriverWrapper.waitFor(()-> isOn() == enabled,
                 "the toggle button did not become " + desiredState, 2000);
         return this;
@@ -54,6 +54,11 @@ public class ToggleButton extends WebDriverComponent<WebDriverComponent<?>.Eleme
     public boolean isOn()
     {
         return getComponentElement().getAttribute("class").contains("toggle-on");
+    }
+
+    public boolean isOff()
+    {
+        return getComponentElement().getAttribute("class").contains("toggle-off");
     }
 
     /*

--- a/src/org/labkey/test/components/react/ToggleButton.java
+++ b/src/org/labkey/test/components/react/ToggleButton.java
@@ -31,10 +31,6 @@ public class ToggleButton extends WebDriverComponent<WebDriverComponent<?>.Eleme
 
     public ToggleButton set(boolean enabled)
     {
-        // if we can't determine the current state of the toggle, then throw without proceeding
-        if (!isOn() && !isOff())
-            throw new IllegalStateException("Unable to determine the current state of the toggle.");
-
         String desiredState = enabled ? "enabled" : "disabled";
         if (enabled && !isOn())
         {
@@ -53,12 +49,13 @@ public class ToggleButton extends WebDriverComponent<WebDriverComponent<?>.Eleme
 
     public boolean isOn()
     {
-        return getComponentElement().getAttribute("class").contains("toggle-on");
-    }
-
-    public boolean isOff()
-    {
-        return getComponentElement().getAttribute("class").contains("toggle-off");
+        String buttonCls = getComponentElement().getAttribute("class");
+        if (buttonCls.contains("toggle-on"))
+            return true;
+        else if (buttonCls.contains("toggle-off"))
+            return false;
+        else
+            throw new IllegalStateException("Unable to determine the current state of the toggle.");
     }
 
     /*


### PR DESCRIPTION
#### Rationale
Fixing some test failures that call the ToggleButton.set() on an element that is already in the desired state.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1688

#### Changes
* change error state check in set() to throw if we can't determine the current state of the ToggleButton
