### PR TITLE
Regression test for password strength gauge

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.awaitility.Awaitility;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
@@ -202,6 +203,8 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
     public BaseWebDriverTest()
     {
+        Awaitility.pollInSameThread(); // We don't do cross thread selenium testing.
+
         _artifactCollector = new ArtifactCollector(this);
         _errorCollector = new DeferredErrorCollector(_artifactCollector);
         _listHelper = new ListHelper(this);

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -604,6 +604,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
             SetPasswordForm setPasswordForm = new SetPasswordForm(getDriver());
             setPasswordForm.setEmail(email);
             setPasswordForm.verifyPasswordStrengthGauge(email);
+            refresh(); // Clear form
 
             log("Testing bad email addresses");
             verifyInitialUserError(null, null, null, "Invalid email address");

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -594,20 +594,22 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         // check to see if we're the first user:
         if (isTextPresent("Welcome! We see that this is your first time logging in."))
         {
+            String email = PasswordUtil.getUsername();
             bootstrapped = true;
             assertTitleEquals("Account Setup");
             log("Need to bootstrap");
             verifyInitialUserRedirects();
 
             log("Verify strength gauge for 'ChangePasswordAction'");
-            new SetPasswordForm(getDriver()).assertPasswordStrengthGauge();
+            SetPasswordForm setPasswordForm = new SetPasswordForm(getDriver());
+            setPasswordForm.setEmail(email);
+            setPasswordForm.verifyPasswordStrengthGauge(email);
 
             log("Testing bad email addresses");
             verifyInitialUserError(null, null, null, "Invalid email address");
             verifyInitialUserError("bogus@bogus@bogus", null, null, "Invalid email address: bogus@bogus@bogus");
 
             log("Testing bad passwords");
-            String email = PasswordUtil.getUsername();
             verifyInitialUserError(email, null, null, "You must enter a password.");
             verifyInitialUserError(email, PasswordUtil.getPassword(), null, "You must confirm your password.");
             verifyInitialUserError(email, null, PasswordUtil.getPassword(), "You must enter a password.");

--- a/src/org/labkey/test/components/core/login/SetPasswordForm.java
+++ b/src/org/labkey/test/components/core/login/SetPasswordForm.java
@@ -125,12 +125,14 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
         {
             // `WebElement.clear()` doesn't trigger `oninput`
             // Need to use this method to update strength guidance
-            getWrapper().actionClear(elementCache().password.getComponentElement());
+            getWrapper().actionClear(elementCache().password);
         }
         else
         {
-            // Set with a single operation to avoid triggering 'oninput' twice
-            elementCache().password.setWithPaste(password1);
+            // Won't trigger 'oninput'
+            elementCache().password.clear();
+            // Paste to avoid triggering 'oninput' twice
+            getWrapper().actionPaste(elementCache().password, password1);
         }
 
         return this;
@@ -181,7 +183,7 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
         // For ChangePasswordAction
         final Input oldPassword = Input(Locator.id("oldPassword"), getDriver()).findWhenNeeded(this);
 
-        final Input password = Input(Locator.id("password"), getDriver()).findWhenNeeded(this);
+        final WebElement password = Locator.id("password").findWhenNeeded(this);
         final Input password2 = Input(Locator.id("password2"), getDriver()).findWhenNeeded(this);
         final WebElement strengthGuidance = Locator.id("strengthGuidance").findWhenNeeded(this);
         final WebElement submitButton = Locator.name("set").findWhenNeeded(this);

--- a/src/org/labkey/test/components/core/login/SetPasswordForm.java
+++ b/src/org/labkey/test/components/core/login/SetPasswordForm.java
@@ -17,6 +17,7 @@ import org.openqa.selenium.WebElement;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.labkey.test.WebDriverWrapper.waitFor;
 import static org.labkey.test.components.html.Input.Input;
 
 /**
@@ -69,8 +70,8 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
     @LogMethod
     public void assertPasswordStrengthGauge()
     {
-        assertPasswordStrengthGauge("", GUIDANCE_PLACEHOLDER);
         assertPasswordStrengthGauge(SIMPLE_PASSWORD, "Very Weak");
+        assertPasswordStrengthGauge("", GUIDANCE_PLACEHOLDER);
         assertPasswordStrengthGauge(SHORT_PASSWORD, "Very Weak");
         // Password is good enough for "GOOD" strength setting; not actually rated as "Good" by entropy calculation
         assertPasswordStrengthGauge(GOOD_PASSWORD, "Weak");
@@ -80,7 +81,10 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
     @LogMethod(quiet = true)
     public void assertPasswordStrengthGauge(@LoggedParam String password, @LoggedParam String expectedGuidance)
     {
+        String previousGuidance = elementCache().strengthGuidance.getText();
         setPassword1(password);
+        //noinspection ResultOfMethodCallIgnored
+        waitFor(() -> !previousGuidance.equals(elementCache().strengthGuidance.getText()), 5_000);
         String strengthGuidance = elementCache().strengthGuidance.getText();
         strengthGuidance = strengthGuidance.substring(strengthGuidance.indexOf(':') + 1).trim();
 

--- a/src/org/labkey/test/components/core/login/SetPasswordForm.java
+++ b/src/org/labkey/test/components/core/login/SetPasswordForm.java
@@ -118,14 +118,12 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
 
     public SetPasswordForm setPassword1(String password1)
     {
-        if (password1.isEmpty())
+        // Make sure correct event fires for blank password to update strength guidance
+        getWrapper().actionClear(elementCache().password);
+
+        if (!password1.isEmpty())
         {
-            // Make sure correct event fires for blank password to update strength guidance
-            getWrapper().actionClear(elementCache().password.getComponentElement());
-        }
-        else
-        {
-            elementCache().password.set(password1);
+            elementCache().password.sendKeys(password1);
         }
 
         return this;
@@ -176,7 +174,7 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
         // For ChangePasswordAction
         final Input oldPassword = Input(Locator.id("oldPassword"), getDriver()).findWhenNeeded(this);
 
-        final Input password = Input(Locator.id("password"), getDriver()).findWhenNeeded(this);
+        final WebElement password = Locator.id("password").findWhenNeeded(this);
         final Input password2 = Input(Locator.id("password2"), getDriver()).findWhenNeeded(this);
         final WebElement strengthGuidance = Locator.id("strengthGuidance").findWhenNeeded(this);
         final WebElement submitButton = Locator.name("set").findWhenNeeded(this);

--- a/src/org/labkey/test/components/core/login/SetPasswordForm.java
+++ b/src/org/labkey/test/components/core/login/SetPasswordForm.java
@@ -121,9 +121,15 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
 
     public SetPasswordForm setPassword1(String password1)
     {
-        // Make sure correct events fire for blank password
-        getWrapper().actionClear(elementCache().password.getComponentElement());
-        elementCache().password.set(password1);
+        if (password1.isEmpty())
+        {
+            // Make sure correct event fires for blank password to update strength guidance
+            getWrapper().actionClear(elementCache().password.getComponentElement());
+        }
+        else
+        {
+            elementCache().password.set(password1);
+        }
 
         return this;
     }

--- a/src/org/labkey/test/components/core/login/SetPasswordForm.java
+++ b/src/org/labkey/test/components/core/login/SetPasswordForm.java
@@ -118,12 +118,16 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
 
     public SetPasswordForm setPassword1(String password1)
     {
-        // Make sure correct event fires for blank password to update strength guidance
-        getWrapper().actionClear(elementCache().password);
-
-        if (!password1.isEmpty())
+        if (password1.isEmpty())
         {
-            elementCache().password.sendKeys(password1);
+            // `WebElement.clear()` doesn't trigger `oninput`
+            // Need to use this method to update strength guidance
+            getWrapper().actionClear(elementCache().password.getComponentElement());
+        }
+        else
+        {
+            // Set with a single operation to avoid triggering 'oninput' twice
+            elementCache().password.setWithPaste(password1);
         }
 
         return this;
@@ -174,7 +178,7 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
         // For ChangePasswordAction
         final Input oldPassword = Input(Locator.id("oldPassword"), getDriver()).findWhenNeeded(this);
 
-        final WebElement password = Locator.id("password").findWhenNeeded(this);
+        final Input password = Input(Locator.id("password"), getDriver()).findWhenNeeded(this);
         final Input password2 = Input(Locator.id("password2"), getDriver()).findWhenNeeded(this);
         final WebElement strengthGuidance = Locator.id("strengthGuidance").findWhenNeeded(this);
         final WebElement submitButton = Locator.name("set").findWhenNeeded(this);

--- a/src/org/labkey/test/components/core/login/SetPasswordForm.java
+++ b/src/org/labkey/test/components/core/login/SetPasswordForm.java
@@ -1,0 +1,161 @@
+package org.labkey.test.components.core.login;
+
+import org.junit.Assert;
+import org.labkey.test.Locator;
+import org.labkey.test.Locators;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.Input;
+import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.LoggedParam;
+import org.labkey.test.util.PasswordUtil;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.labkey.test.components.html.Input.Input;
+
+/**
+ * core/src/org/labkey/core/login/setPassword.jsp
+ */
+public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementCache>
+{
+    public static final String SHORT_PASSWORD = "4asdfg!"; // Only 7 characters long. 3 character types.
+    public static final String SIMPLE_PASSWORD = "3asdfghi"; // Only two character types. 8 characters long.
+    public static final String GOOD_PASSWORD = "Yekbal1!"; // 8 characters long. 3+ character types.
+    public static final String STRONG_PASSWORD = "We'reSo$tr0ng@yekbal1!";
+    public static final String GUIDANCE_PLACEHOLDER = "Password Strength Gauge";
+
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    public SetPasswordForm(WebDriver driver)
+    {
+        _el = Locator.id("setPasswordForm").waitForElement(driver, 5_000);
+        _driver = driver;
+
+        if (getWrapper().getCurrentRelativeURL().contains("changePassword.view") && PasswordUtil.getUsername().equals(getWrapper().getCurrentUser()))
+            throw new IllegalArgumentException("Don't change the primary site admin user's password");
+    }
+
+    // Don't use this unless you're actually testing authentication functionality
+    public static SetPasswordForm goToInitialPasswordForUser(WebDriverWrapper wrapper, String email)
+    {
+        wrapper.beginAt(WebTestHelper.buildURL("security", "showRegistrationEmail", Map.of("email", email)));
+        // Get setPassword URL from notification email.
+        WebElement resetLink = Locator.linkWithHref("setPassword.view").findElement(wrapper.getDriver());
+
+        wrapper.clickAndWait(resetLink, WebDriverWrapper.WAIT_FOR_PAGE);
+
+        return new SetPasswordForm(wrapper.getDriver());
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    @LogMethod
+    public void assertPasswordStrengthGauge()
+    {
+        assertPasswordStrengthGauge("", GUIDANCE_PLACEHOLDER);
+        assertPasswordStrengthGauge(SIMPLE_PASSWORD, "Very Weak");
+        assertPasswordStrengthGauge(SHORT_PASSWORD, "Very Weak");
+        // Password is good enough for "GOOD" strength setting; not actually rated as "Good" by entropy calculation
+        assertPasswordStrengthGauge(GOOD_PASSWORD, "Weak");
+        assertPasswordStrengthGauge(STRONG_PASSWORD, "Very Strong");
+    }
+
+    @LogMethod(quiet = true)
+    public void assertPasswordStrengthGauge(@LoggedParam String password, @LoggedParam String expectedGuidance)
+    {
+        setPassword1(password);
+        String strengthGuidance = elementCache().strengthGuidance.getText();
+        strengthGuidance = strengthGuidance.substring(strengthGuidance.indexOf(':') + 1).trim();
+
+        assertEquals("Strength guidance for password", expectedGuidance, strengthGuidance);
+    }
+
+    public SetPasswordForm setEmail(String email)
+    {
+        elementCache().email.set(email);
+
+        return this;
+    }
+
+    public SetPasswordForm setOldPassword(String oldPassword)
+    {
+        elementCache().oldPassword.set(oldPassword);
+
+        return this;
+    }
+
+    public SetPasswordForm setPassword1(String password1)
+    {
+        elementCache().password.set(password1);
+
+        return this;
+    }
+
+    public SetPasswordForm setPassword2(String password2)
+    {
+        elementCache().password2.set(password2);
+
+        return this;
+    }
+
+    public SetPasswordForm setNewPassword(String password)
+    {
+        return setPassword1(password).setPassword2(password);
+    }
+
+    public void clickSubmit()
+    {
+        clickSubmit(getWrapper().getDefaultWaitForPage());
+    }
+
+    public void clickSubmit(int waitForPage)
+    {
+        getWrapper().clickAndWait(elementCache().submitButton, waitForPage);
+        getWrapper().assertNoLabKeyErrors();
+    }
+
+    public SetPasswordForm clickSubmitExpectingError(String expectedError)
+    {
+        getWrapper().clickAndWait(elementCache().submitButton);
+        Assert.assertEquals("Wrong error message", expectedError, Locators.labkeyError.waitForElement(getDriver(), 10_000).getText());
+
+        return new SetPasswordForm(getDriver());
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        // For InitialUserAction
+        final Input email = Input(Locator.id("email"), getDriver()).findWhenNeeded(this);
+
+        // For ChangePasswordAction
+        final Input oldPassword = Input(Locator.id("oldPassword"), getDriver()).findWhenNeeded(this);
+
+        final Input password = Input(Locator.id("password"), getDriver()).findWhenNeeded(this);
+        final Input password2 = Input(Locator.id("password2"), getDriver()).findWhenNeeded(this);
+        final WebElement strengthGuidance = Locator.id("strengthGuidance").findWhenNeeded(this);
+        final WebElement submitButton = Locator.name("set").findWhenNeeded(this);
+    }
+}

--- a/src/org/labkey/test/components/core/login/SetPasswordForm.java
+++ b/src/org/labkey/test/components/core/login/SetPasswordForm.java
@@ -1,5 +1,6 @@
 package org.labkey.test.components.core.login;
 
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
@@ -14,10 +15,10 @@ import org.labkey.test.util.PasswordUtil;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
+import java.time.Duration;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.labkey.test.WebDriverWrapper.waitFor;
 import static org.labkey.test.components.html.Input.Input;
 
 /**
@@ -81,14 +82,9 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
     @LogMethod(quiet = true)
     public void assertPasswordStrengthGauge(@LoggedParam String password, @LoggedParam String expectedGuidance)
     {
-        String previousGuidance = elementCache().strengthGuidance.getText();
         setPassword1(password);
-        //noinspection ResultOfMethodCallIgnored
-        waitFor(() -> !previousGuidance.equals(elementCache().strengthGuidance.getText()), 5_000);
-        String strengthGuidance = elementCache().strengthGuidance.getText();
-        strengthGuidance = strengthGuidance.substring(strengthGuidance.indexOf(':') + 1).trim();
-
-        assertEquals("Strength guidance for password", expectedGuidance, strengthGuidance);
+        Awaitility.await().atMost(Duration.ofSeconds(2)).untilAsserted(() ->
+                assertEquals("Strength guidance for password", expectedGuidance, elementCache().strengthGuidance.getText()));
     }
 
     public SetPasswordForm setEmail(String email)

--- a/src/org/labkey/test/components/core/login/SetPasswordForm.java
+++ b/src/org/labkey/test/components/core/login/SetPasswordForm.java
@@ -97,6 +97,9 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
     @LogMethod(quiet = true)
     public void assertPasswordGuidance(@LoggedParam String password, @LoggedParam String expectedGuidance)
     {
+        if (!password.isEmpty() && elementCache().strengthGuidance.getText().equals(expectedGuidance))
+            assertPasswordGuidance("", GUIDANCE_PLACEHOLDER); // Clear out previous guidance
+
         setPassword1(password);
         Awaitility.await().atMost(Duration.ofSeconds(2)).untilAsserted(() ->
                 assertEquals("Strength guidance for password", expectedGuidance, elementCache().strengthGuidance.getText()));

--- a/src/org/labkey/test/components/core/login/SetPasswordForm.java
+++ b/src/org/labkey/test/components/core/login/SetPasswordForm.java
@@ -97,9 +97,6 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
     @LogMethod(quiet = true)
     public void assertPasswordGuidance(@LoggedParam String password, @LoggedParam String expectedGuidance)
     {
-        if (!password.isEmpty() && elementCache().strengthGuidance.getText().equals(expectedGuidance))
-            assertPasswordGuidance("", GUIDANCE_PLACEHOLDER); // Clear out previous guidance
-
         setPassword1(password);
         Awaitility.await().atMost(Duration.ofSeconds(2)).untilAsserted(() ->
                 assertEquals("Strength guidance for password", expectedGuidance, elementCache().strengthGuidance.getText()));

--- a/src/org/labkey/test/components/html/Input.java
+++ b/src/org/labkey/test/components/html/Input.java
@@ -20,11 +20,8 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
-import org.labkey.test.util.selenium.WebDriverUtils;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
 
 import java.util.Arrays;
 
@@ -96,14 +93,9 @@ public class Input extends WebDriverComponent<Component<?>.ElementCache> impleme
 
     public void setWithPaste(String value)
     {
-        Keys cmdKey = WebDriverUtils.MODIFIER_KEY;
-        getWrapper().scrollIntoView(getComponentElement());
-        new Actions(getWrapper().getDriver())
-            .keyDown(cmdKey)
-            .sendKeys(getComponentElement(), "a")
-            .keyUp(cmdKey)
-            .perform();
+        getWrapper().actionClear(getComponentElement());
         getWrapper().actionPaste(getComponentElement(), value);
+        getWrapper().fireEvent(getComponentElement(), WebDriverWrapper.SeleniumEvent.change);
     }
 
     public void blur()

--- a/src/org/labkey/test/components/html/Input.java
+++ b/src/org/labkey/test/components/html/Input.java
@@ -20,8 +20,11 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.util.selenium.WebDriverUtils;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 
 import java.util.Arrays;
 
@@ -93,9 +96,14 @@ public class Input extends WebDriverComponent<Component<?>.ElementCache> impleme
 
     public void setWithPaste(String value)
     {
-        getWrapper().actionClear(getComponentElement());
+        Keys cmdKey = WebDriverUtils.MODIFIER_KEY;
+        getWrapper().scrollIntoView(getComponentElement());
+        new Actions(getWrapper().getDriver())
+            .keyDown(cmdKey)
+            .sendKeys(getComponentElement(), "a")
+            .keyUp(cmdKey)
+            .perform();
         getWrapper().actionPaste(getComponentElement(), value);
-        getWrapper().fireEvent(getComponentElement(), WebDriverWrapper.SeleniumEvent.change);
     }
 
     public void blur()

--- a/src/org/labkey/test/pages/user/UpdateUserDetailsPage.java
+++ b/src/org/labkey/test/pages/user/UpdateUserDetailsPage.java
@@ -90,6 +90,7 @@ public class UpdateUserDetailsPage extends LabKeyPage<UpdateUserDetailsPage.Elem
     public void clickSubmit()
     {
         clickAndWait(elementCache().submitButton);
+        assertNoLabKeyErrors();
     }
 
     @Override

--- a/src/org/labkey/test/tests/UserPermissionsTest.java
+++ b/src/org/labkey/test/tests/UserPermissionsTest.java
@@ -220,11 +220,7 @@ public class UserPermissionsTest extends BaseWebDriverTest
         _permissionsHelper.createPermissionsGroup(GAMMA_ADMIN_GROUP_NAME);
         _permissionsHelper.setPermissions(GAMMA_ADMIN_GROUP_NAME, "Project Administrator");
         createUserInProjectForGroup(GAMMA_PROJECT_ADMIN_USER, PERM_PROJECT_NAME, GAMMA_ADMIN_GROUP_NAME, true);
-        clickLinkWithTextNoTarget("here");
-        clickAndWait(Locator.linkContainingText("setPassword.view"));
-        setFormElement(Locator.id("password"), PasswordUtil.getPassword());
-        setFormElement(Locator.id("password2"), PasswordUtil.getPassword());
-        clickButton("Set Password");
+        setInitialPassword(GAMMA_PROJECT_ADMIN_USER);
         signOut();
         signIn(GAMMA_PROJECT_ADMIN_USER);
         clickProject(PERM_PROJECT_NAME);

--- a/src/org/labkey/test/tests/core/login/PasswordTest.java
+++ b/src/org/labkey/test/tests/core/login/PasswordTest.java
@@ -26,10 +26,13 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.BVT;
+import org.labkey.test.components.core.login.SetPasswordForm;
 import org.labkey.test.pages.core.login.DatabaseAuthConfigureDialog;
 import org.labkey.test.pages.core.login.LoginConfigurePage;
 import org.labkey.test.params.login.DatabaseAuthenticationProvider;
 import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.LoggedParam;
+import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.core.login.DbLoginUtils;
 import org.labkey.test.util.core.login.DbLoginUtils.DbLoginProperties;
 import org.labkey.test.util.core.login.DbLoginUtils.PasswordExpiration;
@@ -44,18 +47,16 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.components.core.login.SetPasswordForm.GOOD_PASSWORD;
+import static org.labkey.test.components.core.login.SetPasswordForm.SHORT_PASSWORD;
+import static org.labkey.test.components.core.login.SetPasswordForm.SIMPLE_PASSWORD;
+import static org.labkey.test.components.core.login.SetPasswordForm.STRONG_PASSWORD;
 
 @Category(BVT.class)
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class PasswordTest extends BaseWebDriverTest
 {
     private static final String USER = "user_passwordtest@password.test";
-
-    private static final String SHORT_PASSWORD = "4asdfg!"; // Only 7 characters long. 3 character types.
-    private static final String SIMPLE_PASSWORD = "3asdfghi"; // Only two character types. 8 characters long.
-    private static final String GOOD_PASSWORD = "Yekbal1!"; // 8 characters long. 3+ character types.
-    private static final String STRONG_PASSWORD = "We'reSo$tr0ng@yekbal1!";
-    private static final String GUIDANCE_PLACEHOLDER = "Password Strength Gauge";
 
     @Override
     public List<String> getAssociatedModules()
@@ -117,53 +118,45 @@ public class PasswordTest extends BaseWebDriverTest
                 PasswordStrength.Strong,
                 PasswordExpiration.Never);
 
-        setInitialPassword(USER, SIMPLE_PASSWORD);
-        assertPasswordStrengthGauge("", GUIDANCE_PLACEHOLDER);
-        assertTextPresent("Your password is not complex enough."); // fail, too simple
+        SetPasswordForm setPasswordForm = SetPasswordForm.goToInitialPasswordForUser(this, USER);
+        log("Verify strength gauge for 'SetPasswordAction'");
+        setPasswordForm.assertPasswordStrengthGauge();
 
-        assertPasswordStrengthGauge(SHORT_PASSWORD, "Very Weak");
-        setFormElement(Locator.id("password2"), SHORT_PASSWORD);
-        clickButton("Set Password");
-        assertTextPresent("Your password is not complex enough."); // fail, too short
+        setPasswordForm = setPasswordForm.setNewPassword(SIMPLE_PASSWORD)
+                .clickSubmitExpectingError("Your password is not complex enough."); // fail, too simple
+        setPasswordForm = setPasswordForm.setNewPassword(SHORT_PASSWORD)
+                .clickSubmitExpectingError("Your password is not complex enough."); // fail, too short
+        setPasswordForm = setPasswordForm.setNewPassword(GOOD_PASSWORD)
+                .clickSubmitExpectingError("Your password is not complex enough."); // fail, not complex enough
 
-        // Password is good enough for "GOOD" strength setting; not actually rated as "Good" by entropy calculation
-        assertPasswordStrengthGauge(GOOD_PASSWORD, "Weak");
-        setFormElement(Locator.id("password2"), GOOD_PASSWORD);
-        assertTextPresent("Your password is not complex enough."); // fail, not complex enough
-
-        assertPasswordStrengthGauge(STRONG_PASSWORD, "Very Strong");
-        setFormElement(Locator.id("password2"), STRONG_PASSWORD);
-        clickButton("Set Password");
+        setPasswordForm.setNewPassword(STRONG_PASSWORD).clickSubmit();
         assertSignedInNotImpersonating();
         //success
         impersonate(USER);
 
-        changePassword(STRONG_PASSWORD, SIMPLE_PASSWORD); // fail, too simple
-        assertTextPresent("Your password is not complex enough.");
+        SetPasswordForm changePasswordForm = goToChangePassword();
+        log("Verify strength gauge for 'ChangePasswordAction'");
+        changePasswordForm.assertPasswordStrengthGauge();
 
-        // Test password gauge while we're on this page
-        assertPasswordStrengthGauge(SIMPLE_PASSWORD, "Very Weak");
-        assertPasswordStrengthGauge(SHORT_PASSWORD, "Very Weak");
-        assertPasswordStrengthGauge(GOOD_PASSWORD, "Weak");
-        assertPasswordStrengthGauge(STRONG_PASSWORD, "Very Strong");
+        changePasswordForm = changePasswordForm
+                .setOldPassword(STRONG_PASSWORD)
+                .setNewPassword(SIMPLE_PASSWORD)// fail, too simple
+                .clickSubmitExpectingError("Your password is not complex enough.");
+        changePasswordForm = changePasswordForm
+                .setOldPassword(STRONG_PASSWORD)
+                .setNewPassword(SHORT_PASSWORD) // fail, too short
+                .clickSubmitExpectingError("Your password is not complex enough.");
+        changePasswordForm = changePasswordForm
+                .setOldPassword(STRONG_PASSWORD)
+                .setNewPassword(GOOD_PASSWORD) // fail, not complex enough
+                .clickSubmitExpectingError("Your password is not complex enough.");
 
-        changePassword(STRONG_PASSWORD, SHORT_PASSWORD); // fail, too short
-        assertTextPresent("Your password is not complex enough.");
-        changePassword(STRONG_PASSWORD, GOOD_PASSWORD); // fail, not complex enough
-        assertTextPresent("Your password is not complex enough.");
         String currentPassword = STRONG_PASSWORD + 0;
-        changePassword(STRONG_PASSWORD, currentPassword);
+        changePasswordForm.setOldPassword(STRONG_PASSWORD)
+                .setNewPassword(currentPassword)
+                .clickSubmit();
         assertTextNotPresent("Choose a new password.");
         assertEquals("Signed in as", USER, getCurrentUser());
-    }
-
-    private void assertPasswordStrengthGauge(String shortPassword, String expectedGuidance)
-    {
-        setFormElement(Locator.id("password"), shortPassword);
-        String strengthGuidance = Locator.id("strengthGuidance").findElement(getDriver()).getText();
-        strengthGuidance = strengthGuidance.substring(strengthGuidance.indexOf(':') + 1).trim();
-
-        assertEquals("Strength guidance for password", expectedGuidance, strengthGuidance);
     }
 
     @Test
@@ -179,15 +172,18 @@ public class PasswordTest extends BaseWebDriverTest
         impersonate(USER);
 
         int i = 1;
-        for (; i < 9; i++)
+        for (; i <= 10; i++)
         {
             changePassword(currentPassword, STRONG_PASSWORD + i);
             currentPassword = STRONG_PASSWORD + i;
             assertTextNotPresent("Choose a new password.");
         }
-        changePassword(currentPassword, STRONG_PASSWORD + 0); // fail, used 9 passwords ago.
-        assertTextPresent("Your password must not match a recently used password.");
-        changePassword(STRONG_PASSWORD + i, STRONG_PASSWORD);
+        // fail, used 9 passwords ago.
+        goToChangePassword()
+                .setOldPassword(currentPassword)
+                .setNewPassword(STRONG_PASSWORD + 1)
+                .clickSubmitExpectingError("Your password must not match a recently used password.");
+        changePassword(currentPassword, STRONG_PASSWORD + 0);
         assertTextNotPresent("Choose a new password.");
 
         stopImpersonating();
@@ -255,12 +251,12 @@ public class PasswordTest extends BaseWebDriverTest
     }
 
     @LogMethod
-    protected void attemptSetInvalidPassword(String password1, String password2, String... errors)
+    protected void attemptSetInvalidPassword(String password1, String password2, String error)
     {
-        setFormElement(Locator.id("password"), password1);
-        setFormElement(Locator.id("password2"), password2);
-        clickButton("Set Password");
-        assertTextPresent(errors);
+        new SetPasswordForm(getDriver())
+                .setPassword1(password1)
+                .setPassword2(password2)
+                .clickSubmitExpectingError(error);
     }
 
     /**
@@ -342,6 +338,34 @@ public class PasswordTest extends BaseWebDriverTest
         signInShouldFail(username, password, wrongPasswordEntered);
 
         return newPassword;
+    }
+
+    protected String setInitialPassword(String user, String password)
+    {
+        SetPasswordForm.goToInitialPasswordForUser(this, user)
+                .setNewPassword(password)
+                .clickSubmit();
+
+        return password;
+    }
+
+    @LogMethod (quiet = true)
+    protected void changePassword(String oldPassword, @LoggedParam String password)
+    {
+        goToChangePassword()
+                .setOldPassword(oldPassword)
+                .setNewPassword(password)
+                .clickSubmit();
+    }
+
+    private SetPasswordForm goToChangePassword()
+    {
+        if (PasswordUtil.getUsername().equals(getCurrentUser()))
+            throw new IllegalArgumentException("Don't change the primary site admin user's password");
+
+        goToMyAccount();
+        clickButton("Change Password");
+        return new SetPasswordForm(getDriver());
     }
 
 }

--- a/src/org/labkey/test/util/QuickBootstrapPseudoTest.java
+++ b/src/org/labkey/test/util/QuickBootstrapPseudoTest.java
@@ -11,9 +11,9 @@ import org.labkey.remoteapi.SimpleGetCommand;
 import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.LabKeySiteWrapper;
-import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
+import org.labkey.test.components.core.login.SetPasswordForm;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -117,10 +117,10 @@ public class QuickBootstrapPseudoTest extends BaseWebDriverTest
     private void createInitialUser()
     {
         beginAt(WebTestHelper.buildURL("login", "initialUser"));
-        setFormElement(Locator.id("email"), PasswordUtil.getUsername());
-        setFormElement(Locator.id("password"), PasswordUtil.getPassword());
-        setFormElement(Locator.id("password2"), PasswordUtil.getPassword());
-        clickAndWait(Locator.lkButton("Next"));
+        new SetPasswordForm(getDriver())
+                .setEmail(PasswordUtil.getUsername())
+                .setNewPassword(PasswordUtil.getPassword())
+                .clickSubmit(90_000);
     }
 
     /**

--- a/src/org/labkey/test/util/TestUser.java
+++ b/src/org/labkey/test/util/TestUser.java
@@ -3,15 +3,11 @@ package org.labkey.test.util;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.security.CreateUserResponse;
-import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
-import org.labkey.test.WebTestHelper;
-import org.openqa.selenium.WebElement;
+import org.labkey.test.components.core.login.SetPasswordForm;
 
 import java.io.IOException;
-import java.util.Map;
 
-import static org.labkey.test.WebDriverWrapper.WAIT_FOR_PAGE;
 import static org.labkey.test.util.TestLogger.log;
 
 public class TestUser
@@ -73,17 +69,9 @@ public class TestUser
     {
         if (_password == null)  // if null, this is the initial password - we can use the UI to set it now
         {
-            //... borrowed from LKSW's setInitialPassword - in the future, do via API
-            getWrapper().beginAt(WebTestHelper.buildURL("security", "showRegistrationEmail", Map.of("email", _email)));
-            // Get setPassword URL from notification email.
-            WebElement resetLink = Locator.linkWithHref("setPassword.view").findElement(getWrapper().getDriver());
-
-            getWrapper().clickAndWait(resetLink, WAIT_FOR_PAGE);
-
-            getWrapper().setFormElement(Locator.id("password"), password);
-            getWrapper().setFormElement(Locator.id("password2"), password);
-
-            getWrapper().clickButton("Set Password");
+            SetPasswordForm.goToInitialPasswordForUser(getWrapper(), _email)
+                    .setNewPassword(password)
+                    .clickSubmit();
         }
         else
         {
@@ -98,9 +86,9 @@ public class TestUser
         return _password;
     }
 
-    public TestUser addPermission(String role, String containerContext)
+    public TestUser addPermission(String role, String containerPath)
     {
-        new ApiPermissionsHelper(getWrapper()).addMemberToRole(getEmail(), role, PermissionsHelper.MemberType.user, containerContext);
+        new ApiPermissionsHelper(getWrapper()).addMemberToRole(getEmail(), role, PermissionsHelper.MemberType.user, containerPath);
 
         return this;
     }


### PR DESCRIPTION
#### Rationale
[[Story](https://www.scrumwise.com/scrum/#/backlog-item/11388-labkey-ei-password-rules-strengthening-ui-feedback-test-automation/id-1810-49181-158)]
[[Spec](https://docs.google.com/document/d/1Kv_aA7vEv-uYY00rNcYu_fx3qVUxaMCeN8qJVBPj9f0/edit#heading=h.cotjcd6q8civ)]

Adding regression tests for new password strength gauge.
The form created by `setPassword.jsp` is exercised by numerous test code paths. Creating `SetPasswordForm` test component to centralize those interactions.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4983

#### Changes
* Test password strength gauge on `setPassword`, `changePassword`, and `initialUser` pages
* Create test component for `SetPasswordForm`
