### PR TITLE
Update location of `shouldDoBuild`

### DIFF
--- a/distributions/teamcity/build.gradle
+++ b/distributions/teamcity/build.gradle
@@ -59,7 +59,7 @@ else
     List pathList = []
     project.rootProject.allprojects.each {
         Project otherProject ->
-            if (otherProject != project && ModuleFinder.isPotentialModule(otherProject) && FileModule.shouldDoBuild(otherProject, false))
+            if (otherProject != project && ModuleFinder.isPotentialModule(otherProject) && BuildUtils.shouldDoBuild(otherProject, false))
             {
                 project.evaluationDependsOn(otherProject.path)
                 if (otherProject.plugins.hasPlugin('org.labkey.module') ||


### PR DESCRIPTION
#### Rationale
`shouldDoBuild` has moved from `FileModule` to `BuildUtils` for better accessibility for all

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/186

#### Changes
* Update location of `shouldDoBuild`
