### PR TITLE
Remove deprecated ListColumn and ListColumnType

### DIFF
--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -25,6 +25,7 @@ import org.labkey.remoteapi.domain.PropertyDescriptor;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.test.components.html.OptionSelect;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -459,15 +460,6 @@ public class FieldDefinition extends PropertyDescriptor
 
     }
 
-    // Temporary, for 'ColumnType.values()'
-    private static final List<ColumnType> COLUMN_TYPES = List.of(
-            ColumnType.MultiLine, ColumnType.Integer, ColumnType.String, ColumnType.Subject,
-            ColumnType.DateAndTime, ColumnType.Date, ColumnType.Time,
-            ColumnType.Boolean, ColumnType.Double, ColumnType.Decimal, ColumnType.File, ColumnType.Flag,
-            ColumnType.Attachment, ColumnType.User, ColumnType.Lookup, ColumnType.OntologyLookup, ColumnType.VisitId,
-            ColumnType.VisitDate, ColumnType.Sample, ColumnType.Barcode, ColumnType.TextChoice, ColumnType.SMILES
-    );
-    
     public interface ColumnType
     {
         ColumnType MultiLine = new ColumnTypeImpl("Multi-Line Text", "multiLine");
@@ -531,13 +523,9 @@ public class FieldDefinition extends PropertyDescriptor
             return null;
         }
 
-        /**
-         * @deprecated Bridge for converting away from enum
-         */
-        @Deprecated (since = "22.10")
         static List<ColumnType> values()
         {
-            return COLUMN_TYPES;
+            return ColumnTypeImpl.COLUMN_TYPES;
         }
     }
 
@@ -1028,6 +1016,8 @@ public class FieldDefinition extends PropertyDescriptor
 
 class ColumnTypeImpl implements FieldDefinition.ColumnType
 {
+    static final List<FieldDefinition.ColumnType> COLUMN_TYPES = new ArrayList<>();
+
     private final String _label; // the display value in the UI for this kind of field
     private final String _rangeURI;     // the key used inside the API
     private final String _conceptURI;
@@ -1039,6 +1029,8 @@ class ColumnTypeImpl implements FieldDefinition.ColumnType
         _rangeURI = rangeURI;
         _conceptURI = conceptURI;
         _lookupInfo = lookupInfo;
+
+        COLUMN_TYPES.add(this);
     }
 
     ColumnTypeImpl(String label, String rangeURI)

--- a/src/org/labkey/test/params/list/IntListDefinition.java
+++ b/src/org/labkey/test/params/list/IntListDefinition.java
@@ -9,19 +9,31 @@ import java.util.List;
 
 public class IntListDefinition extends ListDefinition
 {
-    private static final String AUTO_INCREMENT_DOMAIN_KIND = "IntList";
+    private static final String DOMAIN_KIND = "IntList";
+
+    private final boolean isAutoIncrementKey;
 
     public IntListDefinition(String name, String autoIncrementKeyName)
     {
         super(name);
         setKeyName(autoIncrementKeyName);
+        isAutoIncrementKey = true;
+    }
+
+    public IntListDefinition(String name)
+    {
+        super(name);
+        isAutoIncrementKey = false;
     }
 
     @Override
     public List<PropertyDescriptor> getFields()
     {
         List<PropertyDescriptor> fields = super.getFields();
-        fields.add(0, new FieldDefinition(getKeyName(), FieldDefinition.ColumnType.Integer).setPrimaryKey(true));
+        if (isAutoIncrementKey)
+        {
+            fields.add(0, new FieldDefinition(getKeyName(), FieldDefinition.ColumnType.Integer).setPrimaryKey(true));
+        }
         return fields;
     }
 
@@ -29,7 +41,13 @@ public class IntListDefinition extends ListDefinition
     @Override
     protected String getKind()
     {
-        return AUTO_INCREMENT_DOMAIN_KIND;
+        return DOMAIN_KIND;
+    }
+
+    @Override
+    protected String getKeyType()
+    {
+        return isAutoIncrementKey ? "AutoIncrementInteger" : "Integer";
     }
 
     @Override

--- a/src/org/labkey/test/params/list/ListDefinition.java
+++ b/src/org/labkey/test/params/list/ListDefinition.java
@@ -69,6 +69,11 @@ public abstract class ListDefinition extends DomainProps
 
     public ListDefinition setFields(List<? extends PropertyDescriptor> fields)
     {
+        if (!fields.isEmpty() && getKeyName() == null)
+        {
+            // Use first field as key
+            setKeyName(fields.get(0).getName());
+        }
         _fields = new ArrayList<>(fields); // Make sure it isn't immutable
         return this;
     }
@@ -82,6 +87,11 @@ public abstract class ListDefinition extends DomainProps
 
     public ListDefinition addField(@NotNull PropertyDescriptor field)
     {
+        if (getKeyName() == null)
+        {
+            // Use first field as key
+            setKeyName(field.getName());
+        }
         _fields.add(field);
         return this;
     }
@@ -106,7 +116,14 @@ public abstract class ListDefinition extends DomainProps
     protected Domain getDomainDesign()
     {
         Domain domain = new Domain(getName());
-        domain.setFields(new ArrayList<>(getFields()));
+        List<PropertyDescriptor> fields = getFields().stream()
+                .peek(pd -> {
+                    if (pd.getName().equals(getKeyName()))
+                    {
+                        pd.setRequired(true);
+                    }
+                }).toList();
+        domain.setFields(fields);
         domain.setDescription(getDescription());
         return domain;
     }
@@ -119,6 +136,7 @@ public abstract class ListDefinition extends DomainProps
         options.put("name", getName());
         options.put("description", getDescription());
         options.put("keyName", getKeyName());
+        options.put("keyType", getKeyType());
         if (getTitleColumn() != null)
         {
             options.put("titleColumn", getTitleColumn());
@@ -137,4 +155,6 @@ public abstract class ListDefinition extends DomainProps
     {
         return getName();
     }
+
+    protected abstract String getKeyType();
 }

--- a/src/org/labkey/test/params/list/VarListDefinition.java
+++ b/src/org/labkey/test/params/list/VarListDefinition.java
@@ -1,9 +1,6 @@
 package org.labkey.test.params.list;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.remoteapi.domain.PropertyDescriptor;
-
-import java.util.List;
 
 public class VarListDefinition extends ListDefinition
 {
@@ -14,32 +11,16 @@ public class VarListDefinition extends ListDefinition
         super(name);
     }
 
-    @Override
-    public ListDefinition addField(@NotNull PropertyDescriptor field)
-    {
-        if (getKeyName() == null)
-        {
-            // Use first field as key
-            setKeyName(field.getName());
-        }
-        return super.addField(field);
-    }
-
-    @Override
-    public ListDefinition setFields(List<? extends PropertyDescriptor> fields)
-    {
-        if (!fields.isEmpty() && getKeyName() == null)
-        {
-            // Use first field as key
-            setKeyName(fields.get(0).getName());
-        }
-        return super.setFields(fields);
-    }
-
     @NotNull
     @Override
     protected String getKind()
     {
         return DOMAIN_KIND;
+    }
+
+    @Override
+    protected String getKeyType()
+    {
+        return "Varchar";
     }
 }

--- a/src/org/labkey/test/tests/AttachmentFieldTest.java
+++ b/src/org/labkey/test/tests/AttachmentFieldTest.java
@@ -17,7 +17,6 @@ import org.labkey.test.pages.experiment.UpdateSampleTypePage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
 
@@ -99,7 +98,7 @@ public class AttachmentFieldTest extends BaseWebDriverTest
         String fieldName = "testFile";
         goToProjectHome();
         log("Creating the list");
-        _listHelper.createList(getProjectName(), listName, ListHelper.ListColumnType.AutoInteger, "id");
+        _listHelper.createList(getProjectName(), listName, "id");
 
         log("Adding a attachment field with Show attachment in Browser");
         DomainDesignerPage domainDesignerPage = DomainDesignerPage.beginAt(this, getProjectName(), "lists", listName);

--- a/src/org/labkey/test/tests/AuditLogTest.java
+++ b/src/org/labkey/test/tests/AuditLogTest.java
@@ -43,10 +43,10 @@ import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.core.admin.logger.ManagerPage.LoggingLevel;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.AuditLogHelper;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.Log4jUtils;
 import org.labkey.test.util.Maps;
 import org.labkey.test.util.PermissionsHelper;
@@ -368,8 +368,8 @@ public class AuditLogTest extends BaseWebDriverTest
         simpleSignIn();
         _containerHelper.createProject(AUDIT_TEST_PROJECT, null);
         _containerHelper.createSubfolder(AUDIT_TEST_PROJECT, AUDIT_TEST_SUBFOLDER);
-        createList(AUDIT_TEST_PROJECT, "Parent List", "Name\nData",new ListHelper.ListColumn("Name", "Name", ListHelper.ListColumnType.String, "Name") );
-        createList(AUDIT_TEST_PROJECT + "/" + AUDIT_TEST_SUBFOLDER, "Child List", "Name\nData", new ListHelper.ListColumn("Name", "Name", ListHelper.ListColumnType.String, "Name"));
+        createList(AUDIT_TEST_PROJECT, "Parent List", "Name\nData", new FieldDefinition("Name", ColumnType.String).setDescription("Name") );
+        createList(AUDIT_TEST_PROJECT + "/" + AUDIT_TEST_SUBFOLDER, "Child List", "Name\nData", new FieldDefinition("Name", ColumnType.String).setDescription("Name"));
 
         createUserWithPermissions(AUDIT_TEST_USER, AUDIT_TEST_PROJECT, "Editor");
         createUserWithPermissions(AUDIT_TEST_USER2, AUDIT_TEST_PROJECT, "Project Administrator");
@@ -461,9 +461,9 @@ public class AuditLogTest extends BaseWebDriverTest
         }
     }
 
-    private void createList(String containerPath, String listName, @Nullable String tsvData, ListHelper.ListColumn... listColumns)
+    private void createList(String containerPath, String listName, @Nullable String tsvData, FieldDefinition... listColumns)
     {
-        _listHelper.createList(containerPath, listName, ListHelper.ListColumnType.AutoInteger, "Key", listColumns);
+        _listHelper.createList(containerPath, listName, "Key", listColumns);
         if(null != tsvData)
         {
             _listHelper.goToList(listName);
@@ -560,18 +560,18 @@ public class AuditLogTest extends BaseWebDriverTest
         final String FIELD01_NAME = "Field01";
         final String FIELD01_LABEL = "This is Field 01";
         final String FIELD01_UPDATED_LABEL = "This is Update Label for Field 01";
-        final ListHelper.ListColumnType FIELD01_TYPE = ListHelper.ListColumnType.String;
+        final ColumnType FIELD01_TYPE = ColumnType.String;
         final String FIELD01_DESCRIPTION = "Simple String field.";
         final String FIELD01_UPDATED_DESCRIPTION = "This should be a new description for the field.";
 
         final String FIELD02_NAME = "Field02";
         final String FIELD02_LABEL = "This is Field 02";
-        final ListHelper.ListColumnType FIELD02_TYPE = ListHelper.ListColumnType.Integer;
+        final ColumnType FIELD02_TYPE = ColumnType.Integer;
         final String FIELD02_DESCRIPTION = "Simple Integer field.";
 
         final String FIELD03_NAME = "Field03";
         final String FIELD03_LABEL = "Field 03 Lookup";
-        final ListHelper.ListColumnType FIELD03_TYPE = ListHelper.ListColumnType.Integer;
+        final ColumnType FIELD03_TYPE = ColumnType.Integer;
 
         final String DOMAIN_PROPERTY_LOG_NAME = "Domain property events";
 
@@ -581,18 +581,18 @@ public class AuditLogTest extends BaseWebDriverTest
 
         portalHelper.addWebPart("Lists");
 
-        ListHelper.ListColumn[] listColumns = new ListHelper.ListColumn[]{
-                new ListHelper.ListColumn("id", "id", ListHelper.ListColumnType.Integer, "Simple integer index."),
-                new ListHelper.ListColumn("value", "value", ListHelper.ListColumnType.String, "Value of the look up.")};
+        FieldDefinition[] listColumns = new FieldDefinition[]{
+                new FieldDefinition("id", ColumnType.Integer).setLabel("id").setDescription("Simple integer index."),
+                new FieldDefinition("value", ColumnType.String).setLabel("value").setDescription("Value of the look up.")};
 
         log("Create a couple of lists to be used as lookups.");
         createList(AUDIT_PROPERTY_EVENTS_PROJECT, LOOK_UP_LIST01, LIST01_TSV, listColumns);
         createList(AUDIT_PROPERTY_EVENTS_PROJECT, LOOK_UP_LIST02, LIST02_TSV, listColumns);
 
         log("Create the list that will have it's column attributes modified.");
-        listColumns = new ListHelper.ListColumn[]{
-                new ListHelper.ListColumn(FIELD01_NAME, FIELD01_LABEL, FIELD01_TYPE, FIELD01_DESCRIPTION),
-                new ListHelper.ListColumn(FIELD02_NAME, FIELD02_LABEL, FIELD02_TYPE, FIELD02_DESCRIPTION)};
+        listColumns = new FieldDefinition[]{
+                new FieldDefinition(FIELD01_NAME, FIELD01_TYPE).setLabel(FIELD01_LABEL).setDescription(FIELD01_DESCRIPTION),
+                new FieldDefinition(FIELD02_NAME, FIELD02_TYPE).setLabel(FIELD02_LABEL).setDescription(FIELD02_DESCRIPTION)};
 
         createList(AUDIT_PROPERTY_EVENTS_PROJECT, LIST_CHECK_LOG, null, listColumns);
 
@@ -613,11 +613,11 @@ public class AuditLogTest extends BaseWebDriverTest
 
         log("Validate that the expected rows are there.");
         Map<String, String> field01ExpectedColumns = Maps.of("action", "Created");
-        Map<String, String> field01ExpectedComment = Maps.of("Name", FIELD01_NAME,"Label", FIELD01_LABEL,"Type", FIELD01_TYPE.name(),"Description", FIELD01_DESCRIPTION);
+        Map<String, String> field01ExpectedComment = Maps.of("Name", FIELD01_NAME,"Label", FIELD01_LABEL,"Type", "String","Description", FIELD01_DESCRIPTION);
         boolean pass = validateExpectedRowInDomainPropertyAuditLog(domainPropertyEventRows, FIELD01_NAME, field01ExpectedColumns, field01ExpectedComment);
 
         Map<String, String> field02ExpectedColumns = Maps.of("action", "Created");
-        Map<String, String> field02ExpectedComment = Maps.of("Name", FIELD02_NAME,"Label", FIELD02_LABEL,"Type", FIELD02_TYPE.name(),"Description", FIELD02_DESCRIPTION);
+        Map<String, String> field02ExpectedComment = Maps.of("Name", FIELD02_NAME,"Label", FIELD02_LABEL,"Type", FIELD02_TYPE.getLabel(),"Description", FIELD02_DESCRIPTION);
         pass = validateExpectedRowInDomainPropertyAuditLog(domainPropertyEventRows, FIELD02_NAME, field02ExpectedColumns, field02ExpectedComment) && pass;
 
         // We are going to fail, so navigate to the Domain Property Events Audit Log.
@@ -688,7 +688,7 @@ public class AuditLogTest extends BaseWebDriverTest
         listDefinitionPage.getFieldsPanel()
                 .addField(new FieldDefinition(FIELD03_NAME,
                         new FieldDefinition.LookupInfo(null, "lists", LOOK_UP_LIST01)
-                                .setTableType(FieldDefinition.ColumnType.Integer))
+                                .setTableType(ColumnType.Integer))
                         .setLabel(FIELD03_LABEL));
         listDefinitionPage.clickSave();
 
@@ -727,7 +727,7 @@ public class AuditLogTest extends BaseWebDriverTest
         log("Change properties on field '" + FIELD03_NAME + "'.");
         listDefinitionPage.getFieldsPanel()
                 .getField(FIELD03_NAME)
-                .setLookup(new FieldDefinition.LookupInfo(null, "lists", LOOK_UP_LIST02).setTableType(FieldDefinition.ColumnType.Integer));
+                .setLookup(new FieldDefinition.LookupInfo(null, "lists", LOOK_UP_LIST02).setTableType(ColumnType.Integer));
         listDefinitionPage.clickSave();
 
         log("Validate that the expected row is there for the after modifying the Lookup field.");

--- a/src/org/labkey/test/tests/ButtonCustomizationTest.java
+++ b/src/org/labkey/test/tests/ButtonCustomizationTest.java
@@ -22,8 +22,9 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.WikiHelper;
 
@@ -92,11 +93,11 @@ public class ButtonCustomizationTest extends BaseWebDriverTest
     {
         _containerHelper.createProject(PROJECT_NAME, null);
 
-        ListHelper.ListColumn[] columns = new ListHelper.ListColumn[] {
-                new ListHelper.ListColumn("name", "Name", ListHelper.ListColumnType.String, "")
+        FieldDefinition[] columns = new FieldDefinition[] {
+                new FieldDefinition("name", ColumnType.String).setLabel("Name")
         };
 
-        _listHelper.createList(PROJECT_NAME, LIST_NAME, ListHelper.ListColumnType.AutoInteger, "Key", columns);
+        _listHelper.createList(PROJECT_NAME, LIST_NAME, "Key", columns);
         goToManageLists();
         clickAndWait(Locator.linkWithText(LIST_NAME));
         assertButtonNotPresent(METADATA_OVERRIDE_BUTTON);

--- a/src/org/labkey/test/tests/DataRegionTest.java
+++ b/src/org/labkey/test/tests/DataRegionTest.java
@@ -23,10 +23,11 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Data;
+import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.EscapeUtil;
-import org.labkey.test.util.ListHelper;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
@@ -44,13 +45,13 @@ import static org.junit.Assert.assertEquals;
 public class DataRegionTest extends AbstractQWPTest
 {
     private static final String LIST_NAME = "WebColors" + INJECT_CHARS_1;
-    private static final ListHelper.ListColumnType LIST_KEY_TYPE = ListHelper.ListColumnType.Integer;
+    private static final FieldDefinition.ColumnType LIST_KEY_TYPE = FieldDefinition.ColumnType.Integer;
     private static final String LIST_KEY_NAME = "Key";
 
-    private static final ListHelper.ListColumn NAME_COLUMN =
-            new ListHelper.ListColumn("Name", "Name", ListHelper.ListColumnType.String, "Color Name");
-    private static final ListHelper.ListColumn HEX_COLUMN =
-            new ListHelper.ListColumn("Hex", "Hex", ListHelper.ListColumnType.String, "Hexadecimal");
+    private static final FieldDefinition NAME_COLUMN =
+            new FieldDefinition("Name", ColumnType.String).setDescription("Color Name");
+    private static final FieldDefinition HEX_COLUMN =
+            new FieldDefinition("Hex", ColumnType.String).setDescription("Hexadecimal");
 
     private static final String LIST_DATA;
     private static final int TOTAL_ROWS;
@@ -177,7 +178,7 @@ public class DataRegionTest extends AbstractQWPTest
         _containerHelper.createProject(getProjectName(), null);
 
         log("Define list");
-        _listHelper.createList(getProjectName(), LIST_NAME, LIST_KEY_TYPE, LIST_KEY_NAME, NAME_COLUMN, HEX_COLUMN);
+        _listHelper.createList(getProjectName(), LIST_NAME, new FieldDefinition(LIST_KEY_NAME, LIST_KEY_TYPE), NAME_COLUMN, HEX_COLUMN);
 
         log("Upload data");
         _listHelper.goToList(LIST_NAME);

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -39,7 +39,6 @@ import org.labkey.test.pages.experiment.CreateSampleTypePage;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.TestDataGenerator;
 import org.openqa.selenium.WebElement;
@@ -255,7 +254,8 @@ public class DomainDesignerTest extends BaseWebDriverTest
         String sampleType = "TestSampleForInvalidLookupField";
 
         log("Creating a list used for look up");
-        _listHelper.createList(getProjectName(), listName, ListHelper.ListColumnType.AutoInteger, "Id");
+        String containerPath = getProjectName();
+        _listHelper.createList(containerPath, listName, "Id");
 
         log("Creating a sample type with look up field to above list");
         FieldDefinition.LookupInfo lookupInfo1 = new FieldDefinition.LookupInfo(getProjectName(), "exp.materials", sampleType);

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -254,8 +254,7 @@ public class DomainDesignerTest extends BaseWebDriverTest
         String sampleType = "TestSampleForInvalidLookupField";
 
         log("Creating a list used for look up");
-        String containerPath = getProjectName();
-        _listHelper.createList(containerPath, listName, "Id");
+        _listHelper.createList(getProjectName(), listName, "Id");
 
         log("Creating a sample type with look up field to above list");
         FieldDefinition.LookupInfo lookupInfo1 = new FieldDefinition.LookupInfo(getProjectName(), "exp.materials", sampleType);

--- a/src/org/labkey/test/tests/ExportOptionsMetadataOnlyTest.java
+++ b/src/org/labkey/test/tests/ExportOptionsMetadataOnlyTest.java
@@ -137,8 +137,7 @@ public class ExportOptionsMetadataOnlyTest extends BaseWebDriverTest
         String listName = "Export List";
         goToProjectHome();
 
-        String containerPath = getProjectName();
-        _listHelper.createList(containerPath, listName, "id", new FieldDefinition("Color", FieldDefinition.ColumnType.String), new FieldDefinition("Shape", FieldDefinition.ColumnType.String));
+        _listHelper.createList(getProjectName(), listName, "id", new FieldDefinition("Color", FieldDefinition.ColumnType.String), new FieldDefinition("Shape", FieldDefinition.ColumnType.String));
         _listHelper.beginAtList(getProjectName(), listName);
         _listHelper.insertNewRow(Map.of("Color", "Yellow", "Shape", "Triangle"));
 

--- a/src/org/labkey/test/tests/ExportOptionsMetadataOnlyTest.java
+++ b/src/org/labkey/test/tests/ExportOptionsMetadataOnlyTest.java
@@ -17,7 +17,6 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.DataClassDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.PipelineStatusTable;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
@@ -138,7 +137,8 @@ public class ExportOptionsMetadataOnlyTest extends BaseWebDriverTest
         String listName = "Export List";
         goToProjectHome();
 
-        _listHelper.createList(getProjectName(), listName, ListHelper.ListColumnType.AutoInteger, "id", new FieldDefinition("Color", FieldDefinition.ColumnType.String), new FieldDefinition("Shape", FieldDefinition.ColumnType.String));
+        String containerPath = getProjectName();
+        _listHelper.createList(containerPath, listName, "id", new FieldDefinition("Color", FieldDefinition.ColumnType.String), new FieldDefinition("Shape", FieldDefinition.ColumnType.String));
         _listHelper.beginAtList(getProjectName(), listName);
         _listHelper.insertNewRow(Map.of("Color", "Yellow", "Shape", "Triangle"));
 

--- a/src/org/labkey/test/tests/FacetedFilterCutoffTest.java
+++ b/src/org/labkey/test/tests/FacetedFilterCutoffTest.java
@@ -22,8 +22,8 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PortalHelper;
 
@@ -56,9 +56,10 @@ public class FacetedFilterCutoffTest extends BaseWebDriverTest
     {
         _containerHelper.createProject(getProjectName(), null);
         new PortalHelper(this).addWebPart("Lists");
-        ListHelper.ListColumn col1 = new ListHelper.ListColumn(OVER_CUTOFF, OVER_CUTOFF, ListHelper.ListColumnType.Integer, "");
-        ListHelper.ListColumn col2 = new ListHelper.ListColumn(AT_CUTOFF, AT_CUTOFF, ListHelper.ListColumnType.Integer, "");
-        _listHelper.createList(getProjectName(), LIST_NAME, ListHelper.ListColumnType.AutoInteger, "Key", col1, col2);
+        FieldDefinition col1 = new FieldDefinition(OVER_CUTOFF, FieldDefinition.ColumnType.Integer).setLabel(OVER_CUTOFF);
+        FieldDefinition col2 = new FieldDefinition(AT_CUTOFF, FieldDefinition.ColumnType.Integer).setLabel(AT_CUTOFF);
+        String containerPath = getProjectName();
+        _listHelper.createList(containerPath, LIST_NAME, "Key", col1, col2);
         _listHelper.goToList(LIST_NAME);
         _listHelper.clickImportData()
                 .setText(getListData())

--- a/src/org/labkey/test/tests/FacetedFilterCutoffTest.java
+++ b/src/org/labkey/test/tests/FacetedFilterCutoffTest.java
@@ -58,8 +58,7 @@ public class FacetedFilterCutoffTest extends BaseWebDriverTest
         new PortalHelper(this).addWebPart("Lists");
         FieldDefinition col1 = new FieldDefinition(OVER_CUTOFF, FieldDefinition.ColumnType.Integer).setLabel(OVER_CUTOFF);
         FieldDefinition col2 = new FieldDefinition(AT_CUTOFF, FieldDefinition.ColumnType.Integer).setLabel(AT_CUTOFF);
-        String containerPath = getProjectName();
-        _listHelper.createList(containerPath, LIST_NAME, "Key", col1, col2);
+        _listHelper.createList(getProjectName(), LIST_NAME, "Key", col1, col2);
         _listHelper.goToList(LIST_NAME);
         _listHelper.clickImportData()
                 .setText(getListData())

--- a/src/org/labkey/test/tests/FileAttachmentColumnTest.java
+++ b/src/org/labkey/test/tests/FileAttachmentColumnTest.java
@@ -26,6 +26,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.experiment.UpdateSampleTypePage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ListHelper;
@@ -104,9 +105,8 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
         clickTab("Portal");
 
         ListHelper listHelper = new ListHelper(getDriver());
-        listHelper.createList(getProjectName() + "/" + FOLDER_NAME, LIST_NAME, ListHelper.ListColumnType.AutoInteger, LIST_KEY,
-                new ListHelper.ListColumn("Name", "Name", ListHelper.ListColumnType.String),
-                new ListHelper.ListColumn("File", "File", ListHelper.ListColumnType.Attachment));
+        String containerPath = getProjectName() + "/" + FOLDER_NAME;
+        listHelper.createList(containerPath, LIST_NAME, LIST_KEY, new FieldDefinition("Name", ColumnType.String), new FieldDefinition("File", ColumnType.Attachment));
         goToManageLists();
         listHelper.click(Locator.linkContainingText(LIST_NAME));
         // todo: import actual data here
@@ -139,13 +139,13 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
         log("adding sample type with file column");
 
         SampleTypeHelper sampleHelper = new SampleTypeHelper(this);
-        sampleHelper.createSampleType(new SampleTypeDefinition(SAMPLESET_NAME).setFields(List.of(new FieldDefinition("color", FieldDefinition.ColumnType.String))), Collections.singletonList(Map.of("Name", "ed", "color", "green")));
+        sampleHelper.createSampleType(new SampleTypeDefinition(SAMPLESET_NAME).setFields(List.of(new FieldDefinition("color", ColumnType.String))), Collections.singletonList(Map.of("Name", "ed", "color", "green")));
 
         // add a 'file' column
         log("editing fields for sample type");
         clickFolder(FOLDER_NAME);
         UpdateSampleTypePage updatePage = sampleHelper.goToEditSampleType(SAMPLESET_NAME);
-        updatePage.addFields(List.of(new FieldDefinition("File", FieldDefinition.ColumnType.File)));
+        updatePage.addFields(List.of(new FieldDefinition("File", ColumnType.File)));
         updatePage.clickSave();
 
         StringBuilder sb = new StringBuilder("Name\tcolor\tfile\n");

--- a/src/org/labkey/test/tests/FileAttachmentColumnTest.java
+++ b/src/org/labkey/test/tests/FileAttachmentColumnTest.java
@@ -105,8 +105,9 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
         clickTab("Portal");
 
         ListHelper listHelper = new ListHelper(getDriver());
-        String containerPath = getProjectName() + "/" + FOLDER_NAME;
-        listHelper.createList(containerPath, LIST_NAME, LIST_KEY, new FieldDefinition("Name", ColumnType.String), new FieldDefinition("File", ColumnType.Attachment));
+        listHelper.createList(getProjectName() + "/" + FOLDER_NAME, LIST_NAME, LIST_KEY,
+                new FieldDefinition("Name", ColumnType.String),
+                new FieldDefinition("File", ColumnType.Attachment));
         goToManageLists();
         listHelper.click(Locator.linkContainingText(LIST_NAME));
         // todo: import actual data here

--- a/src/org/labkey/test/tests/FiltersOnMultipleGridsTest.java
+++ b/src/org/labkey/test/tests/FiltersOnMultipleGridsTest.java
@@ -8,9 +8,10 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.CustomizeView;
+import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.PortalHelper;
 
 import java.util.Arrays;
@@ -36,10 +37,8 @@ public class FiltersOnMultipleGridsTest extends BaseWebDriverTest
     {
         _containerHelper.createProject(getProjectName());
         log("Creating test list");
-        _listHelper.createList(getProjectName() + "/", LIST_NAME, ListHelper.ListColumnType.AutoInteger, "RowId",
-                new ListHelper.ListColumn("FirstName", "First Name", ListHelper.ListColumnType.String),
-                new ListHelper.ListColumn("LastName", "Last Name", ListHelper.ListColumnType.String),
-                new ListHelper.ListColumn("Age", "Age", ListHelper.ListColumnType.Integer));
+        String containerPath = getProjectName() + "/";
+        _listHelper.createList(containerPath, LIST_NAME, "RowId", new FieldDefinition("FirstName", ColumnType.String), new FieldDefinition("LastName", ColumnType.String), new FieldDefinition("Age", ColumnType.Integer));
 
         log("Adding Single list webpart");
         goToProjectHome();

--- a/src/org/labkey/test/tests/FiltersOnMultipleGridsTest.java
+++ b/src/org/labkey/test/tests/FiltersOnMultipleGridsTest.java
@@ -37,8 +37,10 @@ public class FiltersOnMultipleGridsTest extends BaseWebDriverTest
     {
         _containerHelper.createProject(getProjectName());
         log("Creating test list");
-        String containerPath = getProjectName() + "/";
-        _listHelper.createList(containerPath, LIST_NAME, "RowId", new FieldDefinition("FirstName", ColumnType.String), new FieldDefinition("LastName", ColumnType.String), new FieldDefinition("Age", ColumnType.Integer));
+        _listHelper.createList(getProjectName(), LIST_NAME, "RowId",
+                new FieldDefinition("FirstName", ColumnType.String),
+                new FieldDefinition("LastName", ColumnType.String),
+                new FieldDefinition("Age", ColumnType.Integer));
 
         log("Adding Single list webpart");
         goToProjectHome();
@@ -85,11 +87,11 @@ public class FiltersOnMultipleGridsTest extends BaseWebDriverTest
     private void insertListData(String firstName, String lastName, String age)
     {
         DataRegionTable listTable = DataRegionTable.findDataRegionWithinWebpart(this, LIST_WEBPART_TITLE);
-        listTable.clickInsertNewRow();
-        setFormElement(Locator.name("quf_FirstName"), firstName);
-        setFormElement(Locator.name("quf_LastName"), lastName);
-        setFormElement(Locator.name("quf_Age"), age);
-        clickButton("Submit");
+        listTable.clickInsertNewRow()
+                .setField("FirstName", firstName)
+                .setField("LastName", lastName)
+                .setField("Age", age)
+                .submit();
     }
 
     @Override

--- a/src/org/labkey/test/tests/FolderTest.java
+++ b/src/org/labkey/test/tests/FolderTest.java
@@ -274,7 +274,8 @@ public class FolderTest extends BaseWebDriverTest
     private void createListWithData(String subfolder) throws Exception
     {
         String containerPath = getProjectName() + "/" + subfolder;
-        _listHelper.createList(containerPath, "List1", "RowId", new FieldDefinition("Col1", FieldDefinition.ColumnType.String).setLabel("ColLabel"));
+        _listHelper.createList(containerPath, "List1", "RowId",
+                new FieldDefinition("Col1", FieldDefinition.ColumnType.String).setLabel("ColLabel"));
 
         InsertRowsCommand ir = new InsertRowsCommand("lists", "List1");
         Map<String, Object> row1 = new HashMap<>();
@@ -283,7 +284,7 @@ public class FolderTest extends BaseWebDriverTest
         ir.addRow(row1);
 
         Connection cn = new Connection(WebTestHelper.getBaseURL(), PasswordUtil.getUsername(), PasswordUtil.getPassword());
-        ir.execute(cn, getProjectName() + "/" + subfolder);
+        ir.execute(cn, containerPath);
     }
 
     @Test

--- a/src/org/labkey/test/tests/FolderTest.java
+++ b/src/org/labkey/test/tests/FolderTest.java
@@ -38,9 +38,9 @@ import org.labkey.test.pages.FolderManagementFolderTree;
 import org.labkey.test.pages.admin.FolderManagementPage;
 import org.labkey.test.pages.admin.ReorderFoldersPage;
 import org.labkey.test.pages.list.BeginPage;
+import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.PasswordUtil;
@@ -273,7 +273,8 @@ public class FolderTest extends BaseWebDriverTest
 
     private void createListWithData(String subfolder) throws Exception
     {
-        _listHelper.createList(getProjectName() + "/" + subfolder, "List1", ListHelper.ListColumnType.AutoInteger, "RowId", new ListHelper.ListColumn("Col1", "ColLabel", ListHelper.ListColumnType.String));
+        String containerPath = getProjectName() + "/" + subfolder;
+        _listHelper.createList(containerPath, "List1", "RowId", new FieldDefinition("Col1", FieldDefinition.ColumnType.String).setLabel("ColLabel"));
 
         InsertRowsCommand ir = new InsertRowsCommand("lists", "List1");
         Map<String, Object> row1 = new HashMap<>();

--- a/src/org/labkey/test/tests/HTTPApiTest.java
+++ b/src/org/labkey/test/tests/HTTPApiTest.java
@@ -23,8 +23,8 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.util.APITestHelper;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.PortalHelper;
 
 import java.io.File;
@@ -37,9 +37,9 @@ public class HTTPApiTest extends BaseWebDriverTest
 {
     private static final String LIST_NAME = "Test List";
 
-    private static final FieldDefinition COL1 = new FieldDefinition("Like", FieldDefinition.ColumnType.String).setLabel("Like").setDescription("What the color is like");
-    private static final FieldDefinition COL2 = new FieldDefinition("Month", FieldDefinition.ColumnType.DateAndTime).setLabel("Month to Wear").setDescription("When to wear the color").setFormat("M");
-    private static final FieldDefinition COL3 = new FieldDefinition("Good", FieldDefinition.ColumnType.Integer).setLabel("Quality").setDescription("How nice the color is");
+    private static final FieldDefinition COL1 = new FieldDefinition("Like", ColumnType.String).setLabel("Like").setDescription("What the color is like");
+    private static final FieldDefinition COL2 = new FieldDefinition("Month", ColumnType.DateAndTime).setLabel("Month to Wear").setDescription("When to wear the color").setFormat("M");
+    private static final FieldDefinition COL3 = new FieldDefinition("Good", ColumnType.Integer).setLabel("Quality").setDescription("How nice the color is");
     private final static String[][] TEST_DATA = { { "Blue", "Green", "Red", "Yellow" },
             { "Zany", "Robust", "Mellow", "Light"},
             { "1", "4", "3", "2" },
@@ -91,7 +91,7 @@ public class HTTPApiTest extends BaseWebDriverTest
         portalHelper.addWebPart("Lists");
 
         log("Create List");
-        _listHelper.createList(getProjectName(), LIST_NAME, ListHelper.ListColumnType.String, "Color", COL1, COL2, COL3);
+        _listHelper.createList(getProjectName(), LIST_NAME, new FieldDefinition("Color", ColumnType.String), COL1, COL2, COL3);
         _listHelper.goToList(LIST_NAME);
         EditListDefinitionPage listDefinitionPage = _listHelper.goToEditDesign(LIST_NAME);
         listDefinitionPage.openAdvancedListSettings().setFieldUsedForDisplayTitle("Like").clickApply();

--- a/src/org/labkey/test/tests/InlineImagesListTest.java
+++ b/src/org/labkey/test/tests/InlineImagesListTest.java
@@ -29,10 +29,11 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.list.EditListDefinitionPage;
+import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ExcelHelper;
-import org.labkey.test.util.ListHelper;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
@@ -52,7 +53,7 @@ public class InlineImagesListTest extends BaseWebDriverTest
 {
     protected final static String LIST_NAME = "InlineImagesList";
     protected final static String LIST_KEY_NAME = "Key";
-    protected final static ListHelper.ListColumnType LIST_KEY_TYPE = ListHelper.ListColumnType.Integer;
+    protected final static ColumnType LIST_KEY_TYPE = ColumnType.Integer;
 
     protected final static String LIST_ATTACHMENT01_NAME = "Attachment01";
     protected final static String LIST_ATTACHMENT01_LABEL = "Attachment Column 01";
@@ -62,16 +63,16 @@ public class InlineImagesListTest extends BaseWebDriverTest
     protected final static String LIST_ATTACHMENT02_LABEL = "Attachment Column 02";
     protected final static String LIST_ATTACHMENT02_DESC = "An 2nd attachment column.";
 
-    protected final static ListHelper.ListColumnType LIST_ATTACHMENT_TYPE = ListHelper.ListColumnType.Attachment;
+    protected final static ColumnType LIST_ATTACHMENT_TYPE = ColumnType.Attachment;
 
     protected final static String LIST_DESC_COL_NAME = "Description";
     protected final static String LIST_DESC_COL_LABEL = "Description";
     protected final static String LIST_DESC_COL_DESC = "A simple description(text) field.";
-    protected final static ListHelper.ListColumnType LIST_DESC_COL_TYPE = ListHelper.ListColumnType.String;
+    protected final static ColumnType LIST_DESC_COL_TYPE = ColumnType.String;
 
-    protected final ListHelper.ListColumn _listColAttachment01 = new ListHelper.ListColumn(LIST_ATTACHMENT01_NAME, LIST_ATTACHMENT01_LABEL, LIST_ATTACHMENT_TYPE, LIST_ATTACHMENT01_DESC);
-    protected final ListHelper.ListColumn _listColAttachment02 = new ListHelper.ListColumn(LIST_ATTACHMENT02_NAME, LIST_ATTACHMENT02_LABEL, LIST_ATTACHMENT_TYPE, LIST_ATTACHMENT02_DESC);
-    protected final ListHelper.ListColumn _listColDescription = new ListHelper.ListColumn(LIST_DESC_COL_NAME, LIST_DESC_COL_LABEL, LIST_DESC_COL_TYPE, LIST_DESC_COL_DESC);
+    protected final FieldDefinition _listColAttachment01 = new FieldDefinition(LIST_ATTACHMENT01_NAME, LIST_ATTACHMENT_TYPE).setLabel(LIST_ATTACHMENT01_LABEL).setDescription(LIST_ATTACHMENT01_DESC);
+    protected final FieldDefinition _listColAttachment02 = new FieldDefinition(LIST_ATTACHMENT02_NAME, LIST_ATTACHMENT_TYPE).setLabel(LIST_ATTACHMENT02_LABEL).setDescription(LIST_ATTACHMENT02_DESC);
+    protected final FieldDefinition _listColDescription = new FieldDefinition(LIST_DESC_COL_NAME, LIST_DESC_COL_TYPE).setLabel(LIST_DESC_COL_LABEL).setDescription( LIST_DESC_COL_DESC);
 
     protected final static File LRG_PNG_FILE = TestFileUtils.getSampleData("InlineImages/screenshot.png");
     protected final static File JPG01_FILE = TestFileUtils.getSampleData("InlineImages/help.jpg");
@@ -140,7 +141,7 @@ public class InlineImagesListTest extends BaseWebDriverTest
         List<String> exportedColumn;
 
         log("Create a list named: " + LIST_NAME);
-        _listHelper.createList(getProjectName(), LIST_NAME, LIST_KEY_TYPE, LIST_KEY_NAME, _listColDescription, _listColAttachment01);
+        _listHelper.createList(getProjectName(), LIST_NAME, new FieldDefinition(LIST_KEY_NAME, LIST_KEY_TYPE), _listColDescription, _listColAttachment01);
 
         Map<String, String> newValues = new HashMap<>();
         goToManageLists();

--- a/src/org/labkey/test/tests/MissingValueIndicatorsTest.java
+++ b/src/org/labkey/test/tests/MissingValueIndicatorsTest.java
@@ -22,8 +22,8 @@ import org.labkey.test.Locator;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.LogMethod;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriverException;
@@ -185,7 +185,7 @@ public abstract class MissingValueIndicatorsTest extends BaseWebDriverTest
                         "50";
 
         goToModule("List");
-        _listHelper.createList(getProjectName(), "Ages", ListHelper.ListColumnType.Integer, "Age");
+        _listHelper.createList(getProjectName(), "Ages", new FieldDefinition("Age", ColumnType.Integer));
         _listHelper.goToList("Ages");
         _listHelper.uploadData(TEST_DATA_AGE_LIST);
     }
@@ -202,14 +202,14 @@ public abstract class MissingValueIndicatorsTest extends BaseWebDriverTest
 
         resultsPanel.addField("age")
             .setLabel("Age")
-            .setType(FieldDefinition.ColumnType.Lookup)
+            .setType(ColumnType.Lookup)
             .setFromSchema("lists")
             .setFromTargetTable("Ages (Integer)")
             .setMissingValuesEnabled(true);
 
         resultsPanel.addField("sex")
             .setLabel("Sex")
-            .setType(FieldDefinition.ColumnType.String)
+            .setType(ColumnType.String)
             .setMissingValuesEnabled(true);
 
         assayDesignerPage.clickFinish();

--- a/src/org/labkey/test/tests/ProjectSettingsTest.java
+++ b/src/org/labkey/test/tests/ProjectSettingsTest.java
@@ -330,8 +330,8 @@ public class ProjectSettingsTest extends BaseWebDriverTest
         projectSettingPage.setDefaultDateTimeDisplay(DATE_TIME_FORMAT_INJECTION);
         projectSettingPage.save();
 
-        String containerPath = getProjectName();
-        _listHelper.createList(containerPath, "IceCream", "IceCreamID", new FieldDefinition("IceCreamDate", ColumnType.DateAndTime));
+        _listHelper.createList(getProjectName(), "IceCream", "IceCreamID",
+                new FieldDefinition("IceCreamDate", ColumnType.DateAndTime));
         goToProjectHome();
         clickAndWait(Locator.linkWithText("IceCream"));
         Map<String, String> testRow = new HashMap<>();

--- a/src/org/labkey/test/tests/ProjectSettingsTest.java
+++ b/src/org/labkey/test/tests/ProjectSettingsTest.java
@@ -30,10 +30,10 @@ import org.labkey.test.pages.core.admin.BaseSettingsPage;
 import org.labkey.test.pages.core.admin.LookAndFeelSettingsPage;
 import org.labkey.test.pages.core.admin.ProjectSettingsPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.params.list.IntListDefinition;
 import org.labkey.test.params.list.ListDefinition;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.TestDataGenerator;
 import org.openqa.selenium.WebElement;
@@ -190,9 +190,9 @@ public class ProjectSettingsTest extends BaseWebDriverTest
     {
 
         ListDefinition listDef = new IntListDefinition(DT_LIST_NAME, DT_LIST_ID_COL);
-        listDef.setFields(List.of(new FieldDefinition(DT_LIST_DATE_COL, FieldDefinition.ColumnType.Date),
-                new FieldDefinition(DT_LIST_TIME_COL, FieldDefinition.ColumnType.Time),
-                new FieldDefinition(DT_LIST_DATETIME_COL, FieldDefinition.ColumnType.DateAndTime)));
+        listDef.setFields(List.of(new FieldDefinition(DT_LIST_DATE_COL, ColumnType.Date),
+                new FieldDefinition(DT_LIST_TIME_COL, ColumnType.Time),
+                new FieldDefinition(DT_LIST_DATETIME_COL, ColumnType.DateAndTime)));
 
         TestDataGenerator tdg = listDef.create(createDefaultConnection(), project);
 
@@ -330,8 +330,8 @@ public class ProjectSettingsTest extends BaseWebDriverTest
         projectSettingPage.setDefaultDateTimeDisplay(DATE_TIME_FORMAT_INJECTION);
         projectSettingPage.save();
 
-        _listHelper.createList(getProjectName(), "IceCream", ListHelper.ListColumnType.AutoInteger, "IceCreamID",
-                new ListHelper.ListColumn("IceCreamDate", "", ListHelper.ListColumnType.DateAndTime, ""));
+        String containerPath = getProjectName();
+        _listHelper.createList(containerPath, "IceCream", "IceCreamID", new FieldDefinition("IceCreamDate", ColumnType.DateAndTime));
         goToProjectHome();
         clickAndWait(Locator.linkWithText("IceCream"));
         Map<String, String> testRow = new HashMap<>();

--- a/src/org/labkey/test/tests/SchemaBrowserTest.java
+++ b/src/org/labkey/test/tests/SchemaBrowserTest.java
@@ -22,7 +22,6 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.params.FieldDefinition;
-import org.labkey.test.util.ListHelper;
 
 import java.util.Arrays;
 import java.util.List;
@@ -120,23 +119,10 @@ public class SchemaBrowserTest extends BaseWebDriverTest
 
     public void createLists()
     {
-        _listHelper.createList(PROJECT_NAME, AUTHORS_LIST,
-                ListHelper.ListColumnType.AutoInteger, "AuthorId",
-                new FieldDefinition("FirstName", FieldDefinition.ColumnType.String).setDescription(TEST_DESC_AUTHORS),
-                new FieldDefinition("LastName", FieldDefinition.ColumnType.String)
-        );
+        _listHelper.createList(PROJECT_NAME, AUTHORS_LIST, "AuthorId", new FieldDefinition("FirstName", FieldDefinition.ColumnType.String).setDescription(TEST_DESC_AUTHORS), new FieldDefinition("LastName", FieldDefinition.ColumnType.String));
 
-        _listHelper.createList(PROJECT_NAME, PUBLISHERS_LIST,
-                ListHelper.ListColumnType.AutoInteger, "PublisherId",
-                new FieldDefinition("Name", FieldDefinition.ColumnType.String).setDescription(TEST_DESC_PUBLISHERS)
-        );
+        _listHelper.createList(PROJECT_NAME, PUBLISHERS_LIST, "PublisherId", new FieldDefinition("Name", FieldDefinition.ColumnType.String).setDescription(TEST_DESC_PUBLISHERS));
 
-        _listHelper.createList(PROJECT_NAME, BOOKS_LIST,
-                ListHelper.ListColumnType.AutoInteger, "TitleId",
-                new FieldDefinition("Title", FieldDefinition.ColumnType.String).setDescription(TEST_DESC_BOOKS),
-                new FieldDefinition("Subtitle", FieldDefinition.ColumnType.String),
-                new FieldDefinition("AuthorId", new FieldDefinition.LookupInfo("", "lists", AUTHORS_LIST).setTableType(FieldDefinition.ColumnType.Integer)),
-                new FieldDefinition("PublisherId", new FieldDefinition.LookupInfo("", "lists", PUBLISHERS_LIST).setTableType(FieldDefinition.ColumnType.Integer))
-        );
+        _listHelper.createList(PROJECT_NAME, BOOKS_LIST, "TitleId", new FieldDefinition("Title", FieldDefinition.ColumnType.String).setDescription(TEST_DESC_BOOKS), new FieldDefinition("Subtitle", FieldDefinition.ColumnType.String), new FieldDefinition("AuthorId", new FieldDefinition.LookupInfo("", "lists", AUTHORS_LIST).setTableType(FieldDefinition.ColumnType.Integer)), new FieldDefinition("PublisherId", new FieldDefinition.LookupInfo("", "lists", PUBLISHERS_LIST).setTableType(FieldDefinition.ColumnType.Integer)));
     }
 }

--- a/src/org/labkey/test/tests/SchemaBrowserTest.java
+++ b/src/org/labkey/test/tests/SchemaBrowserTest.java
@@ -119,10 +119,17 @@ public class SchemaBrowserTest extends BaseWebDriverTest
 
     public void createLists()
     {
-        _listHelper.createList(PROJECT_NAME, AUTHORS_LIST, "AuthorId", new FieldDefinition("FirstName", FieldDefinition.ColumnType.String).setDescription(TEST_DESC_AUTHORS), new FieldDefinition("LastName", FieldDefinition.ColumnType.String));
+        _listHelper.createList(PROJECT_NAME, AUTHORS_LIST, "AuthorId",
+                new FieldDefinition("FirstName", FieldDefinition.ColumnType.String).setDescription(TEST_DESC_AUTHORS),
+                new FieldDefinition("LastName", FieldDefinition.ColumnType.String));
 
-        _listHelper.createList(PROJECT_NAME, PUBLISHERS_LIST, "PublisherId", new FieldDefinition("Name", FieldDefinition.ColumnType.String).setDescription(TEST_DESC_PUBLISHERS));
+        _listHelper.createList(PROJECT_NAME, PUBLISHERS_LIST, "PublisherId",
+                new FieldDefinition("Name", FieldDefinition.ColumnType.String).setDescription(TEST_DESC_PUBLISHERS));
 
-        _listHelper.createList(PROJECT_NAME, BOOKS_LIST, "TitleId", new FieldDefinition("Title", FieldDefinition.ColumnType.String).setDescription(TEST_DESC_BOOKS), new FieldDefinition("Subtitle", FieldDefinition.ColumnType.String), new FieldDefinition("AuthorId", new FieldDefinition.LookupInfo("", "lists", AUTHORS_LIST).setTableType(FieldDefinition.ColumnType.Integer)), new FieldDefinition("PublisherId", new FieldDefinition.LookupInfo("", "lists", PUBLISHERS_LIST).setTableType(FieldDefinition.ColumnType.Integer)));
+        _listHelper.createList(PROJECT_NAME, BOOKS_LIST, "TitleId",
+                new FieldDefinition("Title", FieldDefinition.ColumnType.String).setDescription(TEST_DESC_BOOKS),
+                new FieldDefinition("Subtitle", FieldDefinition.ColumnType.String),
+                new FieldDefinition("AuthorId", new FieldDefinition.IntLookup( "lists", AUTHORS_LIST)),
+                new FieldDefinition("PublisherId", new FieldDefinition.IntLookup( "lists", PUBLISHERS_LIST)));
     }
 }

--- a/src/org/labkey/test/tests/TextChoiceImportExportAndOtherDomainsTest.java
+++ b/src/org/labkey/test/tests/TextChoiceImportExportAndOtherDomainsTest.java
@@ -114,8 +114,7 @@ public class TextChoiceImportExportAndOtherDomainsTest extends TextChoiceTest
         log(String.format("Create a list named '%s' with a string field '%s' and a TextChoice field '%s'.",
                 LIST_NAME, LIST_TEXT_FIELD, LIST_TC_FIELD));
 
-        String containerPath = getCurrentContainerPath();
-        _listHelper.createList(containerPath, LIST_NAME, "Key", tcField, txtField);
+        _listHelper.createList(getCurrentContainerPath(), LIST_NAME, "Key", tcField, txtField);
 
         log("Bulk upload data into the list.");
 

--- a/src/org/labkey/test/tests/TextChoiceImportExportAndOtherDomainsTest.java
+++ b/src/org/labkey/test/tests/TextChoiceImportExportAndOtherDomainsTest.java
@@ -18,7 +18,6 @@ import org.labkey.test.pages.issues.IssuesAdminPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.IssuesHelper;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
 
@@ -115,7 +114,8 @@ public class TextChoiceImportExportAndOtherDomainsTest extends TextChoiceTest
         log(String.format("Create a list named '%s' with a string field '%s' and a TextChoice field '%s'.",
                 LIST_NAME, LIST_TEXT_FIELD, LIST_TC_FIELD));
 
-        _listHelper.createList(getCurrentContainerPath(), LIST_NAME, ListHelper.ListColumnType.AutoInteger, "Key", tcField, txtField);
+        String containerPath = getCurrentContainerPath();
+        _listHelper.createList(containerPath, LIST_NAME, "Key", tcField, txtField);
 
         log("Bulk upload data into the list.");
 

--- a/src/org/labkey/test/tests/TimelineTest.java
+++ b/src/org/labkey/test/tests/TimelineTest.java
@@ -20,7 +20,8 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.util.ListHelper;
+import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.WikiHelper;
 import org.openqa.selenium.WebElement;
@@ -41,15 +42,14 @@ public class TimelineTest extends BaseWebDriverTest
     private static final String PROJECT_NAME = "TimelineTestProject";
     private static final String FOLDER_NAME = "timeline folder";
     private final static String LIST_NAME = "People";
-    private final static ListHelper.ListColumnType LIST_KEY_TYPE = ListHelper.ListColumnType.AutoInteger;
     private final static String LIST_KEY_NAME = "Key";
 
-    private final static ListHelper.ListColumn[] LIST_COLUMNS = new ListHelper.ListColumn[]
+    private final static FieldDefinition[] LIST_COLUMNS = new FieldDefinition[]
     {
-        new ListHelper.ListColumn("FirstName", "First Name", ListHelper.ListColumnType.String, "The first name"),
-        new ListHelper.ListColumn("LastName", "Last Name", ListHelper.ListColumnType.String, "The last name"),
-        new ListHelper.ListColumn("DOB", "DOB", ListHelper.ListColumnType.DateAndTime, "Date of Birth"),
-        new ListHelper.ListColumn("DOD", "DOD", ListHelper.ListColumnType.DateAndTime, "Date of Death"),
+        new FieldDefinition("FirstName", ColumnType.String).setDescription("The first name"),
+        new FieldDefinition("LastName", ColumnType.String).setDescription("The last name"),
+        new FieldDefinition("DOB", ColumnType.DateAndTime).setLabel("DOB").setDescription("Date of Birth"),
+        new FieldDefinition("DOD", ColumnType.DateAndTime).setLabel("DOD").setDescription("Date of Death"),
     };
 
     private final static String[][] TEST_DATA =
@@ -156,7 +156,8 @@ public class TimelineTest extends BaseWebDriverTest
 
     private void createList()
     {
-        _listHelper.createList(getProjectName() + "/" + FOLDER_NAME, LIST_NAME, LIST_KEY_TYPE, LIST_KEY_NAME, LIST_COLUMNS);
+        String containerPath = getProjectName() + "/" + FOLDER_NAME;
+        _listHelper.createList(containerPath, LIST_NAME, LIST_KEY_NAME, LIST_COLUMNS);
 
         StringBuilder data = new StringBuilder();
         data.append(LIST_KEY_NAME).append("\t");

--- a/src/org/labkey/test/tests/TimelineTest.java
+++ b/src/org/labkey/test/tests/TimelineTest.java
@@ -156,8 +156,7 @@ public class TimelineTest extends BaseWebDriverTest
 
     private void createList()
     {
-        String containerPath = getProjectName() + "/" + FOLDER_NAME;
-        _listHelper.createList(containerPath, LIST_NAME, LIST_KEY_NAME, LIST_COLUMNS);
+        _listHelper.createList(getProjectName() + "/" + FOLDER_NAME, LIST_NAME, LIST_KEY_NAME, LIST_COLUMNS);
 
         StringBuilder data = new StringBuilder();
         data.append(LIST_KEY_NAME).append("\t");

--- a/src/org/labkey/test/tests/TriggerScriptTest.java
+++ b/src/org/labkey/test/tests/TriggerScriptTest.java
@@ -36,10 +36,10 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Data;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.params.experiment.DataClassDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.Maps;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.exp.SampleTypeAPIHelper;
@@ -179,20 +179,18 @@ public class TriggerScriptTest extends BaseWebDriverTest
 
         //create List
         FieldDefinition[] columns = new FieldDefinition[] {
-                new ListHelper.ListColumn("name", "Name", ListHelper.ListColumnType.String, ""),
-                new ListHelper.ListColumn("ssn","SSN", ListHelper.ListColumnType.String,""),
-                new ListHelper.ListColumn("company","Company",ListHelper.ListColumnType.String,"")
+                new FieldDefinition("name", ColumnType.String).setLabel("Name"),
+                new FieldDefinition("ssn", ColumnType.String).setLabel("SSN"),
+                new FieldDefinition("company", ColumnType.String).setLabel("Company")
 
         };
 
-        _listHelper.createList(getProjectName(), LIST_NAME, ListHelper.ListColumnType.AutoInteger, "Key", columns );
+        String containerPath1 = getProjectName();
+        _listHelper.createList(containerPath1, LIST_NAME, "Key", columns);
 
         log("Create list in subfolder to prevent query validation failure");
-        _listHelper.createList(getProjectName(), "People",
-                ListHelper.ListColumnType.AutoInteger, "Key",
-                new ListHelper.ListColumn("Name", "Name", ListHelper.ListColumnType.String, "Name"),
-                new ListHelper.ListColumn("Age", "Age", ListHelper.ListColumnType.Integer, "Age"),
-                new ListHelper.ListColumn("Crazy", "Crazy", ListHelper.ListColumnType.Boolean, "Crazy?"));
+        String containerPath = getProjectName();
+        _listHelper.createList(containerPath, "People", "Key", new FieldDefinition("Name", ColumnType.String).setDescription("Name"), new FieldDefinition("Age", ColumnType.Integer).setDescription("Age"), new FieldDefinition("Crazy", ColumnType.Boolean).setDescription("Crazy?"));
 
         importFolderFromZip(TestFileUtils.getSampleData("studies/LabkeyDemoStudy.zip"));
 
@@ -815,8 +813,8 @@ public class TriggerScriptTest extends BaseWebDriverTest
 
         DataClassDefinition dataClass = new DataClassDefinition(DATA_CLASSES_NAME)
                 .setFields(List.of(
-                        new FieldDefinition(COMMENTS_FIELD, FieldDefinition.ColumnType.String),
-                        new FieldDefinition(COUNTRY_FIELD, FieldDefinition.ColumnType.String)));
+                        new FieldDefinition(COMMENTS_FIELD, ColumnType.String),
+                        new FieldDefinition(COUNTRY_FIELD, ColumnType.String)));
         dataClass.create(createDefaultConnection(), getProjectName());
     }
 
@@ -827,8 +825,8 @@ public class TriggerScriptTest extends BaseWebDriverTest
     {
         SampleTypeDefinition sampleType = new SampleTypeDefinition(SAMPLE_TYPE_NAME)
                 .setFields(List.of(
-                        new FieldDefinition(COMMENTS_FIELD, FieldDefinition.ColumnType.String),
-                        new FieldDefinition(COUNTRY_FIELD, FieldDefinition.ColumnType.String)));
+                        new FieldDefinition(COMMENTS_FIELD, ColumnType.String),
+                        new FieldDefinition(COUNTRY_FIELD, ColumnType.String)));
         SampleTypeAPIHelper.createEmptySampleType(getProjectName(), sampleType);
     }
 }

--- a/src/org/labkey/test/tests/TriggerScriptTest.java
+++ b/src/org/labkey/test/tests/TriggerScriptTest.java
@@ -185,12 +185,13 @@ public class TriggerScriptTest extends BaseWebDriverTest
 
         };
 
-        String containerPath1 = getProjectName();
-        _listHelper.createList(containerPath1, LIST_NAME, "Key", columns);
+        _listHelper.createList(getProjectName(), LIST_NAME, "Key", columns);
 
         log("Create list in subfolder to prevent query validation failure");
-        String containerPath = getProjectName();
-        _listHelper.createList(containerPath, "People", "Key", new FieldDefinition("Name", ColumnType.String).setDescription("Name"), new FieldDefinition("Age", ColumnType.Integer).setDescription("Age"), new FieldDefinition("Crazy", ColumnType.Boolean).setDescription("Crazy?"));
+        _listHelper.createList(getProjectName(), "People", "Key",
+                new FieldDefinition("Name", ColumnType.String).setDescription("Name"),
+                new FieldDefinition("Age", ColumnType.Integer).setDescription("Age"),
+                new FieldDefinition("Crazy", ColumnType.Boolean).setDescription("Crazy?"));
 
         importFolderFromZip(TestFileUtils.getSampleData("studies/LabkeyDemoStudy.zip"));
 

--- a/src/org/labkey/test/tests/UserDetailsPermissionTest.java
+++ b/src/org/labkey/test/tests/UserDetailsPermissionTest.java
@@ -244,10 +244,9 @@ public class UserDetailsPermissionTest extends BaseWebDriverTest
         // Create list
         impersonate(ADMIN_USER);
         FieldDefinition userColumn = new FieldDefinition("user",
-                new FieldDefinition.LookupInfo(getProjectName(), "core", "Users").setTableType(FieldDefinition.ColumnType.Integer));
+                new FieldDefinition.IntLookup(getProjectName(), "core", "Users"));
 
-        String containerPath = getProjectName();
-        _listHelper.createList(containerPath, EMAIL_TEST_LIST, "Key", userColumn);
+        _listHelper.createList(getProjectName(), EMAIL_TEST_LIST, "Key", userColumn);
         goToManageLists();
         clickAndWait(Locator.linkWithText(EMAIL_TEST_LIST));
         DataRegionTable.findDataRegion(this).clickInsertNewRow();

--- a/src/org/labkey/test/tests/UserDetailsPermissionTest.java
+++ b/src/org/labkey/test/tests/UserDetailsPermissionTest.java
@@ -32,7 +32,6 @@ import org.labkey.test.pages.query.ExecuteQueryPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.PortalHelper;
@@ -247,7 +246,8 @@ public class UserDetailsPermissionTest extends BaseWebDriverTest
         FieldDefinition userColumn = new FieldDefinition("user",
                 new FieldDefinition.LookupInfo(getProjectName(), "core", "Users").setTableType(FieldDefinition.ColumnType.Integer));
 
-        _listHelper.createList(getProjectName(), EMAIL_TEST_LIST, ListHelper.ListColumnType.AutoInteger, "Key", userColumn);
+        String containerPath = getProjectName();
+        _listHelper.createList(containerPath, EMAIL_TEST_LIST, "Key", userColumn);
         goToManageLists();
         clickAndWait(Locator.linkWithText(EMAIL_TEST_LIST));
         DataRegionTable.findDataRegion(this).clickInsertNewRow();

--- a/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
@@ -349,7 +349,7 @@ public class FileContentUploadTest extends BaseWebDriverTest
 
         row = editor.fieldsPanel().addField(COLUMN_NAME);
         row.setLabel(COLUMN_NAME);
-        row.setLookup(new FieldDefinition.LookupInfo(getProjectName(), "lists", LIST_NAME).setTableType(ColumnType.String));
+        row.setLookup(new FieldDefinition.StringLookup(getProjectName(), "lists", LIST_NAME));
         editor.clickFinish();
     }
 

--- a/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
@@ -33,6 +33,7 @@ import org.labkey.test.components.domain.DomainFieldRow;
 import org.labkey.test.components.ext4.ComboBox;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.tests.MessagesLongTest;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
@@ -40,7 +41,6 @@ import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.FileBrowserExtendedProperty;
 import org.labkey.test.util.FileBrowserHelper;
 import org.labkey.test.util.LabKeyExpectedConditions;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.PortalHelper;
@@ -336,7 +336,7 @@ public class FileContentUploadTest extends BaseWebDriverTest
     private void setupCustomFileProperties()
     {
         // Create list for lookup custom file property
-        _listHelper.createList(getProjectName(), LIST_NAME, ListHelper.ListColumnType.String, COLUMN_NAME);
+        _listHelper.createList(getProjectName(), LIST_NAME, new FieldDefinition(COLUMN_NAME, ColumnType.String));
         _listHelper.goToList(LIST_NAME);
         _listHelper.uploadData(COLUMN_NAME+"\n"+LOOKUP_VALUE_1+"\n"+LOOKUP_VALUE_2);
         clickProject(getProjectName());
@@ -349,7 +349,7 @@ public class FileContentUploadTest extends BaseWebDriverTest
 
         row = editor.fieldsPanel().addField(COLUMN_NAME);
         row.setLabel(COLUMN_NAME);
-        row.setLookup(new FieldDefinition.LookupInfo(getProjectName(), "lists", LIST_NAME).setTableType(FieldDefinition.ColumnType.String));
+        row.setLookup(new FieldDefinition.LookupInfo(getProjectName(), "lists", LIST_NAME).setTableType(ColumnType.String));
         editor.clickFinish();
     }
 

--- a/src/org/labkey/test/tests/list/ColumnResizeTest.java
+++ b/src/org/labkey/test/tests/list/ColumnResizeTest.java
@@ -27,6 +27,7 @@ import org.labkey.test.components.domain.DomainFieldRow;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.util.ListHelper;
 
 import java.util.Arrays;
@@ -92,14 +93,14 @@ public class ColumnResizeTest extends BaseWebDriverTest
     private void setUpList(String listName)
     {
         ListHelper listHelper = new ListHelper(this);
-        FieldDefinition maxCol = new FieldDefinition(MAX_COLUMN_NAME, FieldDefinition.ColumnType.String).setScale(Integer.MAX_VALUE);
-        FieldDefinition gtCol = new FieldDefinition(GT_COLUMN_NAME, FieldDefinition.ColumnType.String).setScale(GT_SCALE);
-        FieldDefinition ltCol = new FieldDefinition(LT_COLUMN_NAME, FieldDefinition.ColumnType.String).setScale(LT_SCALE);
-        FieldDefinition fourCol = new FieldDefinition(FOUR_K_COLUMN_NAME, FieldDefinition.ColumnType.String).setScale(DEFAULT_SCALE);
-        FieldDefinition textAreaCol = new FieldDefinition(MULTI_COLUMN_NAME, FieldDefinition.ColumnType.MultiLine);
-        FieldDefinition numberCol = new FieldDefinition(NUMBER_COLUMN_NAME, FieldDefinition.ColumnType.Integer);
+        FieldDefinition maxCol = new FieldDefinition(MAX_COLUMN_NAME, ColumnType.String).setScale(Integer.MAX_VALUE);
+        FieldDefinition gtCol = new FieldDefinition(GT_COLUMN_NAME, ColumnType.String).setScale(GT_SCALE);
+        FieldDefinition ltCol = new FieldDefinition(LT_COLUMN_NAME, ColumnType.String).setScale(LT_SCALE);
+        FieldDefinition fourCol = new FieldDefinition(FOUR_K_COLUMN_NAME, ColumnType.String).setScale(DEFAULT_SCALE);
+        FieldDefinition textAreaCol = new FieldDefinition(MULTI_COLUMN_NAME, ColumnType.MultiLine);
+        FieldDefinition numberCol = new FieldDefinition(NUMBER_COLUMN_NAME, ColumnType.Integer);
 
-        listHelper.createList(PROJECT_NAME, listName, ListHelper.ListColumnType.String, LIST_KEY_NAME,
+        listHelper.createList(PROJECT_NAME, listName, new FieldDefinition(LIST_KEY_NAME, ColumnType.String),
                 maxCol, gtCol, ltCol, fourCol, textAreaCol, numberCol);
     }
 
@@ -153,7 +154,7 @@ public class ColumnResizeTest extends BaseWebDriverTest
         changeScale(fieldsPanel, GT_ROW, LT_SCALE, false);   //Max --> LT
         changeScale(fieldsPanel, FOUR_ROW, GT_SCALE, true); //max checked
         changeScale(fieldsPanel, MULTI_ROW, GT_SCALE, false); //LT --> GT --> Max
-        fieldsPanel.getField(MAX_ROW).setType(FieldDefinition.ColumnType.MultiLine);
+        fieldsPanel.getField(MAX_ROW).setType(ColumnType.MultiLine);
         assertMaxChecked(fieldsPanel, MAX_ROW);
         listDefinitionPage.clickSave();
 

--- a/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
+++ b/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
@@ -162,7 +162,11 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         log(String.format("Create a list named '%s' with date-only, time-only and dateTime fields.", listName));
 
-        _listHelper.createList(PROJECT_NAME, listName, "key", new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date), new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time), new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setLabel(dateTimeCol));
+        _listHelper.createList(PROJECT_NAME, listName, "key",
+                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date),
+                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time),
+                new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setLabel(dateTimeCol)
+        );
 
         log("Validate adding entries in bulk. Use a different format for the date and time values in the second row.");
 
@@ -300,7 +304,11 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         log(String.format("Create a list named '%s' with date-only, time-only and dateTime fields.", listName));
 
-        _listHelper.createList(PROJECT_NAME, listName, "key", new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date), new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time), new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setLabel(dateTimeCol));
+        _listHelper.createList(PROJECT_NAME, listName, "key",
+                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date),
+                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time),
+                new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setLabel(dateTimeCol)
+        );
 
         File excelDateTimeFile = TestFileUtils.getSampleData("lists/Date_And_Time_Format.xlsx");
 
@@ -519,7 +527,10 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         log(String.format("Create a list named '%s' with date-only and time-only fields.", listName));
 
-        _listHelper.createList(PROJECT_NAME, listName, keyCol, new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date), new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time));
+        _listHelper.createList(PROJECT_NAME, listName, keyCol,
+                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date),
+                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time)
+        );
 
         List<Date> dates = createDateAndTimeTestData();
 
@@ -766,7 +777,10 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         log(String.format("Create a list named '%s' with date-only and time-only fields.", listName));
 
-        _listHelper.createList(PROJECT_NAME, listName, keyCol, new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date), new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time));
+        _listHelper.createList(PROJECT_NAME, listName, keyCol,
+                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date),
+                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time)
+        );
 
         List<Date> dates = createDateAndTimeTestData();
 
@@ -1013,7 +1027,11 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         log(String.format("Create a list named '%s' with date-only, time-only and dateTime fields.", listName));
 
-        _listHelper.createList(PROJECT_NAME, listName, "Key", new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date), new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time), new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setLabel(dateTimeCol));
+        _listHelper.createList(PROJECT_NAME, listName, "Key",
+                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date),
+                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time),
+                new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setLabel(dateTimeCol)
+        );
 
         log("Validate adding entries in bulk will give a meaningful error with a bad format.");
 
@@ -1112,7 +1130,11 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         log(String.format("Create a list named '%s' with date-only, time-only and dateTime fields.", listName));
 
-        _listHelper.createList(PROJECT_NAME, listName, "key", new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date).setFormat(dateFormat01), new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time).setFormat(timeFormat01), new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setFormat(dateTimeFormat01).setLabel(dateTimeCol));
+        _listHelper.createList(PROJECT_NAME, listName, "key",
+                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date).setFormat(dateFormat01),
+                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time).setFormat(timeFormat01),
+                new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setFormat(dateTimeFormat01).setLabel(dateTimeCol)
+        );
 
         List<Date> dates = new ArrayList<>();
 
@@ -1237,7 +1259,10 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
         log(String.format("Set the format for one DateTime field to '%s'.", dtFormatDate));
         log(String.format("Set the format for the other DateTime field to '%s'. This field will be converted to a tine-only field.", dtFormatTime));
 
-        _listHelper.createList(PROJECT_NAME, listName, "Key", new FieldDefinition(dateTimeToDateCol, FieldDefinition.ColumnType.DateAndTime).setFormat(dtFormatDate).setLabel(dateTimeToDateCol), new FieldDefinition(dateTimeToTimeCol, FieldDefinition.ColumnType.DateAndTime).setFormat(dtFormatTime).setLabel(dateTimeToTimeCol));
+        _listHelper.createList(PROJECT_NAME, listName, "Key",
+                new FieldDefinition(dateTimeToDateCol, FieldDefinition.ColumnType.DateAndTime).setFormat(dtFormatDate).setLabel(dateTimeToDateCol),
+                new FieldDefinition(dateTimeToTimeCol, FieldDefinition.ColumnType.DateAndTime).setFormat(dtFormatTime).setLabel(dateTimeToTimeCol)
+        );
 
         List<Date> dates = new ArrayList<>();
 

--- a/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
+++ b/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
@@ -28,7 +28,6 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ExcelHelper;
-import org.labkey.test.util.ListHelper;
 
 import java.io.File;
 import java.io.IOException;
@@ -163,11 +162,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         log(String.format("Create a list named '%s' with date-only, time-only and dateTime fields.", listName));
 
-        _listHelper.createList(PROJECT_NAME, listName, ListHelper.ListColumnType.AutoInteger, "key",
-                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date),
-                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time),
-                new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setLabel(dateTimeCol)
-        );
+        _listHelper.createList(PROJECT_NAME, listName, "key", new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date), new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time), new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setLabel(dateTimeCol));
 
         log("Validate adding entries in bulk. Use a different format for the date and time values in the second row.");
 
@@ -305,11 +300,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         log(String.format("Create a list named '%s' with date-only, time-only and dateTime fields.", listName));
 
-        _listHelper.createList(PROJECT_NAME, listName, ListHelper.ListColumnType.AutoInteger, "key",
-                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date),
-                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time),
-                new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setLabel(dateTimeCol)
-        );
+        _listHelper.createList(PROJECT_NAME, listName, "key", new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date), new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time), new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setLabel(dateTimeCol));
 
         File excelDateTimeFile = TestFileUtils.getSampleData("lists/Date_And_Time_Format.xlsx");
 
@@ -528,10 +519,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         log(String.format("Create a list named '%s' with date-only and time-only fields.", listName));
 
-        _listHelper.createList(PROJECT_NAME, listName, ListHelper.ListColumnType.AutoInteger, keyCol,
-                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date),
-                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time)
-        );
+        _listHelper.createList(PROJECT_NAME, listName, keyCol, new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date), new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time));
 
         List<Date> dates = createDateAndTimeTestData();
 
@@ -778,10 +766,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         log(String.format("Create a list named '%s' with date-only and time-only fields.", listName));
 
-        _listHelper.createList(PROJECT_NAME, listName, ListHelper.ListColumnType.AutoInteger, keyCol,
-                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date),
-                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time)
-        );
+        _listHelper.createList(PROJECT_NAME, listName, keyCol, new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date), new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time));
 
         List<Date> dates = createDateAndTimeTestData();
 
@@ -1028,11 +1013,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         log(String.format("Create a list named '%s' with date-only, time-only and dateTime fields.", listName));
 
-        _listHelper.createList(PROJECT_NAME, listName, ListHelper.ListColumnType.AutoInteger, "Key",
-                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date),
-                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time),
-                new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setLabel(dateTimeCol)
-        );
+        _listHelper.createList(PROJECT_NAME, listName, "Key", new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date), new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time), new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setLabel(dateTimeCol));
 
         log("Validate adding entries in bulk will give a meaningful error with a bad format.");
 
@@ -1131,11 +1112,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         log(String.format("Create a list named '%s' with date-only, time-only and dateTime fields.", listName));
 
-        _listHelper.createList(PROJECT_NAME, listName, ListHelper.ListColumnType.AutoInteger, "key",
-                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date).setFormat(dateFormat01),
-                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time).setFormat(timeFormat01),
-                new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setFormat(dateTimeFormat01).setLabel(dateTimeCol)
-        );
+        _listHelper.createList(PROJECT_NAME, listName, "key", new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date).setFormat(dateFormat01), new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time).setFormat(timeFormat01), new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setFormat(dateTimeFormat01).setLabel(dateTimeCol));
 
         List<Date> dates = new ArrayList<>();
 
@@ -1260,10 +1237,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
         log(String.format("Set the format for one DateTime field to '%s'.", dtFormatDate));
         log(String.format("Set the format for the other DateTime field to '%s'. This field will be converted to a tine-only field.", dtFormatTime));
 
-        _listHelper.createList(PROJECT_NAME, listName, ListHelper.ListColumnType.AutoInteger, "Key",
-                new FieldDefinition(dateTimeToDateCol, FieldDefinition.ColumnType.DateAndTime).setFormat(dtFormatDate).setLabel(dateTimeToDateCol),
-                new FieldDefinition(dateTimeToTimeCol, FieldDefinition.ColumnType.DateAndTime).setFormat(dtFormatTime).setLabel(dateTimeToTimeCol)
-        );
+        _listHelper.createList(PROJECT_NAME, listName, "Key", new FieldDefinition(dateTimeToDateCol, FieldDefinition.ColumnType.DateAndTime).setFormat(dtFormatDate).setLabel(dateTimeToDateCol), new FieldDefinition(dateTimeToTimeCol, FieldDefinition.ColumnType.DateAndTime).setFormat(dtFormatTime).setLabel(dateTimeToTimeCol));
 
         List<Date> dates = new ArrayList<>();
 

--- a/src/org/labkey/test/tests/list/ListIndexingTest.java
+++ b/src/org/labkey/test/tests/list/ListIndexingTest.java
@@ -181,8 +181,9 @@ public class ListIndexingTest extends BaseWebDriverTest
     {
         String attachmentList = "List with Attachment";
         File attachmentFile = TestFileUtils.getSampleData("fileTypes/pdf_sample.pdf");
-        String containerPath = getProjectName();
-        _listHelper.createList(containerPath, attachmentList, "id", new FieldDefinition("Name", FieldDefinition.ColumnType.String), new FieldDefinition("File", FieldDefinition.ColumnType.Attachment));
+        _listHelper.createList(getProjectName(), attachmentList, "id",
+                new FieldDefinition("Name", FieldDefinition.ColumnType.String),
+                new FieldDefinition("File", FieldDefinition.ColumnType.Attachment));
         _listHelper.beginAtList(getProjectName(), attachmentList);
         _listHelper.insertNewRow(Map.of("Name", "pdf file",
                 "File", attachmentFile.getAbsolutePath()), false);

--- a/src/org/labkey/test/tests/list/ListIndexingTest.java
+++ b/src/org/labkey/test/tests/list/ListIndexingTest.java
@@ -181,9 +181,8 @@ public class ListIndexingTest extends BaseWebDriverTest
     {
         String attachmentList = "List with Attachment";
         File attachmentFile = TestFileUtils.getSampleData("fileTypes/pdf_sample.pdf");
-        _listHelper.createList(getProjectName(), attachmentList, ListHelper.ListColumnType.AutoInteger, "id",
-                new FieldDefinition("Name", FieldDefinition.ColumnType.String),
-                new FieldDefinition("File", FieldDefinition.ColumnType.Attachment));
+        String containerPath = getProjectName();
+        _listHelper.createList(containerPath, attachmentList, "id", new FieldDefinition("Name", FieldDefinition.ColumnType.String), new FieldDefinition("File", FieldDefinition.ColumnType.Attachment));
         _listHelper.beginAtList(getProjectName(), attachmentList);
         _listHelper.insertNewRow(Map.of("Name", "pdf file",
                 "File", attachmentFile.getAbsolutePath()), false);

--- a/src/org/labkey/test/tests/list/ListMissingValuesTest.java
+++ b/src/org/labkey/test/tests/list/ListMissingValuesTest.java
@@ -7,9 +7,10 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.ImportDataPage;
+import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.tests.MissingValueIndicatorsTest;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.LogMethod;
 
 import java.util.Arrays;
@@ -64,20 +65,21 @@ public class ListMissingValuesTest extends MissingValueIndicatorsTest
                         "J.D.\t50\t\tmale\t.Q";
 
 
-        ListHelper.ListColumn[] columns = new ListHelper.ListColumn[3];
+        FieldDefinition[] columns = new FieldDefinition[3];
 
-        ListHelper.ListColumn listColumn = new ListHelper.ListColumn("name", "Name", ListHelper.ListColumnType.String, "");
+        FieldDefinition listColumn = new FieldDefinition("name", ColumnType.String).setLabel("Name");
         columns[0] = listColumn;
 
-        listColumn = new ListHelper.ListColumn("age with space", "Age with space", ListHelper.ListColumnType.Integer, "");
+        listColumn = new FieldDefinition("age with space", ColumnType.Integer).setLabel("Age with space");
         listColumn.setMvEnabled(true);
         columns[1] = listColumn;
 
-        listColumn = new ListHelper.ListColumn("sex", "Sex", ListHelper.ListColumnType.String, "");
+        listColumn = new FieldDefinition("sex", ColumnType.String).setLabel("Sex");
         listColumn.setMvEnabled(true);
         columns[2] = listColumn;
 
-        _listHelper.createList(getProjectName(), LIST_NAME, ListHelper.ListColumnType.AutoInteger, "Key", columns);
+        String containerPath = getProjectName();
+        _listHelper.createList(containerPath, LIST_NAME, "Key", columns);
 
         log("Test upload list data with a combined data and MVI column");
         _listHelper.goToList(LIST_NAME);

--- a/src/org/labkey/test/tests/list/ListMissingValuesTest.java
+++ b/src/org/labkey/test/tests/list/ListMissingValuesTest.java
@@ -78,8 +78,7 @@ public class ListMissingValuesTest extends MissingValueIndicatorsTest
         listColumn.setMvEnabled(true);
         columns[2] = listColumn;
 
-        String containerPath = getProjectName();
-        _listHelper.createList(containerPath, LIST_NAME, "Key", columns);
+        _listHelper.createList(getProjectName(), LIST_NAME, "Key", columns);
 
         log("Test upload list data with a combined data and MVI column");
         _listHelper.goToList(LIST_NAME);

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -1148,7 +1148,8 @@ public class ListTest extends BaseWebDriverTest
         String listName = "new";
         String origFieldName = "BarBar";
         String newFieldName = "FooFoo";
-        _listHelper.createList(PROJECT_VERIFY, listName, "key", new FieldDefinition(origFieldName, ColumnType.String).setLabel(origFieldName).setDescription("first column"));
+        _listHelper.createList(PROJECT_VERIFY, listName, "key",
+                new FieldDefinition(origFieldName, ColumnType.String).setLabel(origFieldName).setDescription("first column"));
 
         EditListDefinitionPage listDefinitionPage = _listHelper.goToEditDesign(listName);
         listDefinitionPage.getFieldsPanel()
@@ -1177,7 +1178,13 @@ public class ListTest extends BaseWebDriverTest
         String limitedPhiColumn = "LimitedPhiColumn";
         String phiColumn = "PhiColumn";
         String restrictedPhiColumn = "RestrictedPhiColumn";
-        _listHelper.createList(PROJECT_VERIFY, listName, "key", new FieldDefinition("FileName", ColumnType.String).setLabel("FileName").setDescription("name of the file"), new FieldDefinition("FileExtension", ColumnType.String).setLabel("ext").setDescription("the file extension"), new FieldDefinition(notPhiColumn, ColumnType.Attachment).setLabel("NotPhiFile").setDescription("the file itself"), new FieldDefinition(limitedPhiColumn, ColumnType.Attachment).setLabel("LimitedPhiFile").setDescription("the file itself"), new FieldDefinition(phiColumn, ColumnType.Attachment).setLabel("PhiFile").setDescription("the file itself"), new FieldDefinition(restrictedPhiColumn, ColumnType.Attachment).setLabel("RestrictedFile").setDescription("the file itself"));
+        _listHelper.createList(PROJECT_VERIFY, listName, "key",
+                new FieldDefinition("FileName", ColumnType.String).setLabel("FileName").setDescription("name of the file"),
+                new FieldDefinition("FileExtension", ColumnType.String).setLabel("ext").setDescription("the file extension"),
+                new FieldDefinition(notPhiColumn, ColumnType.Attachment).setLabel("NotPhiFile").setDescription("the file itself"),
+                new FieldDefinition(limitedPhiColumn, ColumnType.Attachment).setLabel("LimitedPhiFile").setDescription("the file itself"),
+                new FieldDefinition(phiColumn, ColumnType.Attachment).setLabel("PhiFile").setDescription("the file itself"),
+                new FieldDefinition(restrictedPhiColumn, ColumnType.Attachment).setLabel("RestrictedFile").setDescription("the file itself"));
 
 
         // set phi levels
@@ -1245,8 +1252,9 @@ public class ListTest extends BaseWebDriverTest
         goToProjectHome();
 
         // create list with an attachment column
-        String containerPath = getProjectName();
-        _listHelper.createList(containerPath, listName, "id", col(descriptionCol, ColumnType.String), col(attachmentCol, ColumnType.Attachment));
+        _listHelper.createList(getProjectName(), listName, "id",
+                col(descriptionCol, ColumnType.String),
+                col(attachmentCol, ColumnType.Attachment));
         // index for entire list as single document and index on attachment column
         _listHelper.goToEditDesign(listName)
                 .openAdvancedListSettings()
@@ -1284,8 +1292,8 @@ public class ListTest extends BaseWebDriverTest
         goToProjectHome();
 
         log("create list with an attachment column '" + attachmentCol + "'");
-        String containerPath = getProjectName();
-        _listHelper.createList(containerPath, listName, "id", col(attachmentCol, ColumnType.Attachment));
+        _listHelper.createList(getProjectName(), listName, "id",
+                col(attachmentCol, ColumnType.Attachment));
 
         log("Insert data, upload attachment for col '" + attachmentCol + "'");
         goToProjectHome();
@@ -1309,8 +1317,9 @@ public class ListTest extends BaseWebDriverTest
         goToProjectHome();
 
         // create list with an attachment column
-        String containerPath = getProjectName();
-        _listHelper.createList(containerPath, listName, "id", col(descriptionCol, ColumnType.String), col(attachmentCol, ColumnType.Attachment));
+        _listHelper.createList(getProjectName(), listName, "id",
+                col(descriptionCol, ColumnType.String),
+                col(attachmentCol, ColumnType.Attachment));
         // index on attachment column
         EditListDefinitionPage editListDefinitionPage = _listHelper.goToEditDesign(listName);
         editListDefinitionPage.openAdvancedListSettings()
@@ -1339,7 +1348,10 @@ public class ListTest extends BaseWebDriverTest
         String fieldName1 = "field Name1";
         String fieldName2 = "fieldName_2";
         String fieldName3 = "FieldName@3";
-        _listHelper.createList(PROJECT_VERIFY, listName, "key", new FieldDefinition(fieldName1, ColumnType.Integer), new FieldDefinition(fieldName2, ColumnType.DateAndTime), new FieldDefinition(fieldName3, ColumnType.Boolean));
+        _listHelper.createList(PROJECT_VERIFY, listName, "key",
+                new FieldDefinition(fieldName1, ColumnType.Integer),
+                new FieldDefinition(fieldName2, ColumnType.DateAndTime),
+                new FieldDefinition(fieldName3, ColumnType.Boolean));
 
         // verify initial set of indices
         viewRawTableMetadata(listName);

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -48,14 +48,12 @@ import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.LookupInfo;
+import org.labkey.test.params.FieldDefinition.StringLookup;
 import org.labkey.test.tests.AuditLogTest;
 import org.labkey.test.util.AbstractDataRegionExportOrSignHelper.ColumnHeaderType;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.EscapeUtil;
-import org.labkey.test.util.ListHelper;
-import org.labkey.test.util.ListHelper.ListColumn;
-import org.labkey.test.util.ListHelper.ListColumnType;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.Maps;
 import org.labkey.test.util.PortalHelper;
@@ -91,7 +89,7 @@ public class ListTest extends BaseWebDriverTest
     protected final static String PROJECT_VERIFY = "ListVerifyProject" ;//+ TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
     private final static String PROJECT_OTHER = "OtherListVerifyProject";
     protected final static String LIST_NAME_COLORS = TRICKY_CHARACTERS_NO_QUOTES + "Colors";
-    protected final static ListColumnType LIST_KEY_TYPE = ListColumnType.String;
+    protected final static ColumnType LIST_KEY_TYPE = ColumnType.String;
     protected final static String LIST_KEY_NAME = "Key";
     protected final static String LIST_KEY_NAME2 = "Color";
     protected final static String LIST_DESCRIPTION = "A list of colors and what they are like";
@@ -102,7 +100,7 @@ public class ListTest extends BaseWebDriverTest
     protected final FieldDefinition _listColFake = new FieldDefinition(FAKE_COL_NAME, ColumnType.String).setDescription("What the color is like");
     protected final FieldDefinition _listColDesc = new FieldDefinition("Desc", ColumnType.String).setLabel("Description").setDescription("What the color is like");
 
-    protected final FieldDefinition _listColMonth = new FieldDefinition("Month", FieldDefinition.ColumnType.TextChoice)
+    protected final FieldDefinition _listColMonth = new FieldDefinition("Month", ColumnType.TextChoice)
         .setTextChoiceValues(List.of("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"))
         .setLabel("Month to Wear").setDescription("When to wear the color");
 
@@ -146,10 +144,10 @@ public class ListTest extends BaseWebDriverTest
             LIST_ROW1;
     private final static String TEST_VIEW = "list_view";
     private final static String LIST2_NAME_CARS = TRICKY_CHARACTERS_NO_QUOTES + "Cars";
-    protected final static ListColumnType LIST2_KEY_TYPE = ListColumnType.String;
+    protected final static ColumnType LIST2_KEY_TYPE = ColumnType.String;
     protected final static String LIST2_KEY_NAME = "Car";
 
-    protected final FieldDefinition _list2Col1 = new FieldDefinition(LIST_KEY_NAME2, new LookupInfo(null, "lists", LIST_NAME_COLORS).setTableType(FieldDefinition.ColumnType.String)).setDescription("The color of the car");
+    protected final FieldDefinition _list2Col1 = new FieldDefinition(LIST_KEY_NAME2, new StringLookup(null, "lists", LIST_NAME_COLORS)).setDescription("The color of the car");
     private final static String LIST2_KEY = "Car1";
     private final static String LIST2_FOREIGN_KEY = "Blue";
     private final static String LIST2_KEY2 = "Car2";
@@ -160,10 +158,10 @@ public class ListTest extends BaseWebDriverTest
     private final static String LIST2_KEY4 = "Car4";
     private final static String LIST2_FOREIGN_KEY4 = "Brown";
     private final static String LIST3_NAME_OWNERS = "Owners";
-    private final static ListColumnType LIST3_KEY_TYPE = ListColumnType.String;
+    private final static ColumnType LIST3_KEY_TYPE = ColumnType.String;
     private final static String LIST3_KEY_NAME = "Owner";
     private final FieldDefinition _list3Col2 = new FieldDefinition("Wealth", ColumnType.String);
-    protected final FieldDefinition _list3Col1 = new FieldDefinition(LIST3_KEY_NAME, new LookupInfo("/" + PROJECT_OTHER, "lists", LIST3_NAME_OWNERS).setTableType(FieldDefinition.ColumnType.String)).setDescription("Who owns the car");
+    protected final FieldDefinition _list3Col1 = new FieldDefinition(LIST3_KEY_NAME, new LookupInfo("/" + PROJECT_OTHER, "lists", LIST3_NAME_OWNERS).setTableType(ColumnType.String)).setDescription("Who owns the car");
     private final static String LIST3_COL2 = "Rich";
     private final String LIST2_DATA =
             LIST2_KEY_NAME + "\t" + _list2Col1.getName()  + "\t" + LIST3_KEY_NAME + "\n" +
@@ -257,7 +255,7 @@ public class ListTest extends BaseWebDriverTest
         // Previously it was called from the @BeforeClass method, even though none of the other test cases use this list.
 
         log("Add list -- " + LIST_NAME_COLORS);
-        _listHelper.createList(projectName, LIST_NAME_COLORS, LIST_KEY_TYPE, LIST_KEY_NAME2, _listColFake,
+        _listHelper.createList(projectName, LIST_NAME_COLORS, new FieldDefinition(LIST_KEY_NAME2, LIST_KEY_TYPE), _listColFake,
         _listColMonth, _listColTone);
 
         log("Add description and test edit");
@@ -595,14 +593,14 @@ public class ListTest extends BaseWebDriverTest
         assertTextPresent("Colors", "Views");
 
         log("Add List -- " + LIST3_NAME_OWNERS);
-        _listHelper.createList(PROJECT_OTHER, LIST3_NAME_OWNERS, LIST3_KEY_TYPE, LIST3_KEY_NAME, _list3Col2);
+        _listHelper.createList(PROJECT_OTHER, LIST3_NAME_OWNERS, new FieldDefinition(LIST3_KEY_NAME, LIST3_KEY_TYPE), _list3Col2);
 
         log("Upload data to second list");
         _listHelper.goToList(LIST3_NAME_OWNERS);
         _listHelper.uploadData(LIST3_DATA);
 
         log("Add list -- " + LIST2_NAME_CARS);
-        _listHelper.createList(PROJECT_VERIFY, LIST2_NAME_CARS, LIST2_KEY_TYPE, LIST2_KEY_NAME, _list2Col1, _list3Col1);
+        _listHelper.createList(PROJECT_VERIFY, LIST2_NAME_CARS, new FieldDefinition(LIST2_KEY_NAME, LIST2_KEY_TYPE), _list2Col1, _list3Col1);
 
         log("Upload data to second list");
         _listHelper.goToList(LIST2_NAME_CARS);
@@ -763,7 +761,7 @@ public class ListTest extends BaseWebDriverTest
     {
         String mergeListName = "autoIncrementIdList";
 
-        _listHelper.createList(PROJECT_VERIFY, mergeListName, ListColumnType.AutoInteger, "Key", col("Name", ColumnType.String));
+        _listHelper.createList(PROJECT_VERIFY, mergeListName, "Key", col("Name", ColumnType.String));
 
         ImportDataPage importDataPage = _listHelper.clickImportData();
         checker().verifyFalse("For list with an integer, auto-increment key, merge option should not be available", importDataPage.isPasteMergeOptionPresent());
@@ -773,9 +771,9 @@ public class ListTest extends BaseWebDriverTest
     public void testAddListColumnOverRemoteAPI() throws Exception
     {
         List<FieldDefinition> cols = Arrays.asList(
-                new FieldDefinition("name", FieldDefinition.ColumnType.String),
-                new FieldDefinition("title", FieldDefinition.ColumnType.String),
-                new FieldDefinition("dewey", FieldDefinition.ColumnType.Decimal)
+                new FieldDefinition("name", ColumnType.String),
+                new FieldDefinition("title", ColumnType.String),
+                new FieldDefinition("dewey", ColumnType.Decimal)
         );
         String listName = "remoteApiListTestAddColumn";
         FieldDefinition.LookupInfo info = new FieldDefinition.LookupInfo(getProjectName(), "lists", listName);
@@ -784,7 +782,7 @@ public class ListTest extends BaseWebDriverTest
         DomainResponse createResponse = dgen.createList(createDefaultConnection(), "key");
         Domain listDomain = createResponse.getDomain();
         List<PropertyDescriptor> listFields = createResponse.getDomain().getFields();
-        listFields.add(new FieldDefinition("volume", FieldDefinition.ColumnType.Decimal));
+        listFields.add(new FieldDefinition("volume", ColumnType.Decimal));
         listDomain.setFields(listFields);
 
         // now save with an extra field
@@ -807,10 +805,10 @@ public class ListTest extends BaseWebDriverTest
     public void testRemoveColumnOverAPI() throws Exception
     {
         List<FieldDefinition> cols = Arrays.asList(
-                new FieldDefinition("name", FieldDefinition.ColumnType.String),
-                new FieldDefinition("title", FieldDefinition.ColumnType.String),
-                new FieldDefinition("dewey", FieldDefinition.ColumnType.Decimal),
-                new FieldDefinition("removeMe", FieldDefinition.ColumnType.Decimal)
+                new FieldDefinition("name", ColumnType.String),
+                new FieldDefinition("title", ColumnType.String),
+                new FieldDefinition("dewey", ColumnType.Decimal),
+                new FieldDefinition("removeMe", ColumnType.Decimal)
         );
         String listName = "remoteApiListTestRemoveColumn";
         FieldDefinition.LookupInfo info = new FieldDefinition.LookupInfo(getProjectName(), "lists", listName);
@@ -836,9 +834,9 @@ public class ListTest extends BaseWebDriverTest
     public void testChangeListName() throws Exception
     {
         List<FieldDefinition> cols = Arrays.asList(
-                new FieldDefinition("name", FieldDefinition.ColumnType.String),
-                new FieldDefinition("title", FieldDefinition.ColumnType.String),
-                new FieldDefinition("dewey", FieldDefinition.ColumnType.Decimal)
+                new FieldDefinition("name", ColumnType.String),
+                new FieldDefinition("title", ColumnType.String),
+                new FieldDefinition("dewey", ColumnType.Decimal)
         );
         String listName = "remoteAPIBeforeRename";
         FieldDefinition.LookupInfo info = new FieldDefinition.LookupInfo(getProjectName(), "lists", listName);
@@ -881,9 +879,9 @@ public class ListTest extends BaseWebDriverTest
                 new FieldDefinition(dummyCol, ColumnType.String)
         };
         FieldDefinition lookupCol = new FieldDefinition(lookupField,
-                new FieldDefinition.LookupInfo(null, lookupSchema, lookupTable).setTableType(FieldDefinition.ColumnType.Integer));
+                new FieldDefinition.LookupInfo(null, lookupSchema, lookupTable).setTableType(ColumnType.Integer));
         // create the list
-        _listHelper.createList(PROJECT_VERIFY, listName, ListColumnType.AutoInteger, keyCol, columns);
+        _listHelper.createList(PROJECT_VERIFY, listName, keyCol, columns);
         // now add the lookup column (which references the new table)
         _listHelper.goToEditDesign(listName)
                 .addField(lookupCol)
@@ -914,7 +912,8 @@ public class ListTest extends BaseWebDriverTest
         goToProjectHome(PROJECT_OTHER);
         //create list with look up A
         String lookupColumn = "lookup";
-        _listHelper.createList(PROJECT_OTHER, crossContainerLookupList, ListColumnType.AutoInteger, "Key",  col(PROJECT_VERIFY, lookupColumn, ColumnType.Integer, "A" ));
+        FieldDefinition[] cols = new FieldDefinition[]{col(PROJECT_VERIFY, lookupColumn, ColumnType.Integer, "A" )};
+        _listHelper.createList(PROJECT_OTHER, crossContainerLookupList, "Key", cols);
         _listHelper.goToList(crossContainerLookupList);
         _listHelper.clickImportData();
         setListImportAsTestDataField(lookupColumn + "\n1");
@@ -1030,10 +1029,10 @@ public class ListTest extends BaseWebDriverTest
         log("Verify correct types are inferred from file");
         EditListDefinitionPage listDefinitionPage = _listHelper.goToEditDesign(TSV_LIST_NAME);
         DomainFormPanel fieldsPanel = listDefinitionPage.getFieldsPanel();
-        assertEquals(FieldDefinition.ColumnType.Boolean, fieldsPanel.getField("BoolCol").getType());
-        assertEquals(FieldDefinition.ColumnType.Integer, fieldsPanel.getField("IntCol").getType());
-        assertEquals(FieldDefinition.ColumnType.Decimal, fieldsPanel.getField("NumCol").getType());
-        assertEquals(FieldDefinition.ColumnType.DateAndTime, fieldsPanel.getField("DateCol").getType());
+        assertEquals(ColumnType.Boolean, fieldsPanel.getField("BoolCol").getType());
+        assertEquals(ColumnType.Integer, fieldsPanel.getField("IntCol").getType());
+        assertEquals(ColumnType.Decimal, fieldsPanel.getField("NumCol").getType());
+        assertEquals(ColumnType.DateAndTime, fieldsPanel.getField("DateCol").getType());
         listDefinitionPage.clickSave();
     }
 
@@ -1149,7 +1148,7 @@ public class ListTest extends BaseWebDriverTest
         String listName = "new";
         String origFieldName = "BarBar";
         String newFieldName = "FooFoo";
-        _listHelper.createList(PROJECT_VERIFY, listName, ListColumnType.AutoInteger, "key", new ListColumn(origFieldName, origFieldName, ListColumnType.String, "first column"));
+        _listHelper.createList(PROJECT_VERIFY, listName, "key", new FieldDefinition(origFieldName, ColumnType.String).setLabel(origFieldName).setDescription("first column"));
 
         EditListDefinitionPage listDefinitionPage = _listHelper.goToEditDesign(listName);
         listDefinitionPage.getFieldsPanel()
@@ -1162,7 +1161,7 @@ public class ListTest extends BaseWebDriverTest
         assertTextNotPresent(origFieldName);
 
         listDefinitionPage = _listHelper.goToEditDesign(listName);
-        ListColumn newCol = new ListColumn(origFieldName, origFieldName, ListColumnType.String, "second column");
+        FieldDefinition newCol = new FieldDefinition(origFieldName, ColumnType.String).setLabel(origFieldName).setDescription("second column");
         listDefinitionPage.addField(newCol);
         listDefinitionPage.clickSave();
 
@@ -1178,13 +1177,7 @@ public class ListTest extends BaseWebDriverTest
         String limitedPhiColumn = "LimitedPhiColumn";
         String phiColumn = "PhiColumn";
         String restrictedPhiColumn = "RestrictedPhiColumn";
-        _listHelper.createList(PROJECT_VERIFY, listName, ListColumnType.AutoInteger, "key",
-                new FieldDefinition("FileName", ColumnType.String).setLabel("FileName").setDescription("name of the file"),
-                new FieldDefinition("FileExtension", ColumnType.String).setLabel("ext").setDescription("the file extension"),
-                new FieldDefinition(notPhiColumn, ColumnType.Attachment).setLabel("NotPhiFile").setDescription("the file itself"),
-                new FieldDefinition(limitedPhiColumn, ColumnType.Attachment).setLabel("LimitedPhiFile").setDescription("the file itself"),
-                new FieldDefinition(phiColumn, ColumnType.Attachment).setLabel("PhiFile").setDescription("the file itself"),
-                new FieldDefinition(restrictedPhiColumn, ColumnType.Attachment).setLabel("RestrictedFile").setDescription("the file itself"));
+        _listHelper.createList(PROJECT_VERIFY, listName, "key", new FieldDefinition("FileName", ColumnType.String).setLabel("FileName").setDescription("name of the file"), new FieldDefinition("FileExtension", ColumnType.String).setLabel("ext").setDescription("the file extension"), new FieldDefinition(notPhiColumn, ColumnType.Attachment).setLabel("NotPhiFile").setDescription("the file itself"), new FieldDefinition(limitedPhiColumn, ColumnType.Attachment).setLabel("LimitedPhiFile").setDescription("the file itself"), new FieldDefinition(phiColumn, ColumnType.Attachment).setLabel("PhiFile").setDescription("the file itself"), new FieldDefinition(restrictedPhiColumn, ColumnType.Attachment).setLabel("RestrictedFile").setDescription("the file itself"));
 
 
         // set phi levels
@@ -1252,9 +1245,8 @@ public class ListTest extends BaseWebDriverTest
         goToProjectHome();
 
         // create list with an attachment column
-        _listHelper.createList(getProjectName(), listName, ListColumnType.AutoInteger, "id",
-                col(descriptionCol, ColumnType.String),
-                col(attachmentCol, ColumnType.Attachment));
+        String containerPath = getProjectName();
+        _listHelper.createList(containerPath, listName, "id", col(descriptionCol, ColumnType.String), col(attachmentCol, ColumnType.Attachment));
         // index for entire list as single document and index on attachment column
         _listHelper.goToEditDesign(listName)
                 .openAdvancedListSettings()
@@ -1292,8 +1284,8 @@ public class ListTest extends BaseWebDriverTest
         goToProjectHome();
 
         log("create list with an attachment column '" + attachmentCol + "'");
-        _listHelper.createList(getProjectName(), listName, ListColumnType.AutoInteger, "id",
-                col(attachmentCol, ColumnType.Attachment));
+        String containerPath = getProjectName();
+        _listHelper.createList(containerPath, listName, "id", col(attachmentCol, ColumnType.Attachment));
 
         log("Insert data, upload attachment for col '" + attachmentCol + "'");
         goToProjectHome();
@@ -1317,9 +1309,8 @@ public class ListTest extends BaseWebDriverTest
         goToProjectHome();
 
         // create list with an attachment column
-        _listHelper.createList(getProjectName(), listName, ListColumnType.AutoInteger, "id",
-                               col(descriptionCol, ColumnType.String),
-                               col(attachmentCol, ColumnType.Attachment));
+        String containerPath = getProjectName();
+        _listHelper.createList(containerPath, listName, "id", col(descriptionCol, ColumnType.String), col(attachmentCol, ColumnType.Attachment));
         // index on attachment column
         EditListDefinitionPage editListDefinitionPage = _listHelper.goToEditDesign(listName);
         editListDefinitionPage.openAdvancedListSettings()
@@ -1348,11 +1339,7 @@ public class ListTest extends BaseWebDriverTest
         String fieldName1 = "field Name1";
         String fieldName2 = "fieldName_2";
         String fieldName3 = "FieldName@3";
-        _listHelper.createList(PROJECT_VERIFY, listName, ListColumnType.AutoInteger, "key",
-                new FieldDefinition(fieldName1, ColumnType.Integer),
-                new FieldDefinition(fieldName2, ColumnType.DateAndTime),
-                new FieldDefinition(fieldName3, ColumnType.Boolean)
-        );
+        _listHelper.createList(PROJECT_VERIFY, listName, "key", new FieldDefinition(fieldName1, ColumnType.Integer), new FieldDefinition(fieldName2, ColumnType.DateAndTime), new FieldDefinition(fieldName3, ColumnType.Boolean));
 
         // verify initial set of indices
         viewRawTableMetadata(listName);
@@ -1523,8 +1510,7 @@ public class ListTest extends BaseWebDriverTest
     void createList(String name, List<FieldDefinition> cols, String[][] data)
     {
         log("Add List -- " + name);
-        _listHelper.createList(PROJECT_VERIFY, name, ListHelper.ListColumnType.fromNew(cols.get(0).getType()), cols.get(0).getName(),
-                cols.subList(1, cols.size()).toArray(new FieldDefinition[cols.size() - 1]));
+        _listHelper.createList(PROJECT_VERIFY, name, cols.get(0), cols.subList(1, cols.size()).toArray(new FieldDefinition[cols.size() - 1]));
         _listHelper.goToList(name);
         _listHelper.clickImportData();
         setListImportAsTestDataField(toTSV(cols,data));

--- a/src/org/labkey/test/tests/perf/SchemaBrowserPerfTest.java
+++ b/src/org/labkey/test/tests/perf/SchemaBrowserPerfTest.java
@@ -21,7 +21,8 @@ import org.labkey.serverapi.writer.PrintWriters;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Perf;
-import org.labkey.test.util.ListHelper;
+import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
 
 import java.io.File;
 import java.io.IOException;
@@ -181,11 +182,9 @@ public class SchemaBrowserPerfTest extends PerformanceTest
     {
         for (int x = 0; x < count; x++)
         {
-            _listHelper.createList(getProjectName(), "TestList"+x,
-                    ListHelper.ListColumnType.AutoInteger, "AuthorId",
-                    new ListHelper.ListColumn("FirstName", "First Name", ListHelper.ListColumnType.String, "first name test desc"),
-                    new ListHelper.ListColumn("LastName", "Last Name", ListHelper.ListColumnType.String, "")
-            );
+            String containerPath = getProjectName();
+            FieldDefinition[] cols = new FieldDefinition[]{new FieldDefinition("FirstName", ColumnType.String).setDescription("first name test desc"), new FieldDefinition("LastName", ColumnType.String)};
+            _listHelper.createList(containerPath, "TestList"+x, "AuthorId", cols);
         }
 
     }

--- a/src/org/labkey/test/tests/perf/SchemaBrowserPerfTest.java
+++ b/src/org/labkey/test/tests/perf/SchemaBrowserPerfTest.java
@@ -182,9 +182,10 @@ public class SchemaBrowserPerfTest extends PerformanceTest
     {
         for (int x = 0; x < count; x++)
         {
-            String containerPath = getProjectName();
-            FieldDefinition[] cols = new FieldDefinition[]{new FieldDefinition("FirstName", ColumnType.String).setDescription("first name test desc"), new FieldDefinition("LastName", ColumnType.String)};
-            _listHelper.createList(containerPath, "TestList"+x, "AuthorId", cols);
+            _listHelper.createList(getProjectName(), "TestList"+x,
+                    "AuthorId",
+                    new FieldDefinition("FirstName", ColumnType.String).setDescription("first name test desc"),
+                    new FieldDefinition("LastName", ColumnType.String));
         }
 
     }


### PR DESCRIPTION
#### Rationale
We've been gradually removing redundant functionality from `ListHelper`. `ListColumn` and and `ListColumnType` were deprecated in `20.4` in favor of the more widely used and generic `FieldDefinition`. Time to prune the last of the usages.
During this refactor, discovered that `IntListDefinition` and `VarListDefinition` make some incorrect assumptions.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/247

#### Changes
* Refactor uses of `ListColumn` to use `FieldDefinition`
* Refactor uses of `ListColumnType` to use `FieldDefinition.ColumnType`
* Make `IntListDefinition` work for regular (non-auto-incrementing) Integer keys
