### PR TITLE
Update LinkedSchemaTest for new wrapped column behavior

### DIFF
--- a/src/org/labkey/test/util/SchemaHelper.java
+++ b/src/org/labkey/test/util/SchemaHelper.java
@@ -35,20 +35,6 @@ public class SchemaHelper
         createOrEditLinkedSchema(true, targetContainerPath, name, sourceContainerPath, schemaTemplate, sourceSchemaName, tables, metadata);
     }
 
-    /**
-     * @deprecated Use other {@link #updateLinkedSchema(String, String, String, String, String, String, String)}
-     */
-    @Deprecated (since = "20.10")
-    public void updateLinkedSchema(String projectName, String targetFolder, String name, String sourceContainerPath, String schemaTemplate, String sourceSchemaName, String tables, String metadata)
-    {
-        StringBuilder targetContainerPath = new StringBuilder(projectName);
-        if (targetFolder != null)
-        {
-            targetContainerPath.append("/").append(targetFolder);
-        }
-        updateLinkedSchema(targetContainerPath.toString(), name, sourceContainerPath, schemaTemplate, sourceSchemaName, tables, metadata);
-    }
-
     @LogMethod
     public void updateLinkedSchema(String targetContainerPath, String name, String sourceContainerPath, String schemaTemplate, String sourceSchemaName, String tables, String metadata)
     {


### PR DESCRIPTION
#### Rationale
Defining an invalid metadata filter over a wrapped column no longer generates an error. `LinkedSchemaTest` needs to be updated.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5437

#### Changes
* Update LinkedSchemaTest for new wrapped column behavior\
* Get rid of long deprecated, barely used `updateLinkedSchema` method
