### PR TITLE
wait for pager buttons to become clickable before clicking them

### DIFF
--- a/src/org/labkey/test/components/ui/Pager.java
+++ b/src/org/labkey/test/components/ui/Pager.java
@@ -11,6 +11,7 @@ import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.react.MultiMenu;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 /**
  * Wrapper for UI component defined in 'packages/components/src/internal/components/gridbar/PageSizeSelector.tsx'
@@ -113,6 +114,7 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
         _pagedComponent.doAndWaitForUpdate(() ->
         {
             getWrapper().scrollIntoView(button);
+            getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(button));
             button.click();
         });
         return this;
@@ -130,6 +132,7 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
         _pagedComponent.doAndWaitForUpdate(() ->
         {
             getWrapper().scrollIntoView(button);
+            getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(button));
             button.click();
         });
         return this;


### PR DESCRIPTION
#### Rationale
While debugging a failure in [BiologicsReportTest.testReportSearchFilter](https://teamcity.labkey.org/viewLog.html?buildId=2865792&buildTypeId=LabKey_Trunk_LabkeyPremiumTrunk_GitModules_BiologicsPostgres95&fromSakuraUI=true#testNameId604475822663399969), I realized that Pager.clickNext() does not ensure the next button is enabled before clicking 

This means that unless tests are checking to see if it is, some could be (as testReportSearchFilter was) blindly clicking 'next' and assuming they were on the next page, but were still on the same page.  This change should make that more strict

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/2662

#### Changes
wait for next and prev to be enabled before clicking them
