### PR TITLE
PlateSet remoteAPI updates, DetailPopover

### DIFF
--- a/src/org/labkey/remoteapi/plate/CreatePlateSetCommand.java
+++ b/src/org/labkey/remoteapi/plate/CreatePlateSetCommand.java
@@ -5,8 +5,8 @@ import org.labkey.remoteapi.PostCommand;
 
 public class CreatePlateSetCommand extends PostCommand<PlateSetResponse>
 {
-    private final PlateSetParams _plateSetParams;
-    public CreatePlateSetCommand(PlateSetParams params)
+    private final CreatePlateSetParams _plateSetParams;
+    public CreatePlateSetCommand(CreatePlateSetParams params)
     {
         super("plate", "createPlateSet");
         setRequiredVersion(0);

--- a/src/org/labkey/remoteapi/plate/CreatePlateSetParams.java
+++ b/src/org/labkey/remoteapi/plate/CreatePlateSetParams.java
@@ -1,0 +1,138 @@
+package org.labkey.remoteapi.plate;
+
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CreatePlateSetParams
+{
+    // This will match PlateController.CreatePlateSetForm
+    private String _name;
+    private String _description;
+    private List<CreatePlateSetPlate> _plates = new ArrayList<CreatePlateSetPlate>();
+    private PlateSetType _type;
+    private String _plateSetId; // optional
+    private Integer _rowId;
+    private Integer _parentPlateSetId;
+
+    public CreatePlateSetParams()
+    {
+    }
+
+    public JSONObject toJSON()
+    {
+        JSONObject json = new JSONObject();
+        json.put("name", _name);
+        json.put("description", _description);
+        if (_type != null)
+            json.put("type", _type.getType());
+        json.put("rowId", _rowId);
+        json.put("parentPlateSetId", _parentPlateSetId);
+        if (_plateSetId != null)
+            json.put("plateSetId", _plateSetId);
+        if (_plates.size() > 0)
+        {
+            JSONArray plates = new JSONArray();
+            for (CreatePlateSetPlate plate : _plates)
+                plates.put(plate.toJSON());
+            json.put("plates", plates);
+        }
+        return json;
+    }
+
+    public CreatePlateSetParams setName(String name)
+    {
+        _name = name;
+        return this;
+    }
+
+    public String getName()
+    {
+        return _name;
+    }
+
+    public CreatePlateSetParams setDescription(String description)
+    {
+        _description = description;
+        return this;
+    }
+
+    public String getDescription()
+    {
+        return _description;
+    }
+
+    public CreatePlateSetParams setType(PlateSetType type)
+    {
+        _type = type;
+        return this;
+    }
+
+    public PlateSetType getType()
+    {
+        return _type;
+    }
+
+    public Integer getRowId()
+    {
+        return _rowId;
+    }
+
+    public CreatePlateSetParams setParentPlateSetId(Integer parentPlateSetId)
+    {
+        _parentPlateSetId = parentPlateSetId;
+        return this;
+    }
+
+    public CreatePlateSetParams setPlateSetPlates( List<CreatePlateSetPlate> plates)
+    {
+        _plates = plates;
+        return this;
+    }
+
+    public List<CreatePlateSetPlate> getPlates()
+    {
+        return _plates;
+    }
+
+    public Integer getParentPlateSetId()
+    {
+        return _parentPlateSetId;
+    }
+
+    public String getPlateSetId()
+    {
+        return _plateSetId;
+    }
+
+    public enum PlateSetType
+    {
+        Primary("primary"),
+        Assay("assay");
+
+        PlateSetType(String type)
+                {
+                    this._type = type;
+                }
+        private final String _type;
+        public String getType()
+        {
+            return _type;
+        }
+        public static PlateSetType fromName(String type)
+        {
+            if (type != null)
+            {
+                for (PlateSetType plateSetType : PlateSetType.values())
+                {
+                    if (type.equalsIgnoreCase(plateSetType.getType()))
+                        return plateSetType;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/org/labkey/remoteapi/plate/CreatePlateSetPlate.java
+++ b/src/org/labkey/remoteapi/plate/CreatePlateSetPlate.java
@@ -1,0 +1,48 @@
+package org.labkey.remoteapi.plate;
+
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.List;
+import java.util.Map;
+
+public class CreatePlateSetPlate
+{
+    private final String _name;
+    private final Integer _plateType;
+    private final List<Map<String, Object>> _data;
+
+    public CreatePlateSetPlate(@Nullable String name, PlateTypes plateType, List<Map<String, Object>> data)
+    {
+        _name = name;
+        _plateType = plateType.getRowId();
+        _data = data;
+    }
+
+    public JSONObject toJSON()
+    {
+        JSONObject json = new JSONObject();
+        if (_name != null)
+            json.put("name", _name);
+        json.put("plateType", _plateType);
+        if (_data != null && !_data.isEmpty())
+        {
+            JSONArray data = new JSONArray();
+            for (Map<String, Object> row : _data)
+                data.put(row);
+            json.put("data", data);
+        }
+        return json;
+    }
+
+    public PlateTypes getPlateType()
+    {
+        return PlateTypes.fromRowId(_plateType);
+    }
+
+    public List<Map<String, Object>> getData()
+    {
+        return _data;
+    }
+}

--- a/src/org/labkey/remoteapi/plate/PlateSetParams.java
+++ b/src/org/labkey/remoteapi/plate/PlateSetParams.java
@@ -1,58 +1,91 @@
 package org.labkey.remoteapi.plate;
 
-
 import org.json.JSONObject;
 
 public class PlateSetParams
 {
-    private String _name;
+    private boolean _archived;
+    private String _containerId;
+    private String _containerName;
+    private String _containerPath;
+    private String _created;
+    private Integer _createdBy;
     private String _description;
-    private PlateSetType _type;
+    private String _modified;
+    private Integer _modifiedBy;
+    private String _name;
+    private Integer _plateCount;
     private String _plateSetId;
-    private Integer _rowId;
+    private Integer _primaryPlateSetId;
     private Integer _rootPlateSetId;
-
-    public PlateSetParams()
-    {
-    }
+    private Integer _rowId;
+    private boolean _template;
+    private CreatePlateSetParams.PlateSetType _plateSetType;
 
     public PlateSetParams(JSONObject json)
     {
-        _name = json.getString("name");
-        _description = json.optString("description", null);
-        _type = PlateSetType.fromName(json.optString("type", null));
-        _rowId = json.getInt("rowId");
-        _plateSetId = json.getString("plateSetId");
-        _rootPlateSetId = json.optIntegerObject("rootPlateSetId", null);
+        if (json.has("archived"))
+            _archived = json.getBoolean("archived");
+        if (json.has("containerId"))
+            _containerId = json.getString("containerId");
+        if (json.has("containerName"))
+            _containerName = json.getString("containerName");
+        if (json.has("containerPath"))
+            _containerPath = json.getString("containerPath");
+        if (json.has("created"))
+            _created = json.getString("created");
+        if (json.has("createdBy"))
+            _createdBy = json.getInt("createdBy");
+        if (json.has("description"))
+            _description = json.getString("description");
+        if (json.has("modified"))
+            _modified = json.getString("modified");
+        if (json.has("modifiedBy"))
+            _modifiedBy = json.getInt("modifiedBy");
+        if (json.has("name"))
+            _name = json.getString("name");
+        if (json.has("plateCount"))
+            _plateCount = json.getInt("plateCount");
+        if (json.has("plateSetId"))
+            _plateSetId = json.getString("plateSetId");
+        if (json.has("primaryPlateSetId"))
+            _primaryPlateSetId = json.getInt("primaryPlateSetId");
+        if (json.has("rootPlateSetId"))
+            _rootPlateSetId = json.getInt("rootPlateSetId");
+        if (json.has("rowId"))
+            _rowId = json.getInt("rowId");
+        if (json.has("type"))
+            _plateSetType = CreatePlateSetParams.PlateSetType.fromName(json.getString("type"));
     }
 
-    public JSONObject toJSON()
+    public boolean getArchived()
     {
-        JSONObject json = new JSONObject();
-        json.put("name", _name);
-        json.put("description", _description);
-        if (_type != null)
-            json.put("type", _type.getType());
-        json.put("rowId", _rowId);
-        json.put("parentPlateSetId", _rootPlateSetId);
-        return json;
+        return _archived;
     }
 
-    public PlateSetParams setName(String name)
+    public String getContainerId()
     {
-        _name = name;
-        return this;
+        return _containerId;
     }
 
-    public String getName()
+    public String getContainerName()
     {
-        return _name;
+        return _containerName;
     }
 
-    public PlateSetParams setDescription(String description)
+    public String getContainerPath()
     {
-        _description = description;
-        return this;
+        return _containerPath;
+    }
+
+    public String getCreated()
+    {
+        return _created;
+    }
+
+    public Integer getCreatedBy()
+    {
+        return _createdBy;
     }
 
     public String getDescription()
@@ -60,31 +93,24 @@ public class PlateSetParams
         return _description;
     }
 
-    public PlateSetParams setType(PlateSetType type)
+    public String getModified()
     {
-        _type = type;
-        return this;
+        return _modified;
     }
 
-    public PlateSetType getType()
+    public Integer getModifiedBy()
     {
-        return _type;
+        return _modifiedBy;
     }
 
-    public Integer getRowId()
+    public String getName()
     {
-        return _rowId;
+        return _name;
     }
 
-    public PlateSetParams setRootPlateSetId(Integer rootPlateSetId)
+    public Integer getPlateCount()
     {
-        _rootPlateSetId = rootPlateSetId;
-        return this;
-    }
-
-    public Integer getRootPlateSetId()
-    {
-        return _rootPlateSetId;
+        return _plateCount;
     }
 
     public String getPlateSetId()
@@ -92,31 +118,18 @@ public class PlateSetParams
         return _plateSetId;
     }
 
-    public enum PlateSetType
+    public Integer getPrimaryPlateSetId()
     {
-        Primary("primary"),
-        Assay("assay");
+        return _primaryPlateSetId;
+    }
 
-        PlateSetType(String type)
-                {
-                    this._type = type;
-                }
-        private final String _type;
-        public String getType()
-        {
-            return _type;
-        }
-        public static PlateSetType fromName(String type)
-        {
-            if (type != null)
-            {
-                for (PlateSetType plateSetType : PlateSetType.values())
-                {
-                    if (type.equalsIgnoreCase(plateSetType.getType()))
-                        return plateSetType;
-                }
-            }
-            return null;
-        }
+    public Integer getRootPlateSetId()
+    {
+        return _rootPlateSetId;
+    }
+
+    public Integer getRowId()
+    {
+        return _rowId;
     }
 }

--- a/src/org/labkey/test/components/domain/DetailPopover.java
+++ b/src/org/labkey/test/components/domain/DetailPopover.java
@@ -1,0 +1,122 @@
+package org.labkey.test.components.domain;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.Input;
+import org.labkey.test.components.ui.grids.DetailTable;
+import org.labkey.test.pages.LabKeyPage;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.Map;
+
+import static org.labkey.test.components.html.Input.Input;
+
+public class DetailPopover extends WebDriverComponent<DetailPopover.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected DetailPopover(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    public DetailPopover showPopover()
+    {
+        getWrapper().mouseOver(getComponentElement());
+        return this;
+    }
+
+    public DetailPopover collapse()
+    {
+        getWrapper().mouseOut();
+        clearElementCache();
+        return this;
+    }
+
+    public DetailTable getDetailTable()
+    {
+        showPopover();
+        getWrapper().mouseOver(elementCache().detailTable.getComponentElement());
+        return elementCache().detailTable;
+    }
+
+    public Map<String, String> getTableData()
+    {
+        return getDetailTable().getTableData();
+    }
+
+    public void clickTableLink(String fieldKey)
+    {
+        getDetailTable().clickField(fieldKey);
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        public WebElement popover = Locator.tagWithClass("div", "header-details-hover")
+                .findWhenNeeded(getDriver()).withTimeout(1500);
+        public DetailTable detailTable = new DetailTable.DetailTableFinder(getDriver())
+                .findWhenNeeded(popover);
+    }
+
+
+    public static class DetailPopoverFinder extends WebDriverComponentFinder<DetailPopover, DetailPopoverFinder>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("span", "header-details-link");
+        private String _title = null;
+
+        public DetailPopoverFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        public DetailPopoverFinder withTitle(String title)
+        {
+            _title = title;
+            return this;
+        }
+
+        @Override
+        protected DetailPopover construct(WebElement el, WebDriver driver)
+        {
+            return new DetailPopover(el, driver);
+        }
+
+
+        @Override
+        protected Locator locator()
+        {
+            if (_title != null)
+                return _baseLocator.withText(_title);
+            else
+                return _baseLocator;
+        }
+    }
+}


### PR DESCRIPTION
#### Rationale
This change separates out parameter classes for `CreatePlateSetCommand`/`PlateSetResponse`.
It introduces the ability for tests to configure plates in plate sets as they are created.

It will hopefully support the ability to correctly establish plate set lineage (parentPlateSet, sourcePlateSet) but at this point that does not appear to be working adequately

#### Related Pull Requests
https://github.com/LabKey/limsModules/pull/303

#### Changes
New classes for CreatePlateSetParam, PlateSetParam, 

- [x] New classes for `CreatePlateSetParam`, `PlateSetParam`, `CreatePlateSetPlate`
- [x] new component wrapper for `DetailPopover`
