### PR TITLE
fix intermittently failing test

### DIFF
--- a/src/org/labkey/test/pages/assay/ChooseAssayTypePage.java
+++ b/src/org/labkey/test/pages/assay/ChooseAssayTypePage.java
@@ -7,6 +7,7 @@ import org.labkey.test.components.react.Tabs;
 import org.labkey.test.components.ui.files.FileUploadPanel;
 import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.pages.ReactAssayDesignerPage;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -34,7 +35,16 @@ public class ChooseAssayTypePage extends LabKeyPage<ChooseAssayTypePage.ElementC
     @Override
     protected void waitForPage()
     {
-        waitFor(() -> elementCache().assayTypeTabs.getTabText().size() > 1, WAIT_FOR_PAGE);
+        waitFor(() -> {
+                    try
+                    {
+                        return elementCache().assayTypeTabs.getTabText().size() > 1;
+                    }
+                    catch (NoSuchElementException retry)
+                    {
+                        return false;
+                    }
+                }, WAIT_FOR_PAGE);
     }
 
 


### PR DESCRIPTION
#### Rationale
[BiologicsAssayTest.testSpecialtyAssayRename](https://teamcity.labkey.org/viewLog.html?buildId=2985240&buildTypeId=LabKey_Trunk_LabkeyPremiumTrunk_GitModules_BiologicsPostgres95&fromSakuraUI=true#testNameId-1258201913836784594) fails intermittently because it doesn't catch NoSuchElementException while it awaits tabs to be shown on `ChooseAssayTypePage`
This change causes `ChooseAssayTypePage.waitForPage` to catch the exception and retry until it's found or until the timeout elapses

#### Related Pull Requests
n/a

#### Changes
just fix the waitForPage
