### PR TITLE
Teach test about tweaked error message. Update to commons text 1.11.0.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 aspectjVersion=1.9.20.1
 assertjVersion=3.23.1
 awaitilityVersion=4.2.0
-commonsTextVersion=1.10.0
+commonsTextVersion=1.11.0
 reflectionsVersion=0.9.10
 hamcrestCoreVersion=1.3
 

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -632,7 +632,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
             log("Testing bad passwords");
             String email = PasswordUtil.getUsername();
             verifyInitialUserError(email, null, null, "You must enter a password.");
-            verifyInitialUserError(email, PasswordUtil.getPassword(), null, "You must enter a password.");
+            verifyInitialUserError(email, PasswordUtil.getPassword(), null, "You must confirm your password.");
             verifyInitialUserError(email, null, PasswordUtil.getPassword(), "You must enter a password.");
             verifyInitialUserError(email, "short", "short", "Your password is not complex enough."); // less than weak
             verifyInitialUserError(email, "LongEnough", "LongEnough", "Your password is not complex enough."); // Weak


### PR DESCRIPTION
#### Rationale
Related PR introduced a relevant error message when the confirm password is left blank (fulfilling an intent from 12 years ago).

The commons people updated commons text recently.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4881
