### PR TITLE
Don't reset loggers when running tests locally

### DIFF
--- a/src/org/labkey/test/util/Log4jUtils.java
+++ b/src/org/labkey/test/util/Log4jUtils.java
@@ -60,8 +60,7 @@ public abstract class Log4jUtils
             if (!erroredPackages.contains(name))
             {
                 erroredPackages.add(name);
-                TestLogger.warn("Failed to set log level for '" + name + "'. We will not log any subsequent failures.");
-                e.printStackTrace();
+                TestLogger.warn("Failed to set log level for '" + name + "'. We will not log any subsequent failures.", e);
             }
         }
     }
@@ -69,7 +68,7 @@ public abstract class Log4jUtils
     @LogMethod(quiet = true)
     public static void resetAllLogLevels()
     {
-        if (TestProperties.isPrimaryUserAppAdmin())
+        if (TestProperties.isPrimaryUserAppAdmin() || !TestProperties.isTestRunningOnTeamCity())
             return;
 
         Connection connection = WebTestHelper.getRemoteApiConnection();
@@ -87,8 +86,7 @@ public abstract class Log4jUtils
             if (!loggedResetError)
             {
                 loggedResetError = true;
-                TestLogger.warn("Failed to reset server logging levels. We will not log any subsequent failures.");
-                e.printStackTrace();
+                TestLogger.warn("Failed to reset server logging levels. We will not log any subsequent failures.", e);
             }
         }
     }


### PR DESCRIPTION
#### Rationale
Developers may have customized logging levels on their test server. Tests shouldn't reset loggers.

#### Related Pull Requests
* N/A

#### Changes
* Don't reset loggers when running tests locally
* Fix some IntelliJ warnings in `Log4JUtils`
