### PR TITLE
Sample status colors

### DIFF
--- a/src/org/labkey/test/components/ColorPickerInput.java
+++ b/src/org/labkey/test/components/ColorPickerInput.java
@@ -1,0 +1,70 @@
+package org.labkey.test.components;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.html.Input;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+public class ColorPickerInput extends WebDriverComponent<Component<?>.ElementCache>
+{
+    private final WebDriver _driver;
+    final WebElement _componentElement;
+
+    public ColorPickerInput(WebElement element, WebDriver driver)
+    {
+        _driver = driver;
+        _componentElement = element;
+    }
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _componentElement;
+    }
+
+    @Override
+    protected WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    public void setHexValue(String hexValue)
+    {
+        List<WebElement> inputs = Locator.tag("input").findElements(this);
+        if (inputs.isEmpty())
+            throw new NoSuchElementException("Input tag not found in color picker");
+        WebElement hexInput = inputs.get(0);
+        new Input(hexInput, getDriver()).setWithPaste(hexValue);
+    }
+
+    public String getHexValue()
+    {
+        List<WebElement> inputs = Locator.tag("input").findElements(this);
+        if (inputs.isEmpty())
+            throw new NoSuchElementException("Input tag not found in color picker");
+        WebElement hexInput = inputs.get(0);
+        return new Input(hexInput, getDriver()).getValue();
+    }
+
+    public static class ColorPickerInputFinder extends WebDriverComponentFinder<ColorPickerInput, ColorPickerInput.ColorPickerInputFinder>
+    {
+        private final Locator _locator;
+
+        public ColorPickerInputFinder(WebDriver driver)
+        {
+            super(driver);
+            _locator = Locator.tagWithClass("div", "compact-picker");
+        }
+
+        @Override
+        protected ColorPickerInput construct(WebElement element, WebDriver driver)
+        {
+            return new ColorPickerInput(element, driver);
+        }
+
+        @Override
+        protected Locator locator() { return _locator; }
+    }
+}


### PR DESCRIPTION
#### Rationale
In the related PRs we are adding support for specifying a color when creating a sample status, so we need components to interact with the color picker.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/381
- https://github.com/LabKey/limsModules/pull/121
- https://github.com/LabKey/platform/pull/5401
- https://github.com/LabKey/labkey-ui-components/pull/1467

#### Changes
* Add `ColorPickerInput` component
* Update `ManageSampleStatusesPanel` with methods to add and retrieve the color values for a status
