### PR TITLE
Use 'SystemUtils' to identify test OS

### DIFF
--- a/src/org/labkey/test/Runner.java
+++ b/src/org/labkey/test/Runner.java
@@ -28,6 +28,7 @@ import junit.runner.BaseTestRunner;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
@@ -39,9 +40,6 @@ import org.junit.runner.Description;
 import org.junit.runner.manipulation.Filter;
 import org.junit.runner.manipulation.Filterable;
 import org.junit.runner.manipulation.NoTestsRemainException;
-import org.junit.runner.manipulation.Orderable;
-import org.junit.runner.manipulation.Sortable;
-import org.junit.runner.manipulation.Sorter;
 import org.labkey.junit.runner.WebTestProperties;
 import org.labkey.serverapi.reader.Readers;
 import org.labkey.serverapi.writer.PrintWriters;
@@ -56,7 +54,6 @@ import org.labkey.test.util.DevModeOnlyTest;
 import org.labkey.test.util.ExportDiagnosticsPseudoTest;
 import org.labkey.test.util.NonWindowsTest;
 import org.labkey.test.util.PostgresOnlyTest;
-import org.labkey.test.util.Order;
 import org.labkey.test.util.SqlserverOnlyTest;
 import org.labkey.test.util.TestLogger;
 import org.labkey.test.util.WindowsOnlyTest;
@@ -428,7 +425,6 @@ public class Runner extends TestSuite
             {
                 List<Class<?>> interfaces = ClassUtils.getAllInterfaces(testClass);
                 WebTestHelper.DatabaseType databaseType = WebTestHelper.getDatabaseType();
-                String osName = System.getProperty("os.name", "<unknown>");
                 if (interfaces.contains(PostgresOnlyTest.class) && databaseType != WebTestHelper.DatabaseType.PostgreSQL)
                 {
                     LOG.warn("** Skipping " + testClass.getSimpleName() + " test for unsupported database: " + databaseType);
@@ -445,14 +441,14 @@ public class Runner extends TestSuite
                     LOG.warn("** Skipping " + testClass.getSimpleName() + ": server must be in dev mode");
                     continue;
                 }
-                else if(interfaces.contains(WindowsOnlyTest.class) && !osName.toLowerCase().contains("windows"))
+                else if(interfaces.contains(WindowsOnlyTest.class) && !SystemUtils.IS_OS_WINDOWS)
                 {
-                    LOG.warn("** Skipping " + testClass.getSimpleName() + " test for unsupported operating system: " + osName);
+                    LOG.warn("** Skipping " + testClass.getSimpleName() + " test for unsupported operating system: " + SystemUtils.OS_NAME);
                     continue;
                 }
-                else if(interfaces.contains(NonWindowsTest.class) && osName.toLowerCase().contains("windows"))
+                else if(interfaces.contains(NonWindowsTest.class) && SystemUtils.IS_OS_WINDOWS)
                 {
-                    LOG.warn("** Skipping " + testClass.getSimpleName() + " test for unsupported operating system: " + osName);
+                    LOG.warn("** Skipping " + testClass.getSimpleName() + " test for unsupported operating system: " + SystemUtils.OS_NAME);
                     continue;
                 }
                 test = new JUnit4TestAdapter(testClass);

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3410,8 +3410,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
     public void actionClear(WebElement input)
     {
-        String osName = System.getProperty("os.name");
-        Keys cmdKey = osName.toLowerCase().contains("mac") ? Keys.COMMAND : Keys.CONTROL;
+        Keys cmdKey = WebDriverUtils.MODIFIER_KEY;
         scrollIntoView(input);
         new Actions(getDriver())
             .keyDown(cmdKey)
@@ -3429,8 +3428,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
      */
     public void actionPaste(WebElement input, String text)
     {
-        String osName = System.getProperty("os.name");
-        Keys cmdKey = osName.toLowerCase().contains("mac") ? Keys.COMMAND : Keys.CONTROL;
+        Keys cmdKey = WebDriverUtils.MODIFIER_KEY;
 
         Clipboard c = Toolkit.getDefaultToolkit().getSystemClipboard();
         StringSelection sel = new StringSelection(text);

--- a/src/org/labkey/test/pages/FolderManagementFolderTree.java
+++ b/src/org/labkey/test/pages/FolderManagementFolderTree.java
@@ -15,11 +15,10 @@
  */
 package org.labkey.test.pages;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.components.ext4.Window;
-import org.openqa.selenium.Keys;
+import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -106,9 +105,8 @@ public class FolderManagementFolderTree
 
     public void deselectFolder(String folder)
     {
-        Keys multiSelectKey = SystemUtils.IS_OS_MAC ? Keys.COMMAND : Keys.CONTROL;
         Actions builder = new Actions(_test.getDriver());
-        builder.keyDown(multiSelectKey).click(Locator.xpath("//span[text()='"+ folder +"']").findElement(_test.getDriver())).keyUp(multiSelectKey).build().perform();
+        builder.keyDown(WebDriverUtils.MODIFIER_KEY).click(Locator.xpath("//span[text()='"+ folder +"']").findElement(_test.getDriver())).keyUp(WebDriverUtils.MODIFIER_KEY).build().perform();
     }
 
     public void expandFolderNode(String... folders)

--- a/src/org/labkey/test/tests/ReportThumbnailTest.java
+++ b/src/org/labkey/test/tests/ReportThumbnailTest.java
@@ -16,6 +16,7 @@
 
 package org.labkey.test.tests;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -377,8 +378,7 @@ public class ReportThumbnailTest extends BaseWebDriverTest
         goToDataViews();
 
         // Trying to work around flaky test failures on Windows.
-        String osName = System.getProperty("os.name").toLowerCase();
-        if(osName.contains("windows"))
+        if(SystemUtils.IS_OS_WINDOWS)
         {
             refresh();
         }
@@ -388,7 +388,7 @@ public class ReportThumbnailTest extends BaseWebDriverTest
         if (null == expected)
         {
             // If the thumbnail isn't different, refresh/revisit the page and try again. (Issue 47143)
-            if(THUMBNAIL_DATA.equals(thumbnailData) && osName.contains("windows"))
+            if(THUMBNAIL_DATA.equals(thumbnailData) && SystemUtils.IS_OS_WINDOWS)
             {
                 log("The thumbnail was not updated as expecting. Trying a 'refresh' to get the updated image.");
                 sleep(1_500);

--- a/src/org/labkey/test/tests/announcements/MessagesAttachmentTest.java
+++ b/src/org/labkey/test/tests/announcements/MessagesAttachmentTest.java
@@ -16,6 +16,7 @@
 package org.labkey.test.tests.announcements;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -62,7 +63,7 @@ public class MessagesAttachmentTest extends BaseWebDriverTest implements NonWind
     @BeforeClass
     public static void setupProject() throws Exception
     {
-        assertFalse("Do not run this test on Windows. It uses files with illegal characters", System.getProperty("os.name").toLowerCase().contains("windows"));
+        assertFalse("Do not run this test on Windows. It uses files with illegal characters", SystemUtils.IS_OS_WINDOWS);
 
         MessagesAttachmentTest init = (MessagesAttachmentTest) getCurrentTest();
         init.doSetup();

--- a/src/org/labkey/test/tests/issues/IssuesAttachmentTest.java
+++ b/src/org/labkey/test/tests/issues/IssuesAttachmentTest.java
@@ -16,6 +16,7 @@
 package org.labkey.test.tests.issues;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -81,7 +82,7 @@ public class IssuesAttachmentTest extends BaseWebDriverTest implements NonWindow
 
     private void doSetup() throws Exception
     {
-        assertFalse("Do not run this test on Windows. It uses files with illegal characters", System.getProperty("os.name").toLowerCase().contains("windows"));
+        assertFalse("Do not run this test on Windows. It uses files with illegal characters", SystemUtils.IS_OS_WINDOWS);
 
         TestFileUtils.extractTarGz(FILES_ARCHIVE, EXTRACTION_DIR);
 

--- a/src/org/labkey/test/util/ArtifactCollector.java
+++ b/src/org/labkey/test/util/ArtifactCollector.java
@@ -16,6 +16,7 @@
 package org.labkey.test.util;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
@@ -280,7 +281,7 @@ public class ArtifactCollector
         File screenFile = new File(dir, baseName + "Fullscreen.png");
 
         // Windows doesn't support OS level screenshots for headless environment
-        if (!isTestRunningOnTeamCity() || !System.getProperty("os.name").toLowerCase().contains("win"))
+        if (!isTestRunningOnTeamCity() || !SystemUtils.IS_OS_WINDOWS)
         {
             try
             {

--- a/src/org/labkey/test/util/PasswordUtil.java
+++ b/src/org/labkey/test/util/PasswordUtil.java
@@ -16,6 +16,7 @@
 
 package org.labkey.test.util;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.labkey.remoteapi.NetrcFileParser;
 import org.labkey.serverapi.writer.PrintWriters;
 import org.labkey.test.WebTestHelper;
@@ -84,7 +85,7 @@ public class PasswordUtil
 
     private static File getNetrcFile()
     {
-        return new File(System.getProperty("user.home"), System.getProperty("os.name").toLowerCase().contains("win") ? "_netrc" : ".netrc");
+        return new File(System.getProperty("user.home"), SystemUtils.IS_OS_WINDOWS ? "_netrc" : ".netrc");
     }
 
     private static String getHost()


### PR DESCRIPTION
#### Rationale
Individual tests shouldn't be parsing system properties. `SystemUtils` provides a reliable way to check what OS the test is running on.

#### Related Pull Requests
* N/A

#### Changes
* Use 'SystemUtils' to identify test OS
