### PR TITLE
Test improvements for checking CSP log

### DIFF
--- a/modules/crawlerTest/src/org/labkey/crawlertest/CrawlerTestController.java
+++ b/modules/crawlerTest/src/org/labkey/crawlertest/CrawlerTestController.java
@@ -84,6 +84,21 @@ public class CrawlerTestController extends SpringActionController
         { }
     }
 
+    @RequiresPermission(ReadPermission.class)
+    public static class CspWarningAction extends SimpleViewAction<Object>
+    {
+        @Override
+        public ModelAndView getView(Object form, BindException errors)
+        {
+            getPageConfig().setTitle("CSP Warning Test Page");
+            return new JspView<>("/org/labkey/crawlertest/view/cspWarning.jsp");
+        }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        { }
+    }
+
     public static class InjectForm
     {
         private String _inject;

--- a/modules/crawlerTest/src/org/labkey/crawlertest/view/cspWarning.jsp
+++ b/modules/crawlerTest/src/org/labkey/crawlertest/view/cspWarning.jsp
@@ -1,0 +1,21 @@
+<%
+/*
+ * Copyright (c) 2023 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+%>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+
+<span>Nonce-less script block</span>
+<script>var a = 1;</script>

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -63,7 +63,31 @@ import org.labkey.test.pages.query.NewQueryPage;
 import org.labkey.test.pages.query.SourceQueryPage;
 import org.labkey.test.pages.search.SearchResultsPage;
 import org.labkey.test.teamcity.TeamCityUtils;
-import org.labkey.test.util.*;
+import org.labkey.test.util.APIAssayHelper;
+import org.labkey.test.util.APIContainerHelper;
+import org.labkey.test.util.AbstractAssayHelper;
+import org.labkey.test.util.AbstractContainerHelper;
+import org.labkey.test.util.ApiPermissionsHelper;
+import org.labkey.test.util.ArtifactCollector;
+import org.labkey.test.util.ComponentQuery;
+import org.labkey.test.util.Crawler;
+import org.labkey.test.util.CspLogUtil;
+import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.DebugUtils;
+import org.labkey.test.util.DeferredErrorCollector;
+import org.labkey.test.util.Ext4Helper;
+import org.labkey.test.util.FileBrowserHelper;
+import org.labkey.test.util.ListHelper;
+import org.labkey.test.util.Log4jUtils;
+import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.LoggedParam;
+import org.labkey.test.util.PermissionsHelper;
+import org.labkey.test.util.ReadOnlyTest;
+import org.labkey.test.util.SecurityHelper;
+import org.labkey.test.util.SimpleHttpResponse;
+import org.labkey.test.util.StudyHelper;
+import org.labkey.test.util.TestLogger;
+import org.labkey.test.util.UIPermissionsHelper;
 import org.labkey.test.util.core.webdav.WebDavUploadHelper;
 import org.labkey.test.util.ext4cmp.Ext4FieldRef;
 import org.labkey.test.util.query.QueryUtils;
@@ -77,7 +101,6 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.html5.WebStorage;
-import org.openqa.selenium.html5.LocalStorage;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.remote.UnreachableBrowserException;
 import org.openqa.selenium.remote.service.DriverService;
@@ -602,6 +625,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             {
                 // Running locally, pre-test errors are unlikely to be interesting. Clear them out.
                 resetErrors();
+                CspLogUtil.resetCspLogMark();
             }
             checker().addRecordableErrorType(WebDriverException.class);
             checker().withScreenshot("startupErrors").wrapAssertion(this::checkErrors);
@@ -1541,6 +1565,8 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                 throw new AssertionError("Crawler triggered some server-side errors.");
             }
             goToHome(); // Make sure crawler doesn't leave browser on a bad page
+
+            CspLogUtil.checkNewCspWarnings(getArtifactCollector());
         }
     }
 

--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -72,7 +72,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 /**
- * Static methods for finding finding and reading test-related files
+ * Static methods for finding and reading test-related files
  */
 public abstract class TestFileUtils
 {

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -35,6 +35,9 @@ import java.util.stream.Stream;
 
 public abstract class TestProperties
 {
+
+    private static final String USE_EMBEDDED_TOMCAT = "useEmbeddedTomcat";
+
     static
     {
         // https://github.com/SeleniumHQ/selenium/issues/11750#issuecomment-1470357124
@@ -68,6 +71,26 @@ public abstract class TestProperties
             TestLogger.error("Failed to load " + propFile.getName() + " file. Running with hard-coded defaults");
             ioe.printStackTrace(System.err);
         }
+
+        File serverPropFile = new File(TestFileUtils.getLabKeyRoot(), "gradle.properties");
+        if (!System.getProperties().containsKey(USE_EMBEDDED_TOMCAT) && serverPropFile.isFile())
+        {
+            // Gradle properties don't get pulled into tests when running in IntelliJ
+            try (Reader serverPropReader = Readers.getReader(serverPropFile))
+            {
+                TestLogger.log("Loading properties from " + propFile.getName());
+                Properties properties = new Properties();
+                properties.load(serverPropReader);
+                if (properties.containsKey(USE_EMBEDDED_TOMCAT))
+                    System.setProperty(USE_EMBEDDED_TOMCAT, "");
+            }
+            catch (IOException ioe)
+            {
+                TestLogger.error("Failed to load " + serverPropFile.getName() + " file. Ignoring");
+                ioe.printStackTrace(System.err);
+            }
+        }
+
     }
 
     public static void load()
@@ -229,7 +252,7 @@ public abstract class TestProperties
 
     public static boolean isEmbeddedTomcat()
     {
-        return System.getProperties().containsKey("useEmbeddedTomcat");
+        return System.getProperties().containsKey(USE_EMBEDDED_TOMCAT);
     }
 
     public static boolean isCheckerFatal()

--- a/src/org/labkey/test/tests/CrawlerTest.java
+++ b/src/org/labkey/test/tests/CrawlerTest.java
@@ -1,16 +1,20 @@
 package org.labkey.test.tests;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
+import org.labkey.test.TestProperties;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.Crawler;
+import org.labkey.test.util.CspLogUtil;
 import org.labkey.test.util.PermissionsHelper.MemberType;
 import org.openqa.selenium.UnhandledAlertException;
 
@@ -95,6 +99,15 @@ public class CrawlerTest extends BaseWebDriverTest
         }
     }
 
+    @Test (expected = CspLogUtil.CspWarningDetectedException.class)
+    public void testCspWarning()
+    {
+        Assume.assumeFalse("Can't test for CSP report", TestProperties.isCspCheckSkipped());
+
+        beginAt(WebTestHelper.buildRelativeUrl(MODULE_NAME, getProjectName(), "cspWarning"));
+        CspLogUtil.checkNewCspWarnings(getArtifactCollector());
+    }
+
     // Crawler should flag external links without the correct 'rel' attribute
     // https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=40708
     @Test
@@ -142,6 +155,12 @@ public class CrawlerTest extends BaseWebDriverTest
     private String getInjectUrl(String injectionParam)
     {
         return WebTestHelper.buildRelativeUrl(MODULE_NAME, getProjectName(), "injectJsp", Map.of("inject", injectionParam));
+    }
+
+    @After
+    public void postTest()
+    {
+        CspLogUtil.resetCspLogMark();
     }
 
     @Override

--- a/src/org/labkey/test/util/CspLogUtil.java
+++ b/src/org/labkey/test/util/CspLogUtil.java
@@ -101,13 +101,30 @@ public class CspLogUtil
                         errorMessage.append(": ").append(urls.iterator().next());
                     }
                 }
-                throw new AssertionError(errorMessage);
+                throw new CspWarningDetectedException(errorMessage);
             }
             finally
             {
                 lastSize = logSize;
                 lastModified = modified;
             }
+        }
+    }
+
+    public static void resetCspLogMark()
+    {
+        if (TestProperties.isCspCheckSkipped() || TestProperties.isServerRemote() || !logFile.isFile())
+            return;
+
+        lastSize = logFile.length();
+        lastModified = logFile.lastModified();
+    }
+
+    public static class CspWarningDetectedException extends AssertionError
+    {
+        public CspWarningDetectedException(Object detailMessage)
+        {
+            super(detailMessage);
         }
     }
 }

--- a/test.properties.template
+++ b/test.properties.template
@@ -152,6 +152,8 @@ scriptCheck=true
 queryCheck=false
 ## Verify all custom views after each test class
 viewCheck=false
+## Check for CSP warning after tests
+webtest.cspCheck=false
 
 
 #==============================================================================


### PR DESCRIPTION
#### Rationale
Running the CSP checker more has revealed some areas for improvement.

#### Related Pull Requests
* #1745 

#### Changes
* Add `crawlertest-cspWarning` to test CSP warning detection
* Make the `useEmbeddedTomcat` flag propagate to tests running in IntelliJ
* Run the CSP check after the crawler
* Add method to ignore expected CSP errors
* Add `webtest.cspCheck` flag to `test.properties.template`
