### PR TITLE
await query-backed detail table link

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailTable.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTable.java
@@ -14,6 +14,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+
 /**
  * This is a 'special' table that has only two columns, and no header. An example of this table can be seen in the
  * Sample Detail page. The first column contains the list of attributes for a given sample, and the second column
@@ -25,11 +27,18 @@ public class DetailTable extends WebDriverComponent<DetailTable.ElementCache>
 {
     private final WebElement _tableElement;
     private final WebDriver _driver;
+    private Integer _queryWaitMsec = WAIT_FOR_JAVASCRIPT;
 
     protected DetailTable(WebElement tableElement, WebDriver driver)
     {
         _tableElement = tableElement;
         _driver = driver;
+    }
+
+    public DetailTable setQueryWait(int queryWaitMsec)
+    {
+        _queryWaitMsec = queryWaitMsec;
+        return this;
     }
 
     @Override
@@ -125,7 +134,7 @@ public class DetailTable extends WebDriverComponent<DetailTable.ElementCache>
 
         // Should not click the container, it could be a td which would miss the clickable element.
         // Maybe this shouldn't assume an anchor but should be a generic(*)?
-        Locator.tag("a").waitForElement(getField(fieldCaption), 1500).click();
+        Locator.tag("a").waitForElement(getField(fieldCaption), _queryWaitMsec).click();
 
         WebDriverWrapper.waitFor(()->!urlBefore.equals(getWrapper().getCurrentRelativeURL().toLowerCase()),
                 String.format("Clicking field (link) '%s' did not navigate.", fieldCaption), 500);


### PR DESCRIPTION
#### Rationale
Periodically, [BiologicsBulkRegistryTest.testAddNucleotidesFromFile](https://teamcity.labkey.org/viewLog.html?buildId=2814046&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsPostgres&fromSakuraUI=true#testNameId-2381955727543163758) and some others fail because they call `DetailTable's ` `clickField` method assuming that the link will appear as selected.

Because the link (and much of the detailTable's content) is query backed, the link can take considerable time to appear depending upon the context- this change extends the default timeout (was 1.5 seconds) and makes that timeout configurable

#### Related Pull Requests
n/a

#### Changes

- [x] wait longer for the link to appear
- [x] make configuring the wait timeout possible
