### PR TITLE
Corrected definition of Time column type.

### DIFF
--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -476,7 +476,7 @@ public class FieldDefinition extends PropertyDescriptor
         ColumnType Subject = new ColumnTypeImpl("Subject/Participant", "string", "http://cpas.labkey.com/Study#ParticipantId", null);
         ColumnType DateAndTime = new ColumnTypeImpl("Date Time", "dateTime");
         ColumnType Date = new ColumnTypeImpl("Date", "date");
-        ColumnType Time = new ColumnTypeImpl("Time", "time");
+        ColumnType Time = new ColumnTypeImpl("Time", "http://www.w3.org/2001/XMLSchema#time");
         ColumnType Boolean = new ColumnTypeImpl("Boolean", "boolean");
         ColumnType Double = new ColumnTypeImpl("Number (Double)", "float");
         ColumnType Decimal = new ColumnTypeImpl("Decimal (floating point)", "double");


### PR DESCRIPTION
#### Rationale
Use correct definition for Time column type.
[Issue 50238](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50238): Using CreateDomianCommand to create a sample type with a Time-only field results in a bad picker for the field.

@XingY: This is just an FYI for you.

#### Related Pull Requests
* None

#### Changes
* Changed parameter passed into ColumnTypeImpl for the Time column type.
