### PR TITLE
IntelliJ JavaScript and XPath syntax highlighting in tests

### DIFF
--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -18,6 +18,7 @@ package org.labkey.test;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableObject;
+import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.test.selenium.LazyWebElement;
@@ -59,6 +60,7 @@ public abstract class Locator extends By
     private String _description;
 
     // XPATH fragments
+    @Language("XPath")
     public static final String HIDDEN = "ancestor-or-self::*[" +
             "contains(@style,'display: none') or " +
             "contains(@style,'visibility: hidden') or " +
@@ -66,8 +68,11 @@ public abstract class Locator extends By
             "contains(@class, 'x4-hide-offsets') or " +
             "contains(@class, 'x-hide-offsets')] or " +
             "(@type = 'hidden')";
+    @Language("XPath")
     public static final String NOT_HIDDEN = "not(" + HIDDEN + ")";
+    @Language("XPath")
     public static final String DISABLED = "ancestor-or-self::*[contains(@class, 'disabled')]";
+    @Language("XPath")
     public static final String ENABLED = "not(" + DISABLED + ")";
     public static final String NBSP = "\u00A0";
 
@@ -574,7 +579,7 @@ public abstract class Locator extends By
         return new CssLocator(selector);
     }
 
-    public static XPathLocator xpath(String xpathExpr)
+    public static XPathLocator xpath(@Language("XPath") String xpathExpr)
     {
         return new XPathLocator(xpathExpr);
     }
@@ -1176,7 +1181,7 @@ public abstract class Locator extends By
 
     public static class XPathLocator extends Locator
     {
-        protected XPathLocator(String loc)
+        protected XPathLocator(@Language("XPath") String loc)
         {
             super(loc);
         }
@@ -1229,7 +1234,7 @@ public abstract class Locator extends By
 
         public XPathLocator withoutText()
         {
-            return this.withPredicate("string-length() == 0");
+            return this.withPredicate("string-length() = 0");
         }
 
         public XPathLocator withTextMatching(String regex)
@@ -1321,7 +1326,7 @@ public abstract class Locator extends By
             return withPredicate("last()");
         }
 
-        public XPathLocator append(String clause)
+        public XPathLocator append(@Language("XPath") String clause)
         {
             return new XPathLocator(getLoc() + clause);
         }
@@ -1357,12 +1362,12 @@ public abstract class Locator extends By
             return this.withPredicate(descendant.getLoc());
         }
 
-        public XPathLocator withPredicate(String predicate)
+        public XPathLocator withPredicate(@Language("XPath") String predicate)
         {
             return this.append("[" + getRelativeXPath(predicate) + "]");
         }
 
-        public XPathLocator withoutPredicate(String predicate)
+        public XPathLocator withoutPredicate(@Language("XPath") String predicate)
         {
             return this.append("[not(" + getRelativeXPath(predicate) + ")]");
         }
@@ -1525,7 +1530,7 @@ public abstract class Locator extends By
             return getRelativeXPath(getLoc());
         }
 
-        private String getRelativeXPath(String xpath)
+        private String getRelativeXPath(@Language("XPath") String xpath)
         {
             if (xpath.startsWith("//") || xpath.startsWith("(//"))
                 xpath = xpath.replaceFirst("//", ".//");

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -452,7 +453,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
         return getDriver().getClass().isAssignableFrom(FirefoxDriver.class);
     }
 
-    public Object executeScript(String script, Object... arguments)
+    public Object executeScript(@Language("JavaScript") String script, Object... arguments)
     {
         return ((JavascriptExecutor) getDriver()).executeScript(script, arguments);
     }
@@ -461,7 +462,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
      * Wrapper for executing JavaScript through WebDriver and verifying return type.
      * @param <T> See {@link JavascriptExecutor#executeScript(java.lang.String, java.lang.Object...)} for valid return types
      */
-    public <T> T executeScript(String script, Class<T> expectedResultType, Object... arguments)
+    public <T> T executeScript(@Language("JavaScript") String script, Class<T> expectedResultType, Object... arguments)
     {
         Object o = executeScript(script, arguments);
         if (o != null && !expectedResultType.isAssignableFrom(o.getClass()))
@@ -474,7 +475,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
      * Wrapper for synchronous execution of asynchronous JavaScript. This wrapper extracts the 'callback' from the argument list
      * See {@link JavascriptExecutor#executeAsyncScript(java.lang.String, java.lang.Object...)} for details
      */
-    public Object executeAsyncScript(String script, Object... arguments)
+    public Object executeAsyncScript(@Language("XPath") String script, Object... arguments)
     {
         script = "var callback = arguments[arguments.length - 1];\n" + // See WebDriver documentation for details on injected callback
                 "try {" +
@@ -1475,15 +1476,16 @@ public abstract class WebDriverWrapper implements WrapsDriver
      */
     public void fireEvent(WebElement el, SeleniumEvent event)
     {
-        executeScript("var element = arguments[0];" +
-                "var eventType = arguments[1];" +
-                "var myEvent = document.createEvent('UIEvent');" +
-                "myEvent.initEvent(" +
-                "   eventType, /* event type */" +
-                "   true,      /* can bubble? */" +
-                "   true       /* cancelable? */" +
-                ");" +
-                "element.dispatchEvent(myEvent);", el, event.toString());
+        executeScript("""
+                var element = arguments[0];
+                var eventType = arguments[1];
+                var myEvent = document.createEvent('UIEvent');
+                myEvent.initEvent(
+                   eventType, /* event type */
+                   true,      /* can bubble? */
+                   true       /* cancelable? */
+                );
+                element.dispatchEvent(myEvent);""", el, event.toString());
     }
 
     public void assertTitleEquals(String match)


### PR DESCRIPTION
#### Rationale
IntelliJ can [add syntax highlighting](https://www.jetbrains.com/help/idea/using-language-injections.html#language_annotation) for different languages.

![image](https://github.com/LabKey/testAutomation/assets/5263798/5d6a86cb-1e34-4db4-9338-e7baf92b4ad4)

#### Related Pull Requests
* N/A

#### Changes
* Annotate JavaScript and XPath parameters to enable IDE syntax highlighting
