### PR TITLE
Customize load timeout for SummaryStatisticsDialog

### DIFF
--- a/src/org/labkey/test/components/SummaryStatisticsDialog.java
+++ b/src/org/labkey/test/components/SummaryStatisticsDialog.java
@@ -18,6 +18,7 @@ package org.labkey.test.components;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.components.ext4.Window;
+import org.labkey.test.util.DataRegionTable;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -31,15 +32,10 @@ public class SummaryStatisticsDialog extends Window<SummaryStatisticsDialog.Elem
     private static final String DIALOG_TITLE = "Summary Statistics";
     private final int timeoutMs;
 
-    public SummaryStatisticsDialog(WebDriver driver, int timeoutMs)
+    public SummaryStatisticsDialog(DataRegionTable drt)
     {
-        super(DIALOG_TITLE, driver);
-        this.timeoutMs = timeoutMs;
-    }
-
-    public SummaryStatisticsDialog(WebDriver driver)
-    {
-        this(driver, BaseWebDriverTest.WAIT_FOR_JAVASCRIPT);
+        super(DIALOG_TITLE, drt.getDriver());
+        this.timeoutMs = drt.getUpdateTimeout();
     }
 
     public void apply()

--- a/src/org/labkey/test/components/SummaryStatisticsDialog.java
+++ b/src/org/labkey/test/components/SummaryStatisticsDialog.java
@@ -29,11 +29,17 @@ import static org.junit.Assert.assertEquals;
 public class SummaryStatisticsDialog extends Window<SummaryStatisticsDialog.ElementCache>
 {
     private static final String DIALOG_TITLE = "Summary Statistics";
+    private final int timeoutMs;
+
+    public SummaryStatisticsDialog(WebDriver driver, int timeoutMs)
+    {
+        super(DIALOG_TITLE, driver);
+        this.timeoutMs = timeoutMs;
+    }
 
     public SummaryStatisticsDialog(WebDriver driver)
     {
-        super(DIALOG_TITLE, driver);
-        elementCache().statTableLoc.waitForElement(this, BaseWebDriverTest.WAIT_FOR_JAVASCRIPT);
+        this(driver, BaseWebDriverTest.WAIT_FOR_JAVASCRIPT);
     }
 
     public void apply()
@@ -108,8 +114,13 @@ public class SummaryStatisticsDialog extends Window<SummaryStatisticsDialog.Elem
         return new ElementCache();
     }
 
-    protected class ElementCache extends Window.ElementCache
+    protected class ElementCache extends Window<?>.ElementCache
     {
+        public ElementCache()
+        {
+            statTableLoc.waitForElement(this, timeoutMs);
+        }
+
         Locator.XPathLocator statTableLoc = Locator.tagWithClass("table", "stat-table");
         Locator.XPathLocator statRowLoc = statTableLoc.append(Locator.tagWithClassContaining("tr", "lk-stats-row"));
         Locator.XPathLocator statCellLoc = statRowLoc.append(Locator.tagWithClass("td", "lk-stats-label"));

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -975,7 +975,7 @@ public class DataRegionTable extends DataRegion
         TestLogger.log(clearOrSet + " the " + stat + " summary statistic in " + getDataRegionName() + " for " + columnName);
         clickColumnMenu(columnName, false, "Summary Statistics...");
 
-        SummaryStatisticsDialog statsWindow = new SummaryStatisticsDialog(getDriver());
+        SummaryStatisticsDialog statsWindow = new SummaryStatisticsDialog(getDriver(), getUpdateTimeout());
 
         if (expectedValue != null)
             assertEquals("Stat value not as expected for: " + stat, expectedValue, statsWindow.getValue(stat));

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -975,7 +975,7 @@ public class DataRegionTable extends DataRegion
         TestLogger.log(clearOrSet + " the " + stat + " summary statistic in " + getDataRegionName() + " for " + columnName);
         clickColumnMenu(columnName, false, "Summary Statistics...");
 
-        SummaryStatisticsDialog statsWindow = new SummaryStatisticsDialog(getDriver(), getUpdateTimeout());
+        SummaryStatisticsDialog statsWindow = new SummaryStatisticsDialog(this);
 
         if (expectedValue != null)
             assertEquals("Stat value not as expected for: " + stat, expectedValue, statsWindow.getValue(stat));
@@ -991,7 +991,7 @@ public class DataRegionTable extends DataRegion
     public void verifySummaryStatisticValue(String columnName, String stat, String expectedValue, String filterDescription)
     {
         clickColumnMenu(columnName, false, "Summary Statistics...");
-        SummaryStatisticsDialog statsWindow = new SummaryStatisticsDialog(getDriver());
+        SummaryStatisticsDialog statsWindow = new SummaryStatisticsDialog(this);
         assertEquals("Stat value not as expected for " + stat + " with filter " + filterDescription, expectedValue, statsWindow.getValue(stat));
         statsWindow.cancel();
     }

--- a/src/org/labkey/test/util/SummaryStatisticsHelper.java
+++ b/src/org/labkey/test/util/SummaryStatisticsHelper.java
@@ -135,7 +135,7 @@ public class SummaryStatisticsHelper
         DataRegionTable drt = new DataRegionTable("query", _wrapper);
         drt.clickColumnMenu(columnName, false, "Summary Statistics...");
 
-        SummaryStatisticsDialog statsWindow = new SummaryStatisticsDialog(_wrapper.getDriver());
+        SummaryStatisticsDialog statsWindow = new SummaryStatisticsDialog(drt);
 
         for (String stat : getExpectedColumnStats(colType, isLookup, isPK))
             assertTrue("Expected summary stat is not present: " + stat, statsWindow.isPresent(stat));


### PR DESCRIPTION
#### Rationale
Summary statistics can take a bit longer to load for redshift data source.

#### Related Pull Requests
* N/A

#### Changes
* Make `SummaryStatisticsDialog` share timeout from `DataRegionTable`
