### PR TITLE
Remove dependency on repacked jetty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ project.dependencies {
     implementation "org.seleniumhq.selenium:selenium-ie-driver:${seleniumVersion}"
     // https://github.com/SeleniumHQ/selenium/issues/11750#issuecomment-1470357124
     implementation "org.seleniumhq.selenium:selenium-http-jdk-client:${seleniumVersion}"
-    implementation("org.seleniumhq.selenium:jetty-repacked:${jettyRepackagedVersion}")
+    implementation("org.eclipse.jetty:jetty-util:${jettyVersion}")
 
     implementation("com.google.guava:guava:${guavaVersion}")
     api("org.apache.httpcomponents.core5:httpcore5:${httpcore5Version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ reflectionsVersion=0.9.10
 hamcrestCoreVersion=1.3
 
 lookfirstSardineVersion=5.7
-jettyRepackagedVersion=9.4.12.v20180830
+jettyVersion=12.0.4
 seleniumVersion=4.11.0
 mockserverNettyVersion=5.15.0
 

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.jetty.util.URIUtil;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -96,7 +97,6 @@ import org.openqa.selenium.remote.service.DriverService;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
 import org.openqa.selenium.support.ui.WebDriverWait;
-import org.seleniumhq.jetty9.util.URIUtil;
 
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -31,6 +31,7 @@ import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.assertj.core.api.Assertions;
+import org.eclipse.jetty.util.URIUtil;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.labkey.test.BaseWebDriverTest;
@@ -48,7 +49,6 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.seleniumhq.jetty9.util.URIUtil;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/org/labkey/test/util/URLBuilder.java
+++ b/src/org/labkey/test/util/URLBuilder.java
@@ -1,9 +1,9 @@
 package org.labkey.test.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jetty.util.URIUtil;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.test.WebTestHelper;
-import org.seleniumhq.jetty9.util.URIUtil;
 
 import java.nio.charset.Charset;
 import java.util.Arrays;


### PR DESCRIPTION
#### Rationale
Selenium created a repacked version of jetty for reasons that are unclear to me. It hasn't been updated since 2019 and Selenium no longer uses or updates it and it has a transitive dependency that we are tying to eliminate (`javax.servlet-api`).
Tests only use this for URL encoding, so switching to the non-repacked version should work for our needs.

#### Related Pull Requests
* N/A

#### Changes
* Update test dependency on `org.seleniumhq.selenium:jetty-repacked` to `org.eclipse.jetty:jetty-util`
