### PR TITLE
refactor 'select all/clear all selections' methods out of GridBar, into Grid

### DIFF
--- a/src/org/labkey/test/components/ui/grids/GridBar.java
+++ b/src/org/labkey/test/components/ui/grids/GridBar.java
@@ -196,12 +196,13 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
         // Clear button can have text values of 'Clear', 'Clear both' or 'Clear all ' so just look for clear.
         Locator clearBtn = Locator.xpath("//button[contains(text(), 'Clear')]");
 
-        if(clearBtn.findOptionalElement(this).isPresent())
+        if(WebDriverWrapper.waitFor(()->
+                clearBtn.findOptionalElement(_queryGrid.getComponentElement()).isPresent(), 5_000)) // give it time to appear, else no-op
         {
-            WebElement btn = clearBtn.waitForElement(this, 5_000);
+            WebElement btn = clearBtn.findElement(_queryGrid.getComponentElement());
             btn.click();
 
-            WebDriverWrapper.waitFor(() -> clearBtn.findOptionalElement(this).isEmpty(),
+            WebDriverWrapper.waitFor(() -> clearBtn.findOptionalElement(_queryGrid.getComponentElement()).isEmpty(),
                     WAIT_FOR_JAVASCRIPT);
         }
 

--- a/src/org/labkey/test/components/ui/grids/GridBar.java
+++ b/src/org/labkey/test/components/ui/grids/GridBar.java
@@ -7,7 +7,6 @@ package org.labkey.test.components.ui.grids;
 import org.junit.Assert;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
-import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.html.BootstrapMenu;
@@ -28,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.labkey.test.BaseWebDriverTest.WAIT_FOR_JAVASCRIPT;
 import static org.labkey.test.WebDriverWrapper.sleep;
 
 /**
@@ -164,49 +162,6 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
     {
         pager().clickPrevious();
         return _queryGrid;
-    }
-
-    /**
-     * Click the 'Select All' button in the grid bar.
-     *
-     * @return This grid bar.
-     */
-    public GridBar selectAllRows()
-    {
-        Locator selectBtn = Locator.xpath("//button[contains(text(), 'Select all')]");      // Select all n
-        Locator selectedText = Locator.xpath("//span[@class='QueryGrid-right-spacing' and normalize-space(contains(text(), 'selected'))]");   // n of n
-        Locator allSelected = Locator.xpath("//span[contains(text(), 'All ')]");            // All n selected
-        WebElement btn = selectBtn.waitForElement(_queryGrid, 5_000);
-        btn.click();
-
-        WebDriverWrapper.waitFor(() -> allSelected.findOptionalElement(this).isPresent() ||
-                        selectBtn.findOptionalElement(this).isEmpty() &&
-                                selectedText.findOptionalElement(this).isPresent() ,
-                WAIT_FOR_JAVASCRIPT);
-
-        return this;
-    }
-
-    /**
-     * Click the 'Clear All' button in the grid bar.
-     * @return This grid bar.
-     */
-    public GridBar clearAllSelections()
-    {
-        // Clear button can have text values of 'Clear', 'Clear both' or 'Clear all ' so just look for clear.
-        Locator clearBtn = Locator.xpath("//button[contains(text(), 'Clear')]");
-
-        if(WebDriverWrapper.waitFor(()->
-                clearBtn.findOptionalElement(_queryGrid.getComponentElement()).isPresent(), 5_000)) // give it time to appear, else no-op
-        {
-            WebElement btn = clearBtn.findElement(_queryGrid.getComponentElement());
-            btn.click();
-
-            WebDriverWrapper.waitFor(() -> clearBtn.findOptionalElement(_queryGrid.getComponentElement()).isEmpty(),
-                    WAIT_FOR_JAVASCRIPT);
-        }
-
-        return this;
     }
 
     /**

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -292,26 +292,18 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
      */
     public QueryGrid selectAllRows()
     {
-        if (isGridPanel())
+        WebElement selectAllBtn = elementCache().selectAllBtnLoc.findWhenNeeded(elementCache());
+        if (selectAllBtn.isDisplayed())
         {
-            WebElement selectAllBtn = elementCache().selectAllBtnLoc.findWhenNeeded(elementCache());
-            if (selectAllBtn.isDisplayed())
-            {
-                doAndWaitForUpdate(selectAllBtn::click);
-            }
-            else
-            {
-                ReactCheckBox selectAll = selectAllBox();
-                if (selectAll.isIndeterminate() || !selectAll.isChecked())
-                {
-                    doAndWaitForUpdate(() -> selectAllOnPage(true, null));
-                }
-            }
+            doAndWaitForUpdate(selectAllBtn::click);
         }
         else
         {
-            doAndWaitForUpdate(() ->
-                    getGridBar().selectAllRows());
+            ReactCheckBox selectAll = selectAllBox();
+            if (selectAll.isIndeterminate() || !selectAll.isChecked())
+            {
+                doAndWaitForUpdate(() -> selectAllOnPage(true, null));
+            }
         }
 
         return this;
@@ -334,22 +326,14 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
     {
         if(hasItemsSelected())
         {
-            if (isGridPanel())
+            WebElement clearBtn = elementCache().clearBtnLoc.findWhenNeeded(elementCache());
+            if (clearBtn.isDisplayed())
             {
-                WebElement clearBtn = elementCache().clearBtnLoc.findWhenNeeded(elementCache());
-                if (clearBtn.isDisplayed())
-                {
-                    doAndWaitForUpdate(clearBtn::click);
-                }
-                else
-                {
-                    doAndWaitForUpdate(() -> selectAllOnPage(false));
-                }
+                doAndWaitForUpdate(clearBtn::click);
             }
             else
             {
-                doAndWaitForUpdate(() ->
-                        getGridBar().clearAllSelections());
+                doAndWaitForUpdate(() -> selectAllOnPage(false));
             }
         }
 
@@ -706,15 +690,6 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
     public void closeChart()
     {
         elementCache().closeButton.click();
-    }
-
-    /**
-     * possible this is either a GridPanel, or a QueryGridPanel (QGP is to be deprecated).
-     * use this to test which one so we can fork behavior until QGP is gone
-     */
-    private boolean isGridPanel()
-    {
-        return elementCache().selectionStatusContainerLoc.existsIn(elementCache());
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
While investigating failures in biologics test automation, I noticed that `GridBar.clearAllSelections` has an issue that causes it to no-op silently if there isn't a button containing 'Clear' already present.  Thinking it would be a simple matter of waiting for it to appear, I added that wait- and discovered that the check for its presence was looking within the `GridBar`, when the 'Clear' button is now located outside of that, in the 'selection-status' element, which contains the select-all and clear-all buttons.

Investigating further, I noted that `QueryGrid.clearAllSelections `checks to see if the current grid is a `GridPanel` (versus being a `QueryGridPanel`)- and only calls into `GridBar.clearAllSelections` if it is the latter.  (IIRC, `QueryGridPanel `was to be deprecated).

If QGP is in fact deprecated (@labkey-alan, is this the case?) we should probably remove `GridBar's ``clearAllSelections `method now and refactor its usages to `QueryGrid`'s `clearAllSelections`.
If not, the change in this PR updates `GridBar`'s `clearAllSelections` to function regardless of whether the current grid is a QueryGrid, by finding the 'Clear' button in the QueryGrid's componentElement

#### Related Pull Requests
related changes in biologics
https://github.com/LabKey/biologics/pull/2554

#### Changes
find the button in the QueryGrid component instead of the GridBar
