### PR TITLE
Use correct file root when testing against embedded distribution

### DIFF
--- a/src/org/labkey/junit/runner/WebTestProperties.java
+++ b/src/org/labkey/junit/runner/WebTestProperties.java
@@ -119,7 +119,7 @@ public abstract class WebTestProperties
 
     private static List<String> getInstalledModules()
     {
-        File modulesDir = new File(TestFileUtils.getDefaultDeployDir(), "modules");
+        File modulesDir = TestFileUtils.getModulesDir();
 
         if (!modulesDir.exists())
             return Collections.emptyList();

--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -195,7 +195,7 @@ public abstract class TestFileUtils
             if (TestProperties.isEmbeddedTomcat() && !_baseFileRoot.isDirectory())
             {
                 // File root when deploying from embedded distribution
-                _baseFileRoot = new File(getDefaultDeployDir(), "server/files");
+                _baseFileRoot = new File(getDefaultDeployDir(), "embedded/server/files");
             }
         }
         return _baseFileRoot;

--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -81,7 +81,7 @@ public abstract class TestFileUtils
     private static File _labkeyRoot = null;
     private static File _buildDir = null;
     private static File _testRoot = null;
-    private static File _baseFileRoot = null;
+    private static File _modulesDir = null;
     private static Set<File> _sampledataDirs = null;
 
     public static String getFileContents(String rootRelativePath)
@@ -189,16 +189,8 @@ public abstract class TestFileUtils
 
     private static File getBaseFileRoot()
     {
-        if (_baseFileRoot == null)
-        {
-            _baseFileRoot = new File(getDefaultDeployDir(), "files");
-            if (TestProperties.isEmbeddedTomcat() && !_baseFileRoot.isDirectory())
-            {
-                // File root when deploying from embedded distribution
-                _baseFileRoot = new File(getDefaultDeployDir(), "embedded/server/files");
-            }
-        }
-        return _baseFileRoot;
+        // Files are a sibling of the modules directory
+        return new File(getModulesDir().getParentFile(), "files");
     }
 
     public static File getGradleReportDir()
@@ -206,9 +198,27 @@ public abstract class TestFileUtils
         return new File(getTestBuildDir(), "test/logs/reports");
     }
 
-    public static File getDefaultDeployDir()
+    /**
+     * Private because deployment structure varies between Non-embedded, locally built embedded, and deployed embedded
+     * distribution.
+     */
+    private static File getDefaultDeployDir()
     {
         return new File(getLabKeyRoot(), "build/deploy");
+    }
+
+    public static File getModulesDir()
+    {
+        if (_modulesDir == null)
+        {
+            _modulesDir = new File(getDefaultDeployDir(), "modules");
+            if (TestProperties.isEmbeddedTomcat() && !_modulesDir.isDirectory())
+            {
+                // Module root when deploying from embedded distribution
+                _modulesDir = new File(getDefaultDeployDir(), "embedded/server/modules");
+            }
+        }
+        return _modulesDir;
     }
 
     public static File getDefaultFileRoot(String containerPath)
@@ -218,7 +228,12 @@ public abstract class TestFileUtils
 
     public static String getDefaultWebAppRoot()
     {
-        File path = new File(getDefaultDeployDir(), "labkeyWebapp");
+        File path = new File(getModulesDir().getParentFile(), "labkeyWebapp");
+        if (!path.isDirectory())
+        {
+            // Casing is different when deployed from an embedded distribution
+            path = new File(getModulesDir().getParentFile(), "labkeywebapp");
+        }
         return path.toString();
     }
 

--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -81,6 +81,7 @@ public abstract class TestFileUtils
     private static File _labkeyRoot = null;
     private static File _buildDir = null;
     private static File _testRoot = null;
+    private static File _baseFileRoot = null;
     private static Set<File> _sampledataDirs = null;
 
     public static String getFileContents(String rootRelativePath)
@@ -186,6 +187,20 @@ public abstract class TestFileUtils
         return _buildDir;
     }
 
+    private static File getBaseFileRoot()
+    {
+        if (_baseFileRoot == null)
+        {
+            _baseFileRoot = new File(getDefaultDeployDir(), "files");
+            if (TestProperties.isEmbeddedTomcat() && !_baseFileRoot.isDirectory())
+            {
+                // File root when deploying from embedded distribution
+                _baseFileRoot = new File(getDefaultDeployDir(), "server/files");
+            }
+        }
+        return _baseFileRoot;
+    }
+
     public static File getGradleReportDir()
     {
         return new File(getTestBuildDir(), "test/logs/reports");
@@ -198,12 +213,12 @@ public abstract class TestFileUtils
 
     public static File getDefaultFileRoot(String containerPath)
     {
-        return new File(getLabKeyRoot(), "build/deploy/files/" + containerPath + "/@files");
+        return new File(getBaseFileRoot(), containerPath + "/@files");
     }
 
     public static String getDefaultWebAppRoot()
     {
-        File path = new File(getLabKeyRoot(), "build/deploy/labkeyWebapp");
+        File path = new File(getDefaultDeployDir(), "labkeyWebapp");
         return path.toString();
     }
 

--- a/src/org/labkey/test/tests/CustomizeEmailTemplateTest.java
+++ b/src/org/labkey/test/tests/CustomizeEmailTemplateTest.java
@@ -45,7 +45,6 @@ public class CustomizeEmailTemplateTest extends SpecimenBaseTest
     private static final String _shipping = "123 main street";
     private static final String _comments = "this is my comment";
     private static final String _studyName = "Study 001";
-    private static final String _delim = "::";
     private static final String _notificationDivName = "params";
     private static final List<String> replacementParams = Arrays.asList(
             "action",
@@ -151,7 +150,7 @@ public class CustomizeEmailTemplateTest extends SpecimenBaseTest
         EmailRecordTable emailRecordTable = goToEmailRecord();
         EmailRecordTable.EmailMessage message = emailRecordTable.getEmailAtTableIndex(3);
         emailRecordTable.clickMessage(message);
-        String[] bodyContents = Locator.name(_notificationDivName).findElement(getDriver()).getText().split(_delim);
+        String[] bodyContents = Locator.name(_notificationDivName).findElement(getDriver()).getText().split("\n");
         Map<String, String> emailNVPs = new HashMap<>();
         for (String line : bodyContents)
         {
@@ -168,7 +167,7 @@ public class CustomizeEmailTemplateTest extends SpecimenBaseTest
         assertEquals(_studyName, message.getSubject());
         assertEquals("New Request", emailNVPs.get("status"));
         assertEquals("New Request Created", emailNVPs.get("action"));
-        assertEquals("/labkey", emailNVPs.get("contextPath"));
+        assertEquals(WebTestHelper.getContextPath(), emailNVPs.getOrDefault("contextPath", ""));
         assertEquals("My Study", emailNVPs.get("folderName"));
         assertEquals("/EmailTemplateProject/My Study", emailNVPs.get("folderPath"));
         assertEquals(WebTestHelper.getBaseURL(), emailNVPs.get("homePageURL"));
@@ -178,14 +177,14 @@ public class CustomizeEmailTemplateTest extends SpecimenBaseTest
     {
         String delimiter = "";
         StringBuilder templateBuilder = new StringBuilder();
-        templateBuilder.append("<div name=\"").append(_notificationDivName).append("\">");
+        templateBuilder.append("<div name=\"").append(_notificationDivName).append("\">\n");
         for (String param : replacementParams)
         {
             templateBuilder.append(delimiter);
             templateBuilder.append(String.format("^%s|%s==%%s^", param, param));
-            delimiter = _delim + "\n";
+            delimiter = "<br>\n";
         }
-        templateBuilder.append("</div>");
+        templateBuilder.append("\n</div>");
         return templateBuilder.toString();
     }
 


### PR DESCRIPTION
#### Rationale
Files are stored in `build/deploy/embedded/server/files` instead of `build/deploy/files` when the server was started from an embedded distribution (as on TeamCity).

Failure from `FolderExportTest`:
```
org.openqa.selenium.TimeoutException: Folder export not present: /mnt/teamcity/work/769581da7f79098c/build/deploy/files/FolderExportTest/1 Folder From Zip/@files/export <1m 0s>
  at org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2257)
  at org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2250)
  at org.labkey.test.tests.FolderExportTest.verifyFolderExportAsExpected(FolderExportTest.java:510)
  at org.labkey.test.tests.FolderExportTest.verifyImportFromZip(FolderExportTest.java:491)
  at org.labkey.test.tests.FolderExportTest.testImport(FolderExportTest.java:158)
```

#### Related Pull Requests
* N/A

#### Changes
* Find correct file root when testing against embedded distribution
