### PR TITLE
Add support for comments during edit actions

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -170,6 +170,25 @@ public class EntityBulkUpdateDialog extends ModalDialog
                 "Wrong editable fields", waitMilliseconds);
         return this;
     }
+
+    public boolean isCommentInputPresent()
+    {
+        return elementCache().commentInputLocator.findOptionalElement(getDriver()).isPresent();
+    }
+
+    public EntityBulkUpdateDialog setActionComment(String comment)
+    {
+        elementCache().commentInput.sendKeys(comment);
+        return this;
+    }
+
+    public EntityBulkUpdateDialog clearActionComment()
+    {
+        elementCache().commentInput.clear();
+        return this;
+    }
+
+
     // dismiss the dialog
 
     public void clickEditWithGrid()
@@ -256,6 +275,8 @@ public class EntityBulkUpdateDialog extends ModalDialog
         final Locator textInputLoc = Locator.tagWithAttribute("input", "type", "text");
         final Locator numberInputLoc = Locator.tagWithAttribute("input", "type", "number");
         final Locator checkBoxLoc = Locator.tagWithAttribute("input", "type", "checkbox");
+        final Locator.XPathLocator commentInputLocator = Locator.tagWithId("textarea", "actionComments");
+        final WebElement commentInput = commentInputLocator.refindWhenNeeded(getDriver());
 
         final WebElement updateButton = Locator.tagWithClass("button", "btn-success").findWhenNeeded(this);
     }

--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -433,6 +433,17 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
         return this;
     }
 
+    public void setActionComment(String comment)
+    {
+        elementCache().commentInput.sendKeys(comment);
+    }
+
+    public void clearActionComment()
+    {
+        elementCache().commentInput.clear();
+    }
+
+
     /**
      * Simple finder for this panel.
      */
@@ -495,6 +506,8 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
         final WebElement addButton = Locator
                 .tagContainingText("span", "Add")
                 .findWhenNeeded(this);
+
+        public WebElement commentInput = Locator.tagWithId("textarea", "actionComments").refindWhenNeeded(getDriver());
 
         // This is the remove button that is used to remove a lineage entity.
         WebElement removeButton(int index)

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -423,6 +423,15 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         return errorBanner.getText();
     }
 
+    public void setActionComment(String comment)
+    {
+        elementCache().commentInput.sendKeys(comment);
+    }
+
+    public void clearActionComment()
+    {
+        elementCache().commentInput.clear();
+    }
 
     @Override
     protected ElementCache newElementCache()
@@ -453,6 +462,8 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
                 .findWhenNeeded(this);
         public WebElement cancelButton = Locator.tagWithAttribute("button", "type", "button")
                 .findWhenNeeded(this);
+
+        public WebElement commentInput = Locator.tagWithId("textarea", "actionComments").refindWhenNeeded(getDriver());
 
         public FilteringReactSelect findSelect(String fieldCaption)
         {


### PR DESCRIPTION
#### Rationale
We have previously added the ability for users to provide comments on various types of data changes (deleting, moving, discarding, etc.). With this PR and its relatives we introduce the ability to provide comments for edits of data in various forms, including editing in bulk or in the grid, updating via a file, reimporting and assay run, and editing on a details page.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1434
- https://github.com/LabKey/labkey-ui-premium/pull/349
- https://github.com/LabKey/platform/pull/5286
- https://github.com/LabKey/limsModules/pull/23/files

#### Changes
* Add some locators and methods for interacting with comment (reason) input boxes in various UI components
