### PR TITLE
await menu close if not navigating

### DIFF
--- a/src/org/labkey/test/components/html/BootstrapMenu.java
+++ b/src/org/labkey/test/components/html/BootstrapMenu.java
@@ -20,6 +20,7 @@ import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.react.BaseBootstrapMenu;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -110,6 +111,18 @@ public class BootstrapMenu extends BaseBootstrapMenu
         getWrapper().scrollIntoView(item);
 
         getWrapper().clickAndWait(item, timeout);
+
+        if (0 == timeout)   // if we aren't waiting to navigate, wait for the menu to close
+            WebDriverWrapper.waitFor(()-> {
+                try
+                {
+                    return !isExpanded();
+                }
+                catch (StaleElementReferenceException success)
+                {
+                    return true;
+                }
+            }, 1000);
     }
 
     @LogMethod(quiet = true)


### PR DESCRIPTION
#### Rationale
While writing automation to interact with the remirror editor in Notebook tests, I noticed what might have been some timing issues while selecting styles from the styles menu- there may have been some failures arising from the test trying to interact with the remirror editor before the menu was completely out of the way?
Adding a wait for the menu to close or be stale seems to help

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/2526
https://github.com/LabKey/labbook/pull/581

#### Changes
await the close (or staleness) of the menu if it's not navigating
