### PR TITLE
Refactor auth dialogs to share logo inputs

### DIFF
--- a/src/org/labkey/test/pages/core/login/SsoAuthDialogBase.java
+++ b/src/org/labkey/test/pages/core/login/SsoAuthDialogBase.java
@@ -1,0 +1,64 @@
+package org.labkey.test.pages.core.login;
+
+import org.labkey.test.params.login.AuthenticationProvider;
+import org.openqa.selenium.WebDriver;
+
+import java.io.File;
+
+public abstract class SsoAuthDialogBase<T extends SsoAuthDialogBase<T>> extends AuthDialogBase<T>
+{
+    public SsoAuthDialogBase(AuthenticationProvider<?> provider, WebDriver driver)
+    {
+        super(provider, driver);
+    }
+
+    public SsoAuthDialogBase(LoginConfigRow row)
+    {
+        super(row);
+    }
+
+    public T setPageHeaderLogo(File logoFile)
+    {
+        elementCache().headerLogoPanel.setLogo(logoFile);
+        return getThis();
+    }
+
+    public T clearPageHeaderLogo()
+    {
+        elementCache().headerLogoPanel.clearLogo();
+        return getThis();
+    }
+
+    public T setLoginPageLogo(File logoFile)
+    {
+        elementCache().loginPageLogoPanel.setLogo(logoFile);
+        return getThis();
+    }
+
+    public T clearLoginPageLogo()
+    {
+        elementCache().loginPageLogoPanel.clearLogo();
+        return getThis();
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+    protected class ElementCache extends AuthDialogBase<T>.ElementCache
+    {
+        SsoLogoInputPanel headerLogoPanel = new SsoLogoInputPanel.SsoLogoInputPanelFinder(getDriver())
+                .timeout(4000).withLabel("Page Header Logo").findWhenNeeded(this);
+        SsoLogoInputPanel loginPageLogoPanel = new SsoLogoInputPanel.SsoLogoInputPanelFinder(getDriver())
+                .timeout(4000).withLabel("Login Page Logo").findWhenNeeded(this);
+
+    }
+}

--- a/src/org/labkey/test/util/login/AuthenticationAPIUtils.java
+++ b/src/org/labkey/test/util/login/AuthenticationAPIUtils.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class AuthenticationAPIUtils
 {
@@ -77,6 +78,12 @@ public class AuthenticationAPIUtils
       }
     }
      */
+
+    public static Map<String, Integer> getConfigurationIds(Connection connection)
+    {
+        return getAllConfigurations(connection).stream()
+                .collect(Collectors.toMap(Configuration::getDescription, Configuration::getConfiguration));
+    }
 
     private static List<Configuration> getAllConfigurations(Connection connection)
     {

--- a/src/org/labkey/test/util/login/AuthenticationAPIUtils.java
+++ b/src/org/labkey/test/util/login/AuthenticationAPIUtils.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 public class AuthenticationAPIUtils
 {
@@ -78,12 +77,6 @@ public class AuthenticationAPIUtils
       }
     }
      */
-
-    public static Map<String, Integer> getConfigurationIds(Connection connection)
-    {
-        return getAllConfigurations(connection).stream()
-                .collect(Collectors.toMap(Configuration::getDescription, Configuration::getConfiguration));
-    }
 
     private static List<Configuration> getAllConfigurations(Connection connection)
     {


### PR DESCRIPTION
#### Rationale
Several test components have these same inputs. Pulling them up into a shared base component.

#### Related Pull Requests
* 

#### Changes
* Refactor auth dialogs to share logo inputs
