### PR TITLE
backport test fixes from develop

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -30,6 +30,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     private final WebElement _formElement;
     private final WebDriver _driver;
     private String _title;
+    private int _readyTimeout = WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 
     protected DetailTableEdit(WebElement formElement, WebDriver driver)
     {
@@ -54,6 +55,12 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         if (_title == null)
             _title = elementCache().header.getText();
         return _title;
+    }
+
+    public DetailTableEdit setReadyTimeout(int readyTimeout)
+    {
+        _readyTimeout = readyTimeout;
+        return this;
     }
 
     /**
@@ -264,18 +271,6 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         return reactSelect.getValue();
     }
 
-    /**
-     * clears the selections from the specified reactSelect
-     * @param fieldCaption The label text for the select box
-     * @return A reference to the current object
-     */
-    public DetailTableEdit clearSelectionValues(String fieldCaption)
-    {
-        FilteringReactSelect reactSelect = elementCache().findSelect(fieldCaption);
-        reactSelect.clearSelection();
-        return this;
-    }
-
     /*
         This allows you to query a given select in the edit panel to see what options it offers
      */
@@ -329,7 +324,30 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
      **/
     public DetailTableEdit clearSelectValue(String fieldCaption)
     {
-        elementCache().findSelect(fieldCaption).clearSelection();
+        return clearSelectValue(fieldCaption, true, true);
+    }
+
+    /**
+     * Clear a given select field
+     * @param fieldCaption The caption/label of the field to clear.
+     * @param waitForSelection If true, wait for the select to have a selection before clearing it
+     * @param assertSelection  If true, assert if no selection appears (note: does nothing if waitForSelection is not true)
+     * @return
+     */
+    public DetailTableEdit clearSelectValue(String fieldCaption, boolean waitForSelection, boolean assertSelection)
+    {
+        var select = elementCache().findSelect(fieldCaption);
+        if (waitForSelection)
+        {
+            if (assertSelection) {
+                WebDriverWrapper.waitFor(() -> select.hasSelection(),
+                        String.format("The %s select did not have any selection in time", fieldCaption), _readyTimeout);
+            }
+            else {
+                WebDriverWrapper.waitFor(() -> select.hasSelection(), 1000);
+            }
+        }
+        select.clearSelection();
         return this;
     }
 


### PR DESCRIPTION
#### Rationale
Recently, the following tests failed in 23.11 in ways that have been addressed in develop

- [BiologicsBulkDataTest.bulkRegisterProtSequenceError](https://teamcity.labkey.org/viewLog.html?buildId=2857421&buildTypeId=LabKey_2311Release_Premium_ProductSuites_Biologics_BiologicsPostgres&fromSakuraUI=true#testNameId-4562705730679503998)
    - The 'cancel' button is not clickable, 'fade-modal' obscures it.  In develop we wait for the button to be clickable in `AppCreateDataClassesPage`
- [BiologicsTest.testRegisterMoleculeMultipleProtein](https://teamcity.labkey.org/viewLog.html?buildId=2857421&buildTypeId=LabKey_2311Release_Premium_ProductSuites_Biologics_BiologicsPostgres&fromSakuraUI=true#testNameId-4907259645465356935)
    - The `ComponentTag `component took more than a second between name-click and render. In develop, we await for the staleness of the clicked component, for the `AppMoleculeOverviewPage`, and we give time to find the next `ComponentTag`
- [BiologicsAutoPopulateAssayJobSamplesTest.testAssociateTaskToExistingAssayRun](https://teamcity.labkey.org/viewLog.html?buildId=2855846&buildTypeId=LabKey_2311Release_Premium_ProductSuites_Biologics_BiologicsPostgres&fromSakuraUI=true#testNameId-3261285293786488283)
    - The `DetailTableEdit `cannot click 'save' because no edit occurred. This is likely because the call to `clearSelectValue `occurred before the selection appeared in the select, and when no selection is there, `BaseReactSelect.clearSelectValue` no-ops.  In develop, the test can have `DetailTableEdit `wait for that value before clearing it
- [BiologicsSampleCreateTest.testDashboardCreateSamples](https://teamcity.labkey.org/viewLog.html?buildId=2855846&buildTypeId=LabKey_2311Release_Premium_ProductSuites_Biologics_BiologicsPostgres&fromSakuraUI=true#testNameId-1930444423740823537)
    - The `EntityInsertPanel `component assumes that if the grid isn't shown, it must be that the 'show grid' tab needs to be clicked. In develop, we first wait for either a tab or a grid to be present, and then act accordingly to reveal the grid if it isn't shown. (we also pull more operations into elementCache to force waitForReady to evaluate)

These changes seek to address test-noise failures in 23.11 by backporting changes from develop

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/2654

prs as merged into develop
https://github.com/LabKey/testAutomation/pull/1787 (`DetailTableEdit`- wait for selection before clearing)
https://github.com/LabKey/biologics/pull/2536 (`ComponentTag`- better syncing while verifying molecule components)
https://github.com/LabKey/biologics/pull/2576 (sync on form button staleness, multiple page classes)
https://github.com/LabKey/testAutomation/pull/1718 (`EntityInsertPanel`- wait for panel before selecting grid)

#### Changes

- [x] backport changes to `AppCreateDataClassesPage`
- [x] backport changes to `ComponentTag`
- [x] backport `waitForPage `on `AppMoleculeOverviewPage`
- [x] backport `DetailTableEdit `changes
- [x] update test calls to `DetailTableEdit.clearSelectValue`
- [x] backport changes to `EntityInsertPanel`
