### PR TITLE
Regression tests for Java API special character handling

### DIFF
--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -36,7 +36,7 @@ public class FieldDefinition extends PropertyDescriptor
     private static final String ANGSTROM = "\u00C5";
     private static final String A_UMLAUT = "\u00E4";
     // Non-alphanumeric characters supported for field names
-    public static final String TRICKY_CHARACTERS = "><&$,/%\\'}{][ \"" + SNOWMAN + ANGSTROM + A_UMLAUT;
+    public static final String TRICKY_CHARACTERS = "><&$,/%\\'}{][ \";:" + SNOWMAN + ANGSTROM + A_UMLAUT;
 
     // for UI helpers
     private ColumnType _type;

--- a/src/org/labkey/test/tests/JavaClientApiTest.java
+++ b/src/org/labkey/test/tests/JavaClientApiTest.java
@@ -263,7 +263,7 @@ public class JavaClientApiTest extends BaseWebDriverTest
         UpdateRowsCommand updateCmd = new UpdateRowsCommand("lists", LIST_NAME);
         rowMap = new HashMap<>();
         rowMap.put("Key", key);
-        rowMap.put("firstname", "UPDATED first name"); //testing for case-insensitivity
+        rowMap.put("firstname", "UPDATED first name" + FieldDefinition.TRICKY_CHARACTERS); //testing for case-insensitivity
         rowMap.put("gooamount", 5.5);
         updateCmd.addRow(rowMap);
         saveResp = updateCmd.execute(cn, PROJECT_NAME);
@@ -273,12 +273,12 @@ public class JavaClientApiTest extends BaseWebDriverTest
         selectCmd.addFilter("Key", key, Filter.Operator.EQUAL);
         selResp = selectCmd.execute(cn, PROJECT_NAME);
         responseRow = selResp.getRows().get(0);
-        assertEquals("UPDATED first name", responseRow.get("FirstName"));
+        assertEquals("UPDATED first name" + FieldDefinition.TRICKY_CHARACTERS, responseRow.get("FirstName"));
         assertEquals(5.5, (Double)responseRow.get("GooAmount"), 0.001);
 
         //verify that it's updated in the browser as well
         refresh();
-        assertTextPresent("UPDATED first name");
+        assertTextPresent("UPDATED first name" + FieldDefinition.TRICKY_CHARACTERS);
 
         //delete the record
         log("Deleting the record...");


### PR DESCRIPTION
#### Rationale
[Issue 49320: Test for Java API SaveRowsResponse handling special characters](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49320)
Found two additional issues while testing:
- [Issue 49960: Java API Sort/Colum/Filter do not handle special characters](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49960)
- [Issue 49959: UpdateRowsAction can't handle fields with quotes in their name](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=49959)


#### Related Pull Requests
* N/A

#### Changes
* Add regression test for special characters in SaveRowsResponse
* Add reverse regression tests for special characters in sort/filter/column list
* Add reverse regression test for quotes in field names
