### PR TITLE
provide optional wait for selection

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -324,23 +324,28 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
      **/
     public DetailTableEdit clearSelectValue(String fieldCaption)
     {
-        return clearSelectValue(fieldCaption, true);
+        return clearSelectValue(fieldCaption, true, true);
     }
 
     /**
      * Clear a given select field
      * @param fieldCaption The caption/label of the field to clear.
      * @param waitForSelection If true, wait for the select to have a selection before clearing it
-     *                         and assert if no selection appears
+     * @param assertSelection  If true, assert if no selection appears (note: does nothing if waitForSelection is not true)
      * @return
      */
-    public DetailTableEdit clearSelectValue(String fieldCaption, boolean waitForSelection)
+    public DetailTableEdit clearSelectValue(String fieldCaption, boolean waitForSelection, boolean assertSelection)
     {
         var select = elementCache().findSelect(fieldCaption);
         if (waitForSelection)
         {
-            WebDriverWrapper.waitFor(() -> select.hasSelection(),
-                    String.format("The %s select did not have any selection in time", fieldCaption), _readyTimeout);
+            if (assertSelection) {
+                WebDriverWrapper.waitFor(() -> select.hasSelection(),
+                        String.format("The %s select did not have any selection in time", fieldCaption), _readyTimeout);
+            }
+            else {
+                WebDriverWrapper.waitFor(() -> select.hasSelection(), _readyTimeout);
+            }
         }
         select.clearSelection();
         return this;

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -30,7 +30,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     private final WebElement _formElement;
     private final WebDriver _driver;
     private String _title;
-    private int _readyTimeout = 1000;
+    private int _readyTimeout = WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 
     protected DetailTableEdit(WebElement formElement, WebDriver driver)
     {
@@ -344,7 +344,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
                         String.format("The %s select did not have any selection in time", fieldCaption), _readyTimeout);
             }
             else {
-                WebDriverWrapper.waitFor(() -> select.hasSelection(), _readyTimeout);
+                WebDriverWrapper.waitFor(() -> select.hasSelection(), 1000);
             }
         }
         select.clearSelection();

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -30,7 +30,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     private final WebElement _formElement;
     private final WebDriver _driver;
     private String _title;
-    private int _readyTimeout = WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+    private int _readyTimeout = 1000;
 
     protected DetailTableEdit(WebElement formElement, WebDriver driver)
     {

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -324,9 +324,24 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
      **/
     public DetailTableEdit clearSelectValue(String fieldCaption)
     {
+        return clearSelectValue(fieldCaption, true);
+    }
+
+    /**
+     * Clear a given select field
+     * @param fieldCaption The caption/label of the field to clear.
+     * @param waitForSelection If true, wait for the select to have a selection before clearing it
+     *                         and assert if no selection appears
+     * @return
+     */
+    public DetailTableEdit clearSelectValue(String fieldCaption, boolean waitForSelection)
+    {
         var select = elementCache().findSelect(fieldCaption);
-        WebDriverWrapper.waitFor(()-> select.hasSelection(),
-            String.format("The %s select did not have any selection in time", fieldCaption), _readyTimeout);
+        if (waitForSelection)
+        {
+            WebDriverWrapper.waitFor(() -> select.hasSelection(),
+                    String.format("The %s select did not have any selection in time", fieldCaption), _readyTimeout);
+        }
         select.clearSelection();
         return this;
     }


### PR DESCRIPTION
#### Rationale
Today [BiologicsTest.editNucleotideDetails](https://teamcity.labkey.org/viewLog.html?buildId=2844344&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsPostgres&fromSakuraUI=true#testNameId2291990734087517910) began failing because yesterday https://github.com/LabKey/testAutomation/pull/1787 introduced a change causing tests that call DetailTableEdit.clearSelectionValue when no selection is going to appear

For background, some tests have been failing because they call BaseReactSelect.clearSelection (which no-ops if no selection is present) before the selection appears, and then proceed to fail when trying to save the edit that didn't happen because the DetailTableEdit's save button didn't become enabled.

Apparently some tests need to clear selections that might not exist (just to set state that might not be known beforehand), so making it separately optional to wait and to assert if no selection appears

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/2637

#### Changes

- [x] make wait optional
- [x] make assert optional
