### PR TITLE
wait for the search indexer more generally before cleaning up after tests

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -91,6 +91,7 @@ import org.labkey.test.util.UIPermissionsHelper;
 import org.labkey.test.util.core.webdav.WebDavUploadHelper;
 import org.labkey.test.util.ext4cmp.Ext4FieldRef;
 import org.labkey.test.util.query.QueryUtils;
+import org.labkey.test.util.search.SearchAdminAPIHelper;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.ElementClickInterceptedException;
@@ -1229,6 +1230,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             TestLogger.log(pendingRequestCount.getValue() + " requests still pending after " + msWait + "ms");
         if (pendingRequestCount.getValue() < 0)
             TestLogger.log("Unable to fetch pending request count" + msWait + "ms");
+        SearchAdminAPIHelper.waitForIndexerBackground();
     }
 
     private int getPendingRequestCount(Connection connection)


### PR DESCRIPTION
#### Rationale
This is a follow-up to discussion in https://github.com/LabKey/biologics/pull/2711.
To recap, it was suggested that a wait for the indexer before cleaning up after tests might be a reasonable way to more broadly prevent tests from generating failures if the search indexer is indexing something (as in this case, a sampleType) while test-cleanup is deleting it.

This adds a call to `SearchAdminAPIHelper.waitForIndexerBackground()` in `BaseWebDriverTest.waitForPendingRequests()` with the intention of avoiding race-condition failures where the container delete gets there before the indexer is finished

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/2711

#### Changes

- [x] wait for the indexer after the rest of `waitForPendingRequests()`
