### PR TITLE
TabbedGridPanel: add a timeout for exportMenu

### DIFF
--- a/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
+++ b/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
@@ -132,7 +132,7 @@ public class TabbedGridPanel extends WebDriverComponent<TabbedGridPanel.ElementC
         MultiMenu gridAssayMenu = gridAssayMenuFinder.findWhenNeeded(this);
 
         final WebElement body = Locator.tagWithClass("div", "tabbed-grid-panel__body")
-                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+                .refindWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
         final Locator navTab = Locator.tagWithClass("ul", "nav-tabs")
                 .child(Locator.tag("li").withChild(Locator.tag("a")));
 


### PR DESCRIPTION
#### Rationale
For some reason the SMSampleUpdateFromGridTest.testDirtyPageAlerts test is failing on my branch. We seem to be navigating to a page and trying to click the menu too quickly. Adding a timeout resolves the issue.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1341
- https://github.com/LabKey/labkey-ui-premium/pull/247
- https://github.com/LabKey/biologics/pull/2504
- https://github.com/LabKey/inventory/pull/1089
- https://github.com/LabKey/sampleManagement/pull/2222
- https://github.com/LabKey/testAutomation/pull/1716

#### Changes
* TabbedGridPanel: add a timeout for exportMenu
