### PR TITLE
Add cleanup method to site configuration interface

### DIFF
--- a/src/org/labkey/test/util/ConfiguresSite.java
+++ b/src/org/labkey/test/util/ConfiguresSite.java
@@ -23,4 +23,5 @@ public interface ConfiguresSite
     void configureSite();
     void configureProject(String project);
     void configureFolder(String containerPath);
+    default void cleanupSite() {}
 }

--- a/src/org/labkey/test/util/ReflectionUtils.java
+++ b/src/org/labkey/test/util/ReflectionUtils.java
@@ -17,35 +17,42 @@ package org.labkey.test.util;
 
 import org.labkey.test.WebDriverWrapper;
 
+import java.lang.reflect.InvocationTargetException;
+
 public class ReflectionUtils
 {
     public static ConfiguresSite getSiteConfigurerOrDefault(String className, WebDriverWrapper driverWrapper)
     {
         try
         {
-            Class<?> aClass = Class.forName(className);
-            if (ConfiguresSite.class.isAssignableFrom(aClass))
-            {
-                try
-                {
-                    ConfiguresSite siteConfigurer = (ConfiguresSite) aClass.newInstance();
-                    siteConfigurer.setWrapper(driverWrapper);
-                    return siteConfigurer;
-                }
-                catch (InstantiationException | IllegalAccessException e)
-                {
-                    throw new IllegalArgumentException("Unable to instantiate site configurer: " + className);
-                }
-            }
-            else
-            {
-                throw new IllegalArgumentException(className + " does not implement " + ConfiguresSite.class.getName());
-            }
+            ConfiguresSite siteConfigurer = getSiteConfigurer(className);
+            siteConfigurer.setWrapper(driverWrapper);
+            return siteConfigurer;
         }
         catch (ClassNotFoundException e)
         {
-            TestLogger.log("Site configurer does not exist: " + className + ". Using default.");
+            TestLogger.warn("Site configurer does not exist: " + className + ". Using default.", e);
             return new DefaultSiteConfigurer();
+        }
+    }
+
+    public static ConfiguresSite getSiteConfigurer(String className) throws ClassNotFoundException
+    {
+        Class<?> aClass = Class.forName(className);
+        if (ConfiguresSite.class.isAssignableFrom(aClass))
+        {
+            try
+            {
+                return (ConfiguresSite) aClass.getDeclaredConstructor().newInstance();
+            }
+            catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e)
+            {
+                throw new IllegalArgumentException("Unable to instantiate site configurer: " + className, e);
+            }
+        }
+        else
+        {
+            throw new IllegalArgumentException(className + " does not implement " + ConfiguresSite.class.getName());
         }
     }
 }


### PR DESCRIPTION
#### Rationale
This will allow tests to reference some docker setup and cleanup methods without adding a compilation dependency.

#### Related Pull Requests
* https://github.com/LabKey/limsModules/pull/11
* https://github.com/LabKey/docker/pull/101

#### Changes
* Add cleanup method to site configuration interface
* Add `ConfigurationUtils.getSiteConfigurer` that doesn't provide a default 
