### PR TITLE
Fix test references to "NoPermissionsRole"

### DIFF
--- a/src/org/labkey/test/util/PermissionsHelper.java
+++ b/src/org/labkey/test/util/PermissionsHelper.java
@@ -75,8 +75,8 @@ public abstract class PermissionsHelper
                     _roles.put(simpleRoleClassName, uniqueName);
                     _roles.put(role.getName(), uniqueName);
                 }
-                _roles.put("NoPermissionsRole", "org.labkey.api.security.roles.NoPermissionsRole");
-                _roles.put("No Permissions", "org.labkey.api.security.roles.NoPermissionsRole");
+                _roles.putIfAbsent("NoPermissionsRole", "org.labkey.api.security.roles.NoPermissionsRole");
+                _roles.putIfAbsent("No Permissions", "org.labkey.api.security.roles.NoPermissionsRole");
             }
             catch (IOException | CommandException e)
             {

--- a/src/org/labkey/test/util/PermissionsHelper.java
+++ b/src/org/labkey/test/util/PermissionsHelper.java
@@ -75,6 +75,8 @@ public abstract class PermissionsHelper
                     _roles.put(simpleRoleClassName, uniqueName);
                     _roles.put(role.getName(), uniqueName);
                 }
+                _roles.put("NoPermissionsRole", "org.labkey.api.security.roles.NoPermissionsRole");
+                _roles.put("No Permissions", "org.labkey.api.security.roles.NoPermissionsRole");
             }
             catch (IOException | CommandException e)
             {


### PR DESCRIPTION
#### Rationale
`security-getRoles.view` doesn't include `NoPermissionsRole`. Need to hard-code it into `PermissionsHelper.getRoles` so that tests can reference it.
```
java.lang.RuntimeException: No role found matching 'No Permissions'
  at org.labkey.test.util.PermissionsHelper.toRole(PermissionsHelper.java:53)
  at org.labkey.test.util.UIPermissionsHelper.assertPermissionSetting(UIPermissionsHelper.java:123)
  at org.labkey.test.tests.BasicAdminTest.testFolderAndRole(BasicAdminTest.java:92)
```

#### Related Pull Requests
* #1697 

#### Changes
* Fix test references to "NoPermissionsRole"
