### PR TITLE
Fix Expected Time Format

### DIFF
--- a/src/org/labkey/test/tests/GpatAssayTest.java
+++ b/src/org/labkey/test/tests/GpatAssayTest.java
@@ -470,7 +470,7 @@ public class GpatAssayTest extends BaseWebDriverTest
         // Converting a date, time or dateTime field to String will be different between MSSQL and postgres.
         if (WebTestHelper.getDatabaseType() == WebTestHelper.DatabaseType.MicrosoftSQLServer)
         {
-            expectedText = "Jan 1 1970 " + new SimpleDateFormat("hh:mma").format(date);
+            expectedText = "Jan 1 1970 " + new SimpleDateFormat("h:mma").format(date);
         }
         else
         {


### PR DESCRIPTION
#### Rationale
Fix an issue in one of the newer tame and date tests. Converting a time or date column to a string column will format the result differently. A wrong assumption was made about the time format on MSSQL.

[BVT Runs on MSSQL](https://teamcity.labkey.org/buildConfiguration/bt8?branch=fixGpatTest&buildTypeTab=overview&mode=builds). One before noon the other after.
[BVT Runs on Postgres](https://teamcity.labkey.org/buildConfiguration/bt7?branch=fixGpatTest&buildTypeTab=overview&mode=builds). One before noon the other after.

#### Related Pull Requests
* None

#### Changes
* Change format from hh:mma to h:mma
