### PR TITLE
Await insert panel readiness before attempting to select grid

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -189,7 +189,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     private Optional<EditableGrid> optionalGrid()
     {
-        return new EditableGrid.EditableGridFinder(_driver).findOptional(this);
+        return elementCache().optionalGrid();
     }
 
     public EntityInsertPanel setMergeData(boolean allowMerge)
@@ -213,7 +213,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     protected FileUploadPanel fileUploadPanel()
     {
-        return new FileUploadPanel.FileUploadPanelFinder(_driver).timeout(WAIT_FOR_JAVASCRIPT).waitFor(this);
+        return elementCache().fileUploadPanel();
     }
 
     private Optional<FileUploadPanel> optionalFileUploadPanel()
@@ -272,7 +272,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     public boolean hasTabs()
     {
-        return Locator.tagWithClassContaining("ul", "list-group").existsIn(this);
+        return elementCache().hasTabs();
     }
 
     public boolean isFileUploadVisible()
@@ -329,8 +329,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
     {
         /* either this is a grid-only insert panel, or there will be a mode-select list-item to
             allow the user to select the grid. Await one or the other to be present   */
-        WebDriverWrapper.waitFor(()-> isGridVisible() ||
-                modeSelectListItem("from Grid").existsIn(this),
+        WebDriverWrapper.waitFor(()-> isGridVisible() || hasTabs(),
                 "Neither the grid nor its selector appeared within the ready timeout", _readyTimeout);
 
         if (!isGridVisible())
@@ -435,8 +434,28 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
         EditableGrid grid = new EditableGrid.EditableGridFinder(_driver).timeout(WAIT_FOR_JAVASCRIPT).findWhenNeeded();
 
+        private Optional<EditableGrid> optionalGrid()
+        {
+            return new EditableGrid.EditableGridFinder(_driver).findOptional(this);
+        }
+
+        private Optional<FileUploadPanel> optionalFileUploadPanel()
+        {
+            return new FileUploadPanel.FileUploadPanelFinder(getDriver()).findOptional();
+        }
+
+        protected FileUploadPanel fileUploadPanel()
+        {
+            return new FileUploadPanel.FileUploadPanelFinder(_driver).timeout(WAIT_FOR_JAVASCRIPT).waitFor(this);
+        }
+
         WebElement formatString = Locator.tagWithClass("div","file-form-formats")
                 .refindWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+
+        public boolean hasTabs()
+        {
+            return Locator.tagWithClassContaining("ul", "list-group").existsIn(elementCache());
+        }
     }
 
     public static class EntityInsertPanelFinder extends WebDriverComponent.WebDriverComponentFinder<EntityInsertPanel, EntityInsertPanelFinder>

--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -327,6 +327,12 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     public EntityInsertPanel showGrid()
     {
+        /* either this is a grid-only insert panel, or there will be a mode-select list-item to
+            allow the user to select the grid. Await one or the other to be present   */
+        WebDriverWrapper.waitFor(()-> isGridVisible() ||
+                modeSelectListItem("from Grid").existsIn(this),
+                "Neither the grid nor its selector appeared within the ready timeout", _readyTimeout);
+
         if (!isGridVisible())
         {
             modeSelectListItem("from Grid")

--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -187,11 +187,6 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
         return panel.fileUploadPanel();
     }
 
-    private Optional<EditableGrid> optionalGrid()
-    {
-        return elementCache().optionalGrid();
-    }
-
     public EntityInsertPanel setMergeData(boolean allowMerge)
     {
         var panel = showFileUpload();
@@ -233,7 +228,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     public boolean isGridVisible()
     {
-        var optionalGrid = optionalGrid();
+        var optionalGrid = elementCache().optionalGrid();
         return optionalGrid.isPresent() && optionalGrid.get().isDisplayed();
     }
 


### PR DESCRIPTION
#### Rationale
Recently, [BiologicsSampleCreateTest.testDashboardCreateSamples](https://teamcity.labkey.org/viewLog.html?buildId=2737125&tab=buildResultsDiv&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_LimsStarter_LimsStarterB&branch_LabKey_Trunk_Premium_ProductSuites_Biologics_LimsStarter=%3Cdefault%3E#testNameId-1930444423740823537) failed because `EntityInsertPanel.showGrid` makes the wrong assumption that if the grid is not already shown, there will already be a list-item there to allow the user to show the grid.  This used to be reliably true, but perhaps running on a faster browser allows the test to get to the race condition.  

Sometimes, the `EntityInsertPanel `doesn't support file-upload, and grid-upload is the only option (and thus, no mode-selection is offered). In this situation, when showGrid is called and the grid isn't already present, showGrid will try to select grid-mode and fail because no mode-selector will be there.

This change causes` EntityInsertPanel.showGrid `to await the presence of either the editable grid or the mode-selector before figuring out whether the grid is already shown.

#### Related Pull Requests
n/a

#### Changes

- [x] await the presence of either the grid or the mode selector before acting
