### PR TITLE
Exclude search index from files to publish to TeamCity

### DIFF
--- a/src/org/labkey/test/util/ArtifactCollector.java
+++ b/src/org/labkey/test/util/ArtifactCollector.java
@@ -329,7 +329,7 @@ public class ArtifactCollector
     private ArrayList<File> listFilesRecursive(File path, final FileFilter filter)
     {
         FileFilter directoryOrArtifactFilter = pathname ->
-                pathname.isDirectory() && !pathname.isHidden() ||
+                pathname.isDirectory() && !pathname.isHidden() && !pathname.getName().equals("@labkey_full_text_index") ||
                pathname.lastModified() > _testStart && filter.accept(pathname);
 
         File[] files = path.listFiles(directoryOrArtifactFilter);


### PR DESCRIPTION
#### Rationale
One of our improvements for embedded Tomcat was to put the Lucene search index under the server's file root by default. This has been getting uploaded to TeamCity because we upload the file root to TeamCity to assist with test failure investigations.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5295

#### Changes
* Exclude search index from files to publish to TeamCity
