### PR TITLE
Disable constant CSP checking for CrawlerTest

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -324,12 +324,22 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         }
         closeExtraWindows();
 
-        if (!TestProperties.isCspCheckSkipped())
+        if (!TestProperties.isCspCheckSkipped() && cspFailFast())
         {
             addPageLoadListener(_cspCheckPageLoadListener);
         }
     }
 
+    /**
+     * Specifies whether the CSP log should be checked before each page load.
+     * Tests that only want the CSP log to be checked at the end should override this method.
+     * @return true to check for CSP violations before each navigation
+     */
+    protected boolean cspFailFast()
+    {
+        return true;
+    }
+    
     public ArtifactCollector getArtifactCollector()
     {
         return _artifactCollector;

--- a/src/org/labkey/test/tests/CrawlerTest.java
+++ b/src/org/labkey/test/tests/CrawlerTest.java
@@ -157,6 +157,12 @@ public class CrawlerTest extends BaseWebDriverTest
         return WebTestHelper.buildRelativeUrl(MODULE_NAME, getProjectName(), "injectJsp", Map.of("inject", injectionParam));
     }
 
+    @Override
+    protected boolean cspFailFast()
+    {
+        return false;
+    }
+
     @After
     public void postTest()
     {


### PR DESCRIPTION
#### Rationale
`CrawlerTest` triggers numerous intentional CSP violations. It needs a mechanism to disable the new, more aggressive CSP check that was just introduced.

#### Related Pull Requests
* #1930

#### Changes
* Disable constant CSP checking for CrawlerTest
