### PR TITLE
don't call searchIndexer unless search module is present

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1230,7 +1230,9 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             TestLogger.log(pendingRequestCount.getValue() + " requests still pending after " + msWait + "ms");
         if (pendingRequestCount.getValue() < 0)
             TestLogger.log("Unable to fetch pending request count" + msWait + "ms");
-        SearchAdminAPIHelper.waitForIndexerBackground();
+
+        if (_containerHelper.getAllModules().contains("Search"))
+            SearchAdminAPIHelper.waitForIndexerBackground();
     }
 
     private int getPendingRequestCount(Connection connection)


### PR DESCRIPTION
#### Rationale
Recently in https://github.com/LabKey/testAutomation/pull/1826 I added a call to `SearchAdminAPIHelper.waitForIndexerBackground()` to `BaseWebDriverTest.WaitForPendingRequests` (which is called before cleaning up tests), with the intention of preventing intermittent failures that can arise when the indexer is indexing something when it is being deleted.

Unfortunately, this caused failures in tests that don't have the Search module (🤦doh)
This change checks beforehand to see if` _containerHelper.getAllModules.contains("Search")` and only asks the indexer to wait if the Search module is present

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/1826

#### Changes
Only ask search indexer to wait if search module is there
