### PR TITLE
Test Automation Fixes for Shared Components

### DIFF
--- a/src/org/labkey/test/components/domain/DomainPanel.java
+++ b/src/org/labkey/test/components/domain/DomainPanel.java
@@ -1,11 +1,13 @@
 package org.labkey.test.components.domain;
 
+import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.util.LabKeyExpectedConditions;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.Optional;
 
@@ -62,8 +64,11 @@ public abstract class DomainPanel<EC extends DomainPanel<EC, T>.ElementCache, T 
         {
             elementCache().expandToggle.click();
             waitFor(() -> isExpanded() == expand, "Panel failed to " + (expand ? "expand" : "collapse"), 2_000);
-            getWrapper().shortWait()
-                    .until(LabKeyExpectedConditions.animationIsDone(elementCache().panelBody)); // wait for transition to happen
+
+            // wait for transition to happen and no spinners to be present
+            getWrapper().longWait()
+                    .until(ExpectedConditions.and(LabKeyExpectedConditions.animationIsDone(elementCache().panelBody),
+                            ExpectedConditions.numberOfElementsToBe(BootstrapLocators.loadingSpinner, 0)));
         }
         return getThis();
     }

--- a/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
+++ b/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
@@ -41,9 +41,9 @@ public class DeleteConfirmationDialog<SourcePage extends WebDriverWrapper, Confi
     protected void waitForReady()
     {
         WebDriverWrapper.waitFor(()-> elementCache().body.isDisplayed() &&
-                        !elementCache().title.getText().isEmpty() &&
                         !BootstrapLocators.loadingSpinner.existsIn(this) &&
-                        elementCache().commentInput.getComponentElement().isDisplayed(),
+                        (elementCache().commentInput.getComponentElement().isDisplayed() ||
+                                elementCache().title.getText().toLowerCase().contains("cannot")),
                 "The delete confirmation dialog did not become ready.", 1_000);
     }
 

--- a/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
+++ b/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
@@ -41,8 +41,9 @@ public class DeleteConfirmationDialog<SourcePage extends WebDriverWrapper, Confi
     protected void waitForReady()
     {
         WebDriverWrapper.waitFor(()-> elementCache().body.isDisplayed() &&
-                !elementCache().title.getText().isEmpty() &&
-                !BootstrapLocators.loadingSpinner.existsIn(this),
+                        !elementCache().title.getText().isEmpty() &&
+                        !BootstrapLocators.loadingSpinner.existsIn(this) &&
+                        elementCache().commentInput.getComponentElement().isDisplayed(),
                 "The delete confirmation dialog did not become ready.", 1_000);
     }
 
@@ -82,9 +83,29 @@ public class DeleteConfirmationDialog<SourcePage extends WebDriverWrapper, Confi
 
     public DeleteConfirmationDialog setUserComment(String comment)
     {
-        var commentInput = Input.Input(Locator.tagWithClass("textarea", "form-control"), getDriver()).timeout(2000)
-                .refindWhenNeeded(this);
-        commentInput.set(comment);
+        elementCache().commentInput.set(comment);
         return this;
     }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+    protected class ElementCache extends ModalDialog.ElementCache
+    {
+
+        Input commentInput = Input.Input(Locator.tagWithClass("textarea", "form-control"), getDriver()).timeout(2000)
+                .refindWhenNeeded(this);
+
+    }
+
+
 }

--- a/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
+++ b/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
@@ -41,9 +41,8 @@ public class DeleteConfirmationDialog<SourcePage extends WebDriverWrapper, Confi
     protected void waitForReady()
     {
         WebDriverWrapper.waitFor(()-> elementCache().body.isDisplayed() &&
-                        !BootstrapLocators.loadingSpinner.existsIn(this) &&
-                        (elementCache().commentInput.getComponentElement().isDisplayed() ||
-                                elementCache().title.getText().toLowerCase().contains("cannot")),
+                !elementCache().title.getText().isEmpty() &&
+                !BootstrapLocators.loadingSpinner.existsIn(this),
                 "The delete confirmation dialog did not become ready.", 1_000);
     }
 
@@ -83,6 +82,10 @@ public class DeleteConfirmationDialog<SourcePage extends WebDriverWrapper, Confi
 
     public DeleteConfirmationDialog setUserComment(String comment)
     {
+
+        WebDriverWrapper.waitFor(()-> elementCache().commentInput.getComponentElement().isDisplayed(),
+                "The 'Comment' field is not visible.", 2_500);
+
         elementCache().commentInput.set(comment);
         return this;
     }

--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -140,10 +140,10 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
                 infoCount <= 1);
 
         // A reference to the editing header title
-        WebElement editorHeading = Locator.tagWithClass("div", "panel-heading").startsWith("Editing").refindWhenNeeded(getDriver());
+        Locator editingLocator = Locator.tagWithClass("div", "panel-heading").startsWith("Editing");
 
-        Assert.assertTrue("Cannot find a panel with 'Editing' in the header. There isn't a panel in edit mode.",
-                editorHeading.isDisplayed());
+        Assert.assertEquals("Cannot find a panel with 'Editing' in the header. There isn't a panel in edit mode.",
+                1, editingLocator.findElements(getDriver()).size());
 
         // Shouldn't need to do this, but when tests fail, because the panel did not exit edit mode, the button is not in view.
         getWrapper().scrollIntoView(button);
@@ -156,7 +156,8 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
 
         // Wait until the counts of panels not in edit mode increases and the editor heading is no longer visible.
         WebDriverWrapper.waitFor(()->
-                        (defaultPanel.findElements(getDriver()).size() > defaultCount) && !editorHeading.isDisplayed(),
+                        defaultPanel.findElements(getDriver()).size() > defaultCount &&
+                                editingLocator.findElements(getDriver()).isEmpty(),
                 "Panel did not change state.", wait);
     }
 

--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -140,7 +140,10 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
                 infoCount <= 1);
 
         // A reference to the editing header title
-        WebElement editorHeading = Locator.tagWithClass("div", "panel-heading").startsWith("Editing").findWhenNeeded(getDriver());
+        WebElement editorHeading = Locator.tagWithClass("div", "panel-heading").startsWith("Editing").refindWhenNeeded(getDriver());
+
+        Assert.assertTrue("Cannot find a panel with 'Editing' in the header. There isn't a panel in edit mode.",
+                editorHeading.isDisplayed());
 
         // Shouldn't need to do this, but when tests fail, because the panel did not exit edit mode, the button is not in view.
         getWrapper().scrollIntoView(button);

--- a/src/org/labkey/test/components/ui/grids/CustomizeGridViewDialog.java
+++ b/src/org/labkey/test/components/ui/grids/CustomizeGridViewDialog.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.time.Duration;
@@ -316,11 +317,21 @@ public class CustomizeGridViewDialog extends ModalDialog
     public CustomizeGridViewDialog removeColumn(String column, int index)
     {
         WebElement listItem = getShownInGridListItems(column).get(index);
-        WebElement removeIcon = Locator.tagWithClass("span", "view-field__action").findWhenNeeded(listItem);
+
+        // Make sure the mouse is on the identified row. Tests that remove columns one after another can show the mouse
+        // hovering for a moment over the remove icon of the previous row.
+        listItem.click();
+
+        WebElement removeIcon = Locator.tagWithClass("span", "view-field__action").findElement(listItem);
+        getWrapper().mouseOver(removeIcon);
         removeIcon.click();
 
-        WebDriverWrapper.waitFor(()->!removeIcon.isDisplayed(),
-                String.format("Column '%s' was not removed from list.", column), 500);
+        // Move the mouse over the dialog title.
+        getWrapper().mouseOver(Locator.tagWithClass("h4", "modal-title").findElement(this));
+
+        getWrapper().shortWait()
+                .withMessage(String.format("Column '%s' was not removed from list.", column))
+                .until(ExpectedConditions.stalenessOf(listItem));
 
         return this;
     }

--- a/src/org/labkey/test/components/ui/pipeline/ImportsPage.java
+++ b/src/org/labkey/test/components/ui/pipeline/ImportsPage.java
@@ -34,7 +34,7 @@ public class ImportsPage extends LabKeyPage<LabKeyPage<?>.ElementCache>
                     }
                 },
                 "The 'Background Imports' page did not load in time.",
-                2_500);
+                15_000);
     }
 
     public static ImportsPage beginAt(WebDriverWrapper webDriverWrapper, String containerPath)

--- a/src/org/labkey/test/components/ui/pipeline/StatusPage.java
+++ b/src/org/labkey/test/components/ui/pipeline/StatusPage.java
@@ -6,6 +6,7 @@ import org.labkey.test.pages.LabKeyPage;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +35,7 @@ public class StatusPage extends LabKeyPage<LabKeyPage<?>.ElementCache>
                     }
                 },
                 "The 'Pipeline Status' page did not load in time.",
-                2_500);
+                5_000);
     }
 
     public String getPageHeader()


### PR DESCRIPTION
#### Rationale
Addressing failures that most often happen in MSSQL runs on Windows. Most failures are timing issues with actions taking a little longer and the component needing to be better about waiting.

#### Related Pull Requests
- [SampleManager](https://github.com/LabKey/sampleManagement/pull/2320)
- [Inventory](https://github.com/LabKey/inventory/pull/1135)
- [Labbook](https://github.com/LabKey/labbook/pull/591)

#### Changes
* Wait for spinners to disappear after expanding a DomainPanel
* Add a better check for ParentEntityEditPanel.
* Update CustomizeGridViewDialog to make sure the mouse isn't in the way and to validate and a column us removed from the list in the dialog before returning. 
* Increase wait times on pipeline Import and status pages.
* Wait for comment field to be present on DeleteConfirmationDialog before trying to set it.
