### PR TITLE
Use correct directory for embedded file roots

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -916,7 +916,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             {
                 if (isTestRunningOnTeamCity())
                 {
-                    getArtifactCollector().addArtifactLocation(new File(TestFileUtils.getLabKeyRoot(), "build/deploy/files"));
+                    getArtifactCollector().addArtifactLocation(TestFileUtils.getBaseFileRoot());
                     getArtifactCollector().dumpPipelineFiles();
                 }
             }

--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -187,7 +187,7 @@ public abstract class TestFileUtils
         return _buildDir;
     }
 
-    private static File getBaseFileRoot()
+    public static File getBaseFileRoot()
     {
         // Files are a sibling of the modules directory
         return new File(getModulesDir().getParentFile(), "files");

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -1518,9 +1518,9 @@ public class SimpleModuleTest extends BaseWebDriverTest
             assertTrue("R api labkey.getModuleProperty is not returning module properties as expected", apiModulePropResults.contains(expected));
 
         log("Set site and folder level module properties using Rlabkey api");
-        String fileRootPath1 = getDefaultFileRoot(getProjectName() + "/" + FOLDER_NAME).getAbsolutePath();
-        String fileRootPath2 = getDefaultFileRoot(getProjectName() + "/" + FOLDER_NAME_2).getAbsolutePath();
-        String fileRootPath3 = getDefaultFileRoot(getProjectName() + "/" + FOLDER_NAME_3).getAbsolutePath();
+        String fileRootPath1 = getContainerRoot(getProjectName() + "/" + FOLDER_NAME);
+        String fileRootPath2 = getContainerRoot(getProjectName() + "/" + FOLDER_NAME_2);
+        String fileRootPath3 = getContainerRoot(getProjectName() + "/" + FOLDER_NAME_3);
         String fileRootFolder1 = getRStr(fileRootPath1);
         String fileRootFolder2 = getRStr(fileRootPath2);
         String fileRootFolder3 = getRStr(fileRootPath3);
@@ -1564,6 +1564,12 @@ public class SimpleModuleTest extends BaseWebDriverTest
 
         goToProjectHome();
         assertEquals("Module context not set properly", "DefaultValue", executeScript("return LABKEY.getModuleContext('simpletest')." + prop2));
+    }
+
+    private String getContainerRoot(String containerPath)
+    {
+        File containerRoot = getDefaultFileRoot(containerPath).getParentFile();
+        return containerRoot.getPath();
     }
 
     private String getRStr(String rawString)

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -80,7 +80,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.labkey.test.TestFileUtils.getLabKeyRoot;
+import static org.labkey.test.TestFileUtils.getDefaultFileRoot;
 
 /**
 * Tests the simple module and file-based resources introduced in version 9.1
@@ -1455,6 +1455,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
               \t.libPaths(c(paths[1], paths[2]))
              \s
               .libPaths()
+              print(propValue)
             }
                 \s
             folderPath = "SimpleModuleTest Project/subfolder"
@@ -1517,9 +1518,9 @@ public class SimpleModuleTest extends BaseWebDriverTest
             assertTrue("R api labkey.getModuleProperty is not returning module properties as expected", apiModulePropResults.contains(expected));
 
         log("Set site and folder level module properties using Rlabkey api");
-        String fileRootPath1 = getContainerRoot(getProjectName() + "/" + FOLDER_NAME);
-        String fileRootPath2 = getContainerRoot(getProjectName() + "/" + FOLDER_NAME_2);
-        String fileRootPath3 = getContainerRoot(getProjectName() + "/" + FOLDER_NAME_3);
+        String fileRootPath1 = getDefaultFileRoot(getProjectName() + "/" + FOLDER_NAME).getAbsolutePath();
+        String fileRootPath2 = getDefaultFileRoot(getProjectName() + "/" + FOLDER_NAME_2).getAbsolutePath();
+        String fileRootPath3 = getDefaultFileRoot(getProjectName() + "/" + FOLDER_NAME_3).getAbsolutePath();
         String fileRootFolder1 = getRStr(fileRootPath1);
         String fileRootFolder2 = getRStr(fileRootPath2);
         String fileRootFolder3 = getRStr(fileRootPath3);
@@ -1563,12 +1564,6 @@ public class SimpleModuleTest extends BaseWebDriverTest
 
         goToProjectHome();
         assertEquals("Module context not set properly", "DefaultValue", executeScript("return LABKEY.getModuleContext('simpletest')." + prop2));
-    }
-
-    private String getContainerRoot(String containerPath)
-    {
-        File containerRoot = new File(getLabKeyRoot(), "build/deploy/files/" + containerPath);
-        return containerRoot.getPath();
     }
 
     private String getRStr(String rawString)

--- a/src/org/labkey/test/util/ArtifactCollector.java
+++ b/src/org/labkey/test/util/ArtifactCollector.java
@@ -150,7 +150,7 @@ public class ArtifactCollector
         if (!isLocalServer())
             return;
 
-        File threadDumpRequest = new File(TestFileUtils.getLabKeyRoot() + "/build/deploy", "threadDumpRequest");
+        File threadDumpRequest = new File(TestFileUtils.getModulesDir().getParentFile(), "threadDumpRequest");
         threadDumpRequest.setLastModified(System.currentTimeMillis()); // Touch file to trigger automatic thread dump.
         TestLogger.log("Threads dumped to standard labkey log file");
     }


### PR DESCRIPTION
#### Rationale
Some test/helpers are looking in the wrong place for file roots. The previous fix didn't cover everything.

#### Related Pull Requests
* #1789

#### Changes
* Use correct directory for file roots on embedded Tomcat
