### PR TITLE
Improve embedded tomcat detection

### DIFF
--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -199,10 +199,10 @@ public abstract class TestFileUtils
     }
 
     /**
-     * Private because deployment structure varies between Non-embedded, locally built embedded, and deployed embedded
-     * distribution.
+     * Access is restricted because deployment structure varies between Non-embedded, locally built embedded, and
+     * deployed embedded distribution.
      */
-    private static File getDefaultDeployDir()
+    static File getDefaultDeployDir()
     {
         return new File(getLabKeyRoot(), "build/deploy");
     }

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -36,8 +36,6 @@ import java.util.stream.Stream;
 public abstract class TestProperties
 {
 
-    private static final String USE_EMBEDDED_TOMCAT = "useEmbeddedTomcat";
-
     static
     {
         // https://github.com/SeleniumHQ/selenium/issues/11750#issuecomment-1470357124
@@ -70,25 +68,6 @@ public abstract class TestProperties
         {
             TestLogger.error("Failed to load " + propFile.getName() + " file. Running with hard-coded defaults");
             ioe.printStackTrace(System.err);
-        }
-
-        File serverPropFile = new File(TestFileUtils.getLabKeyRoot(), "gradle.properties");
-        if (!System.getProperties().containsKey(USE_EMBEDDED_TOMCAT) && serverPropFile.isFile())
-        {
-            // Gradle properties don't get pulled into tests when running in IntelliJ
-            try (Reader serverPropReader = Readers.getReader(serverPropFile))
-            {
-                TestLogger.log("Loading properties from " + propFile.getName());
-                Properties properties = new Properties();
-                properties.load(serverPropReader);
-                if (properties.containsKey(USE_EMBEDDED_TOMCAT))
-                    System.setProperty(USE_EMBEDDED_TOMCAT, "");
-            }
-            catch (IOException ioe)
-            {
-                TestLogger.error("Failed to load " + serverPropFile.getName() + " file. Ignoring");
-                ioe.printStackTrace(System.err);
-            }
         }
 
     }
@@ -252,7 +231,7 @@ public abstract class TestProperties
 
     public static boolean isEmbeddedTomcat()
     {
-        return System.getProperties().containsKey(USE_EMBEDDED_TOMCAT);
+        return System.getProperties().containsKey("useEmbeddedTomcat") || new File(TestFileUtils.getDefaultDeployDir(), "embedded").isDirectory();
     }
 
     public static boolean isCheckerFatal()

--- a/src/org/labkey/test/tests/CrawlerTest.java
+++ b/src/org/labkey/test/tests/CrawlerTest.java
@@ -164,7 +164,7 @@ public class CrawlerTest extends BaseWebDriverTest
     }
 
     @Override
-    public void checkLinks() { /* Will try to crawl 'crawlerTest' actions without special handling */ }
+    public void checkLinks() { /* Nothing interesting to crawl */ }
 
     @Override
     protected BrowserType bestBrowser()

--- a/src/org/labkey/test/tests/CrawlerTest.java
+++ b/src/org/labkey/test/tests/CrawlerTest.java
@@ -164,6 +164,9 @@ public class CrawlerTest extends BaseWebDriverTest
     }
 
     @Override
+    public void checkLinks() { /* Will try to crawl 'crawlerTest' actions without special handling */ }
+
+    @Override
     protected BrowserType bestBrowser()
     {
         return BrowserType.CHROME;


### PR DESCRIPTION
#### Rationale
- Checking the root `gradle.properties` isn't a reliable way to determine whether LabKey is running embedded tomcat. Just checking for the `embedded` directory should be more reliable; still not perfect but most tests shouldn't care.
- `CrawlerTest` already does crawling manually, no need to do the normal link check afterward.

#### Related Pull Requests
* N/A

#### Changes
* Improve embedded tomcat detection
* Skip link check after `CrawlerTest`
