### PR TITLE
Enable ChartingAPITest.advancedBrushTest

### DIFF
--- a/modules/chartingapi/resources/views/interactivityTest.html
+++ b/modules/chartingapi/resources/views/interactivityTest.html
@@ -98,7 +98,9 @@
                     var colorScale = scatterPlotBrushing.scales.color.scale;
                     var colorAcc = function(d) {
                         var x = d.x, y = d.y;
-                        d.isSelected = (x > extent[0][0] && x < extent[1][0] && y > extent[0][1] && y < extent[1][1])
+                        d.isSelected =
+                                (!Number.isFinite(extent[0][0]) || x > extent[0][0] && x < extent[1][0]) &&
+                                (!Number.isFinite(extent[0][1]) || y > extent[0][1] && y < extent[1][1]);
                         if (d.isSelected) {
                             return '#14C9CC';
                         }

--- a/modules/chartingapi/resources/views/setAesTest.html
+++ b/modules/chartingapi/resources/views/setAesTest.html
@@ -288,7 +288,9 @@
                     var colorScale = scatterPlotBrushing.scales.color.scale;
                     var colorAcc = function(d) {
                         var x = d.x, y = d.y;
-                        d.isSelected = (x > extent[0][0] && x < extent[1][0] && y > extent[0][1] && y < extent[1][1])
+                        d.isSelected =
+                                (!Number.isFinite(extent[0][0]) || x > extent[0][0] && x < extent[1][0]) &&
+                                (!Number.isFinite(extent[0][1]) || y > extent[0][1] && y < extent[1][1]);
                         if (d.isSelected) {
                             return '#14C9CC';
                         }

--- a/src/org/labkey/test/tests/ChartingAPITest.java
+++ b/src/org/labkey/test/tests/ChartingAPITest.java
@@ -28,7 +28,6 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
@@ -443,13 +442,9 @@ public class ChartingAPITest extends BaseWebDriverTest
         verifyBottomLeftGroupNotBrushed();
     }
 
-    @Test @Ignore
+    @Test
     public void advancedBrushTest()
     {
-        // Only run this in Chrome. There is a bug in web driver for Firefox that prevents it from properly releasing
-        // the mouse. You can view the (very old) issue here:
-        // https://code.google.com/p/selenium/issues/detail?id=3356
-
         Actions builder = new Actions(getDriver());
         goToChartingTestPage("interactivityTest");
         waitForSvgWithTitle("Interactive Plot");

--- a/src/org/labkey/test/tests/ChartingAPITest.java
+++ b/src/org/labkey/test/tests/ChartingAPITest.java
@@ -477,16 +477,16 @@ public class ChartingAPITest extends BaseWebDriverTest
         builder.moveToElement(Locator.css(".x-axis-handle .background").findElement(getDriver())).moveByOffset(-280, 0).clickAndHold().moveByOffset(180, 0).release().perform();
         verifyBottomLeftGroupBrushed();
         verifyTopRightGroupNotBrushed();
-        assertEquals("Brushed area was not the expected height", "385", Locator.css(".brush .extent").findElement(getDriver()).getAttribute("height"));
+        assertEquals("Brushed area was not the expected height", "377", Locator.css(".brush .extent").findElement(getDriver()).getAttribute("height"));
         // Make sure when making a 1D selection that the opposite axis handle isn't visible.
         assertElementNotVisible(Locator.css(".y-axis-handle .resize.n"));
         assertElementNotVisible(Locator.css(".y-axis-handle .resize.s"));
 
         // 1D selection on y axis (select top right)
-        builder.moveToElement(Locator.css(".y-axis-handle .background").findElement(getDriver())).moveByOffset(0, -190).clickAndHold().moveByOffset(0, 190).release().perform();
+        builder.moveToElement(Locator.css(".y-axis-handle .background").findElement(getDriver())).moveByOffset(0, -188).clickAndHold().moveByOffset(0, 188).release().perform();
         verifyTopRightGroupBrushed();
         verifyBottomLeftGroupNotBrushed();
-        assertEquals("Brushed area was not the expected width", "619.9999999999999", Locator.css(".brush .extent").findElement(getDriver()).getAttribute("width"));
+        assertEquals("Brushed area was not the expected width", "612", Locator.css(".brush .extent").findElement(getDriver()).getAttribute("width"));
         // Make sure when making a 1D selection that the opposite axis handle isn't visible.
         assertElementNotVisible(Locator.css(".x-axis-handle .resize.e"));
         assertElementNotVisible(Locator.css(".x-axis-handle .resize.w"));


### PR DESCRIPTION
#### Rationale
The Selenium issue mentioned in `ChartingAPITest.advancedBrushTest` doesn't seem to be a problem anymore. Enabling this test revealed a regression (or maybe a bug that's always been there). The example in [interactivityTest.html](https://github.com/LabKey/testAutomation/blob/develop/modules/chartingapi/resources/views/interactivityTest.html#L101) doesn't highlight properly for one-dimensional brushing.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5544

#### Changes
* Enable `ChartingAPITest.advancedBrushTest`
