### PR TITLE
test components for charting in apps

### DIFF
--- a/src/org/labkey/test/components/react/QueryChartDialog.java
+++ b/src/org/labkey/test/components/react/QueryChartDialog.java
@@ -1,0 +1,323 @@
+package org.labkey.test.components.react;
+
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.components.bootstrap.ModalDialog;
+import org.labkey.test.components.html.Checkbox;
+import org.labkey.test.components.html.Input;
+import org.labkey.test.components.ui.grids.QueryGrid;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.labkey.test.components.html.Input.Input;
+
+public class QueryChartDialog extends ModalDialog
+{
+    private final QueryGrid _queryGrid;
+
+    /**
+     * Contains
+     * @param title "Create Chart" or "Edit Chart"
+     * @param driver the webDriver
+     * @param grid the associated QueryGrid
+     */
+    public QueryChartDialog(String title, WebDriver driver, QueryGrid grid)
+    {
+        super(new ModalDialogFinder(driver).withTitle(title));
+        _queryGrid = grid;
+    }
+
+    public QueryChartDialog setName(String value)
+    {
+        elementCache().nameInput.set(value);
+        return this;
+    }
+
+    public String getName()
+    {
+        return elementCache().nameInput.get();
+    }
+
+    public QueryChartDialog setShared(boolean checked)
+    {
+        elementCache().sharedCheckbox.set(checked);
+        return this;
+    }
+
+    public boolean getShared()
+    {
+        return elementCache().sharedCheckbox.get();
+    }
+
+    // field selects
+
+    /*
+        X axis is an option for bar, box, line, scatter charts
+     */
+    public QueryChartDialog selectXAxis(String field)
+    {
+        elementCache().reactSelectByLabel("X Axis *").select(field);
+        return this;
+    }
+
+    public String getXAxisSelection()
+    {
+        return elementCache().reactSelectByLabel("X Axis").getValue();
+    }
+
+    /*
+        Y Axis is an option for bar, box, line, scatter charts
+     */
+    public QueryChartDialog selectYAxis(String field)
+    {
+        elementCache().reactSelectByLabel("Y Axis").select(field);
+        return this;
+    }
+
+    public String getYAxisSelection()
+    {
+        return elementCache().reactSelectByLabel("Y Axis").getValue();
+    }
+
+    /*
+        groupBy is an option for bar charts only
+     */
+    public QueryChartDialog selectGroupBy(String field)
+    {
+        elementCache().reactSelectByLabel("Group By").select(field);
+        return this;
+    }
+
+    /*
+     * color is an option for Box, Scatter charts
+     */
+    public QueryChartDialog selectColor(String field)
+    {
+        elementCache().reactSelectByLabel("Color").select(field);
+        return this;
+    }
+
+    /*
+        shape is an option for Scatter, Box charts
+     */
+    public QueryChartDialog selectShape(String field)
+    {
+        elementCache().reactSelectByLabel("Shape").select(field);
+        return this;
+    }
+
+    /*
+        series is an option for line
+     */
+    public QueryChartDialog selectSeries(String field)
+    {
+        elementCache().reactSelectByLabel("Series").select(field);
+        return this;
+    }
+
+    /*
+        categories is an option for pie charts
+     */
+    public QueryChartDialog selectCategories(String field)
+    {
+        elementCache().reactSelectByLabel("Categories").select(field);
+        return this;
+    }
+
+    // chart type selection
+    /*
+        Note: Chart Type is not settable when opened for edit/ it is only settable
+        when creating the chart
+     */
+    public QueryChartDialog setChartType(CHART_TYPE chartType)
+    {
+        elementCache().selectChartType(chartType);
+        return this;
+    }
+
+    public CHART_TYPE getSelectedChartType()
+    {
+        return elementCache().getSelectedChartType();
+    }
+
+    public WebElement waitForPreview()
+    {
+        WebDriverWrapper.waitFor(()-> elementCache().isPreviewRendered(),
+                "the preview was not rendered in time", 2000);
+        return elementCache().svg();
+    }
+
+    public void clickCancel()
+    {
+        dismiss("Cancel");
+    }
+
+    public boolean isCreateChartButtonEnabled()
+    {
+        Locator createChartBtnLoc = Locator.button("Create Chart");
+        return createChartBtnLoc.existsIn(this ) &&
+                createChartBtnLoc.findElement(this).isEnabled();
+    }
+
+    public boolean isSaveChartButtonEnabled()
+    {
+        Locator createChartBtnLoc = Locator.button("Save Chart");
+        return createChartBtnLoc.existsIn(this ) &&
+                createChartBtnLoc.findElement(this).isEnabled();
+    }
+
+    /*
+        appears when dialog is in 'edit' mode
+     */
+    public QueryChartPanel clickCreateChart()
+    {
+        WebDriverWrapper.waitFor(this::isCreateChartButtonEnabled,
+                "the create chart button did not become enabled", 2000);
+        dismiss("Create Chart");
+        return _queryGrid.getChartPanel();
+    }
+
+    /*
+        appears when dialog is in 'edit' mode
+     */
+    public QueryChartPanel clickSaveChart()
+    {
+        WebDriverWrapper.waitFor(this::isSaveChartButtonEnabled,
+                "the Save chart button did not become enabled", 2000);
+        dismiss("Save Chart");
+        return _queryGrid.getChartPanel();
+    }
+
+    /*
+        appears when dialog is in 'edit' mode
+     */
+    public void clickDeleteChart(boolean confirmDelete)
+    {
+        // clicking 'delete chart' shows a prompt + cancel/delete buttons
+        var dismissBtn = Locators.dismissButton("Delete Chart").waitForElement(getComponentElement(), 1500);
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(dismissBtn));
+        dismissBtn.click();
+        getWrapper().shortWait().until(ExpectedConditions.stalenessOf(dismissBtn));
+
+        // warn div contains cancel and delete buttons
+        var warnDiv = Locator.tagWithClass("div", "form-buttons__right")
+                .containing("Are you sure you want to permanently delete this chart?")
+                .waitForElement(this, 1000);
+        if (confirmDelete)
+        {
+            Locators.dismissButton("Delete").waitForElement(warnDiv, 500).click();
+            waitForClose();
+        }
+        else
+        {
+            var cancelBtn = Locators.dismissButton("Cancel").waitForElement(warnDiv, 500);
+            cancelBtn.click();
+            getWrapper().shortWait().until(ExpectedConditions.stalenessOf(cancelBtn));
+        }
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+    protected class ElementCache extends ModalDialog.ElementCache
+    {
+        final Input nameInput = Input(Locator.input("name"), getDriver()).findWhenNeeded(this);
+        final Checkbox sharedCheckbox = Checkbox.Checkbox(Locator.input("shared")).findWhenNeeded(this);
+
+        Locator.XPathLocator chartBuilderType = Locator.tagWithClass("div", "chart-builder-type");
+        public CHART_TYPE getSelectedChartType()
+        {
+            var selectedEl = chartBuilderType.withAttributeContaining("class", "selected")
+                    .waitForElement(this, 1500);
+            String dataName = selectedEl.getAttribute("data-name");
+            return CHART_TYPE.fromChartType(dataName);
+        }
+
+        // note: selecting a chart type will cause most select fields to go stale
+        public void selectChartType(CHART_TYPE chartType)
+        {
+            if (getSelectedChartType().equals(chartType))
+                return;
+
+            var el = chartBuilderType.withAttribute("data-name", chartType.getChartType())
+                    .waitForElement(this, 1500);
+            getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(el));
+            el.click();
+            WebDriverWrapper.waitFor(()-> getSelectedChartType().equals(chartType),
+                    "The requested chart type did not become selected", 2000);
+        }
+
+        public ReactSelect reactSelectByLabel(String label)
+        {
+            WebElement container = Locator.tag("div").withChild(Locator.tagContainingText("label", label))
+                    .waitForElement(this, 1500);
+            return ReactSelect.finder(getDriver()).find(container);
+        }
+
+        private Locator.XPathLocator previewContainerLoc = Locator.tag("div").withChild(Locator.tagWithText("label", "Preview"));
+        public WebElement previewContainer()
+        {
+            return previewContainerLoc.waitForElement(this, 1500);
+        }
+        public String grayTextPreviewInstruction()
+        {
+            return Locator.tagWithClass("div", "gray-text").waitForElement(previewContainer(), 1500).getText();
+        }
+
+        private Locator previewBodyLoc = Locator.tagWithClass("div", "chart-builder-preview-body");
+        public boolean isPreviewRendered()
+        {
+            return previewBodyLoc.existsIn(previewContainer());
+        }
+
+        public WebElement svg()
+        {
+            return Locator.tagWithClass("div", "svg-chart__chart").waitForElement(previewContainer(), 1500);
+        }
+
+    }
+
+    public enum CHART_TYPE{
+        Bar("bar_chart"),
+        Box("box_plot"),
+        Line("line_plot"),
+        Pie("pie_chart"),
+        Scatter("scatter_plot");
+        CHART_TYPE(String chartType)
+        {
+            _chartType = chartType;
+        }
+
+        static {
+            Map<String,CHART_TYPE> map = new HashMap<String,CHART_TYPE>();
+            for(CHART_TYPE instance : CHART_TYPE.values())
+            {
+                map.put(instance.getChartType(), instance);
+            }
+            CHART_TYPE_MAP = map;
+        }
+        private String _chartType;
+        private static final Map<String,CHART_TYPE> CHART_TYPE_MAP;
+        public String getChartType()
+        {
+            return _chartType;
+        }
+        public static CHART_TYPE fromChartType(String chartType)
+        {
+            return CHART_TYPE_MAP.get(chartType);
+        }
+    }
+}

--- a/src/org/labkey/test/components/react/QueryChartDialog.java
+++ b/src/org/labkey/test/components/react/QueryChartDialog.java
@@ -60,7 +60,7 @@ public class QueryChartDialog extends ModalDialog
      */
     public QueryChartDialog selectXAxis(String field)
     {
-        elementCache().reactSelectByLabel("X Axis *").select(field);
+        elementCache().reactSelectByLabel("X Axis").select(field);
         return this;
     }
 
@@ -146,8 +146,8 @@ public class QueryChartDialog extends ModalDialog
 
     public WebElement waitForPreview()
     {
-        WebDriverWrapper.waitFor(()-> elementCache().isPreviewRendered(),
-                "the preview was not rendered in time", 2000);
+        WebDriverWrapper.waitFor(()-> elementCache().isPreviewPresent(),
+                "the preview was not present in time", 2000);
         return elementCache().svg();
     }
 
@@ -278,14 +278,15 @@ public class QueryChartDialog extends ModalDialog
         }
 
         private Locator previewBodyLoc = Locator.tagWithClass("div", "chart-builder-preview-body");
-        public boolean isPreviewRendered()
+        private Locator svgLoc = Locator.tagWithClass("div", "svg-chart__chart");
+        public boolean isPreviewPresent()
         {
-            return previewBodyLoc.existsIn(previewContainer());
+            return previewBodyLoc.existsIn(previewContainer()) && svgLoc.existsIn(previewContainer());
         }
 
         public WebElement svg()
         {
-            return Locator.tagWithClass("div", "svg-chart__chart").waitForElement(previewContainer(), 1500);
+            return svgLoc.waitForElement(previewContainer(), 1500);
         }
 
     }

--- a/src/org/labkey/test/components/react/QueryChartDialog.java
+++ b/src/org/labkey/test/components/react/QueryChartDialog.java
@@ -151,6 +151,12 @@ public class QueryChartDialog extends ModalDialog
         return elementCache().svg();
     }
 
+    public WebElement svg()
+    {
+        waitForPreview();
+        return elementCache().svg();
+    }
+
     public void clickCancel()
     {
         dismiss("Cancel");

--- a/src/org/labkey/test/components/react/QueryChartPanel.java
+++ b/src/org/labkey/test/components/react/QueryChartPanel.java
@@ -1,0 +1,119 @@
+package org.labkey.test.components.react;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.ui.grids.QueryGrid;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+
+/*
+    Wraps the chart-panel of a query grid when it is showing a chart
+ */
+public class QueryChartPanel extends WebDriverComponent<QueryChartPanel.ElementCache>
+{
+    private final QueryGrid _queryGrid;
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected QueryChartPanel(WebElement element, WebDriver driver, QueryGrid queryGrid)
+    {
+        _el = element;
+        _driver = driver;
+        _queryGrid = queryGrid;
+    }
+
+    public QueryChartDialog clickEdit()
+    {
+        var editButton = elementCache().editButton;
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(editButton));
+        editButton.click();
+        return new QueryChartDialog("Edit Chart", getDriver(), _queryGrid);
+    }
+
+    public String getTitle()
+    {
+        return elementCache().getTitle();
+    }
+
+    public WebElement svgChart()
+    {
+        return Locator.byClass("svg-chart").waitForElement(this, WAIT_FOR_JAVASCRIPT);
+    }
+
+    public QueryGrid clickClose()
+    {
+        var btn = elementCache().closeButton;
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(btn));
+        btn.click();
+        getWrapper().shortWait().until(ExpectedConditions.stalenessOf(btn));
+        return _queryGrid;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        public WebElement headingEl = Locator.tagWithClass("div", "chart-panel__heading")
+                .findWhenNeeded(this).withTimeout(2000);
+        public WebElement editButton = Locator.tagWithAttribute("button", "title", "Edit chart")
+                .findWhenNeeded(headingEl);
+        public WebElement closeButton = Locator.tagWithAttribute("button", "title", "Hide chart")
+                .findWhenNeeded(headingEl);
+        public String getTitle()
+        {
+            return Locator.tagWithClass("div", "chart-panel__heading-title").findElement(headingEl).getText();
+        }
+
+    }
+
+
+    public static class QueryChartPanelFinder extends WebDriverComponentFinder<QueryChartPanel, QueryChartPanelFinder>
+    {
+        private final QueryGrid _queryGrid;
+        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "chart-panel");
+
+        public QueryChartPanelFinder(WebDriver driver, QueryGrid queryGrid)
+        {
+            super(driver);
+            _queryGrid = queryGrid;
+        }
+
+        @Override
+        protected QueryChartPanel construct(WebElement el, WebDriver driver)
+        {
+            return new QueryChartPanel(el, driver, _queryGrid);
+        }
+
+        @Override
+        protected Locator locator()
+        {
+            return _baseLocator;
+        }
+    }
+}

--- a/src/org/labkey/test/components/react/QueryChartPanel.java
+++ b/src/org/labkey/test/components/react/QueryChartPanel.java
@@ -36,10 +36,10 @@ public class QueryChartPanel extends WebDriverComponent<QueryChartPanel.ElementC
 
     public String getTitle()
     {
-        return elementCache().getTitle();
+        return elementCache().titleElement.getText();
     }
 
-    public WebElement svgChart()
+    public WebElement getSvgChart()
     {
         return Locator.byClass("svg-chart").waitForElement(this, WAIT_FOR_JAVASCRIPT);
     }
@@ -79,17 +79,14 @@ public class QueryChartPanel extends WebDriverComponent<QueryChartPanel.ElementC
 
     protected class ElementCache extends Component<?>.ElementCache
     {
-        public WebElement headingEl = Locator.tagWithClass("div", "chart-panel__heading")
+        public final WebElement headingEl = Locator.tagWithClass("div", "chart-panel__heading")
                 .findWhenNeeded(this).withTimeout(2000);
-        public WebElement editButton = Locator.tagWithAttribute("button", "title", "Edit chart")
+        public final WebElement editButton = Locator.tagWithAttribute("button", "title", "Edit chart")
                 .findWhenNeeded(headingEl);
-        public WebElement closeButton = Locator.tagWithAttribute("button", "title", "Hide chart")
+        public final WebElement closeButton = Locator.tagWithAttribute("button", "title", "Hide chart")
                 .findWhenNeeded(headingEl);
-        public String getTitle()
-        {
-            return Locator.tagWithClass("div", "chart-panel__heading-title").findElement(headingEl).getText();
-        }
-
+        public final WebElement titleElement= Locator.tagWithClass("div", "chart-panel__heading-title")
+                .findWhenNeeded(headingEl);
     }
 
 

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -9,6 +9,8 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.bootstrap.Panel;
 import org.labkey.test.components.html.BootstrapMenu;
+import org.labkey.test.components.react.QueryChartPanel;
+import org.labkey.test.components.react.QueryChartDialog;
 import org.labkey.test.components.react.MultiMenu;
 import org.labkey.test.components.react.ReactCheckBox;
 import org.labkey.test.components.ui.FilterStatusValue;
@@ -702,10 +704,24 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         return this;
     }
 
-    public WebElement showChart(String chartName)
+    public QueryChartPanel showChart(String chartName)
     {
         elementCache().chartsMenu.clickSubMenu(false, chartName);
-        return elementCache().svgChart();
+        return getChartPanel();
+    }
+
+    public QueryChartDialog createChart()
+    {
+        elementCache().chartsMenu.clickSubMenu(false, "Create Chart");
+        return new QueryChartDialog("Create Chart", getDriver(), this);
+    }
+
+    /*
+        gets a chart panel that is already being shown
+     */
+    public QueryChartPanel getChartPanel()
+    {
+        return new QueryChartPanel.QueryChartPanelFinder(getDriver(), this).waitFor(this);
     }
 
     public WebElement showRReport(String reportName)
@@ -716,7 +732,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
 
     public void closeChart()
     {
-        elementCache().closeButton.click();
+        getChartPanel().clickClose();
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We have added the ability (in biologics, with an experimental feature) to compose, edit, and delete charts on queryGrids. This change adds and updates classes necessary to interact with new UI in the apps.

The new Dialog `QueryChartDialog` supports create and edit of charts, and could (if we think that's a good idea) be refactored into 2 dialog classes that would only have methods related to buttons of the dialog in that mode.  Here it is in create mode: 
![image](https://github.com/LabKey/testAutomation/assets/16809856/b2f3d529-ea6f-4a9f-91e2-eba58a25ff16)
and in edit mode: 
![image](https://github.com/LabKey/testAutomation/assets/16809856/2275c15e-089d-4451-a580-ea55d0e3de39)

Because we've introduced the ability to add, edit, save, and delete charts in the apps, I've taken the liberty of creating a new component, QueryChartPanel (which contains the chart in the QueryGrid when charts or reports are shown) to surface the ability to find the chart's svg, to click to edit the chart, and to close the chart view- it's highlit in red, here:
![image](https://github.com/LabKey/testAutomation/assets/16809856/05aa7e9a-55c8-4f65-8d6f-5463bb0728e2)


#### Related Pull Requests
https://github.com/LabKey/limsModules/pull/105 <- contains test coverage using new/changed components in this PR

#### Changes

- [x] new create/edit chart dialog, `QueryChartDialog`
- [ ] new chart/report panel in `QueryGrid`, `QueryChartPanel `(which provides the means to get the edit dialog, to dismiss the chart when it is shown, to find the chart/report)
