### PR TITLE
Try to prevent race condition with initial password form

### DIFF
--- a/src/org/labkey/test/components/core/login/SetPasswordForm.java
+++ b/src/org/labkey/test/components/core/login/SetPasswordForm.java
@@ -46,6 +46,12 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
 
         if (getWrapper().getCurrentRelativeURL().contains("changePassword.view") && PasswordUtil.getUsername().equals(getWrapper().getCurrentUser()))
             throw new IllegalArgumentException("Don't change the primary site admin user's password");
+
+        if (elementCache().strengthGuidance.isDisplayed())
+        {
+            // Not all password strength requirements display password guidance meter
+            assertGuidanceMessage(GUIDANCE_PLACEHOLDER);
+        }
     }
 
     // Don't use this unless you're actually testing authentication functionality
@@ -101,6 +107,11 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
             assertPasswordGuidance("", GUIDANCE_PLACEHOLDER); // Clear out previous guidance
 
         setPassword1(password);
+        assertGuidanceMessage(expectedGuidance);
+    }
+
+    private void assertGuidanceMessage(String expectedGuidance)
+    {
         Awaitility.await().atMost(Duration.ofSeconds(2)).untilAsserted(() ->
                 assertEquals("Strength guidance for password", expectedGuidance, elementCache().strengthGuidance.getText()));
     }

--- a/src/org/labkey/test/components/core/login/SetPasswordForm.java
+++ b/src/org/labkey/test/components/core/login/SetPasswordForm.java
@@ -106,7 +106,8 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
         if (!password.isEmpty() && elementCache().strengthGuidance.getText().equals(expectedGuidance))
             assertPasswordGuidance("", GUIDANCE_PLACEHOLDER); // Clear out previous guidance
 
-        setPassword1(password);
+        // Paste password to avoid triggering 'oninput' multiple times
+        pastePassword(password);
         assertGuidanceMessage(expectedGuidance);
     }
 
@@ -130,21 +131,26 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
         return this;
     }
 
-    public SetPasswordForm setPassword1(String password1)
+    private void pastePassword(String password1)
     {
         if (password1.isEmpty())
         {
             // `WebElement.clear()` doesn't trigger `oninput`
             // Need to use this method to update strength guidance
-            getWrapper().actionClear(elementCache().password);
+            getWrapper().actionClear(elementCache().password.getComponentElement());
         }
         else
         {
             // Won't trigger 'oninput'
-            elementCache().password.clear();
+            elementCache().password.getComponentElement().clear();
             // Paste to avoid triggering 'oninput' twice
-            getWrapper().actionPaste(elementCache().password, password1);
+            getWrapper().actionPaste(elementCache().password.getComponentElement(), password1);
         }
+    }
+
+    public SetPasswordForm setPassword1(String password1)
+    {
+        elementCache().password.set(password1);
 
         return this;
     }
@@ -194,7 +200,7 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
         // For ChangePasswordAction
         final Input oldPassword = Input(Locator.id("oldPassword"), getDriver()).findWhenNeeded(this);
 
-        final WebElement password = Locator.id("password").findWhenNeeded(this);
+        final Input password = Input(Locator.id("password"), getDriver()).findWhenNeeded(this);
         final Input password2 = Input(Locator.id("password2"), getDriver()).findWhenNeeded(this);
         final WebElement strengthGuidance = Locator.id("strengthGuidance").findWhenNeeded(this);
         final WebElement submitButton = Locator.name("set").findWhenNeeded(this);

--- a/src/org/labkey/test/tests/ApiKeyTest.java
+++ b/src/org/labkey/test/tests/ApiKeyTest.java
@@ -41,10 +41,7 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.components.ui.grids.QueryGrid;
 import org.labkey.test.pages.core.admin.CustomizeSitePage;
-import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.Maps;
-import org.labkey.test.util.PasswordUtil;
-import org.labkey.test.util.PermissionsHelper;
 import org.labkey.test.util.TestUser;
 import org.labkey.test.util.URLBuilder;
 import org.openqa.selenium.WebElement;
@@ -93,7 +90,7 @@ public class ApiKeyTest extends BaseWebDriverTest
         _containerHelper.createProject(getProjectName(), null);
 
         EDITOR_USER.create(this)
-                .setPassword(PasswordUtil.getPassword())
+                .setInitialPassword()
                 .addPermission("Editor", getProjectName());
     }
 

--- a/src/org/labkey/test/util/TestUser.java
+++ b/src/org/labkey/test/util/TestUser.java
@@ -59,12 +59,28 @@ public class TestUser
     }
 
     /**
+     * Set the initial password for a newly created user. Uses the reset link emailed to the user.
+     * Stores the password in the bean for later use.
+     *  Note: this can only be done once for a given user account
+     * @return The current instance
+     * @see #getPassword()
+     */
+    public TestUser setInitialPassword()
+    {
+        return setPassword(PasswordUtil.getPassword());
+    }
+
+    /**
      * Uses the UI to reset the randomly-generated password a user gets when created, by following the reset link they'll
      * receive in mail. Also stores the provided password in the bean for later use.
      *  Note: this can only be done once for a given user account
      * @param password  The password
      * @return  The current instance
+     * @deprecated There is no need to specify a particular password for most test scenarios.
+     *  Such scenarios should not use this class.
+     * @see #setInitialPassword()
      */
+    @Deprecated (since = "24.6")
     public TestUser setPassword(String password)
     {
         if (_password == null)  // if null, this is the initial password - we can use the UI to set it now
@@ -83,6 +99,10 @@ public class TestUser
 
     public String getPassword()
     {
+        if (_password == null)
+        {
+            throw new IllegalStateException("Password has not been set for user: " + _email);
+        }
         return _password;
     }
 


### PR DESCRIPTION
#### Rationale
`TestUser.setPassword` has been failing intermittently.
```
java.lang.AssertionError: Unexpected error found: You must enter a password.
	at org.junit.Assert.fail(Assert.java:89)
	at org.labkey.test.WebDriverWrapper.assertNoLabKeyErrors(WebDriverWrapper.java:1521)
	at org.labkey.test.components.core.login.SetPasswordForm.clickSubmit(SetPasswordForm.java:161)
	at org.labkey.test.components.core.login.SetPasswordForm.clickSubmit(SetPasswordForm.java:155)
	at org.labkey.test.util.TestUser.setPassword(TestUser.java:74)
```
Updating `SetPasswordForm` to wait for the password strength guage to initialize and using normal `sendKeys` to set the password.
Hopefully one of these will eliminate these errors.

Also deprecating the ability to set a specific password with `TestUser.setPassword` as we did with `WebDriverWrapper.setInitialPassword`

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1628

#### Changes
* `SetPasswordForm` to wait for the password strength guage
* Don't paste password
* Deprecate `TestUser.setPassword`
