### PR TITLE
Add additional exportData methods for storage map export

### DIFF
--- a/src/org/labkey/test/components/ui/grids/ExportMenu.java
+++ b/src/org/labkey/test/components/ui/grids/ExportMenu.java
@@ -48,6 +48,13 @@ public class ExportMenu extends WebDriverComponent<Component.ElementCache>
         return getWrapper().doAndWaitForDownload(exportButton::click);
     }
 
+
+    public File exportData(GridBar.ExportType exportType, int index)
+    {
+        WebElement exportButton = getExportMenuItem(exportType, index);
+        return getWrapper().doAndWaitForDownload(exportButton::click);
+    }
+
     public TabSelectionExportDialog openExcelTabsModal()
     {
         WebElement exportButton = getExportMenuItem(GridBar.ExportType.EXCEL);
@@ -60,5 +67,11 @@ public class ExportMenu extends WebDriverComponent<Component.ElementCache>
     {
         _menu.expand();
         return Locator.css("span.export-menu-icon").withClass(exportType.buttonCssClass()).findElement(this);
+    }
+
+    private WebElement getExportMenuItem(GridBar.ExportType exportType, int index)
+    {
+        _menu.expand();
+        return Locator.css("span.export-menu-icon").withClass(exportType.buttonCssClass()).findElements(this).get(index);
     }
 }

--- a/src/org/labkey/test/components/ui/grids/GridBar.java
+++ b/src/org/labkey/test/components/ui/grids/GridBar.java
@@ -60,6 +60,11 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
         return elementCache().exportMenu.exportData(exportType);
     }
 
+    public File exportData(ExportType exportType, int index)
+    {
+        return elementCache().exportMenu.exportData(exportType, index);
+    }
+
     public TabSelectionExportDialog openExcelTabsModal()
     {
         return elementCache().exportMenu.openExcelTabsModal();


### PR DESCRIPTION
#### Rationale
See related PRs

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1478
- https://github.com/LabKey/platform/pull/5448
- https://github.com/LabKey/limsModules/pull/184

#### Changes
* Add `exportData` methods that can choose one of many from different export types.