### PR TITLE
Adjust SecurityApiTest for Developers group changes

### DIFF
--- a/data/api/security-api.xml
+++ b/data/api/security-api.xml
@@ -21,12 +21,7 @@
                             "isProjectGroup": false,
                             "type": "g",
                             "effectivePermissions": [],
-                            "groups": [{
-                                "isSystemGroup": true,
-                                "name": "Developers",
-                                "id": -4,
-                                "isProjectGroup": false
-                            }],
+                            "groups": []
                         },
                         {
                             "role": "NO_PERMISSIONS",
@@ -142,12 +137,6 @@
         <url>security/Security%20Api%20Test%20Project/getGroupsForCurrentUser.view?</url>
         <response>
             {"groups": [
-                    {
-                        "id": -4,
-                        "name": "Developers",
-                        "isSystemGroup": true,
-                        "isProjectGroup": false
-                    },
                     {
                         "id": -3,
                         "name": "Guests",

--- a/src/org/labkey/test/tests/SecurityApiTest.java
+++ b/src/org/labkey/test/tests/SecurityApiTest.java
@@ -24,7 +24,6 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.util.APITestHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
-import org.labkey.test.util.PasswordUtil;
 
 import java.io.File;
 import java.util.Arrays;
@@ -128,12 +127,12 @@ public class SecurityApiTest extends BaseWebDriverTest
      * JSON output. A little ways down is a comment "Actual:" with the actual JSON output (go figure). It might be easier
      * to compare the expected vs. actual results from this log output.
      *
-     * The expected output comes from the security-api.xml file. If this is a role and/or permission error odds are you
+     * The expected output comes from the security-api.xml file. If this is a role and/or permission error, odds are you
      * will need to make a change to that file. Try to make the smallest change possible. If you are changing permissions,
      * either adding or removing, you will need to update the value(s) in the effectivePermissions collection for a given role.
      *
      * For example, under the Editor role ("roleLabel": "Editor") there is a effectivePermissions collections that shows
-     * the permissions for that role ("effectivePermissions": ["org.labkey.api.security.permissions.InsertPermission",etc...).
+     * the permissions for that role ("effectivePermissions": ["org.labkey.api.security.permissions.InsertPermission", etc...).
      * This collection is what you would most likely be modifying.
      *
      * If you still have a hard time getting the test to pass locally try running with a bootstrapped database. That is


### PR DESCRIPTION
#### Rationale
Site Administrators are no longer added to the Developers group; teach SecurityApiTest.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4978