### PR TITLE
Check for CSP violations before each page load

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -197,6 +197,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     private static boolean _dumpedHeap = false;
     private final ArtifactCollector _artifactCollector;
     private final DeferredErrorCollector _errorCollector;
+    private final CspCheckPageLoadListener _cspCheckPageLoadListener; // Need a strong reference to this
 
     public AbstractContainerHelper _containerHelper = new APIContainerHelper(this);
     public final CustomizeView _customizeViewsHelper;
@@ -241,6 +242,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         _errorCollector = new DeferredErrorCollector(_artifactCollector);
         _listHelper = new ListHelper(this);
         _customizeViewsHelper = new CustomizeView(this);
+        _cspCheckPageLoadListener = new CspCheckPageLoadListener(this);
 
         String seleniumBrowser = System.getProperty("selenium.browser");
         if (seleniumBrowser == null || seleniumBrowser.length() == 0)
@@ -324,7 +326,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
         if (!TestProperties.isCspCheckSkipped())
         {
-            addPageLoadListener(new CspCheckPageLoadListener(this));
+            addPageLoadListener(_cspCheckPageLoadListener);
         }
     }
 

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -241,6 +241,25 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         _listHelper = new ListHelper(this);
         _customizeViewsHelper = new CustomizeView(this);
 
+        if (!TestProperties.isCspCheckSkipped())
+        {
+            addPageLoadListener(new PageLoadListener()
+            {
+                @Override
+                public void beforePageLoad()
+                {
+                    try
+                    {
+                        CspLogUtil.checkNewCspWarnings(_artifactCollector);
+                    }
+                    catch (CspLogUtil.CspWarningDetectedException ex)
+                    {
+                        checker().withScreenshot("csp_violation").recordError(ex);
+                    }
+                }
+            });
+        }
+
         String seleniumBrowser = System.getProperty("selenium.browser");
         if (seleniumBrowser == null || seleniumBrowser.length() == 0)
         {

--- a/src/org/labkey/test/util/ArtifactCollector.java
+++ b/src/org/labkey/test/util/ArtifactCollector.java
@@ -90,6 +90,11 @@ public class ArtifactCollector
         _testStart = System.currentTimeMillis();
     }
 
+    public String getDumpDirName()
+    {
+        return _dumpDirName;
+    }
+
     public File ensureDumpDir()
     {
         return ensureDumpDir(_dumpDirName);

--- a/src/org/labkey/test/util/CspLogUtil.java
+++ b/src/org/labkey/test/util/CspLogUtil.java
@@ -38,7 +38,7 @@ public class CspLogUtil
 
     public static void checkNewCspWarnings(ArtifactCollector artifactCollector)
     {
-        if (TestProperties.isCspCheckSkipped() || TestProperties.isServerRemote() || missingLog)
+        if (TestProperties.isServerRemote() || missingLog)
             return;
 
         if (!logFile.isFile())

--- a/src/org/labkey/test/util/DeferredErrorCollector.java
+++ b/src/org/labkey/test/util/DeferredErrorCollector.java
@@ -76,7 +76,7 @@ public class DeferredErrorCollector
      *
      * @param errorType Additional error type to be recorded.
      */
-    public void addRecordableErrorType(Class<? extends Exception> errorType)
+    public void addRecordableErrorType(Class<? extends Throwable> errorType)
     {
         errorTypes.add(errorType);
     }
@@ -486,7 +486,7 @@ class DeferredErrorCollectorWrapper extends DeferredErrorCollector
     }
 
     @Override
-    public void addRecordableErrorType(Class<? extends Exception> errorType)
+    public void addRecordableErrorType(Class<? extends Throwable> errorType)
     {
         wrappedCollector.addRecordableErrorType(errorType);
     }


### PR DESCRIPTION
#### Rationale
Waiting until the end of a test to check for CSP violations loses some context. If we check before each navigation, we have a greater chance of getting useful information about the violation.

#### Related Pull Requests
* N/A

#### Changes
* Register a `PageLoadListener` to check for CSP violations before each navigation
