### PR TITLE
Add Commons Text and switch to commons.text.StringEscapeUtils

### DIFF
--- a/src/org/labkey/serverapi/reader/TabLoader.java
+++ b/src/org/labkey/serverapi/reader/TabLoader.java
@@ -17,8 +17,8 @@ package org.labkey.serverapi.reader;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.CharSequenceReader;
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.test.util.TestLogger;


### PR DESCRIPTION
#### Rationale
`commons.lang3.StringEscapeUtils` is deprecated in favor of `commons.text.StringEscapeUtils`