### PR TITLE
Set display names via API

### DIFF
--- a/src/org/labkey/test/pages/user/UpdateUserDetailsPage.java
+++ b/src/org/labkey/test/pages/user/UpdateUserDetailsPage.java
@@ -90,6 +90,7 @@ public class UpdateUserDetailsPage extends LabKeyPage<UpdateUserDetailsPage.Elem
     public void clickSubmit()
     {
         clickAndWait(elementCache().submitButton);
+        assertNoLabKeyErrors();
     }
 
     @Override

--- a/src/org/labkey/test/util/APIUserHelper.java
+++ b/src/org/labkey/test/util/APIUserHelper.java
@@ -28,7 +28,7 @@ import org.labkey.remoteapi.security.GetUsersCommand;
 import org.labkey.remoteapi.security.GetUsersResponse;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.pages.user.UpdateUserDetailsPage;
+import org.labkey.test.util.query.QueryApiHelper;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -75,10 +75,15 @@ public class APIUserHelper extends AbstractUserHelper
             throw new IllegalArgumentException("No such user: " + email);
         }
 
-        // TODO: Update via API
-        final UpdateUserDetailsPage updateUserDetailsPage = UpdateUserDetailsPage.beginAt(getWrapper(), userId);
-        updateUserDetailsPage.setDisplayName(newDisplayName);
-        updateUserDetailsPage.clickSubmit();
+        try
+        {
+            new QueryApiHelper(getWrapper().createDefaultConnection(), "/", "core", "siteusers")
+                    .updateRows(List.of(Maps.of("userId", userId, "DisplayName", newDisplayName)));
+        }
+        catch (IOException | CommandException e)
+        {
+            throw new RuntimeException("Failed to set display name for user:" + email, e);
+        }
     }
 
     @Override

--- a/src/org/labkey/test/util/AbstractUserHelper.java
+++ b/src/org/labkey/test/util/AbstractUserHelper.java
@@ -28,8 +28,10 @@ import java.util.Map;
 
 public abstract class AbstractUserHelper
 {
-    private WebDriverWrapper _driverWrapper;
-    protected static final Map<String, String> usersAndDisplayNames = new HashMap<>();
+    private static final int DISPLAY_NAME_LENGTH = 64;
+    private static final Map<String, String> usersAndDisplayNames = new HashMap<>();
+
+    private final WebDriverWrapper _driverWrapper;
 
     protected AbstractUserHelper(WebDriverWrapper driverWrapper)
     {
@@ -72,8 +74,14 @@ public abstract class AbstractUserHelper
     @LogMethod
     public final String setInjectionDisplayName(@LoggedParam String email)
     {
-        String newDisplayName = getDefaultDisplayName(email) +
-                (WebTestHelper.RANDOM.nextBoolean() ? BaseWebDriverTest.INJECT_CHARS_1 : BaseWebDriverTest.INJECT_CHARS_2);
+        String prefix = getDefaultDisplayName(email);
+        String suffix = WebTestHelper.RANDOM.nextBoolean() ? BaseWebDriverTest.INJECT_CHARS_1 : BaseWebDriverTest.INJECT_CHARS_2;
+        int tooLongBy = prefix.length() + suffix.length() - DISPLAY_NAME_LENGTH;
+        if (tooLongBy > 0)
+        {
+            prefix = prefix.substring(tooLongBy);
+        }
+        String newDisplayName = prefix + suffix;
         setDisplayName(email, newDisplayName);
         return newDisplayName;
     }

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -1224,8 +1224,8 @@ public class Crawler
 
     public static final String injectedAlert = "8(";
     public static final String maliciousScript = "alert('" + injectedAlert + "')";
-    public static final String injectScriptBlock = "-->\">'>'\"<script>" + maliciousScript + "</script>";
-    public static final String injectAttributeScript = "-->\">'>'\"</script><img src=\"xss\" onerror=\"" + maliciousScript + "\">";
+    public static final String injectScriptBlock = "\">'>'\"<script>" + maliciousScript + "</script>";
+    public static final String injectAttributeScript = "\">'>'\"</script><img src=\"x\" onerror=\"" + maliciousScript + "\">";
 
     public static void tryInject(WebDriverWrapper test, Runnable r)
     {


### PR DESCRIPTION
#### Rationale
`APIUserHelper._setDisplayName` was using the UI. I was able to switch it to use the API.
I also noticed that display name has a 64 character limit. Some tests were violating this limit but the UI helper didn't notice the error.

#### Related Pull Requests
* N/A

#### Changes
* Check for errors after updating user details
* Update `APIUserHelper._setDisplayName` to use API instead of UI
* Update `AbstractUserHelper.setInjectionDisplayName` to avoid exceeding length limit
