### PR TITLE
Allow TeamCity to disable embedded tomcat

### DIFF
--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -231,7 +231,7 @@ public abstract class TestProperties
 
     public static boolean isEmbeddedTomcat()
     {
-        return System.getProperties().containsKey("useEmbeddedTomcat") || new File(TestFileUtils.getDefaultDeployDir(), "embedded").isDirectory();
+        return !System.getProperty("useEmbeddedTomcat", "false").equals("false") || new File(TestFileUtils.getDefaultDeployDir(), "embedded").isDirectory();
     }
 
     public static boolean isCheckerFatal()


### PR DESCRIPTION
#### Rationale
In order to make embedded tomcat the default, we need a way to turn it off for testing on TeamCity.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/195
* https://github.com/LabKey/server/pull/695

#### Changes
* Update `useEmbeddedTomcat` parameter handling
