### PR TITLE
Add helper for checking state of dismiss button

### DIFF
--- a/src/org/labkey/test/components/bootstrap/ModalDialog.java
+++ b/src/org/labkey/test/components/bootstrap/ModalDialog.java
@@ -121,6 +121,11 @@ public class ModalDialog extends WebDriverComponent<ModalDialog.ElementCache>
         waitForClose(waitSeconds);
     }
 
+    public boolean isDismissEnabled(String buttonText)
+    {
+        return Locators.dismissButton(buttonText).findElement(getComponentElement()).isEnabled();
+    }
+
     protected void waitForClose()
     {
         waitForClose(10);

--- a/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
+++ b/src/org/labkey/test/components/ui/DeleteConfirmationDialog.java
@@ -63,6 +63,11 @@ public class DeleteConfirmationDialog<SourcePage extends WebDriverWrapper, Confi
         return _confirmPageSupplier.get();
     }
 
+    public Boolean isDeleteEnabled()
+    {
+        return isDismissEnabled("Yes, Delete");
+    }
+
     public ConfirmPage confirmPermanentlyDelete()
     {
         return confirmPermanentlyDelete(10);


### PR DESCRIPTION
#### Rationale
In the related PRs we are adding a configuration to our applications to require comments for data changes (particularly for delete at the moment, but also for other actions), so our tests need a nice way to check of the buttons to confirm or perform certain actions within modals are enabled or disabled.

#### Related Pull Requests
- https://github.com/LabKey/sampleManagement/pull/2401
- https://github.com/LabKey/biologics/pull/2665
- https://github.com/LabKey/inventory/pull/1171
- https://github.com/LabKey/labkey-ui-premium/pull/311
- https://github.com/LabKey/platform/pull/5154
- https://github.com/LabKey/labkey-ui-components/pull/1399

#### Changes
* add helpers to check for disabled state for buttons.
