### PR TITLE
Filling Gaps in Test Components

### DIFF
--- a/src/org/labkey/test/components/ManageSampleStatusesPanel.java
+++ b/src/org/labkey/test/components/ManageSampleStatusesPanel.java
@@ -94,19 +94,21 @@ public class ManageSampleStatusesPanel extends WebDriverComponent<ManageSampleSt
         }
         else
         {
+
             WebDriverWrapper.waitFor(()->
                     {
                         try
                         {
                             return groupItem.getText().trim().toLowerCase()
-                                    .contains(getWrapper().getFormElement(elementCache().labelField.getComponentElement()).trim().toLowerCase());
+                                    .contains(elementCache().labelField.get().trim().toLowerCase());
                         }
                         catch (NoSuchElementException | StaleElementReferenceException exp)
                         {
                             return false;
                         }
                     },
-                    "Edit part of the panel for a locked status did not render in time.", 1_000);
+                    String.format("Edit part of the panel for a locked status did not render in time. Value in label textbox '%s' did not contain '%s'.",
+                            elementCache().labelField.get(), groupItem.getText()), 1_000);
 
         }
 

--- a/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
@@ -7,6 +7,7 @@ import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.components.domain.DomainDesigner;
 import org.labkey.test.components.domain.DomainFormPanel;
+import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.html.SelectWrapper;
 import org.labkey.test.components.html.ValidatingInput;
@@ -38,6 +39,15 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
     }
 
     protected abstract T getThis();
+
+    public T setSystemFieldVisibility(String fieldName, boolean isVisible)
+    {
+        var xpath = "//div[contains(@class, 'domain-system-fields__grid')]//td[text()='" + fieldName + "']/preceding-sibling::td//input";
+        var checkBox = Checkbox.Checkbox(Locator.xpath(xpath));
+        var enabledCheckBox = checkBox.find(getFieldsPanel());
+        enabledCheckBox.set(isVisible);
+        return getThis();
+    }
 
     public T removeField(boolean confirmDialogExpected, String fieldName)
     {

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -1000,13 +1000,21 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
         private final WebElement selectColumn = Locator.xpath("//th/input[@type='checkbox']").findWhenNeeded(table);
 
-        private final List<String> columnNames = new ArrayList<>();
+        private List<String> columnNames = new ArrayList<>();
 
         public List<String> getColumnNames()
         {
+
+            // If the number of header cells is not equal to the list of columnName the columns have been modified since
+            // the last call to getColumnNames so get the column names again.
+            List<WebElement> headerCells = Locators.headerCells.waitForElements(table, WAIT_FOR_JAVASCRIPT);
+            if(columnNames.size() != headerCells.size())
+            {
+                columnNames = new ArrayList<>();
+            }
+
             if (columnNames.isEmpty())
             {
-                List<WebElement> headerCells = Locators.headerCells.waitForElements(table, WAIT_FOR_JAVASCRIPT);
 
                 for (WebElement el : headerCells)
                 {


### PR DESCRIPTION
#### Rationale
Two primary changes, and one smaller change.

First, have the editable grid take into account that columns can be added after the grid is created. The editable grid would get a static list of column headers, this is a problem when creating samples in the grid and parent is added. This insert a new column into the grid.

Before:
![Screenshot 2024-05-13 at 5 34 23 PM](https://github.com/LabKey/testAutomation/assets/12738200/c99cb202-3b77-4aec-8514-23892aafd902)

After:
![Screenshot 2024-05-13 at 5 34 41 PM](https://github.com/LabKey/testAutomation/assets/12738200/dda04794-acdf-4f61-a485-eb337f07aafc)


Second, as far as I could tell the EntityDesigner did not have the ability to changes the visibility of system fields. This add the ability to change the visibility of system fields.
![Screenshot 2024-05-13 at 5 43 48 PM](https://github.com/LabKey/testAutomation/assets/12738200/a535ece3-1840-44e3-95d7-baee3c49b553)

Smaller change:
Simplified the way the label value for a sample status is retrieved on the ManageSampleStatusPanel:
<img width="1119" alt="Screenshot 2024-05-15 at 12 54 06 PM" src="https://github.com/LabKey/testAutomation/assets/12738200/b24fc504-4783-4da8-9319-73e584b2754a">

#### Related Pull Requests
* https://github.com/LabKey/limsModules/pull/257

#### Changes
* Added  setSystemFieldVisibility to EntityTypeDesigner.
* Added logic to get column headers again if the count has changed since the last time they were retrieved.
* Simplify how the ManageSampleStatusPanel gets the text of the for the given status.
