### PR TITLE
Test components for biologics cross-folder input form actions tests

### DIFF
--- a/src/org/labkey/test/components/react/SelectInputOption.java
+++ b/src/org/labkey/test/components/react/SelectInputOption.java
@@ -79,7 +79,7 @@ public class SelectInputOption extends WebDriverComponent<SelectInputOption.Elem
             {
                 WebElement keyEl = Locator.tag("strong").findElement(el);
                 WebElement valEl = Locator.tag("span").findElement(el);
-                data.put(StringUtils.stripEnd(keyEl.getText(), ":"), valEl.getAttribute("title"));
+                data.put(StringUtils.stripEnd(keyEl.getText(), ":"), valEl.getText());
             }
             return data;
         }

--- a/src/org/labkey/test/components/react/SelectInputOption.java
+++ b/src/org/labkey/test/components/react/SelectInputOption.java
@@ -1,5 +1,6 @@
 package org.labkey.test.components.react;
 
+import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.util.Pair;
@@ -78,7 +79,7 @@ public class SelectInputOption extends WebDriverComponent<SelectInputOption.Elem
             {
                 WebElement keyEl = Locator.tag("strong").findElement(el);
                 WebElement valEl = Locator.tag("span").findElement(el);
-                data.put(keyEl.getText(), valEl.getAttribute("title"));
+                data.put(StringUtils.stripEnd(keyEl.getText(), ":"), valEl.getAttribute("title"));
             }
             return data;
         }

--- a/src/org/labkey/test/components/react/SelectInputOption.java
+++ b/src/org/labkey/test/components/react/SelectInputOption.java
@@ -1,0 +1,126 @@
+package org.labkey.test.components.react;
+
+import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.CaseInsensitiveMapWrapper;
+import org.labkey.api.util.Pair;
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.Input;
+import org.labkey.test.pages.LabKeyPage;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.labkey.test.components.html.Input.Input;
+
+/*
+    This component is meant to wrap the verbose options in filteringReactSelect, ReactSelect
+ */
+public class SelectInputOption extends WebDriverComponent<SelectInputOption.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected SelectInputOption(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    public boolean isFocused()
+    {
+        return getComponentElement().getAttribute("class").contains("select-input__option--is-focused");
+    }
+
+    public Map<String, String> getData()
+    {
+        return elementCache().getData();
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        public Locator.XPathLocator text_truncatePairLoc = Locator.tagWithClass("div", "text__truncate");
+
+        public Map<String, String> getData()
+        {
+            Map<String, String> data = new CaseInsensitiveHashMap<>();
+            var elements = text_truncatePairLoc.findElements(this);
+            for (WebElement el : elements)
+            {
+                WebElement keyEl = Locator.tag("strong").findElement(el);
+                WebElement valEl = Locator.tag("span").findElement(el);
+                data.put(keyEl.getText(), valEl.getAttribute("title"));
+            }
+            return data;
+        }
+
+    }
+
+
+    public static class SelectInputOptionFinder extends WebDriverComponentFinder<SelectInputOption, SelectInputOptionFinder>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "select-input__option");
+        private String _key = null;
+        private String _value = null;
+
+        public SelectInputOptionFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        public SelectInputOptionFinder withValue(String key, String value)
+        {
+            _key = key;
+            _value = value;
+            return this;
+        }
+
+        @Override
+        protected SelectInputOption construct(WebElement el, WebDriver driver)
+        {
+            return new SelectInputOption(el, driver);
+        }
+
+
+        @Override
+        protected Locator locator()
+        {
+            if (_key != null)
+                return _baseLocator.withChild(Locator.tagWithClass("div", "text__truncate")
+                        .withChild(Locator.tagWithText("strong",_key))
+                        .parent()   // children are siblings
+                        .withChild(Locator.tagWithAttributeContaining("span", "title", _value)));
+            else
+                return _baseLocator;
+        }
+    }
+}

--- a/src/org/labkey/test/components/ui/navigation/apps/ChangeProjectsAndResetFormModalDialog.java
+++ b/src/org/labkey/test/components/ui/navigation/apps/ChangeProjectsAndResetFormModalDialog.java
@@ -1,0 +1,30 @@
+package org.labkey.test.components.ui.navigation.apps;
+
+import org.labkey.test.components.UpdatingComponent;
+import org.labkey.test.components.bootstrap.ModalDialog;
+import org.openqa.selenium.WebDriver;
+
+
+
+public class ChangeProjectsAndResetFormModalDialog extends ModalDialog
+{
+    private final UpdatingComponent _updatingComponent;
+    public ChangeProjectsAndResetFormModalDialog(WebDriver driver, UpdatingComponent updatingComponent)
+    {
+        super(new ModalDialogFinder(driver).withTitle("Change projects and reset form?"));
+        this._updatingComponent = updatingComponent;
+    }
+
+
+    public void clickCancel()
+    {
+        dismiss("Cancel");
+    }
+
+    public void clickChangeProjects()
+    {
+        _updatingComponent.doAndWaitForUpdate(()->
+                dismiss("Change Projects"));
+
+    }
+}

--- a/src/org/labkey/test/components/ui/navigation/apps/ChangeTargetFolderDialog.java
+++ b/src/org/labkey/test/components/ui/navigation/apps/ChangeTargetFolderDialog.java
@@ -1,15 +1,14 @@
 package org.labkey.test.components.ui.navigation.apps;
 
-import org.labkey.test.components.UpdatingComponent;
 import org.labkey.test.components.bootstrap.ModalDialog;
 import org.openqa.selenium.WebDriver;
 
 
 
-public class ChangeProjectsAndResetFormModalDialog extends ModalDialog
+public class ChangeTargetFolderDialog extends ModalDialog
 {
-    private final UpdatingComponent _updatingComponent;
-    public ChangeProjectsAndResetFormModalDialog(WebDriver driver, UpdatingComponent updatingComponent)
+    private final UpdatesTargetFolder _updatingComponent;
+    public ChangeTargetFolderDialog(WebDriver driver, UpdatesTargetFolder updatingComponent)
     {
         super(new ModalDialogFinder(driver).withTitle("Change projects and reset form?"));
         this._updatingComponent = updatingComponent;
@@ -23,8 +22,15 @@ public class ChangeProjectsAndResetFormModalDialog extends ModalDialog
 
     public void clickChangeProjects()
     {
-        _updatingComponent.doAndWaitForUpdate(()->
+        _updatingComponent.doAndWaitForFolderUpdate(()->
                 dismiss("Change Projects"));
 
+    }
+
+
+
+    static public interface UpdatesTargetFolder
+    {
+        void doAndWaitForFolderUpdate(Runnable func);
     }
 }


### PR DESCRIPTION
#### Rationale
This adds components to support test coverage of cross-folder form-based data inputs in Biologics.

It's possible both of these components belong in biologics but I'm starting them out here because they might be shared at some point 
Also, they probably belong in different locations- they're in the best places I could figure out, given the context. @labkey-tchad , probably this is your bailiwick

`SelectInputOption` is useful for scraping row data out of reactSelect options that put lots of metadata into them- this format is definitely used in component selectors in biologics registry, not sure if this data format is universal or if these select-items are formatted on an ad-hoc basis @labkey-nicka , @labkey-alan, thoughts?

The Modal dialog, when submitted, calls the '`doAndWaitForUpdate`' method implemented on the component getting it 

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/2704

#### Changes

- [x] Dialog to prompt changing target project, clearing form
- [x] wrapper for select-input-option
