### PR TITLE
Fix issue with CustomizeGridViewDialog.removeColumn accidentally clic…

### DIFF
--- a/src/org/labkey/test/components/ui/grids/CustomizeGridViewDialog.java
+++ b/src/org/labkey/test/components/ui/grids/CustomizeGridViewDialog.java
@@ -324,11 +324,6 @@ public class CustomizeGridViewDialog extends ModalDialog
     public CustomizeGridViewDialog removeColumn(String column, int index)
     {
         WebElement listItem = getShownInGridListItems(column).get(index);
-
-        // Make sure the mouse is on the identified row. Tests that remove columns one after another can show the mouse
-        // hovering for a moment over the remove icon of the previous row.
-        listItem.click();
-
         WebElement removeIcon = Locator.tagWithClass("span", "view-field__action").findElement(listItem);
         getWrapper().mouseOver(removeIcon);
         removeIcon.click();


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1494
- https://github.com/LabKey/labkey-ui-premium/pull/412
- https://github.com/LabKey/limsModules/pull/260
- https://github.com/LabKey/platform/pull/5507
- https://github.com/LabKey/testAutomation/pull/1940

#### Changes
* Fix issue with CustomizeGridViewDialog.removeColumn accidentally clicking the edit icon
    * If the column name is long enough the edit icon appears exactly in the middle of the column element
    * Clicking on the listItem has no other effect when removing the column, so I just removed the code