### PR TITLE
Update Check for Removed Grid Filter

### DIFF
--- a/src/org/labkey/test/components/ui/FilterStatusValue.java
+++ b/src/org/labkey/test/components/ui/FilterStatusValue.java
@@ -4,9 +4,9 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
-import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class FilterStatusValue extends WebDriverComponent<FilterStatusValue.ElementCache>
 {
@@ -57,17 +57,10 @@ public class FilterStatusValue extends WebDriverComponent<FilterStatusValue.Elem
 
         // If the item you're dismissing is not the rightmost, it won't become stale; instead, its text will
         // be swapped out with the one to its right.  So, we check to see that either the text has changed or
-        // the item became stale.
-        WebDriverWrapper.waitFor(()-> {
-                    try
-                    {
-                        return !getText().equals(originalText);
-                    }
-                    catch (StaleElementReferenceException s)
-                    {
-                        return true;
-                    }
-                }
+        // the item became stale. ExpectedConditions.textToBePresentInElement returns false if element is stale.
+        WebDriverWrapper.waitFor(()-> ExpectedConditions.not(
+                ExpectedConditions.textToBePresentInElement(elementCache().textSpan(), originalText))
+                        .apply(getDriver())
                 , "The value item ["+originalText+"] did not disappear.", 1000);
     }
 

--- a/src/org/labkey/test/components/ui/FilterStatusValue.java
+++ b/src/org/labkey/test/components/ui/FilterStatusValue.java
@@ -33,7 +33,7 @@ public class FilterStatusValue extends WebDriverComponent<FilterStatusValue.Elem
 
     public String getText()
     {
-        return elementCache().textSpan().getText();
+        return elementCache().textSpan.getText();
     }
 
     private boolean isActive()
@@ -59,7 +59,7 @@ public class FilterStatusValue extends WebDriverComponent<FilterStatusValue.Elem
         // be swapped out with the one to its right.  So, we check to see that either the text has changed or
         // the item became stale. ExpectedConditions.textToBePresentInElement returns false if element is stale.
         WebDriverWrapper.waitFor(()-> ExpectedConditions.not(
-                ExpectedConditions.textToBePresentInElement(elementCache().textSpan(), originalText))
+                ExpectedConditions.textToBePresentInElement(elementCache().textSpan, originalText))
                         .apply(getDriver())
                 , "The value item ["+originalText+"] did not disappear.", 1000);
     }
@@ -82,10 +82,7 @@ public class FilterStatusValue extends WebDriverComponent<FilterStatusValue.Elem
 
     protected class ElementCache extends Component<?>.ElementCache
     {
-        public WebElement textSpan()
-        {
-            return Locator.tag("span").findElement(getComponentElement());
-        }
+        public final WebElement textSpan = Locator.tag("span").refindWhenNeeded(getComponentElement());
 
         public final WebElement icon = Locator.tag("i").findWhenNeeded(getComponentElement());
     }

--- a/src/org/labkey/test/components/ui/FilterStatusValue.java
+++ b/src/org/labkey/test/components/ui/FilterStatusValue.java
@@ -4,9 +4,9 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class FilterStatusValue extends WebDriverComponent<FilterStatusValue.ElementCache>
 {
@@ -52,16 +52,23 @@ public class FilterStatusValue extends WebDriverComponent<FilterStatusValue.Elem
         getWrapper().mouseOver(getComponentElement());
         getWrapper().mouseOver(elementCache().icon);
         WebDriverWrapper.waitFor(()-> isActive() && isClose(),
-                "the filter status item with text ["+getText()+"] did not become active", 500);
+                "The filter status item with text ["+getText()+"] did not become active.", 500);
         elementCache().icon.click();
 
-        // if the item you're dismissing is not the rightmost, it won't become stale; instead, its text will
+        // If the item you're dismissing is not the rightmost, it won't become stale; instead, its text will
         // be swapped out with the one to its right.  So, we check to see that either the text has changed or
         // the item became stale.
-        WebDriverWrapper.waitFor(()->  {
-                return ExpectedConditions.stalenessOf(getComponentElement()).apply(getDriver())
-                        || !getText().equals(originalText);
-        }, "the value item ["+originalText+"] did not disappear", 1000);
+        WebDriverWrapper.waitFor(()-> {
+                    try
+                    {
+                        return !getText().equals(originalText);
+                    }
+                    catch (StaleElementReferenceException s)
+                    {
+                        return true;
+                    }
+                }
+                , "The value item ["+originalText+"] did not disappear.", 1000);
     }
 
     /**


### PR DESCRIPTION
#### Rationale
Timing issues can cause the check for a removed grid filter to fail with a staleElementReference error. Using ExpectedConditions.textToBePresentInElement should cover both conditional checks.

#### Related Pull Requests
* None

#### Changes
* Change check to use ExpectedConditions.textToBePresentInElement
