### PR TITLE
Don't fail if all CSP violations are ignored

### DIFF
--- a/src/org/labkey/test/util/CspLogUtil.java
+++ b/src/org/labkey/test/util/CspLogUtil.java
@@ -79,12 +79,14 @@ public class CspLogUtil
                     throw new RuntimeException("Failed to read recent CSP violations.", e);
                 }
 
+                boolean foundVioloation = false;
                 MultiValuedMap<Crawler.ControllerActionId, String> violoations = new HashSetValuedHashMap<>();
                 for (String line : warningLines)
                 {
                     String[] split = line.split("ContentSecurityPolicy warning on page: ");
                     if (split.length > 1)
                     {
+                        foundVioloation = true;
                         String url = split[1];
                         if (ignoredVioloations.stream().anyMatch(url::contains))
                         {
@@ -98,7 +100,7 @@ public class CspLogUtil
                     }
                 }
 
-                if (violoations.isEmpty())
+                if (!foundVioloation)
                 {
                     throw new AssertionError("Detected CSP violations but unable to parse log file: " + recentWarningsFile.getAbsolutePath());
                 }


### PR DESCRIPTION
#### Rationale
The CSP log check can now ignore certain violations but it also assumes there was a problem parsing the log file if it exists but no violations are found. 

#### Related Pull Requests
* #1908 

#### Changes
* Don't fail if all CSP violations are ignored
