### PR TITLE
change id to not use "."

### DIFF
--- a/src/org/labkey/test/tests/flow/FlowFolderReimportTest.java
+++ b/src/org/labkey/test/tests/flow/FlowFolderReimportTest.java
@@ -116,7 +116,7 @@ public class FlowFolderReimportTest extends BaseWebDriverTest
     {
         clickAndWait(Locator.linkWithText("Import FlowJo Workspace Analysis"));
         // 1. Select Workspace
-        setFormElement(Locator.id("workspace.file"), FLOW_WORKSPACE);
+        setFormElement(Locator.id("workspace_file"), FLOW_WORKSPACE);
         clickAndWait(Locator.lkButton("Next"));
         // 2. Select FCS Files
         clickAndWait(Locator.lkButton("Next"));


### PR DESCRIPTION
#### Rationale
addHandler() was changed to use queryselector, so ids with "." are not compatible.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
