### PR TITLE
Make tests default to ROOT context path

### DIFF
--- a/src/org/labkey/test/WebTestHelper.java
+++ b/src/org/labkey/test/WebTestHelper.java
@@ -408,7 +408,7 @@ public class WebTestHelper
                     _contextPath = DEFAULT_CONTEXT_PATH;
                 }
                 else
-                    LOG.info("Using labkey context path '" + _contextPath + "', as provided by system property 'labkey.contextPath'.");
+                    LOG.info("Using labkey context path '" + _contextPath + "', as provided by system property 'labkey.contextpath'.");
 
                 _contextPath = StringUtils.strip(_contextPath, "/ ");
                 if (!_contextPath.isEmpty())

--- a/test.properties.template
+++ b/test.properties.template
@@ -105,7 +105,7 @@ selenium.debug.port=5005
 #==============================================================================
 labkey.port=8080
 labkey.server=http://localhost
-labkey.contextpath=/labkey
+labkey.contextpath=
 
 
 #==============================================================================


### PR DESCRIPTION
#### Rationale
`test.properties.template` should reflect the defaults in test code (`WebTestHelper.DEFAULT_CONTEXT_PATH`). It is also easier to overwrite a blank property than it is to clear a non-blank property.

#### Related Pull Requests
* N/A

#### Changes
* Make tests default to ROOT context path
