### PR TITLE
Handle minor behavior differences caused by ListColumn removal

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -68,7 +68,7 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
         }
         if (def.getDimension() != null)
         {
-            advancedSettings.add(AdvancedFieldSetting.measure(def.getDimension()));
+            advancedSettings.add(AdvancedFieldSetting.dimension(def.getDimension()));
         }
         if (def.getMvEnabled() != null)
         {

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -80,10 +80,6 @@ public class FieldDefinition extends PropertyDescriptor
     {
         Map<String, Object> allProperties = new HashMap<>(_extraFieldProperties);
         allProperties.putIfAbsent("defaultValueType", DefaultType.FIXED_EDITABLE);
-        if (getMeasure() == null)
-        {
-            setMeasure(getType().isMeasureByDefault());
-        }
         return allProperties;
     }
 

--- a/src/org/labkey/test/tests/AuditLogTest.java
+++ b/src/org/labkey/test/tests/AuditLogTest.java
@@ -709,7 +709,7 @@ public class AuditLogTest extends BaseWebDriverTest
         Map<String, String> field03ExpectedColumns = Maps.of("action", "Created");
         Map<String, String> field03ExpectedComment = Maps.of("Name", FIELD03_NAME,
                 "Label", FIELD03_LABEL,
-                "Type", FIELD03_TYPE.toString(),
+                "Type", FIELD03_TYPE.getLabel(),
                 "Lookup", "[Schema: lists, Query: " + LOOK_UP_LIST01 + "]");
         pass = validateExpectedRowInDomainPropertyAuditLog(domainPropertyEventRows, FIELD03_NAME, field03ExpectedColumns, field03ExpectedComment);
 
@@ -727,7 +727,7 @@ public class AuditLogTest extends BaseWebDriverTest
         log("Change properties on field '" + FIELD03_NAME + "'.");
         listDefinitionPage.getFieldsPanel()
                 .getField(FIELD03_NAME)
-                .setLookup(new FieldDefinition.LookupInfo(null, "lists", LOOK_UP_LIST02).setTableType(ColumnType.Integer));
+                .setLookup(new FieldDefinition.IntLookup(null, "lists", LOOK_UP_LIST02));
         listDefinitionPage.clickSave();
 
         log("Validate that the expected row is there for the after modifying the Lookup field.");


### PR DESCRIPTION
#### Rationale
Fixing a couple of failures that popped up after the recent ListHelper update.
 - `FieldDefinition#getAllProperties` shouldn't mutate the `FieldDefinition`. Doing so is causing a failure in SM and it isn't really necessary.
 - `FieldDefinition.ColumnType#toString` doesn't match the removed `ListHelper.ListColumnType#toString`. Need to use `getLabel` instead.

#### Related Pull Requests
* #1947 

#### Changes
* Don't modify `FieldDefinition` to specify measure flag
* Don't use `FieldDefinition.ColumnType#toString`
* Set dimension flag correctly in `DomainFormPanel.advancedSettingsFromFieldDefinition`
