### PR TITLE
Force version consistency for annotations and reflections

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 aspectjVersion=1.9.21
 assertjVersion=3.23.1
 awaitilityVersion=4.2.0
-reflectionsVersion=0.9.10
 
 lookfirstSardineVersion=5.7
 jettyVersion=12.0.4


### PR DESCRIPTION
#### Rationale
A recent dependency update in `tcrdb` caused some version discrepancies.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/710

#### Changes
* Use `reflectionsVersion` property from root project 
