### PR TITLE
Regression test for Impersonating Troubleshooter

### DIFF
--- a/src/org/labkey/remoteapi/user/ImpersonateRolesCommand.java
+++ b/src/org/labkey/remoteapi/user/ImpersonateRolesCommand.java
@@ -1,0 +1,25 @@
+package org.labkey.remoteapi.user;
+
+import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.PostCommand;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ImpersonateRolesCommand extends PostCommand<CommandResponse>
+{
+    private final Map<String, Object> _parameters = new HashMap<>();
+
+    public ImpersonateRolesCommand(String... roleNames)
+    {
+        super("user", "impersonateRoles.api");
+        _parameters.put("roleNames", Arrays.asList(roleNames));
+    }
+
+    @Override
+    protected Map<String, Object> createParameterMap()
+    {
+        return new HashMap<>(_parameters); // Return a copy
+    }
+}

--- a/src/org/labkey/test/pages/PermissionsEditor.java
+++ b/src/org/labkey/test/pages/PermissionsEditor.java
@@ -18,6 +18,9 @@ package org.labkey.test.pages;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.components.ext4.Window;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
@@ -32,11 +35,18 @@ public class PermissionsEditor
 {
     private static final String READY_SIGNAL = "policyRendered";
     private static final Locator SIGNAL_LOC = Locators.pageSignal(READY_SIGNAL);
-    protected BaseWebDriverTest _test;
 
-    public PermissionsEditor(BaseWebDriverTest test)
+    private final WebDriverWrapper _test;
+
+    public PermissionsEditor(WebDriverWrapper test)
     {
         _test = test;
+    }
+
+    public static PermissionsEditor beginAt(WebDriverWrapper wdw, String containerPath)
+    {
+        wdw.beginAt(WebTestHelper.buildURL("security", containerPath, "permissions"));
+        return new PermissionsEditor(wdw);
     }
 
     public void selectFolder(String folderName)
@@ -84,6 +94,12 @@ public class PermissionsEditor
         _test._ext4Helper.waitForMaskToDisappear();
     }
 
+    public Window<?> clickSaveExpectingError()
+    {
+        _test.clickButton("Save", 0);
+        return new Window.WindowFinder(_test.getDriver()).withTitle("Error").waitFor();
+    }
+
     @LogMethod
     public void setPermissions(@LoggedParam String groupName, @LoggedParam String... permissionStrings)
     {
@@ -91,7 +107,6 @@ public class PermissionsEditor
         {
             _setPermissions(groupName, permissionString, "pGroup");
         }
-        savePermissions();
     }
 
     @LogMethod
@@ -101,7 +116,6 @@ public class PermissionsEditor
         {
             _setPermissions(groupName, permissionString, "pSite");
         }
-        savePermissions();
     }
 
     @LogMethod
@@ -111,7 +125,6 @@ public class PermissionsEditor
         {
             _setPermissions(userName, permissionString, "pUser");
         }
-        savePermissions();
     }
 
     private void _setPermissions(String userOrGroupName, String permissionString, String className)
@@ -159,7 +172,6 @@ public class PermissionsEditor
         {
             _test.click(close);
             _test.waitForElementToDisappear(close);
-            savePermissions();
         }
     }
 
@@ -179,7 +191,7 @@ public class PermissionsEditor
         return enterPermissionsUI(_test);
     }
 
-    public static PermissionsEditor enterPermissionsUI(BaseWebDriverTest test)
+    public static PermissionsEditor enterPermissionsUI(WebDriverWrapper test)
     {
         if (!test.isElementPresent(SIGNAL_LOC))
         {

--- a/src/org/labkey/test/tests/core/security/AppAdminRoleTest.java
+++ b/src/org/labkey/test/tests/core/security/AppAdminRoleTest.java
@@ -70,7 +70,9 @@ public class AppAdminRoleTest extends BaseWebDriverTest
         _userHelper.createUserAndNotify(APP_ADMIN, true);
         setInitialPassword(APP_ADMIN);
 
-        new ApiPermissionsHelper(this).addUserAsAppAdmin(APP_ADMIN);
+        ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
+        apiPermissionsHelper.addUserAsAppAdmin(APP_ADMIN);
+        createSiteGroups(apiPermissionsHelper);
     }
 
     private void deleteSiteGroups(ApiPermissionsHelper apiPermissionsHelper)
@@ -82,7 +84,7 @@ public class AppAdminRoleTest extends BaseWebDriverTest
     }
 
     @LogMethod
-    private void recreateSiteGroups(ApiPermissionsHelper apiPermissionsHelper)
+    private void createSiteGroups(ApiPermissionsHelper apiPermissionsHelper)
     {
         deleteSiteGroups(apiPermissionsHelper);
         apiPermissionsHelper.createGlobalPermissionsGroup(SITE_GROUP);
@@ -107,8 +109,6 @@ public class AppAdminRoleTest extends BaseWebDriverTest
     @Test
     public void testAssignGroupSiteAdmin()
     {
-        recreateSiteGroups(new ApiPermissionsHelper(this));
-
         CommandException apiException = getApiException(() -> permissionsApiAsAppAdmin().addMemberToRole(SITE_GROUP, "Site Admin", MemberType.group, "/"));
         if (apiException == null)
             fail("App Admin was able to assign group to Site Admin role");
@@ -129,8 +129,6 @@ public class AppAdminRoleTest extends BaseWebDriverTest
     @Test
     public void testAssignGroupPlatformDeveloper()
     {
-        recreateSiteGroups(new ApiPermissionsHelper(this));
-
         CommandException apiException = getApiException(() -> permissionsApiAsAppAdmin().addMemberToRole(SITE_GROUP, "Platform Developer", MemberType.group, "/"));
         if (apiException == null)
             fail("App Admin was able to assign group to Platform Developer role");
@@ -156,8 +154,6 @@ public class AppAdminRoleTest extends BaseWebDriverTest
     @Test
     public void testModifyPrivilegedGroup()
     {
-        recreateSiteGroups(new ApiPermissionsHelper(this));
-
         CommandException apiException = getApiException(() -> permissionsApiAsAppAdmin().addUserToSiteGroup(USER, ADMIN_GROUP));
         if (apiException == null)
             fail("App Admin was able to modify privileged group");
@@ -168,7 +164,6 @@ public class AppAdminRoleTest extends BaseWebDriverTest
     @Test
     public void testPermissionsUi()
     {
-        recreateSiteGroups(new ApiPermissionsHelper(this));
         impersonate(APP_ADMIN);
         PermissionsEditor permissionsEditor;
 

--- a/src/org/labkey/test/tests/core/security/ImpersonatingTroubleshooterRoleTest.java
+++ b/src/org/labkey/test/tests/core/security/ImpersonatingTroubleshooterRoleTest.java
@@ -1,0 +1,87 @@
+package org.labkey.test.tests.core.security;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.util.ApiPermissionsHelper;
+import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.PermissionsHelper;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Category({})
+public class ImpersonatingTroubleshooterRoleTest extends BaseWebDriverTest
+{
+    private static final String IMP_T = "impersonating_troubleshooter@imptrouble.test";
+    private static final String USER = "user@imptrouble.test";
+    private static final String ADMIN_GROUP = "Custom Admin Group";
+    private static final String DEV_GROUP = "Custom Developer Group";
+    private static final String IT_GROUP = "Custom IT Group";
+    private static final String SITE_GROUP = "Custom Site Group";
+
+    @Override
+    protected void doCleanup(boolean afterTest)
+    {
+        _containerHelper.deleteProject(getProjectName(), afterTest);
+        _userHelper.deleteUsers(afterTest, USER, IMP_T);
+    }
+
+    @BeforeClass
+    public static void setupProject()
+    {
+        ImpersonatingTroubleshooterRoleTest init = (ImpersonatingTroubleshooterRoleTest) getCurrentTest();
+
+        init.doSetup();
+    }
+
+    private void doSetup()
+    {
+        _containerHelper.createProject(getProjectName(), null);
+        _userHelper.createUser(USER);
+        _userHelper.createUser(IMP_T);
+        setInitialPassword(IMP_T);
+        new ApiPermissionsHelper(this).addMemberToRole(IMP_T, "Impersonating Troubleshooter", PermissionsHelper.MemberType.user, "/");
+    }
+
+    private void deleteSiteGroups(ApiPermissionsHelper apiPermissionsHelper)
+    {
+        apiPermissionsHelper.deleteGroup(ADMIN_GROUP, "/", false);
+        apiPermissionsHelper.deleteGroup(SITE_GROUP, "/", false);
+        apiPermissionsHelper.deleteGroup(DEV_GROUP, "/", false);
+        apiPermissionsHelper.deleteGroup(IT_GROUP, "/", false);
+    }
+
+    @LogMethod
+    private void recreateSiteGroups(ApiPermissionsHelper apiPermissionsHelper)
+    {
+        deleteSiteGroups(apiPermissionsHelper);
+        apiPermissionsHelper.createGlobalPermissionsGroup(SITE_GROUP);
+        apiPermissionsHelper.createGlobalPermissionsGroup(ADMIN_GROUP);
+        apiPermissionsHelper.addMemberToRole(ADMIN_GROUP, "Site Administrator", PermissionsHelper.MemberType.group, "/");
+        apiPermissionsHelper.createGlobalPermissionsGroup(DEV_GROUP);
+        apiPermissionsHelper.addMemberToRole(DEV_GROUP, "Platform Developer", PermissionsHelper.MemberType.group, "/");
+        apiPermissionsHelper.createGlobalPermissionsGroup(IT_GROUP);
+        apiPermissionsHelper.addMemberToRole(IT_GROUP, "Impersonating Troubleshooter", PermissionsHelper.MemberType.group, "/");
+    }
+
+    @Test
+    public void testSomething()
+    {
+        Assert.fail("Write some tests");
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return "ImpersonatingTroubleshooterRoleTest Project";
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Arrays.asList();
+    }
+}

--- a/src/org/labkey/test/tests/core/security/ImpersonatingTroubleshooterRoleTest.java
+++ b/src/org/labkey/test/tests/core/security/ImpersonatingTroubleshooterRoleTest.java
@@ -18,12 +18,12 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.labkey.test.util.PermissionsHelper.IMP_TROUBLESHOOTER_ROLE;
 import static org.labkey.test.util.PermissionsHelper.toRole;
 
 @Category({Daily.class})
 public class ImpersonatingTroubleshooterRoleTest extends TroubleshooterRoleTest
 {
-    private static final String ROLE = "Impersonating Troubleshooter";
     private static final String USER = "user@imptrouble.test";
 
     private final ApiPermissionsHelper _apiPermissionsHelper = new ApiPermissionsHelper(this);
@@ -45,7 +45,7 @@ public class ImpersonatingTroubleshooterRoleTest extends TroubleshooterRoleTest
     @Override
     protected String getRole()
     {
-        return ROLE;
+        return IMP_TROUBLESHOOTER_ROLE;
     }
 
     /**

--- a/src/org/labkey/test/tests/core/security/TroubleshooterRoleTest.java
+++ b/src/org/labkey/test/tests/core/security/TroubleshooterRoleTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertTrue;
 @BaseWebDriverTest.ClassTimeout(minutes = 4)
 public class TroubleshooterRoleTest extends BaseWebDriverTest
 {
-    private static final String TROUBLESHOOTER = "troubleshooter@troubleshooter.test";
+    protected static final String TROUBLESHOOTER = "troubleshooter@troubleshooter.test";
 
     @BeforeClass
     public static void setupProject()
@@ -42,12 +42,17 @@ public class TroubleshooterRoleTest extends BaseWebDriverTest
         _containerHelper.deleteProject(getProjectName(), afterTest);
     }
 
-    private void doSetup()
+    protected void doSetup()
     {
         _userHelper.createUser(TROUBLESHOOTER);
         ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
-        apiPermissionsHelper.addMemberToRole(TROUBLESHOOTER,"Troubleshooter", PermissionsHelper.MemberType.user,"/");
+        apiPermissionsHelper.addMemberToRole(TROUBLESHOOTER, getRole(), PermissionsHelper.MemberType.user,"/");
         _containerHelper.createProject(getProjectName());
+    }
+
+    protected String getRole()
+    {
+        return "Troubleshooter";
     }
 
     @Test
@@ -71,6 +76,12 @@ public class TroubleshooterRoleTest extends BaseWebDriverTest
         File exportedFile = logTable.expandExportPanel().exportText();
         int exportedRowCount = IteratorUtils.size(FileUtils.lineIterator(exportedFile)) - 1;
         assertTrue("Empty downloaded [" + exportedFile.getName() + "]", exportedRowCount > 0);
+    }
+
+    @Test
+    public void testAdminConsoleVisibility()
+    {
+        impersonate(TROUBLESHOOTER);
 
         log("Verify permissions from troubleshooter");
         verifySitePermissionSetting(false);
@@ -79,7 +90,6 @@ public class TroubleshooterRoleTest extends BaseWebDriverTest
         log("Verify the permissions for admin ");
         goToHome();
         verifySitePermissionSetting(true);
-
     }
 
     /**
@@ -98,7 +108,7 @@ public class TroubleshooterRoleTest extends BaseWebDriverTest
         assertTextPresent("You do not have permission to see this data.");
     }
 
-    private void verifySitePermissionSetting(boolean canSave)
+    protected void verifySitePermissionSetting(boolean canSave)
     {
         log("Verify permissions for look and feel setting");
         goToAdminConsole().goToSettingsSection().clickLookAndFeelSettings();

--- a/src/org/labkey/test/util/APIUserHelper.java
+++ b/src/org/labkey/test/util/APIUserHelper.java
@@ -26,6 +26,7 @@ import org.labkey.remoteapi.security.CreateUserResponse;
 import org.labkey.remoteapi.security.DeleteUserCommand;
 import org.labkey.remoteapi.security.GetUsersCommand;
 import org.labkey.remoteapi.security.GetUsersResponse;
+import org.labkey.remoteapi.security.GetUsersResponse.UserInfo;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.pages.user.UpdateUserDetailsPage;
@@ -37,6 +38,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -52,17 +54,21 @@ public class APIUserHelper extends AbstractUserHelper
     @Override
     public String getDisplayNameForEmail(@NotNull String email)
     {
-        GetUsersResponse users = getUsers(true);
-        Optional<GetUsersResponse.UserInfo> user = users.getUsersInfo().stream()
-                .filter(userInfo -> email.equals(userInfo.getEmail())).findFirst();
-        if (user.isPresent())
+        Map<String, String> displayNames = getDisplayNames();
+        if (displayNames.containsKey(email))
         {
-            return user.get().getDisplayName();
+            return displayNames.get(email);
         }
         else
         {
             return super.getDisplayNameForEmail(email);
         }
+    }
+
+    public Map<String, String> getDisplayNames()
+    {
+        GetUsersResponse users = getUsers(true);
+        return users.getUsersInfo().stream().collect(Collectors.toMap(UserInfo::getEmail, UserInfo::getDisplayName));
     }
 
     @Override
@@ -172,8 +178,8 @@ public class APIUserHelper extends AbstractUserHelper
     public Map<String, Integer> getUserIds(List<String> userEmails, boolean includeDeactivated)
     {
         Map<String, Integer> userIds = new HashMap<>();
-        List<GetUsersResponse.UserInfo> usersInfo = getUsers(includeDeactivated).getUsersInfo();
-        for (GetUsersResponse.UserInfo userInfo : usersInfo)
+        List<UserInfo> usersInfo = getUsers(includeDeactivated).getUsersInfo();
+        for (UserInfo userInfo : usersInfo)
         {
             if (userEmails.contains(userInfo.getEmail()))
                 userIds.put(userInfo.getEmail(), userInfo.getUserId());

--- a/src/org/labkey/test/util/ApiPermissionsHelper.java
+++ b/src/org/labkey/test/util/ApiPermissionsHelper.java
@@ -696,22 +696,20 @@ public class ApiPermissionsHelper extends PermissionsHelper
         }
     }
 
-    private static final String APP_ADMIN = "Application Admin";
-
     public void addUserAsAppAdmin(String userEmail)
     {
         if(!isUserAppAdmin(userEmail))
-            addMemberToRole(userEmail, APP_ADMIN, PermissionsHelper.MemberType.user, "/");
+            addMemberToRole(userEmail, APP_ADMIN_ROLE, PermissionsHelper.MemberType.user, "/");
     }
 
     public void removeUserFromAppAdmin(String userEmail)
     {
         if (isUserAppAdmin(userEmail))
-            removeUserRoleAssignment(userEmail, APP_ADMIN, "/");
+            removeUserRoleAssignment(userEmail, APP_ADMIN_ROLE, "/");
     }
 
     private boolean isUserAppAdmin(String userEmail)
     {
-        return doesUserHaveRole(userEmail, APP_ADMIN, "/");
+        return doesUserHaveRole(userEmail, APP_ADMIN_ROLE, "/");
     }
 }

--- a/src/org/labkey/test/util/ApiPermissionsHelper.java
+++ b/src/org/labkey/test/util/ApiPermissionsHelper.java
@@ -299,7 +299,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
         return getUserPerms(container, user).getProperty("container.groups");
     }
 
-    private List<String> getUserRoles(String container, String user)
+    public List<String> getUserRoles(String container, String user)
     {
         try
         {

--- a/src/org/labkey/test/util/PermissionsHelper.java
+++ b/src/org/labkey/test/util/PermissionsHelper.java
@@ -18,7 +18,6 @@ package org.labkey.test.util;
 import org.apache.commons.lang3.ObjectUtils;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.GuestCredentialsProvider;
 import org.labkey.remoteapi.security.GetRolesCommand;
 import org.labkey.remoteapi.security.GetRolesResponse;
 import org.labkey.test.WebTestHelper;
@@ -35,6 +34,11 @@ import static org.junit.Assert.fail;
  */
 public abstract class PermissionsHelper
 {
+    public static final String SITE_ADMIN_ROLE = "Site Administrator";
+    public static final String APP_ADMIN_ROLE = "Application Admin";
+    public static final String DEVELOPER_ROLE = "Platform Developer";
+    public static final String IMP_TROUBLESHOOTER_ROLE = "Impersonating Troubleshooter";
+
     public static String toRole(final String name)
     {
         if (name.contains("."))

--- a/src/org/labkey/test/util/PermissionsHelper.java
+++ b/src/org/labkey/test/util/PermissionsHelper.java
@@ -18,8 +18,10 @@ package org.labkey.test.util;
 import org.apache.commons.lang3.ObjectUtils;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.GuestCredentialsProvider;
 import org.labkey.remoteapi.security.GetRolesCommand;
 import org.labkey.remoteapi.security.GetRolesResponse;
+import org.labkey.test.WebTestHelper;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -33,32 +35,30 @@ import static org.junit.Assert.fail;
  */
 public abstract class PermissionsHelper
 {
-    private static final String permissionClassPkg = "org.labkey.api.security.roles.";
-    public String toRole(final String perm)
+    public static String toRole(final String name)
     {
-        if (perm.contains("."))
-            return perm;
+        if (name.contains("."))
+            return name;
 
-        Map<String, String> specialRoleClasses = new HashMap<>();
-        specialRoleClasses.put("See Audit Log Events", permissionClassPkg + "CanSeeAuditLogRole");
+        String roleClassName = name.replaceAll("[- ]", "").replace("Administrator", "Admin") + "Role";
 
-        String roleClassName = perm.replaceAll("[- ]", "").replace("Administrator", "Admin") + "Role";
+        String role = ObjectUtils.firstNonNull(
+                getRoles().get(name),
+                getRoles().get(roleClassName));
+        if (role == null)
+            throw new RuntimeException("No role found matching '" + name + "'");
 
-        return ObjectUtils.firstNonNull(
-                specialRoleClasses.get(perm),
-                getRoles().get(perm),
-                getRoles().get(roleClassName),
-                permissionClassPkg + roleClassName);
+        return role;
     }
 
-    private Map<String, String> _roles;
-    private Map<String, String> getRoles()
+    private static Map<String, String> _roles;
+    private static Map<String, String> getRoles()
     {
         if (_roles == null)
         {
             _roles = new HashMap<>();
             GetRolesCommand command = new GetRolesCommand();
-            Connection connection = getConnection();
+            Connection connection = WebTestHelper.getRemoteApiConnection();
 
             try
             {
@@ -66,9 +66,10 @@ public abstract class PermissionsHelper
                 List<GetRolesResponse.Role> roles = response.getRoles();
                 for (GetRolesResponse.Role role : roles)
                 {
-                    String[] roleParts = role.getUniqueName().split("\\.");
-                    _roles.put(roleParts[roleParts.length - 1], role.getUniqueName());
-                    _roles.put(role.getName(), role.getUniqueName());
+                    String uniqueName = role.getUniqueName();
+                    String simpleRoleClassName = uniqueName.substring(uniqueName.lastIndexOf(".") + 1);
+                    _roles.put(simpleRoleClassName, uniqueName);
+                    _roles.put(role.getName(), uniqueName);
                 }
             }
             catch (IOException | CommandException e)


### PR DESCRIPTION
#### Rationale
The new `ImpersonatingTroubleshooterRole` needs testing.
`PermissionsEditor` automatically saves after several operations, which makes it difficult to test error conditions. It isn't widely used however (it duplicates a lot of functionality from the more populare `UIPermissionsHelper`).

#### Story
* https://github.com/LabKey/platform/issues/4866

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/1697
- https://github.com/LabKey/sampleManagement/pull/2201
- https://github.com/LabKey/labbook/pull/566

#### Changes
* Regression test for Impersonating Troubleshooter
* Additional regression tests for App Admin
* Update `PermissionsEditor` test page
* Make `PermissionsHelper.getRoles` static
