### PR TITLE
give caller ability to set parentDetailPanel ready timeout

### DIFF
--- a/src/org/labkey/test/components/ChartTypeDialog.java
+++ b/src/org/labkey/test/components/ChartTypeDialog.java
@@ -16,6 +16,7 @@
 package org.labkey.test.components;
 
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.pages.TimeChartWizard;
 import org.labkey.test.selenium.LazyWebElement;
 import org.labkey.test.util.Ext4Helper;
@@ -94,10 +95,7 @@ public class ChartTypeDialog extends ChartWizardDialog<ChartTypeDialog.ElementCa
                 classValue = "-disabled";
         }
 
-        if(classValue.contains("-disabled"))
-            return false;
-        else
-            return true;
+        return !classValue.contains("-disabled");
     }
 
     public List<String> getListOfChartTypes()
@@ -182,7 +180,7 @@ public class ChartTypeDialog extends ChartWizardDialog<ChartTypeDialog.ElementCa
             Locator.byClass("field-selection-text").findElement(measureEl).click();
         }
         WebElement arrow = Locator.tagWithClass("i", "fa-arrow-circle-" + side.name().toLowerCase()).waitForElement(measureEl, 5_000);
-        WebDriverWait quickWait = new WebDriverWait(getWrapper().getDriver(), Duration.ofSeconds(2));
+        WebDriverWait quickWait = new WebDriverWait(getWrapper().getDriver(), Duration.ofSeconds(4));
         quickWait.until(ExpectedConditions.visibilityOf(arrow));
         arrow.click();
         quickWait.until(ExpectedConditions.stalenessOf(arrow));
@@ -313,7 +311,8 @@ public class ChartTypeDialog extends ChartWizardDialog<ChartTypeDialog.ElementCa
         WebElement column = elementCache().getColumn(columnName, columnGridCls);
         getWrapper().scrollIntoView(column);
         column.click();
-        getWrapper().waitFor(() -> {
+        getWrapper();
+        WebDriverWrapper.waitFor(() -> {
             return target.isDisplayed();
         }, "Target element is not displayed", 5000);
         getWrapper().actionClick(target); // The drop text may be obscured, just need to click the location

--- a/src/org/labkey/test/components/ui/grids/ParentDetailPanel.java
+++ b/src/org/labkey/test/components/ui/grids/ParentDetailPanel.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+
 /*
     Wraps the read-only state of ParentEntityEditPanel.
     If no parent is selected, the detailsTable is singluar and contains information saying that no parent/source type has been selected.
@@ -26,6 +28,8 @@ public class ParentDetailPanel extends WebDriverComponent<ParentDetailPanel.Elem
 {
     private final WebElement _el;
     private final WebDriver _driver;
+
+    private Integer _readyTimeout = WAIT_FOR_JAVASCRIPT;
 
     protected ParentDetailPanel(WebElement element, WebDriver driver)
     {
@@ -43,6 +47,12 @@ public class ParentDetailPanel extends WebDriverComponent<ParentDetailPanel.Elem
     public WebDriver getDriver()
     {
         return _driver;
+    }
+
+    public ParentDetailPanel setReadyTimeout(int timeoutMsec)
+    {
+        _readyTimeout = timeoutMsec;
+        return this;
     }
 
     public String title()
@@ -133,7 +143,7 @@ public class ParentDetailPanel extends WebDriverComponent<ParentDetailPanel.Elem
                         return true;
                     }
                 },
-                "the component did not become ready in time", 4000);
+                "the component did not become ready in time", _readyTimeout);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Recently, [BiologicsSampleCreateTest.testCrossfolderSampleDerivation](https://teamcity.labkey.org/viewLog.html?buildId=2798792&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsPostgres&fromSakuraUI=true#testNameId4744865710225756707) failed because a query-backed component (in this case, `ParentDetailPanel`) took longer than the component's hard-coded 4-second timeout period.

The screenshot shows a ready component, which suggests that it took very little time beyond that 4 second window- this change extends the default time the component's `waitForReady `method will wait to 10 seconds, and it gives callers and containing page classes the ability to set that timeout.

Failures like this one are essentially noise, the intention of this change is to give callers and page classes the ability to allow for query-backed components like this one to await the backing query.

#### Related Pull Requests
n/a

#### Changes

- [x] make `_waitForReadyTimeout `a settable class variable, default at `WAIT_FOR_JAVASCRIPT`
