### PR TITLE
Fix for WNPRC test failure.

### DIFF
--- a/src/org/labkey/test/pages/assay/ChooseAssayTypePage.java
+++ b/src/org/labkey/test/pages/assay/ChooseAssayTypePage.java
@@ -78,7 +78,7 @@ public class ChooseAssayTypePage extends LabKeyPage<ChooseAssayTypePage.ElementC
 
     public ChooseAssayTypePage selectAssayLocation(String value)
     {
-        selectStandardAssay();
+        elementCache().assayTypeTabs.selectTab("Standard Assay");
         selectOptionByText(elementCache().containerSelect, value);
         return this;
     }


### PR DESCRIPTION
#### Rationale
Fix for wnprc_ehr.WNPRC_EHRTest](https://teamcity.labkey.org/viewLog.html?buildId=2999488&buildTypeId=LabkeyTrunk_EhrPostgres&fromSakuraUI=true#testNameId-4031106202433799349) 
Unable to find element: css=select[id="assay-type-select-container"]

selectStandardAssay() clicks submit as well, which made test fail on develop.
#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
