### PR TITLE
Issue 48810: Field editor should check reserved field names based on the domain kind during create as it does during update

### DIFF
--- a/src/org/labkey/test/tests/DataClassTest.java
+++ b/src/org/labkey/test/tests/DataClassTest.java
@@ -146,21 +146,23 @@ public class DataClassTest extends BaseWebDriverTest
         DomainFormPanel domainFormPanel = createPage.getDomainEditor();
         domainFormPanel.manuallyDefineFields("created");
         assertEquals("Data class reserved field name error", Arrays.asList(
-                "Property name 'created' is a reserved name."),
+                "'created' is a reserved field name in 'Reserved Field Names Test'.",
+                "Please correct errors in Reserved Field Names Test before saving."),
                 createPage.clickSaveExpectingErrors());
         domainFormPanel.removeAllFields(false);
 
         domainFormPanel.manuallyDefineFields("rowid");
         assertEquals("Data class reserved field name error", Arrays.asList(
-                "Property name 'rowid' is a reserved name."),
+                "'rowid' is a reserved field name in 'Reserved Field Names Test'.",
+                "Please correct errors in Reserved Field Names Test before saving."),
                 createPage.clickSaveExpectingErrors());
         domainFormPanel.removeAllFields(false);
 
         domainFormPanel.manuallyDefineFields("name");
         assertEquals("Data class reserved field name error", Arrays.asList(
-                "Property name 'name' is a reserved name."),
+                "'name' is a reserved field name in 'Reserved Field Names Test'.",
+                "Please correct errors in Reserved Field Names Test before saving."),
                 createPage.clickSaveExpectingErrors());
-        domainFormPanel.removeAllFields(false);
 
         createPage.clickCancel();
     }

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -1303,22 +1303,23 @@ public class SampleTypeTest extends BaseWebDriverTest
         log("Verify error message for reserved field names");
         domainFormPanel.manuallyDefineFields("created");
         checker().verifyEquals("Sample Type reserved field name error",
-                Arrays.asList("Property name 'created' is a reserved name."),
+                Arrays.asList("'created' is a reserved field name in 'ReservedFieldNameValidation'.",
+                        "Please correct errors in Fields before saving."),
                 createPage.clickSaveExpectingErrors());
         domainFormPanel.removeAllFields(false);
 
         domainFormPanel.manuallyDefineFields("rowid");
         checker().verifyEquals("Sample Type reserved field name error",
-                Arrays.asList("Property name 'rowid' is a reserved name."),
+                Arrays.asList("'rowid' is a reserved field name in 'ReservedFieldNameValidation'.",
+                        "Please correct errors in Fields before saving."),
                 createPage.clickSaveExpectingErrors());
         domainFormPanel.removeAllFields(false);
 
         log("Verify error message for a few other special field names");
         domainFormPanel.manuallyDefineFields("name");
         checker().verifyEquals("Sample Type 'name' field name error",
-                Arrays.asList(
-                "The field name 'Name' is already taken. Please provide a unique name for each field.",
-                "Please correct errors in Fields before saving."),
+                Arrays.asList("The field name 'Name' is already taken. Please provide a unique name for each field.",
+                        "Please correct errors in Fields before saving."),
                 createPage.clickSaveExpectingErrors());
         domainFormPanel.removeAllFields(false);
 
@@ -1327,7 +1328,6 @@ public class SampleTypeTest extends BaseWebDriverTest
         checker().verifyEquals("Sample Type SampleId field name error",
                 Arrays.asList("The SampleID field name is reserved for imported or generated sample ids."),
                 createPage.clickSaveExpectingErrors());
-        domainFormPanel.removeAllFields(false);
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48810

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5060

#### Changes
- SampleTypeTest fix for reserved field name error message text update
