### PR TITLE
Add test to verify delete confirmation for Flow

### DIFF
--- a/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
+++ b/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
@@ -92,6 +92,28 @@ public class FlowSpecimenTest extends BaseFlowTest
 
         // Issue 16945: flow specimen FK doesn't work for 'fake' FCS file wells created during FlowJo import
         verifyFlowDatasetSpecimenFK();
+
+        verifyDeleteConfirmation();
+    }
+
+    private void verifyDeleteConfirmation()
+    {
+        log("** Attempt Specimen run delete, confirm usage before delete ");
+        goToFlowDashboard();
+        clickAndWait(Locator.linkContainingText("FCS Analyses"));
+        final DataRegionTable drt = new DataRegionTable("query", this);
+        drt.checkCheckbox(0);
+        doAndWaitForPageToLoad(() -> drt.clickHeaderButton("Delete"));
+        assertTextPresent("Confirm Deletion", "One dataset(s) have one or more rows which will also be deleted", String.format("/%1$s/%2$s", getProjectName(), STUDY_FOLDER));
+        clickAndWait(Locator.lkButton("Cancel"));
+        drt.uncheckCheckbox(0);
+        goToFlowDashboard();
+        clickAndWait(Locator.linkContainingText("FCS Files ("));
+        final DataRegionTable fcsDRT = new DataRegionTable("query", this);
+        fcsDRT.checkCheckbox(0);
+        doAndWaitForPageToLoad(() -> drt.clickHeaderButton("Delete"));
+        assertTextPresent("Confirm Deletion");
+        assertTextNotPresent("One dataset(s) have one or more rows which will also be deleted", String.format("/%1$s/%2$s", getProjectName(), STUDY_FOLDER));
     }
 
     @Override

--- a/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
+++ b/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
@@ -99,15 +99,38 @@ public class FlowSpecimenTest extends BaseFlowTest
 
     private void verifyDeleteConfirmation()
     {
+        String fcsFilename = "version";
+        String fcsAnalysisName = "microFCS.xml";
         log("** Attempt Specimen run delete, confirm usage before delete ");
+        log("check that table selection for the \"different\" run types are separated");
         goToFlowDashboard();
-        log("check that delete confirmation for unconnected files does not show Study linkage text");
         clickAndWait(Locator.linkContainingText("FCS Files ("));
         final DataRegionTable fcsDRT = new DataRegionTable("query", this);
-        fcsDRT.checkCheckbox(0);
+        fcsDRT.checkCheckbox(1);
         doAndWaitForPageToLoad(() -> fcsDRT.clickHeaderButton("Delete"));
+        assertElementPresent(Locator.linkWithText(fcsFilename));
         assertTextPresent("Confirm Deletion");
-        assertTextNotPresent("One dataset(s) have one or more rows which will also be deleted", String.format("/%1$s/%2$s", getProjectName(), STUDY_FOLDER));
+        assertTextNotPresent(fcsAnalysisName);
+        clickAndWait(Locator.lkButton("Cancel"));
+        goToFlowDashboard();
+        clickAndWait(Locator.linkContainingText("FCS Analyses"));
+        final DataRegionTable fcsAnalysisDRT = new DataRegionTable("query", this);
+        fcsAnalysisDRT.checkCheckbox(0);
+        doAndWaitForPageToLoad(() -> fcsAnalysisDRT.clickHeaderButton("Delete"));
+        assertTextPresent("Confirm Deletion", "One dataset(s) have one or more rows which will also be deleted", String.format("/%1$s/%2$s", getProjectName(), STUDY_FOLDER), fcsAnalysisName);
+        assertElementNotPresent(Locator.linkWithText(fcsFilename));
+        clickAndWait(Locator.lkButton("Cancel"));
+        log("Cancel works...");
+
+        log("check that delete confirmation for unconnected files does not show Study linkage text");
+        goToFlowDashboard();
+        clickAndWait(Locator.linkContainingText("FCS Files ("));
+        final DataRegionTable fcsDeleteDRT = new DataRegionTable("query", this);
+        fcsDeleteDRT.checkCheckbox(1);
+        doAndWaitForPageToLoad(() -> fcsDeleteDRT.clickHeaderButton("Delete"));
+        assertElementPresent(Locator.linkWithText(fcsFilename));
+        assertTextPresent("Confirm Deletion");
+        assertTextNotPresent("One dataset(s) have one or more rows which will also be deleted", String.format("/%1$s/%2$s", getProjectName(), STUDY_FOLDER), fcsAnalysisName);
         clickAndWait(Locator.lkButton("Confirm Delete"));
         beginAt("/study/" + getProjectName() + "/" + STUDY_FOLDER + "/dataset.view?datasetId=5001");
         DataRegionTable table = new DataRegionTable(getDriver().getCurrentUrl().contains("dataset.view") ? "Dataset" : "query", this);
@@ -117,15 +140,9 @@ public class FlowSpecimenTest extends BaseFlowTest
         goToFlowDashboard();
         log("Check that delete confirmation shows study linkage");
         clickAndWait(Locator.linkContainingText("FCS Analyses"));
-        final DataRegionTable drt = new DataRegionTable("query", this);
-        drt.checkCheckbox(0);
-        doAndWaitForPageToLoad(() -> drt.clickHeaderButton("Delete"));
-        assertTextPresent("Confirm Deletion", "One dataset(s) have one or more rows which will also be deleted", String.format("/%1$s/%2$s", getProjectName(), STUDY_FOLDER));
-        clickAndWait(Locator.lkButton("Cancel"));
-        log("Cancel works...");
-
-        drt.checkCheckbox(0);
-        doAndWaitForPageToLoad(() -> drt.clickHeaderButton("Delete"));
+        final DataRegionTable fcsAnalysisDeleteDRT = new DataRegionTable("query", this);
+        fcsAnalysisDeleteDRT.checkCheckbox(0);
+        doAndWaitForPageToLoad(() -> fcsAnalysisDeleteDRT.clickHeaderButton("Delete"));
         assertTextPresent("Confirm Deletion", "One dataset(s) have one or more rows which will also be deleted", String.format("/%1$s/%2$s", getProjectName(), STUDY_FOLDER));
         clickAndWait(Locator.lkButton("Confirm Delete"));
         assertTextPresent("No data to show.");

--- a/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
+++ b/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
@@ -99,6 +99,7 @@ public class FlowSpecimenTest extends BaseFlowTest
 
     private void verifyDeleteConfirmation()
     {
+        // Add check for shared selection contexts between FCSFiles/FCSAnalysis table types Issue #49062
         String fcsFilename = "version";
         String fcsAnalysisName = "microFCS.xml";
         log("** Attempt Specimen run delete, confirm usage before delete ");

--- a/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
+++ b/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
@@ -93,6 +93,7 @@ public class FlowSpecimenTest extends BaseFlowTest
         // Issue 16945: flow specimen FK doesn't work for 'fake' FCS file wells created during FlowJo import
         verifyFlowDatasetSpecimenFK();
 
+        // Issue 48308: Flow: warn when deleting flow run with fcs files linked to study
         verifyDeleteConfirmation();
     }
 
@@ -100,20 +101,32 @@ public class FlowSpecimenTest extends BaseFlowTest
     {
         log("** Attempt Specimen run delete, confirm usage before delete ");
         goToFlowDashboard();
+        log("check that delete confirmation for unconnected files does not show Study linkage text");
+        clickAndWait(Locator.linkContainingText("FCS Files ("));
+        final DataRegionTable fcsDRT = new DataRegionTable("query", this);
+        fcsDRT.checkCheckbox(0);
+        doAndWaitForPageToLoad(() -> fcsDRT.clickHeaderButton("Delete"));
+        assertTextPresent("Confirm Deletion");
+        assertTextNotPresent("One dataset(s) have one or more rows which will also be deleted", String.format("/%1$s/%2$s", getProjectName(), STUDY_FOLDER));
+
+        goToFlowDashboard();
+        log("Check that delete confirmation shows study linkage");
         clickAndWait(Locator.linkContainingText("FCS Analyses"));
         final DataRegionTable drt = new DataRegionTable("query", this);
         drt.checkCheckbox(0);
         doAndWaitForPageToLoad(() -> drt.clickHeaderButton("Delete"));
         assertTextPresent("Confirm Deletion", "One dataset(s) have one or more rows which will also be deleted", String.format("/%1$s/%2$s", getProjectName(), STUDY_FOLDER));
         clickAndWait(Locator.lkButton("Cancel"));
-        drt.uncheckCheckbox(0);
-        goToFlowDashboard();
-        clickAndWait(Locator.linkContainingText("FCS Files ("));
-        final DataRegionTable fcsDRT = new DataRegionTable("query", this);
-        fcsDRT.checkCheckbox(0);
+        log("Cancel works...");
+
+        drt.checkCheckbox(0);
         doAndWaitForPageToLoad(() -> drt.clickHeaderButton("Delete"));
-        assertTextPresent("Confirm Deletion");
-        assertTextNotPresent("One dataset(s) have one or more rows which will also be deleted", String.format("/%1$s/%2$s", getProjectName(), STUDY_FOLDER));
+        assertTextPresent("Confirm Deletion", "One dataset(s) have one or more rows which will also be deleted", String.format("/%1$s/%2$s", getProjectName(), STUDY_FOLDER));
+        clickAndWait(Locator.lkButton("Confirm Delete"));
+        assertTextPresent("No data to show.");
+        beginAt("/study/" + getProjectName() + "/" + STUDY_FOLDER + "/dataset.view?datasetId=5001");
+        assertTextPresent("No data to show.");
+        log("Delete successful");
     }
 
     @Override

--- a/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
+++ b/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
@@ -108,6 +108,11 @@ public class FlowSpecimenTest extends BaseFlowTest
         doAndWaitForPageToLoad(() -> fcsDRT.clickHeaderButton("Delete"));
         assertTextPresent("Confirm Deletion");
         assertTextNotPresent("One dataset(s) have one or more rows which will also be deleted", String.format("/%1$s/%2$s", getProjectName(), STUDY_FOLDER));
+        clickAndWait(Locator.lkButton("Confirm Delete"));
+        beginAt("/study/" + getProjectName() + "/" + STUDY_FOLDER + "/dataset.view?datasetId=5001");
+        DataRegionTable table = new DataRegionTable(getDriver().getCurrentUrl().contains("dataset.view") ? "Dataset" : "query", this);
+        assertEquals("Dataset data not as expected after FCSFile delete", 2, table.getDataRowCount());
+        log("Non-Study data delete successful");
 
         goToFlowDashboard();
         log("Check that delete confirmation shows study linkage");
@@ -126,7 +131,7 @@ public class FlowSpecimenTest extends BaseFlowTest
         assertTextPresent("No data to show.");
         beginAt("/study/" + getProjectName() + "/" + STUDY_FOLDER + "/dataset.view?datasetId=5001");
         assertTextPresent("No data to show.");
-        log("Delete successful");
+        log("Study linked data delete successful");
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
[Issue 48308: Flow: warn when deleting flow run with fcs files linked to study](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48308)

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/676

#### Changes
* Added a delete verification step to the FlowSpecimenTest
