### PR TITLE
Add test flag to check for CSP warnings

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -601,6 +601,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             checker().withScreenshot("startupErrors").wrapAssertion(this::checkErrors);
             checker().withScreenshot("startupLeaks").wrapAssertion(this::checkLeaks);
             checker().wrapAssertion(() -> CspLogUtil.checkNewCspWarnings(getArtifactCollector()));
+            checker().setErrorMark(); // Nothing to screenshot from CSP check
             checker().resetErrorTypes();
             _checkedLeaksAndErrors = true;
         }

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -599,7 +599,8 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             }
             checker().addRecordableErrorType(WebDriverException.class);
             checker().withScreenshot("startupErrors").wrapAssertion(this::checkErrors);
-            checker().withScreenshot("startupLeaks").wrapAssertion(() -> checkLeaks());
+            checker().withScreenshot("startupLeaks").wrapAssertion(this::checkLeaks);
+            checker().wrapAssertion(() -> CspLogUtil.checkNewCspWarnings(getArtifactCollector()));
             checker().resetErrorTypes();
             _checkedLeaksAndErrors = true;
         }
@@ -1140,6 +1141,8 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
         if (isTestRunningOnTeamCity())
             checkActionCoverage();
+
+        CspLogUtil.checkNewCspWarnings(getArtifactCollector());
 
         checkLinks();
 

--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -151,6 +151,18 @@ public abstract class TestFileUtils
         return _labkeyRoot.toString();
     }
 
+    public static File getServerLogDir()
+    {
+        if (TestProperties.isEmbeddedTomcat())
+        {
+            return new File(getDefaultDeployDir(), "embedded/logs");
+        }
+        else
+        {
+            return new File(TestProperties.getTomcatHome(), "logs");
+        }
+    }
+
     public static File getTestRoot()
     {
         if (_testRoot == null)

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -122,6 +122,12 @@ public abstract class TestProperties
         return "false".equals(System.getProperty("queryCheck", "true"));
     }
 
+    public static boolean isCspCheckSkipped()
+    {
+        // Skip by default
+        return "false".equals(System.getProperty("webtest.cspCheck", "false"));
+    }
+
     public static boolean isNewWebDriverForEachTest()
     {
         return !"true".equals(System.getProperty("selenium.reuseWebDriver", "false"));
@@ -219,6 +225,11 @@ public abstract class TestProperties
     public static boolean isTrialServer()
     {
         return "true".equals(System.getProperty("webtest.server.trial"));
+    }
+
+    public static boolean isEmbeddedTomcat()
+    {
+        return System.getProperties().containsKey("useEmbeddedTomcat");
     }
 
     public static boolean isCheckerFatal()

--- a/src/org/labkey/test/util/CspLogUtil.java
+++ b/src/org/labkey/test/util/CspLogUtil.java
@@ -79,15 +79,16 @@ public class CspLogUtil
                 StringBuilder errorMessage = new StringBuilder()
                         .append("Detected CSP violations on the following actions (See log for more detail: ")
                         .append(recentWarningsFile.getAbsolutePath())
-                        .append("):\n");
+                        .append("):");
                 for (Crawler.ControllerActionId actionId : violoations.keySet())
                 {
+                    errorMessage.append("\n\t");
                     Collection<String> urls = violoations.get(actionId);
                     errorMessage.append(actionId);
                     if (urls.size() > 1)
                     {
-                        errorMessage.append("\n\t");
-                        errorMessage.append(String.join("\n\t", urls));
+                        errorMessage.append("\n\t\t");
+                        errorMessage.append(String.join("\n\t\t", urls));
                     }
                     else
                     {

--- a/src/org/labkey/test/util/CspLogUtil.java
+++ b/src/org/labkey/test/util/CspLogUtil.java
@@ -1,0 +1,80 @@
+package org.labkey.test.util;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
+import org.labkey.test.TestFileUtils;
+import org.labkey.test.TestProperties;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+
+public class CspLogUtil
+{
+    private static final String logName = "csp-report.log";
+    private static final File logFile = new File(TestFileUtils.getServerLogDir(), logName);
+
+    private static long lastSize = 0;
+    private static long lastModified = 0;
+
+    private CspLogUtil() { }
+
+    public static void checkNewCspWarnings(ArtifactCollector artifactCollector)
+    {
+        if (TestProperties.isCspCheckSkipped())
+            return;
+
+        assertFalse("Cannot check CSP log on remote server", TestProperties.isServerRemote());
+        assertThat(logFile).as("CSP log file").isFile();
+
+        long logSize = logFile.length();
+        long modified = logFile.lastModified();
+        if (logSize > lastSize || modified > lastModified)
+        {
+            try
+            {
+                // Modified but got smaller? Log file probably rotated.
+                Assert.assertTrue("CSP log file seems to have rotated. Check manually.", logSize > lastSize);
+                List<String> warningLines;
+                File recentWarningsFile = new File(artifactCollector.ensureDumpDir(), logName);
+
+                try (FileInputStream fIn = new FileInputStream(logFile))
+                {
+                    //noinspection ResultOfMethodCallIgnored
+                    fIn.skip(lastSize);
+                    warningLines = IOUtils.readLines(fIn, Charset.defaultCharset());
+                    TestFileUtils.writeFile(recentWarningsFile, StringUtils.join(warningLines.toArray(), System.lineSeparator()));
+                }
+                catch (IOException e)
+                {
+                    throw new RuntimeException("Failed to read recent CSP violations.", e);
+                }
+
+                List<String> violations = new ArrayList<>();
+                for (String line : warningLines)
+                {
+                    String[] split = line.split("ContentSecurityPolicy warning on page: ");
+                    if (split.length > 1)
+                    {
+                        violations.add(split[1]);
+                    }
+                }
+
+                throw new AssertionError("Detected CSP violations on the following pages (See log for more detail: %s):\n%s"
+                        .formatted(recentWarningsFile.getAbsolutePath(), String.join("\n", violations)));
+            }
+            finally
+            {
+                lastSize = logSize;
+                lastModified = modified;
+            }
+        }
+    }
+}

--- a/src/org/labkey/test/util/CspLogUtil.java
+++ b/src/org/labkey/test/util/CspLogUtil.java
@@ -36,7 +36,7 @@ public class CspLogUtil
 
         long logSize = logFile.length();
         long modified = logFile.lastModified();
-        if (logSize > lastSize || modified > lastModified)
+        if (logSize > 0 && (logSize > lastSize || modified > lastModified))
         {
             try
             {


### PR DESCRIPTION
#### Rationale
A Tomcat Content Security Policy can be configured to report back to a server. LabKey now supports this reporting and logs warnings to `csp-report.log`. Tests should be able to check this file for warnings, similar to how we check the server's error log.
The new `webtest.cspCheck` flag enables this check.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4836

#### Changes
* Add test flag to check for CSP warnings
