### PR TITLE
Fix intermittent survey extjs datetime field failure

### DIFF
--- a/src/org/labkey/test/tests/SurveyTest.java
+++ b/src/org/labkey/test/tests/SurveyTest.java
@@ -256,10 +256,10 @@ public class SurveyTest extends BaseWebDriverTest
         _permissionsHelper.enterPermissionsUI();
         _permissionsHelper.setUserPermissions(EDITOR, "Reader");
         clickButton("Save and Finish");
-//        clickFolder(FOLDER_NAME);
-//        _permissionsHelper.enterPermissionsUI();
-//        _permissionsHelper.setUserPermissions(EDITOR, "Editor");
-//        clickButton("Save and Finish");
+        clickFolder(FOLDER_NAME);
+        _permissionsHelper.enterPermissionsUI();
+        _permissionsHelper.setUserPermissions(EDITOR, "Editor");
+        clickButton("Save and Finish");
     }
 
     protected void createSurveyDesign(String project, @Nullable String folder, @Nullable String tabName, String designName, @Nullable String description,

--- a/src/org/labkey/test/tests/SurveyTest.java
+++ b/src/org/labkey/test/tests/SurveyTest.java
@@ -154,7 +154,13 @@ public class SurveyTest extends BaseWebDriverTest
 
         var dateTimeFieldTimeValue = "12:45";
         final WebElement timeInput = Locator.name(DATETIME_TIME_FIELD_NAME).findElement(getDriver());
-        timeInput.clear();
+        int attempt = 0;
+        while (attempt++ < 5 && !"".equals(getFormElement(Locator.name(DATETIME_TIME_FIELD_NAME))))
+        {
+            timeInput.clear();
+            shortWait();
+        }
+        assertEquals("'Date Time Field (time)' not cleared.", "", getFormElement(Locator.name(DATETIME_TIME_FIELD_NAME)));
         timeInput.sendKeys(dateTimeFieldTimeValue);
         assertEquals("'Date Time Field (time)' not set.", dateTimeFieldTimeValue, getFormElement(Locator.name(DATETIME_TIME_FIELD_NAME)));
 
@@ -250,10 +256,10 @@ public class SurveyTest extends BaseWebDriverTest
         _permissionsHelper.enterPermissionsUI();
         _permissionsHelper.setUserPermissions(EDITOR, "Reader");
         clickButton("Save and Finish");
-        clickFolder(FOLDER_NAME);
-        _permissionsHelper.enterPermissionsUI();
-        _permissionsHelper.setUserPermissions(EDITOR, "Editor");
-        clickButton("Save and Finish");
+//        clickFolder(FOLDER_NAME);
+//        _permissionsHelper.enterPermissionsUI();
+//        _permissionsHelper.setUserPermissions(EDITOR, "Editor");
+//        clickButton("Save and Finish");
     }
 
     protected void createSurveyDesign(String project, @Nullable String folder, @Nullable String tabName, String designName, @Nullable String description,


### PR DESCRIPTION
#### Rationale
[SurveyTest.testDateTimeWithExtConfig](https://teamcity.labkey.org/viewLog.html?buildId=2997733&buildTypeId=LabKey_243Release_Community_DailyPostgres2&fromSakuraUI=true#testNameId8900511595216068056)
clear() on extjs time input doesn't seem to reliably delete input values. 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
