### PR TITLE
use java command wrappers and params to create plates

### DIFF
--- a/src/org/labkey/remoteapi/plate/CreatePlateSetCommand.java
+++ b/src/org/labkey/remoteapi/plate/CreatePlateSetCommand.java
@@ -1,0 +1,27 @@
+package org.labkey.remoteapi.plate;
+
+import org.json.JSONObject;
+import org.labkey.remoteapi.PostCommand;
+
+public class CreatePlateSetCommand extends PostCommand<PlateSetResponse>
+{
+    private final PlateSetParams _plateSetParams;
+    public CreatePlateSetCommand(PlateSetParams params)
+    {
+        super("plate", "createPlateSet");
+        setRequiredVersion(0);
+        _plateSetParams = params;
+    }
+
+    @Override
+    protected PlateSetResponse createResponse(String text, int status, String contentType, JSONObject json)
+    {
+        return new PlateSetResponse(text, status, contentType, json);
+    }
+
+    @Override
+    public JSONObject getJsonObject()
+    {
+        return _plateSetParams.toJSON();
+    }
+}

--- a/src/org/labkey/remoteapi/plate/PlateSetParams.java
+++ b/src/org/labkey/remoteapi/plate/PlateSetParams.java
@@ -7,7 +7,7 @@ public class PlateSetParams
 {
     private String _name = null;
     private String _description = null;
-    private String _type = null;
+    private PlateSetType _type = null;
     private Integer _id = null;
     private Integer _parentPlateSetId = null;
 
@@ -19,7 +19,7 @@ public class PlateSetParams
     {
         _name = json.getString("name");
         _description = json.optString("description", null);
-        _type = json.optString("type", null);
+        _type = PlateSetType.fromName(json.optString("type", null));
         _id = json.getInt("rowId");
         _parentPlateSetId = json.optIntegerObject("parentPlateSetId", null);
     }
@@ -29,7 +29,8 @@ public class PlateSetParams
         JSONObject json = new JSONObject();
         json.put("name", _name);
         json.put("description", _description);
-        json.put("type", _type);
+        if (_type != null)
+            json.put("type", _type.getType());
         json.put("rowId", _id);
         json.put("parentPlateSetId", _parentPlateSetId);
         return json;
@@ -57,13 +58,13 @@ public class PlateSetParams
         return _description;
     }
 
-    public PlateSetParams setType(String type)
+    public PlateSetParams setType(PlateSetType type)
     {
         _type = type;
         return this;
     }
 
-    public String getType()
+    public PlateSetType getType()
     {
         return _type;
     }
@@ -84,4 +85,32 @@ public class PlateSetParams
         return _parentPlateSetId;
     }
 
+
+    public enum PlateSetType
+    {
+        Primary("primary"),
+        Assay("assay");
+
+        PlateSetType(String type)
+                {
+                    this._type = type;
+                }
+        private final String _type;
+        public String getType()
+        {
+            return _type;
+        }
+        public static PlateSetType fromName(String type)
+        {
+            if (type != null)
+            {
+                for (PlateSetType plateSetType : PlateSetType.values())
+                {
+                    if (type.equalsIgnoreCase(plateSetType.getType()))
+                        return plateSetType;
+                }
+            }
+            return null;
+        }
+    }
 }

--- a/src/org/labkey/remoteapi/plate/PlateSetParams.java
+++ b/src/org/labkey/remoteapi/plate/PlateSetParams.java
@@ -1,0 +1,92 @@
+package org.labkey.remoteapi.plate;
+
+
+import org.json.JSONObject;
+
+public class PlateSetParams
+{
+    private String _name = null;
+    private String _description = null;
+    private String _type = null;
+    private Integer _id = null;
+    private Integer _parentPlateSetId = null;
+
+    public PlateSetParams()
+    {
+    }
+
+    public PlateSetParams(JSONObject json)
+    {
+        _name = json.getString("name");
+        _description = json.optString("description", null);
+        _type = json.optString("type", null);
+        _id = json.getInt("rowId");
+        _parentPlateSetId = json.optIntegerObject("parentPlateSetId", null);
+    }
+
+    public JSONObject toJSON()
+    {
+        JSONObject json = new JSONObject();
+        if (_name != null)
+            json.put("name", _name);
+        if (_description != null)
+            json.put("description", _description);
+        if (_type != null)
+            json.put("type", _type);
+        if (_id != null)
+            json.put("rowId", _id);
+        if (_parentPlateSetId != null)
+            json.put("parentPlateSetId", _parentPlateSetId);
+        return json;
+    }
+
+    public PlateSetParams setName(String name)
+    {
+        _name = name;
+        return this;
+    }
+
+    public String getName()
+    {
+        return _name;
+    }
+
+    public PlateSetParams setDescription(String description)
+    {
+        _description = description;
+        return this;
+    }
+
+    public String getDescription()
+    {
+        return _description;
+    }
+
+    public PlateSetParams setType(String type)
+    {
+        _type = type;
+        return this;
+    }
+
+    public String getType()
+    {
+        return _type;
+    }
+
+    public Integer getId()
+    {
+        return _id;
+    }
+
+    public PlateSetParams setParentPlateSetId(Integer parentPlateSetId)
+    {
+        _parentPlateSetId = parentPlateSetId;
+        return this;
+    }
+
+    public Integer getParentPlateSetId()
+    {
+        return _parentPlateSetId;
+    }
+
+}

--- a/src/org/labkey/remoteapi/plate/PlateSetParams.java
+++ b/src/org/labkey/remoteapi/plate/PlateSetParams.java
@@ -27,16 +27,11 @@ public class PlateSetParams
     public JSONObject toJSON()
     {
         JSONObject json = new JSONObject();
-        if (_name != null)
-            json.put("name", _name);
-        if (_description != null)
-            json.put("description", _description);
-        if (_type != null)
-            json.put("type", _type);
-        if (_id != null)
-            json.put("rowId", _id);
-        if (_parentPlateSetId != null)
-            json.put("parentPlateSetId", _parentPlateSetId);
+        json.put("name", _name);
+        json.put("description", _description);
+        json.put("type", _type);
+        json.put("rowId", _id);
+        json.put("parentPlateSetId", _parentPlateSetId);
         return json;
     }
 

--- a/src/org/labkey/remoteapi/plate/PlateSetResponse.java
+++ b/src/org/labkey/remoteapi/plate/PlateSetResponse.java
@@ -1,0 +1,20 @@
+package org.labkey.remoteapi.plate;
+
+import org.json.JSONObject;
+import org.labkey.remoteapi.CommandResponse;
+
+public class PlateSetResponse extends CommandResponse
+{
+    private final PlateSetParams _plateSetParams;
+
+    public PlateSetResponse(String text, int statusCode, String contentType, JSONObject json)
+    {
+        super(text, statusCode, contentType, json);
+        _plateSetParams = new PlateSetParams(json.getJSONObject("data"));
+    }
+
+    public PlateSetParams getPlateSetParams()
+    {
+        return _plateSetParams;
+    }
+}


### PR DESCRIPTION
#### Rationale
This adds command/response wrappers to create plate sets used in biologics for now, (I'm not sure if this will be limited to lims modules or not, so creating here)

The reason to create via API at this point is that the UI doesn't yet support creating child or parent-type plate sets, this allows us to get automated regression coverage in place until it does

#### Related Pull Requests
https://github.com/LabKey/limsModules/pull/65

#### Changes
create command/response/params classes for use in testing plate automation
