### PR TITLE
Remove hard-coded context paths from tests

### DIFF
--- a/data/api/http-api.xml
+++ b/data/api/http-api.xml
@@ -1,7 +1,7 @@
 <ApiTests xmlns="http://labkey.org/query/xml">
     <test name="recorded test case 1" type="post">
         <url>
-            <![CDATA[query/HTTPApiVerifyProject/insertRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
+            <![CDATA[HTTPApiVerifyProject/query-insertRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
         <formData>{ "schemaName": "lists",
             "queryName": "Test List",
             "command": "insert",
@@ -31,7 +31,7 @@
 
     <test name="recorded test case 2" type="get">
         <url>
-            <![CDATA[query/HTTPApiVerifyProject/selectRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
+            <![CDATA[HTTPApiVerifyProject/query-selectRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
         <response><![CDATA[{"schemaName":"lists",
 "queryName":"Test List",
 "formatVersion":8.3,
@@ -134,35 +134,35 @@
 "rows":[{
     "Good": 10,
     "Like": "Zany",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Blue",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Blue",
     "Month": "2000-01-01 00:00:00.000",
     "Color": "Blue"
 },
 {
     "Good": 9,
     "Like": "Robust",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Green",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Green",
     "Month": "2000-04-04 00:00:00.000",
     "Color": "Green"
 },
 {
     "Good": 4,
     "Like": "Magenta",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Purple",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Purple",
     "Month": "2000-01-01 00:00:00.000",
     "Color": "Purple"
 },
 {
     "Good": 8,
     "Like": "Mellow",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Red",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Red",
     "Month": "2000-03-03 00:00:00.000",
     "Color": "Red"
 },
 {
     "Good": 7,
     "Like": "Light",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Yellow",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Yellow",
     "Month": "2000-02-02 00:00:00.000",
     "Color": "Yellow"
 }],
@@ -171,7 +171,7 @@
 
     <test name="recorded test case 3" type="post">
         <url>
-            <![CDATA[query/HTTPApiVerifyProject/insertRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
+            <![CDATA[HTTPApiVerifyProject/query-insertRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
         <formData>{ "schemaName": "lists",
             "queryName": "Test List",
             "command": "insert",
@@ -225,7 +225,7 @@
 
     <test name="recorded test case 4" type="get">
         <url>
-            <![CDATA[query/HTTPApiVerifyProject/selectRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
+            <![CDATA[HTTPApiVerifyProject/query-selectRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
         <response><![CDATA[{"schemaName":"lists",
 "queryName":"Test List",
 "formatVersion":8.3,
@@ -304,56 +304,56 @@
 "rows":[{
     "Good": 10,
     "Like": "Zany",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Blue",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Blue",
     "Month": "2000-01-01 00:00:00.000",
     "Color": "Blue"
 },
 {
     "Good": 1,
     "Like": "Red",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Fuscia",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Fuscia",
     "Month": "2000-03-01 00:00:00.000",
     "Color": "Fuscia"
 },
 {
     "Good": 2,
     "Like": "Black",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Gray",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Gray",
     "Month": "2000-04-01 00:00:00.000",
     "Color": "Gray"
 },
 {
     "Good": 9,
     "Like": "Robust",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Green",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Green",
     "Month": "2000-04-04 00:00:00.000",
     "Color": "Green"
 },
 {
     "Good": 7,
     "Like": "Rose",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Pink",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Pink",
     "Month": "2000-02-01 00:00:00.000",
     "Color": "Pink"
 },
 {
     "Good": 4,
     "Like": "Magenta",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Purple",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Purple",
     "Month": "2000-01-01 00:00:00.000",
     "Color": "Purple"
 },
 {
     "Good": 8,
     "Like": "Mellow",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Red",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Red",
     "Month": "2000-03-03 00:00:00.000",
     "Color": "Red"
 },
 {
     "Good": 7,
     "Like": "Light",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Yellow",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Yellow",
     "Month": "2000-02-02 00:00:00.000",
     "Color": "Yellow"
 }],
@@ -362,7 +362,7 @@
 
     <test name="recorded test case 5" type="post">
         <url>
-            <![CDATA[query/HTTPApiVerifyProject/updateRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
+            <![CDATA[HTTPApiVerifyProject/query-updateRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
         <formData>{ "schemaName": "lists",
             "queryName": "Test List",
             "command": "insert",
@@ -402,7 +402,7 @@
 
     <test name="recorded test case 6" type="get">
         <url>
-            <![CDATA[query/HTTPApiVerifyProject/selectRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
+            <![CDATA[HTTPApiVerifyProject/query-selectRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
         <response><![CDATA[{"schemaName":"lists",
 "queryName":"Test List",
 "formatVersion":8.3,
@@ -481,56 +481,56 @@
 "rows":[{
     "Good": 10,
     "Like": "Zany",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Blue",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Blue",
     "Month": "2000-01-01 00:00:00.000",
     "Color": "Blue"
 },
 {
     "Good": 1,
     "Like": "Crimson",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Fuscia",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Fuscia",
     "Month": "2000-03-01 00:00:00.000",
     "Color": "Fuscia"
 },
 {
     "Good": 2,
     "Like": "Black",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Gray",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Gray",
     "Month": "2000-04-01 00:00:00.000",
     "Color": "Gray"
 },
 {
     "Good": 2,
     "Like": "Jungle Green",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Green",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Green",
     "Month": "2000-01-11 00:00:00.000",
     "Color": "Green"
 },
 {
     "Good": 7,
     "Like": "Rose",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Pink",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Pink",
     "Month": "2000-02-01 00:00:00.000",
     "Color": "Pink"
 },
 {
     "Good": 4,
     "Like": "Magenta",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Purple",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Purple",
     "Month": "2000-01-01 00:00:00.000",
     "Color": "Purple"
 },
 {
     "Good": 8,
     "Like": "Mellow",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Red",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Red",
     "Month": "2000-03-03 00:00:00.000",
     "Color": "Red"
 },
 {
     "Good": 7,
     "Like": "Light",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Yellow",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Yellow",
     "Month": "2000-02-02 00:00:00.000",
     "Color": "Yellow"
 }],
@@ -539,7 +539,7 @@
 
     <test name="recorded test case 7" type="post">
         <url>
-            <![CDATA[query/HTTPApiVerifyProject/deleteRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
+            <![CDATA[HTTPApiVerifyProject/query-deleteRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
         <formData>{ "schemaName": "lists",
             "queryName": "Test List",
             "command": "delete",
@@ -568,7 +568,7 @@
 
     <test name="recorded test case 8" type="get">
         <url>
-            <![CDATA[query/HTTPApiVerifyProject/selectRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
+            <![CDATA[HTTPApiVerifyProject/query-selectRows.api?schemaName=lists&query.queryName=Test%20List]]></url>
         <response><![CDATA[{"schemaName":"lists",
 "queryName":"Test List",
 "formatVersion":8.3,
@@ -647,35 +647,35 @@
 "rows":[{
     "Good": 1,
     "Like": "Crimson",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Fuscia",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Fuscia",
     "Month": "2000-03-01 00:00:00.000",
     "Color": "Fuscia"
 },
 {
     "Good": 2,
     "Like": "Black",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Gray",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Gray",
     "Month": "2000-04-01 00:00:00.000",
     "Color": "Gray"
 },
 {
     "Good": 4,
     "Like": "Magenta",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Purple",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Purple",
     "Month": "2000-01-01 00:00:00.000",
     "Color": "Purple"
 },
 {
     "Good": 8,
     "Like": "Mellow",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Red",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Red",
     "Month": "2000-03-03 00:00:00.000",
     "Color": "Red"
 },
 {
     "Good": 7,
     "Like": "Light",
-    "_labkeyurl_Like": "/labkey/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Yellow",
+    "_labkeyurl_Like": "%contextPath%/list/HTTPApiVerifyProject/details.view?listId=64&amp;pk=Yellow",
     "Month": "2000-02-02 00:00:00.000",
     "Color": "Yellow"
 }],
@@ -684,7 +684,7 @@
 
     <test name="apiVersion=17.1, includeMetadata=false, includeUpdateColumn=true" type="post">
         <url>
-            <![CDATA[query/HTTPApiVerifyProject/selectRows.api]]></url>
+            <![CDATA[HTTPApiVerifyProject/query-selectRows.api]]></url>
         <formData>{
             "schemaName": "lists",
             "queryName": "Test List",
@@ -704,7 +704,7 @@
         "value" : "2000-04-01 00:00:00.000"
       },
       "Like" : {
-        "url" : "/labkey/HTTPApiVerifyProject/list-details.view?name=Test%20List&pk=Gray",
+        "url" : "%contextPath%/HTTPApiVerifyProject/list-details.view?name=Test%20List&pk=Gray",
         "value" : "Black"
       },
       "Color" : {
@@ -716,7 +716,7 @@
     },
     "links" : {
       "edit" : {
-        "href" : "/labkey/HTTPApiVerifyProject/query-updateQueryRow.view?schemaName=lists&query.queryName=Test%20List&Color=Gray",
+        "href" : "%contextPath%/HTTPApiVerifyProject/query-updateQueryRow.view?schemaName=lists&query.queryName=Test%20List&Color=Gray",
         "title" : "edit"
       }
     }
@@ -727,7 +727,7 @@
 
     <test name="apiVersion=17.1, includeMetadata=false, columns=*, includeUpdateColumn=true" type="post">
         <url>
-            <![CDATA[query/HTTPApiVerifyProject/selectRows.api]]></url>
+            <![CDATA[HTTPApiVerifyProject/query-selectRows.api]]></url>
         <formData>{
             "schemaName": "lists",
             "queryName": "Test List",
@@ -753,7 +753,7 @@
     },
     "links" : {
       "edit" : {
-        "href" : "/labkey/HTTPApiVerifyProject/query-updateQueryRow.view?schemaName=lists&query.queryName=Test%20List&Color=Gray",
+        "href" : "%contextPath%/HTTPApiVerifyProject/query-updateQueryRow.view?schemaName=lists&query.queryName=Test%20List&Color=Gray",
         "title" : "edit"
       }
     }

--- a/data/api/security-api.xml
+++ b/data/api/security-api.xml
@@ -1,7 +1,7 @@
 <ApiTests xmlns="http://labkey.org/query/xml">
 
     <test name="get group permissions" type="get">
-        <url>security/Security%20API%20Test%20Project/getGroupPerms.view?</url>
+        <url>Security%20API%20Test%20Project/security-getGroupPerms.view?</url>
         <response>
             {"container":
                 {
@@ -135,7 +135,7 @@
     </test>
 
     <test name="groups for current user" type="get">
-        <url>security/Security%20Api%20Test%20Project/getGroupsForCurrentUser.view?</url>
+        <url>Security%20Api%20Test%20Project/security-getGroupsForCurrentUser.view?</url>
         <response>
             {"groups": [
                     {
@@ -162,7 +162,7 @@
     </test>
 
     <test name="ensure login" type="get">
-        <url>security/Security%20Api%20Test%20Project/ensureLogin.view?</url>
+        <url>Security%20Api%20Test%20Project/security-ensureLogin.view?</url>
         <response>
             {"currentUser":
                 {

--- a/data/api/study-api.xml
+++ b/data/api/study-api.xml
@@ -123,7 +123,7 @@
             label: 'Non Controller',
             }
         </formData>
-        <url>participant-group/StudyVerifyProject/My%20Study/deleteParticipantCategory.view?</url>
+        <url>StudyVerifyProject/My%20Study/participant-group-deleteParticipantCategory.view?</url>
         <response>{"success": true}</response>
     </test>
 </ApiTests>

--- a/data/api/timechart-api.xml
+++ b/data/api/timechart-api.xml
@@ -1,6 +1,6 @@
 <ApiTests xmlns="http://labkey.org/query/xml">
     <test name="recorded test case" type="get">
-    <url>visualization/TimeChartTest%20Project%E2%98%83~%21%40%24%26%28%29_%2B%7B%7D-%3D%5B%5D%2C.%23%C3%A4%C3%B6%C3%BC%C3%85/Demo%20Study/getVisualizationTypes.view?</url>
+    <url>TimeChartTest%20Project%E2%98%83~%21%40%24%26%28%29_%2B%7B%7D-%3D%5B%5D%2C.%23%C3%A4%C3%B6%C3%BC%C3%85/Demo%20Study/visualization-getVisualizationTypes.view?</url>
     <response>{
         "types": [
             {
@@ -34,7 +34,7 @@
     }</response>
       </test>
     <test name="recorded test case" type="get">
-        <url>visualization/TimeChartTest%20Project%E2%98%83~%21%40%24%26%28%29_%2B%7B%7D-%3D%5B%5D%2C.%23%C3%A4%C3%B6%C3%BC%C3%85/Demo%20Visit%20Study/getVisualizationTypes.view?</url>
+        <url>TimeChartTest%20Project%E2%98%83~%21%40%24%26%28%29_%2B%7B%7D-%3D%5B%5D%2C.%23%C3%A4%C3%B6%C3%BC%C3%85/Demo%20Visit%20Study/visualization-getVisualizationTypes.view?</url>
         <response>{
         "types": [
             {

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -284,7 +284,7 @@ public abstract class TestProperties
         }
         catch (NumberFormatException nfe)
         {
-            return 60;
+            return 120;
         }
     }
 

--- a/src/org/labkey/test/WebTestHelper.java
+++ b/src/org/labkey/test/WebTestHelper.java
@@ -108,6 +108,8 @@ public class WebTestHelper
     private static final Map<String, Map<String, Cookie>> savedCookies = new HashMap<>();
     private static final Map<String, String> savedSessionKeys = new HashMap<>();
 
+    static { TestProperties.load(); }
+
     public static void setUseContainerRelativeUrl(boolean useContainerRelativeUrl)
     {
         USE_CONTAINER_RELATIVE_URL = useContainerRelativeUrl;
@@ -226,7 +228,7 @@ public class WebTestHelper
             if (_webPort == null)
             {
                 String webPortStr = System.getProperty("labkey.port");
-                if (webPortStr == null || webPortStr.trim().length() == 0)
+                if (webPortStr == null || StringUtils.isBlank(webPortStr))
                 {
                     LOG.info("Using default labkey port (" + DEFAULT_WEB_PORT +
                                         ").\nThis can be changed by setting the property 'labkey.port=[yourport]'.");
@@ -246,10 +248,10 @@ public class WebTestHelper
     {
         synchronized (SERVER_LOCK)
         {
-            if (_targetServer == null || !_targetServer.equals(System.getProperty("labkey.server")))
+            if (_targetServer == null)
             {
                 _targetServer = System.getProperty("labkey.server");
-                if (_targetServer == null || _targetServer.length() == 0)
+                if (_targetServer == null || _targetServer.isEmpty())
                 {
                     LOG.info("Using default target server (" + DEFAULT_TARGET_SERVER +
                                         ").\nThis can be changed by setting the property 'labkey.server=[yourserver]'.");
@@ -537,7 +539,7 @@ public class WebTestHelper
             String [] splitMessage = message.split("\n");
             for (String thisMessage: splitMessage)
             {
-                if (thisMessage.length() > 0)
+                if (!thisMessage.isEmpty())
                     logToServer(thisMessage, connection);
             }
             return;

--- a/src/org/labkey/test/tests/JUnitTest.java
+++ b/src/org/labkey/test/tests/JUnitTest.java
@@ -354,6 +354,7 @@ public class JUnitTest extends TestSuite
         }
     }
 
+    @SuppressWarnings("JUnitMalformedDeclaration")
     public static class RemoteTest extends TestCase
     {
         String _remoteClass;

--- a/src/org/labkey/test/tests/core/security/GetReadableContainersAPITest.java
+++ b/src/org/labkey/test/tests/core/security/GetReadableContainersAPITest.java
@@ -214,7 +214,7 @@ public class GetReadableContainersAPITest extends BaseWebDriverTest
         if (depth != null)
             config.put("depth", depth);
         if (container != null)
-            config.put("container", container);
+            config.put("container", "/" + container);
 
         String script = "var config = arguments[0];\n" +
                 "config.success = callback;\n" +

--- a/src/org/labkey/test/tests/core/security/GetReadableContainersAPITest.java
+++ b/src/org/labkey/test/tests/core/security/GetReadableContainersAPITest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 @Category({Daily.class})
 public class GetReadableContainersAPITest extends BaseWebDriverTest
 {
-    private static final String PROJECT_PREFIX = "/GetReadableContainersAPITest";
+    private static final String PROJECT_PREFIX = "GetReadableContainersAPITest";
     private static final String READABLE_PROJECT = PROJECT_PREFIX + " Readable";
     private static final String UNREADABLE_PROJECT = PROJECT_PREFIX + " Unreadable";
     private static final String USER = "reader@containersapi.test";
@@ -190,7 +190,7 @@ public class GetReadableContainersAPITest extends BaseWebDriverTest
     private Set<String> getReadableContainers(Boolean includeSubfolders, Integer depth, Object container)
     {
         List<String> response = executeGetReadableContainers(includeSubfolders, depth, container, List.class);
-        return response.stream().filter(path -> path.startsWith(PROJECT_PREFIX)).collect(Collectors.toSet());
+        return response.stream().filter(path -> path.startsWith("/" + PROJECT_PREFIX)).collect(Collectors.toSet());
     }
 
     private List<Map<String, String>> getReadableContainersErrors(Boolean includeSubfolders, Integer depth, Object container)

--- a/src/org/labkey/test/util/APITestHelper.java
+++ b/src/org/labkey/test/util/APITestHelper.java
@@ -145,7 +145,8 @@ public class APITestHelper
 
         String response = element.getResponse();
         if (response != null)
-            testCase.setResponse(StringUtils.trim(response));
+            testCase.setResponse(StringUtils.trim(response)
+                    .replaceAll("%contextPath%", WebTestHelper.getContextPath()));
 
         String formData = element.getFormData();
         if (formData != null)


### PR DESCRIPTION
#### Rationale
`http-api.xml` has some hard-coded context paths (`/labkey`), which causes tests to fail when running against embedded tomcat.
Also, many tests are using old style URLs (`controller/containerPath/action.api`); modernizing some of these (`containerPath/controller-action.api`).

#### Related Pull Requests
* N/A

#### Changes
* Remove hard-coded context paths from tests
* Update `ApiTestHelper` to inject correct context path
* Remove leading slash from project name in `GetReadableContainersAPITest`
