### PR TITLE
Regression coverage for Issue 48517

### DIFF
--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -687,6 +687,12 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         return elementCache().svgChart();
     }
 
+    public WebElement showRReport(String reportName)
+    {
+        elementCache().chartsMenu.clickSubMenu(false, reportName);
+        return elementCache().rReport();
+    }
+
     public void closeChart()
     {
         elementCache().closeButton.click();
@@ -741,6 +747,11 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         public WebElement svgChart()
         {
             return Locator.byClass("svg-chart").waitForElement(elementCache().chartPanel, WAIT_FOR_JAVASCRIPT);
+        }
+
+        public WebElement rReport()
+        {
+            return Locator.byClass("r-report").waitForElement(elementCache().chartPanel, WAIT_FOR_JAVASCRIPT);
         }
 
         final WebElement closeButton = Locator.tagContainingText("button", "Close").refindWhenNeeded(chartPanel);


### PR DESCRIPTION
#### Rationale
This adds support for QueryGrid to show R reports in the same way it shows charts. Both appear by clicking the 'charts' menu, and they validate finding the expected kind of report (whether a chart, or an r report)

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/2569

#### Changes
new methods to click the chart menu and find an R report
