### PR TITLE
Correctly parse content disposition header

### DIFF
--- a/src/org/labkey/test/util/SimpleHttpRequest.java
+++ b/src/org/labkey/test/util/SimpleHttpRequest.java
@@ -22,6 +22,8 @@ import org.labkey.remoteapi.Connection;
 import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebDriver;
 
+import javax.mail.internet.ContentDisposition;
+import javax.mail.internet.ParseException;
 import java.io.File;
 import java.io.IOException;
 import java.net.Authenticator;
@@ -33,7 +35,6 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -177,28 +178,16 @@ public class SimpleHttpRequest
                 // Example:
                 // attachment; filename="diagnostics_2023-03-31_12-36-31.zip"
                 String contentDisposition = StringUtils.trimToEmpty(con.getHeaderField("Content-Disposition"));
-                String[] splitDisposition = contentDisposition.split("; ");
-                Map<String, String> params = new LinkedHashMap<>();
-                for (String s : splitDisposition)
+                String responseFilename = null;
+                if (!contentDisposition.isEmpty())
                 {
-                    String[] param = s.split("=", 2);
-                    params.put(param[0], param.length == 2 ? StringUtils.strip(param[1], "\"") : null);
-                }
-                String responseFilename = params.get("filename");
-                if (responseFilename == null)
-                {
-                    // Sometimes filename includes encoding information
-                    // attachment; filename*=UTF-8''diagnostics_2023-10-19_14-39-56.zip
-                    responseFilename = params.get("filename*");
-                    if (responseFilename != null)
+                    try
                     {
-                        String[] split = responseFilename.split("'", 3);
-                        if (split.length == 3)
-                        {
-                            responseFilename = split[2];
-                        }
+                        responseFilename = new ContentDisposition(contentDisposition).getParameter("filename");
                     }
+                    catch (ParseException ignore) { }
                 }
+
                 if (fileName == null)
                 {
                     if (responseFilename == null)


### PR DESCRIPTION
#### Rationale
My hand-crafted parsing of the `Content-Disposition` header for downloading files wasn't working correctly and started failing on Windows when I switched to use embedded tomcat.
```
java.nio.file.InvalidPathException: Illegal char <?> at index 62: D:\teamcity\work\a7b1f3583054d6ed\build\testTemp\diagnostics\=?UTF-8?Q?SQL=5FQueries=5F2024-05-09=5F08-10-05.tsv?=
  at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
  at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
  at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
  at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
  at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:232)
  at java.base/java.io.File.toPath(File.java:2387)
  at org.apache.commons.io.FileUtils.newOutputStream(FileUtils.java:2479)
  at org.apache.commons.io.FileUtils.copyToFile(FileUtils.java:1025)
  at org.apache.commons.io.FileUtils.copyInputStreamToFile(FileUtils.java:934)
  at org.labkey.test.util.SimpleHttpRequest.getResponseAsFile(SimpleHttpRequest.java:220)
```
I found a library that parses out the filename correctly.

#### Related Pull Requests
* N/A

#### Changes
* Correctly parse content disposition header
