### PR TITLE
wait for the select to have a selection before calling clearSelection

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -329,7 +329,10 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
      **/
     public DetailTableEdit clearSelectValue(String fieldCaption)
     {
-        elementCache().findSelect(fieldCaption).clearSelection();
+        var select = elementCache().findSelect(fieldCaption);
+        WebDriverWrapper.waitFor(()-> select.hasSelection(),
+            String.format("The %s select did not have any selection in time"), WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
+        select.clearSelection();
         return this;
     }
 

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -30,6 +30,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     private final WebElement _formElement;
     private final WebDriver _driver;
     private String _title;
+    private int _readyTimeout = WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 
     protected DetailTableEdit(WebElement formElement, WebDriver driver)
     {
@@ -54,6 +55,12 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         if (_title == null)
             _title = elementCache().header.getText();
         return _title;
+    }
+
+    public DetailTableEdit setReadyTimeout(int readyTimeout)
+    {
+        _readyTimeout = readyTimeout;
+        return this;
     }
 
     /**
@@ -264,18 +271,6 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         return reactSelect.getValue();
     }
 
-    /**
-     * clears the selections from the specified reactSelect
-     * @param fieldCaption The label text for the select box
-     * @return A reference to the current object
-     */
-    public DetailTableEdit clearSelectionValues(String fieldCaption)
-    {
-        FilteringReactSelect reactSelect = elementCache().findSelect(fieldCaption);
-        reactSelect.clearSelection();
-        return this;
-    }
-
     /*
         This allows you to query a given select in the edit panel to see what options it offers
      */
@@ -331,7 +326,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     {
         var select = elementCache().findSelect(fieldCaption);
         WebDriverWrapper.waitFor(()-> select.hasSelection(),
-            String.format("The %s select did not have any selection in time"), WebDriverWrapper.WAIT_FOR_JAVASCRIPT);
+            String.format("The %s select did not have any selection in time", fieldCaption), _readyTimeout);
         select.clearSelection();
         return this;
     }


### PR DESCRIPTION
#### Rationale
[BiologicsAutoPopulateAssayJobSamplesTest.testAssociateTaskToExistingAssayRun](https://teamcity.labkey.org/viewLog.html?tab=queuedBuildOverviewTab&buildId=2842046&buildTypeId=LabKey_2311Release_Premium_ProductSuites_Biologics_LimsStarter_LimsStarterB&fromSakuraUI=true#testNameId-3261285293786488283) has been intermittently failing (23.11, starter) because the opens a detailTable for edit, calls `clearSelectValue ` to empty the Workflow Task select, and expects to be able to click the 'Save Run Details' button.

It happens that BaseReactSelect.clearSelection() does not check to ensure there is a selection (if there isn't, it No-ops). This means it is probably likely that the test called it before the select was populated and then failed to save changes because there were no changes and the save button never became enabled.

This change tells `DetailTableEdit.clearSelectValue()` to wait for the select to have any selection before calling `clearSelection()`

While doing this refactor, I discovered that DetailTableEdit has two clearSelectValue methods, this eliminates one and the related PR consolidates usages in biologics

Targeting develop for this fix, will consider backporting after

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/2634

#### Changes

- [x] eliminate redundant method
- [x] add readyTimeout member, make it settable
- [x] use readyTimeout to await value before clearing
- [x] wait for select to have a selection before calling `clearSelection`
