### PR TITLE
wait for success when saving metadata

### DIFF
--- a/src/org/labkey/test/pages/query/EditMetadataPage.java
+++ b/src/org/labkey/test/pages/query/EditMetadataPage.java
@@ -45,6 +45,7 @@ public class EditMetadataPage extends BaseDomainDesigner<EditMetadataPage.Elemen
     public EditMetadataPage clickSave()
     {
         elementCache().saveBtn.click();
+        waitForSuccess();
         return this;
     }
 


### PR DESCRIPTION
#### Rationale
Recently, [BiologicsLookupFilterTest.testResetToDefaultDoesNotBreakParentLookup](https://teamcity.labkey.org/viewLog.html?tab=queuedBuildOverviewTab&buildId=2730636&buildTypeId=LabKey_237Release_Premium_ProductSuites_Biologics_BiologicsAPostgres&fromSakuraUI=true#testNameId-648691882869885389) failed when running in 23.7 Biologics because the test clicked 'save' and immediately navigated away from the page, causing the page to surface a dirty-bit 'Save Changes?' dialog to make sure the user really meant to do that.

This adds a call to waitForSuccess to EditMetadataPage.clickSave(). Clicking the 'Save' button in this situation appears to always produce a success banner.

#### Related Pull Requests
n/a

#### Changes

- [x] wait for the success banner after clicking 'save'
