### PR TITLE
Remove unused `javax.servlet` dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ project.dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}")
     implementation("org.apache.commons:commons-collections4:${commonsCollections4Version}")
     implementation("net.sf.opencsv:opencsv:${opencsvVersion}")
-    implementation("javax.servlet:javax.servlet-api:${javaxServletApiVersion}")
     aspectj "org.aspectj:aspectjtools:${aspectjVersion}"
     implementation "org.apache.logging.log4j:log4j-core:${log4j2Version}"
     implementation "org.apache.logging.log4j:log4j-iostreams:${log4j2Version}"


### PR DESCRIPTION
#### Rationale
This is just a transitive dependency of `mockserver`. Not used directly by any tests.

#### Related Commit
* https://github.com/LabKey/testAutomation/commit/07cad9497c6a570b91788f04214b4d9a4534b4d5

#### Changes
* Remove unused `javax.servlet` dependency
