### PR TITLE
Use existing 'Tabs' component for 'LoginConfigurePage'

### DIFF
--- a/src/org/labkey/test/components/react/Tabs.java
+++ b/src/org/labkey/test/components/react/Tabs.java
@@ -35,7 +35,7 @@ public class Tabs extends WebDriverComponent<Tabs.ElementCache>
     private final WebElement _el;
     private final WebDriver _driver;
 
-    protected Tabs(WebElement element, WebDriver driver)
+    public Tabs(WebElement element, WebDriver driver)
     {
         _el = element;
         _driver = driver;

--- a/src/org/labkey/test/components/react/Tabs.java
+++ b/src/org/labkey/test/components/react/Tabs.java
@@ -15,11 +15,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Controls 'Tabs' and 'Tab' components from 'react-bootstrap'
+ * Controls 'Tabs' and 'Tab' components from 'react-bootstrap' or 'packages/components/src/internal/Tabs.tsx'
  *
  * Corresponding application code looks something like:
  * <pre>{@code
- * <Tabs id="panel-tabs" >
+ * <Tabs className="panel-tabs" >
  *     <Tab title="First Tab">
  *         <PanelComponent1/>
  *     </Tab>

--- a/src/org/labkey/test/components/ui/ontology/ConceptInfoTabs.java
+++ b/src/org/labkey/test/components/ui/ontology/ConceptInfoTabs.java
@@ -1,17 +1,14 @@
 package org.labkey.test.components.ui.ontology;
 
 import org.labkey.test.Locator;
-import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.Locator.XPathLocator;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
-import org.labkey.test.util.LabKeyExpectedConditions;
+import org.labkey.test.components.react.Tabs;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
-import java.util.Optional;
-
-import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
 
 public class ConceptInfoTabs extends WebDriverComponent<ConceptInfoTabs.ElementCache>
 {
@@ -36,34 +33,14 @@ public class ConceptInfoTabs extends WebDriverComponent<ConceptInfoTabs.ElementC
         return _driver;
     }
 
-    private boolean isOverviewDisplayed()
+    public WebElement showOverview()
     {
-        return "false".equals(elementCache().overviewPane.getAttribute("aria-hidden")) &&
-                "true".equals(elementCache().pathInformationPane.getAttribute("aria-hidden"));
+        return elementCache().conceptTabs.selectTab("Overview");
     }
 
-    public ConceptInfoTabs showOverview()
+    public WebElement showPathInformation()
     {
-        if (!isOverviewDisplayed())
-        {
-            elementCache().overviewTab.click();
-            getWrapper().shortWait().until(LabKeyExpectedConditions.animationIsDone(elementCache().overviewPane));
-            WebDriverWrapper.waitFor(() -> isOverviewDisplayed(),
-                    "the overview pane did not become enabled", 2000);
-        }
-        return this;
-    }
-
-    public ConceptInfoTabs showPathInformation()
-    {
-        if (isOverviewDisplayed())
-        {
-            elementCache().pathInformationTab.click();
-            getWrapper().shortWait().until(LabKeyExpectedConditions.animationIsDone(elementCache().overviewPane));
-            WebDriverWrapper.waitFor(() -> !isOverviewDisplayed(),
-                    "the path information pane did not become enabled", 2000);
-        }
-        return this;
+        return elementCache().conceptTabs.selectTab("Path Information");
     }
 
     /**
@@ -73,28 +50,22 @@ public class ConceptInfoTabs extends WebDriverComponent<ConceptInfoTabs.ElementC
      */
     public String getTitle()
     {
-        showOverview();
-        if (elementCache().noneSelectedElement().isPresent())
-            return elementCache().noneSelectedElement().get().getText();
-        return elementCache().title.getText();
+        return elementCache().getTitle(showOverview());
     }
 
     public String getCode()
     {
-        showOverview();
-        return elementCache().codeBox.getText();
+        return Locator.tagWithClass("span", "code").findElement(showOverview()).getText();
     }
 
     public List<String> getSynonyms()
     {
-        showOverview();
-        return  getWrapper().getTexts(elementCache().synonyms());
+        return getWrapper().getTexts(elementCache().synonyms(showOverview()));
     }
 
     public List<String> getSelectedPath()
     {
-        showPathInformation();
-        return getWrapper().getTexts(elementCache().conceptPathParts());
+        return getWrapper().getTexts(elementCache().conceptPathParts(showPathInformation()));
     }
 
     @Override
@@ -106,65 +77,43 @@ public class ConceptInfoTabs extends WebDriverComponent<ConceptInfoTabs.ElementC
 
     protected class ElementCache extends Component<?>.ElementCache
     {
-        // navigation tabs
-        WebElement tabListContainer = Locator.tagWithClass("ul", "nav-tabs")
-                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
-        WebElement overviewTab = Locator.tag("li").withChild(Locator.id("concept-information-tabs-tab-overview"))
-                .findWhenNeeded(tabListContainer);
-        WebElement pathInformationTab = Locator.tag("li").withChild(Locator.id("concept-information-tabs-tab-pathinfo"))
-                .findWhenNeeded(tabListContainer);
+        final Tabs conceptTabs = new Tabs(getComponentElement(), getDriver());
 
-        // panes
-        WebElement tabContentContainer = Locator.tagWithClass("div", "tab-content")
-                .findWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
+        // overview pane items
 
-        // overview pane
-        WebElement overviewPane = Locator.id("concept-information-tabs-pane-overview")
-                .refindWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
-        WebElement title = Locator.tagWithClass("div", "title").findWhenNeeded(overviewPane);
-        WebElement codeBox = Locator.tagWithClass("span", "code").findWhenNeeded(overviewPane);
-        List<WebElement> synonyms()
+        List<WebElement> synonyms(WebElement overviewPane)
         {
             return Locator.tagWithClass("ul", "synonyms-text").child(Locator.tag("li"))
                     .findElements(overviewPane);
         }
 
-        // if no concept is selected, this element will be shown instead of the 'title' element
-        Optional<WebElement> noneSelectedElement()
+        String getTitle(WebElement overviewPane)
         {
-            return Locator.tagWithClass("div", "none-selected").findOptionalElement(overviewPane);
+            return XPathLocator.union(
+                            Locator.byClass("none-selected"), // if no concept is selected, this element will be shown instead of the 'title' element
+                            Locator.byClass("title"))
+                    .findElement(overviewPane).getText();
         }
 
-        // path info pane
-        WebElement pathInformationPane = Locator.id("concept-information-tabs-pane-pathinfo")
-                .refindWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT);
-        WebElement conceptPathContainer()
+        // path info pane items
+        List<WebElement> conceptPathParts(WebElement pathInformationPane)
         {
-            return Locator.tagWithClass("div", "concept-path-container")
-                    .findWhenNeeded(pathInformationPane);
-        }
-        List<WebElement> conceptPathParts()
-        {
-            return Locator.tagWithClass("div", "concept-path")
-                    .child(Locator.tagWithClass("span", "concept-path-label")).findElements(conceptPathContainer());
+            return Locator.tagWithClass("div", "concept-path-container").append(Locator.tagWithClass("div", "concept-path")
+                    .child(Locator.tagWithClass("span", "concept-path-label"))).findElements(pathInformationPane);
         }
 
-        WebElement alternatePathContainer()
+        List<WebElement> alternateConceptPathParts(WebElement pathInformationPane)
         {
             return Locator.tagWithClass("div", "alternate-paths-container")
-                    .findWhenNeeded(pathInformationPane);
-        }
-        List<WebElement> alternateConceptPathParts()
-        {
-            return Locator.tagWithClass("div", "concept-path")
-                    .child(Locator.tagWithClass("span", "concept-path-label")).findElements(alternatePathContainer());
+                    .append(Locator.tagWithClass("div", "concept-path").child(Locator.tagWithClass("span", "concept-path-label")))
+                    .findElements(pathInformationPane);
         }
     }
 
 
     public static class ConceptInfoTabsFinder extends WebDriverComponentFinder<ConceptInfoTabs, ConceptInfoTabsFinder>
     {
-        private final Locator.XPathLocator _baseLocator = Locator.id("concept-information-tabs");
+        private final XPathLocator _baseLocator = Locator.id("concept-information-tabs");
 
         public ConceptInfoTabsFinder(WebDriver driver)
         {

--- a/src/org/labkey/test/pages/core/login/LoginConfigRow.java
+++ b/src/org/labkey/test/pages/core/login/LoginConfigRow.java
@@ -1,6 +1,7 @@
 package org.labkey.test.pages.core.login;
 
 import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.params.login.AuthenticationProvider;
@@ -44,7 +45,7 @@ public class LoginConfigRow extends WebDriverComponent<LoginConfigRow.ElementCac
         return new LoginConfigurePage(getDriver());
     }
 
-    public <P extends AuthDialogBase> P clickEdit(AuthenticationProvider<P> authenticationProvider)
+    public <P extends AuthDialogBase<?>> P clickEdit(AuthenticationProvider<P> authenticationProvider)
     {
         getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().editButton));
         elementCache().editButton.click();
@@ -75,7 +76,7 @@ public class LoginConfigRow extends WebDriverComponent<LoginConfigRow.ElementCac
     }
 
 
-    protected class ElementCache extends WebDriverComponent.ElementCache
+    protected class ElementCache extends Component<?>.ElementCache
     {
         final WebElement baseFieldsElement = Locator.tagWithClass("div", "domain-row-base-fields").findWhenNeeded(this);
         final WebElement description = Locator.tagWithClass("div", "description").findWhenNeeded(baseFieldsElement);

--- a/src/org/labkey/test/pages/core/login/LoginConfigurePage.java
+++ b/src/org/labkey/test/pages/core/login/LoginConfigurePage.java
@@ -6,6 +6,7 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.react.MultiMenu;
 import org.labkey.test.components.html.BootstrapMenu;
+import org.labkey.test.components.react.Tabs;
 import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.pages.core.admin.ShowAdminPage;
 import org.labkey.test.params.login.AuthenticationProvider;
@@ -35,7 +36,7 @@ public class LoginConfigurePage extends LabKeyPage<LoginConfigurePage.ElementCac
         Locator.waitForAnyElement(shortWait(), Locator.button("Done"), Locator.button("Cancel"));
     }
 
-    public <D extends AuthDialogBase> D addConfiguration(AuthenticationProvider<D> authenticationProvider)
+    public <D extends AuthDialogBase<?>> D addConfiguration(AuthenticationProvider<D> authenticationProvider)
     {
         togglePrimaryConfiguration();
         elementCache().addPrimaryMenu.
@@ -44,18 +45,13 @@ public class LoginConfigurePage extends LabKeyPage<LoginConfigurePage.ElementCac
         return authenticationProvider.getNewDialog(getDriver());
     }
 
-    public <D extends AuthDialogBase> D editConfiguration(AuthenticationProvider<D> authenticationProvider, String description)
-    {
-        return clickEditConfiguration(description, authenticationProvider);
-    }
-
     public boolean canAddConfiguration()
     {
         togglePrimaryConfiguration();
         return elementCache().primaryMenuFinder.findOptional(getDriver()).isPresent();
     }
 
-    public <D extends AuthDialogBase> D addSecondaryConfiguration(AuthenticationProvider<D> authenticationProvider)
+    public <D extends AuthDialogBase<?>> D addSecondaryConfiguration(AuthenticationProvider<D> authenticationProvider)
     {
         toggleSecondaryConfiguration();
         WebDriverWrapper.waitFor(() -> elementCache().addSecondaryMenu.getComponentElement().isDisplayed(), 2000);
@@ -75,16 +71,6 @@ public class LoginConfigurePage extends LabKeyPage<LoginConfigurePage.ElementCac
     {
         toggleSecondaryConfiguration();
         return !elementCache().addSecondaryMenu.isMenuItemDisabled(option);
-    }
-
-    private boolean isPrimarySelected()
-    {
-        return elementCache().panelTab1.getAttribute("aria-selected").equals("true");
-    }
-
-    private boolean isSecondarySelected()
-    {
-        return elementCache().panelTab2.getAttribute("aria-selected").equals("true");
     }
 
     // global settings
@@ -121,58 +107,37 @@ public class LoginConfigurePage extends LabKeyPage<LoginConfigurePage.ElementCac
         return elementCache().autoCreateCheckBox.get();
     }
 
-    public LoginConfigurePage togglePrimaryConfiguration()
+    private WebElement togglePrimaryConfiguration()
     {
-        if (!isPrimarySelected())
-            elementCache().panelTab1.click();
-        waitFor(() -> isPrimarySelected(), 1000);
-        return this;
+        return elementCache().authTabs.selectTab("Primary");
     }
 
     public LoginConfigRow getPrimaryConfigurationRow(String description)
     {
         return new LoginConfigRow.LoginConfigRowFinder(getDriver()).withDescription(description)
-                .waitFor(elementCache().tabPane1);
+                .waitFor(togglePrimaryConfiguration());
     }
 
     public List<LoginConfigRow> getPrimaryConfigurations()
     {
-        togglePrimaryConfiguration();
-        return new LoginConfigRow.LoginConfigRowFinder(getDriver()).findAll(elementCache().tabPane1);
+        return new LoginConfigRow.LoginConfigRowFinder(getDriver())
+                .findAll(togglePrimaryConfiguration());
     }
 
-    public LoginConfigurePage toggleSecondaryConfiguration()
+    private WebElement toggleSecondaryConfiguration()
     {
-        if (!isSecondarySelected())
-            elementCache().panelTab2.click();
-        waitFor(() -> isSecondarySelected(), 1000);
-        return this;
+        return elementCache().authTabs.selectTab("Secondary");
     }
 
     public List<LoginConfigRow> getSecondaryConfigurations()
     {
-        toggleSecondaryConfiguration();
-        return new LoginConfigRow.LoginConfigRowFinder(getDriver()).findAll(elementCache().tabPane2);
+        return new LoginConfigRow.LoginConfigRowFinder(getDriver()).findAll(toggleSecondaryConfiguration());
     }
 
     public LoginConfigRow getSecondaryConfigurationRow(String description)
     {
-        toggleSecondaryConfiguration();
         return new LoginConfigRow.LoginConfigRowFinder(getDriver())
-                .withDescription(description).waitFor(elementCache().tabPane2);
-    }
-
-    public LoginConfigurePage removeConfiguration(String description)      // assumes for now we're doing primary only
-    {
-        new LoginConfigRow.LoginConfigRowFinder(getDriver()).withDescription(description).waitFor()
-                .clickDelete();
-        return this;
-    }
-
-    public <D extends AuthDialogBase> D clickEditConfiguration(String description, AuthenticationProvider<D> authenticationProvider)
-    {
-        LoginConfigRow row = new LoginConfigRow.LoginConfigRowFinder(getDriver()).withDescription(description).waitFor(getDriver());
-        return row.clickEdit(authenticationProvider);
+                .withDescription(description).waitFor(toggleSecondaryConfiguration());
     }
 
     public ShowAdminPage clickSaveAndFinish()
@@ -188,16 +153,12 @@ public class LoginConfigurePage extends LabKeyPage<LoginConfigurePage.ElementCac
         return new ElementCache();
     }
 
-    protected class ElementCache extends LabKeyPage.ElementCache
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
         Checkbox selfSignupCheckBox = new Checkbox(this, "Allow self sign up");
         Checkbox allowUserEmailEditCheckbox = new Checkbox(this, "Allow users to edit their own email addresses");
         Checkbox autoCreateCheckBox = new Checkbox(this,"Auto-create authenticated users");
-        WebElement tabPanel = Locator.id("tab-panel").refindWhenNeeded(getDriver()).withTimeout(WAIT_FOR_JAVASCRIPT);
-        WebElement panelTab1 = Locator.id("tabs3-tab-primary").refindWhenNeeded(getDriver()).withTimeout(WAIT_FOR_JAVASCRIPT);
-        WebElement tabPane1 = Locator.id("tabs3-pane-primary").refindWhenNeeded(getDriver()).withTimeout(WAIT_FOR_JAVASCRIPT);
-        WebElement panelTab2 = Locator.id("tabs3-tab-secondary").refindWhenNeeded(getDriver()).withTimeout(WAIT_FOR_JAVASCRIPT);
-        WebElement tabPane2 = Locator.id("tabs3-pane-secondary").refindWhenNeeded(getDriver()).withTimeout(WAIT_FOR_JAVASCRIPT);
+        final Tabs authTabs = new Tabs.TabsFinder(getDriver()).locatedBy(Locator.byClass("lk-tabs")).findWhenNeeded(this);
         MultiMenu.MultiMenuFinder primaryMenuFinder = new MultiMenu.MultiMenuFinder(getDriver())
                 .withText("Add New Primary Configuration").timeout(WAIT_FOR_JAVASCRIPT);
         BootstrapMenu addPrimaryMenu = primaryMenuFinder.findWhenNeeded(this);


### PR DESCRIPTION
#### Rationale
`LoginConfigurePage` and `ontology.ConceptInfoTabs` rolled their own tab functionality instead of using the existing `Tabs` component.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5284

#### Changes
* Use existing 'Tabs' component for 'LoginConfigurePage'
