### PR TITLE
Improve detection of sign in page

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -130,7 +130,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
             return;
         }
 
-        if (!Locator.tagWithName("form", "login").existsIn(getDriver()))
+        if (!Locator.tagWithName("form", "login").existsIn(getDriver()) || !Locator.name("email").existsIn(getDriver()))
         {
             executeScript("window.onbeforeunload = null;"); // Just get logged in, ignore 'unload' alerts
             beginAt(WebTestHelper.buildURL("login", "login"));


### PR DESCRIPTION
#### Rationale
The terms of use acceptance page also has a `<form name="login">`, need to check for an 'email' input as well.

#### Related Pull Requests
* #1907 

#### Changes
* Navigate to `login-login.view` if email input isn't present.
