### PR TITLE
Test components for FileField assay tests

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -11,6 +11,8 @@ import org.labkey.test.components.html.Input;
 import org.labkey.test.components.react.FilteringReactSelect;
 import org.labkey.test.components.react.ReactDateTimePicker;
 import org.labkey.test.components.react.ToggleButton;
+import org.labkey.test.components.ui.files.FileAttachmentContainer;
+import org.labkey.test.components.ui.files.FileUploadField;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -123,6 +125,17 @@ public class EntityBulkUpdateDialog extends ModalDialog
     public String getDateField(String fieldKey)
     {
         return elementCache().dateInput(fieldKey).get();
+    }
+
+    public FileAttachmentContainer getFileField(String fieldKey)
+    {
+        return elementCache().fileUploadField(fieldKey);
+    }
+
+    public EntityBulkUpdateDialog removeFile(String fieldKey)
+    {
+        getFileField(fieldKey).removeFile();
+        return this;
     }
 
     public EntityBulkUpdateDialog setBooleanField(String fieldKey, boolean checked)
@@ -275,6 +288,11 @@ public class EntityBulkUpdateDialog extends ModalDialog
         {
             return new ReactDateTimePicker.ReactDateTimeInputFinder(getDriver())
                     .withInputId(fieldKey).waitFor(formRow(fieldKey));
+        }
+
+        public FileAttachmentContainer fileUploadField(String fieldKey)
+        {
+            return new FileAttachmentContainer(formRow(fieldKey), getDriver());
         }
 
         final Locator textInputLoc = Locator.tagWithAttribute("input", "type", "text");

--- a/src/org/labkey/test/components/ui/files/AttachmentCard.java
+++ b/src/org/labkey/test/components/ui/files/AttachmentCard.java
@@ -77,6 +77,7 @@ public class AttachmentCard extends WebDriverComponent<AttachmentCard.ElementCac
             return false;
         elementCache().menu.get().openMenuTo();
         List<String> menuOptions = getWrapper().getTexts(elementCache().menu.get().findVisibleMenuItems());
+        elementCache().menu.get().collapse();
         return menuOptions.contains(DOWNLOAD_ATTACHMENT);
     }
 

--- a/src/org/labkey/test/components/ui/files/AttachmentCard.java
+++ b/src/org/labkey/test/components/ui/files/AttachmentCard.java
@@ -144,15 +144,29 @@ public class AttachmentCard extends WebDriverComponent<AttachmentCard.ElementCac
     {
         private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "attachment-card");
         private String _fileName = null;
+        private String _title = null;
 
         public FileAttachmentCardFinder(WebDriver driver)
         {
             super(driver);
         }
 
-        public FileAttachmentCardFinder withFile(String fileName)
+        /*
+            Finds the card by the componentElement's title attribute
+            This is often the file name but can include more information, such as its location
+         */
+        public FileAttachmentCardFinder withTitle(String title)
         {
-            _fileName = fileName;
+            _title = title;
+            return this;
+        }
+
+        /*
+            Finds the card by the text of its attachment-card__name element
+         */
+        public FileAttachmentCardFinder withFileName(String name)
+        {
+            _fileName = name;
             return this;
         }
 
@@ -165,8 +179,11 @@ public class AttachmentCard extends WebDriverComponent<AttachmentCard.ElementCac
         @Override
         protected Locator locator()
         {
-            if (_fileName != null)
-                return _baseLocator.withAttribute("title", _fileName);
+            if (_title != null)
+                return _baseLocator.withAttribute("title", _title);
+            else if (_fileName != null)
+                return _baseLocator.withDescendant(
+                        Locator.tagWithClass("div", "attachment-card__name").withText(_fileName));
             else
                 return _baseLocator;
         }

--- a/src/org/labkey/test/components/ui/files/FileAttachmentContainer.java
+++ b/src/org/labkey/test/components/ui/files/FileAttachmentContainer.java
@@ -14,8 +14,7 @@ import java.io.File;
 import java.util.List;
 
 /*
-    Wraps https://github.com/LabKey/labkey-ui-components/blob/fb_assayResultsFiles/packages/components/src/internal/components/files/FileAttachmentContainer.tsx
-
+    Wraps https://github.com/LabKey/labkey-ui-components/blob/develop/packages/components/src/internal/components/files/FileAttachmentContainer.tsx
  */
 public class FileAttachmentContainer extends WebDriverComponent<FileAttachmentContainer.ElementCache>
 {

--- a/src/org/labkey/test/components/ui/files/FileAttachmentContainer.java
+++ b/src/org/labkey/test/components/ui/files/FileAttachmentContainer.java
@@ -73,17 +73,17 @@ public class FileAttachmentContainer extends WebDriverComponent<FileAttachmentCo
     }
 
     /*
-        Errors can be shown when you try to drop multiple files on a single-mode container
+        Alerts can be shown when you try to drop multiple files on a single-mode container
         they can also occur when files the container won't accept are uploaded
      */
-    public boolean hasError()
+    public boolean hasAlert()
     {
-        return elementCache().uploadErrorLoc.existsIn(this);
+        return elementCache().uploadAlertLoc.existsIn(this);
     }
 
-    public String getUploadError()
+    public String getUploadAlert()
     {
-        return elementCache().uploadErrorLoc.findElement(this).getText();
+        return elementCache().uploadAlertLoc.findElement(this).getText();
     }
 
     public FileAttachmentContainer attachFile(File file)
@@ -103,22 +103,47 @@ public class FileAttachmentContainer extends WebDriverComponent<FileAttachmentCo
         return this;
     }
 
+    public String attachFileExpectingAlert(File file)
+    {
+        elementCache().fileInput.set(file);
+        return elementCache().uploadAlertLoc.findElement(this).getText();
+    }
+
+    /**
+     * Returns true if there is a file with that name in the current instance
+     */
     private boolean hasFile(String fileName)
     {
         return new FileAttachmentEntry.FileAttachmentEntryFinder(getDriver())
                 .withTitle(fileName).findOptional(this).isPresent();
     }
 
+    /*
+        Assumes there is an attached file
+     */
     public FileAttachmentContainer removeFile()
     {
         getAttachedFileEntries().get(0).remove();
         return this;
     }
 
+    /**
+     * removes the specified attachment
+     * @param fileName the name of the attached file to detach
+     * @return the current instance
+     */
     public FileAttachmentContainer removeFile(String fileName)
     {
         getAttachedFileEntry(fileName).remove();
         clearElementCache();
+        return this;
+    }
+
+    public FileAttachmentContainer removeAllAttachedFiles()
+    {
+        var entries = getAttachedFileEntries();
+        for (FileAttachmentEntry entry : entries)
+            entry.remove();
         return this;
     }
 
@@ -173,7 +198,7 @@ public class FileAttachmentContainer extends WebDriverComponent<FileAttachmentCo
                 .findWhenNeeded(this);
         public WebElement fileEntryList = Locator.tagWithClass("div", "file-upload--file-entry-listing")
                 .findWhenNeeded(this);
-        public Locator uploadErrorLoc = Locator.tagWithClass("div", "alert-danger");
+        public Locator uploadAlertLoc = Locator.tagWithClass("div", "alert");
         public Locator fileUploadScrollFooterLoc = Locator.tagWithClass("div", "file-upload--scroll-footer");
     }
 

--- a/src/org/labkey/test/components/ui/files/FileAttachmentContainer.java
+++ b/src/org/labkey/test/components/ui/files/FileAttachmentContainer.java
@@ -155,7 +155,7 @@ public class FileAttachmentContainer extends WebDriverComponent<FileAttachmentCo
 
     public List<FileAttachmentEntry> getAttachedFileEntries()
     {
-        return new FileAttachmentEntry.FileAttachmentEntryFinder(getDriver()).timeout(2000)
+        return new FileAttachmentEntry.FileAttachmentEntryFinder(getDriver())
                 .findAll(elementCache().fileEntryList);
     }
 

--- a/src/org/labkey/test/components/ui/files/FileAttachmentContainer.java
+++ b/src/org/labkey/test/components/ui/files/FileAttachmentContainer.java
@@ -1,0 +1,224 @@
+package org.labkey.test.components.ui.files;
+
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.FileInput;
+import org.labkey.test.components.html.Input;
+import org.openqa.selenium.ElementNotInteractableException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.io.File;
+import java.util.List;
+
+/*
+    Wraps https://github.com/LabKey/labkey-ui-components/blob/fb_assayResultsFiles/packages/components/src/internal/components/files/FileAttachmentContainer.tsx
+
+ */
+public class FileAttachmentContainer extends WebDriverComponent<FileAttachmentContainer.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    public FileAttachmentContainer(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+    public boolean isMulti()
+    {
+        return elementCache().fileInput.getComponentElement().getAttribute("multiple") != null;
+    }
+
+    /*
+        in single-mode, when a file has been attached, the drop target is hidden
+        in multi-mode, the drop target is shown at all times
+        in compact-mode, drop target is sometimes not present
+     */
+    public boolean isDropTargetHidden()
+    {
+        var dropTarget = elementCache().dropTargetLoc.findOptionalElement(this);
+        if (dropTarget.isEmpty())
+            return true;
+        else
+            return dropTarget.get().getAttribute("class").contains("hidden");
+    }
+
+    /*
+        Errors can be shown when you try to drop multiple files on a single-mode container
+        they can also occur when files the container won't accept are uploaded
+     */
+    public boolean hasError()
+    {
+        return elementCache().uploadErrorLoc.existsIn(this);
+    }
+
+    public String getUploadError()
+    {
+        return elementCache().uploadErrorLoc.findElement(this).getText();
+    }
+
+    public FileAttachmentContainer attachFile(File file)
+    {
+        try
+        {
+            elementCache().fileInput.set(file);
+        }catch(ElementNotInteractableException nie)
+        {
+            WebDriverWrapper.sleep(1000);
+            elementCache().fileInput.set(String.valueOf(file));
+        }
+        WebDriverWrapper.waitFor(()-> hasFile(file.getName()),
+                "the file ["+ file.getName() +"] was not added", 2000);
+
+        clearElementCache();
+        return this;
+    }
+
+    private boolean hasFile(String fileName)
+    {
+        return new FileAttachmentEntry.FileAttachmentEntryFinder(getDriver())
+                .withTitle(fileName).findOptional(this).isPresent();
+    }
+
+    public FileAttachmentContainer removeFile()
+    {
+        getAttachedFileEntries().get(0).remove();
+        return this;
+    }
+
+    public FileAttachmentContainer removeFile(String fileName)
+    {
+        getAttachedFileEntry(fileName).remove();
+        clearElementCache();
+        return this;
+    }
+
+    public FileAttachmentEntry getAttachedFileEntry(String fileName)
+    {
+        return new FileAttachmentEntry.FileAttachmentEntryFinder(getDriver()).withTitle(fileName)
+                .waitFor(elementCache().fileEntryList);
+    }
+
+    public List<FileAttachmentEntry> getAttachedFileEntries()
+    {
+        return new FileAttachmentEntry.FileAttachmentEntryFinder(getDriver()).timeout(2000)
+                .findAll(elementCache().fileEntryList);
+    }
+
+    /*
+        When the input accepts only specific file types, that information will be here
+     */
+    public String accepts()
+    {
+        return elementCache().fileInput.getComponentElement().getAttribute("accept");
+    }
+
+    public List<String> getAttachedFileNames()
+    {
+        return getAttachedFileEntries().stream().map(FileAttachmentEntry::getFileName).toList();
+    }
+
+    public boolean hasFooterMessage()
+    {
+        return elementCache().fileUploadScrollFooterLoc.existsIn(this);
+    }
+
+    /*
+        scroll footer appears when this isMulti- contains message like 'n files will be uploaded' when the form is submitted
+     */
+    public String getFooterMessage()
+    {
+        return elementCache().fileUploadScrollFooterLoc.findElement(this).getText();
+    }
+
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        public Locator dropTargetLoc = Locator.XPathLocator.union(
+                Locator.tagWithClass("div", "file-upload--container"),
+                Locator.tagWithClass("div", "file-upload--container--compact"));
+        public Locator labelLoc = Locator.XPathLocator.union(
+                Locator.tagWithClass("label", "file-upload--label"),
+                Locator.tagWithClass("label", "file-upload--label--compact"));
+        public FileInput fileInput = Input.FileInput(Locator.tagWithClass("input", "file-upload--input"), getDriver())
+                .findWhenNeeded(this);
+        public WebElement fileEntryList = Locator.tagWithClass("div", "file-upload--file-entry-listing")
+                .findWhenNeeded(this);
+        public Locator uploadErrorLoc = Locator.tagWithClass("div", "alert-danger");
+        public Locator fileUploadScrollFooterLoc = Locator.tagWithClass("div", "file-upload--scroll-footer");
+    }
+
+
+    public static class FileAttachmentContainerFinder extends WebDriverComponentFinder<FileAttachmentContainer, FileAttachmentContainerFinder>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "file-upload--container").parent("div");
+        private String _inputName = null;
+        private String _label = null;
+
+        public FileAttachmentContainerFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        public FileAttachmentContainerFinder withNamedInput(String inputName)
+        {
+            _inputName = inputName;
+            return this;
+        }
+
+        public FileAttachmentContainerFinder withLabelFor(String label)
+        {
+            _label = label;
+            return this;
+        }
+
+        @Override
+        protected FileAttachmentContainer construct(WebElement el, WebDriver driver)
+        {
+            return new FileAttachmentContainer(el, driver);
+        }
+
+        @Override
+        protected Locator locator()
+        {
+            if (_inputName != null)
+                return _baseLocator.withDescendant(Locator.tagWithClass("input", "file-upload--input")
+                        .withAttribute("name", _inputName));
+            else if (_label != null)
+                return Locator.tagWithClass("label", "file-upload--label")
+                        .withAttributeMatchingOtherElementAttribute("name", Locator.tag("label").withText(_label), "for")
+                        .parent("*");
+            else
+                return _baseLocator;
+        }
+    }
+}

--- a/src/org/labkey/test/components/ui/files/FileAttachmentEntry.java
+++ b/src/org/labkey/test/components/ui/files/FileAttachmentEntry.java
@@ -1,0 +1,116 @@
+package org.labkey.test.components.ui.files;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+/*
+    Wraps FileAttachmentEntry.tsx, packages/components/src/internal/components/files/FileAttachmentEntry.tsx
+ */
+public class FileAttachmentEntry extends WebDriverComponent<FileAttachmentEntry.ElementCache>
+{
+    private final WebElement _el;
+    private final WebDriver _driver;
+
+    protected FileAttachmentEntry(WebElement element, WebDriver driver)
+    {
+        _el = element;
+        _driver = driver;
+    }
+
+    @Override
+    public WebElement getComponentElement()
+    {
+        return _el;
+    }
+
+    @Override
+    public WebDriver getDriver()
+    {
+        return _driver;
+    }
+
+    /*
+        checks to see if the entry has a red-x-circle remove icon
+     */
+    public boolean allowsRemove()
+    {
+        return elementCache().removeIconLoc.existsIn(this);
+    }
+
+    public void remove()
+    {
+        var removeBtn = elementCache().removeIcon;
+        removeBtn.click();
+        getWrapper().shortWait().until(ExpectedConditions.stalenessOf(removeBtn));
+    }
+
+    public String getFileName()
+    {
+        return getComponentElement().getText();
+    }
+
+    public WebElement getIcon()
+    {
+        return elementCache().fileIcon;
+    }
+
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+    protected class ElementCache extends Component<?>.ElementCache
+    {
+        public Locator removeIconLoc = Locator.tagWithClass("span", "file-upload__remove--icon");
+        public WebElement removeIcon = removeIconLoc.findWhenNeeded(this);
+        public WebElement fileIcon = Locator.tagWithClass("span", "attached-file--icon").findWhenNeeded(this);
+    }
+
+
+    public static class FileAttachmentEntryFinder extends WebDriverComponentFinder<FileAttachmentEntry, FileAttachmentEntryFinder>
+    {
+        private final Locator.XPathLocator _baseLocator = Locator.XPathLocator.union(
+                Locator.tagWithClass("div", "attached-file--container"),
+                Locator.tagWithClass("div", "attached-file--inline-container"));
+        private String _title = null;
+
+        public FileAttachmentEntryFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        public FileAttachmentEntryFinder withTitle(String title)
+        {
+            _title = title;
+            return this;
+        }
+
+        @Override
+        protected FileAttachmentEntry construct(WebElement el, WebDriver driver)
+        {
+            return new FileAttachmentEntry(el, driver);
+        }
+
+
+        @Override
+        protected Locator locator()
+        {
+            if (_title != null)
+                return _baseLocator.withText(_title);
+            else
+                return _baseLocator;
+        }
+    }
+}

--- a/src/org/labkey/test/components/ui/files/FileUploadPanel.java
+++ b/src/org/labkey/test/components/ui/files/FileUploadPanel.java
@@ -78,6 +78,16 @@ public class FileUploadPanel extends WebDriverComponent<FileUploadPanel.ElementC
         return getWrapper().doAndWaitForDownload(()->elementCache().downloadTemplate.click());
     }
 
+    /*
+        for situations in which there are more than a single file attachment container/target,
+        you can specify which one you want by input name
+     */
+    public FileAttachmentContainer getFileAttachmentContainer(String inputName)
+    {
+        return new FileAttachmentContainer.FileAttachmentContainerFinder(getDriver())
+                .withNamedInput(inputName).waitFor(getDriver());
+    }
+
     @Override
     protected ElementCache newElementCache()
     {

--- a/src/org/labkey/test/pages/ReactAssayDesignerPage.java
+++ b/src/org/labkey/test/pages/ReactAssayDesignerPage.java
@@ -260,7 +260,7 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
 
     public ReactAssayDesignerPage removeTransformScript(String fileName)
     {
-        AttachmentCard card = new AttachmentCard.FileAttachmentCardFinder(getDriver()).withFile(fileName).waitFor(this);
+        AttachmentCard card = new AttachmentCard.FileAttachmentCardFinder(getDriver()).withTitle(fileName).waitFor(this);
         int beforeCount = Locator.tagWithClass("div", "attachment-card__description").findElements(this).size();
         card.clickRemove();
         int afterCount = Locator.tagWithClass("div", "attachment-card__description").findElements(this).size();

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -674,6 +674,28 @@ public class FileBrowserHelper extends WebDriverWrapper
         return actions;
     }
 
+    public ActionStatus getActionStatus(BrowserAction action)
+    {
+        List<WebElement> buttons = findBrowserButtons();
+        for(WebElement button : buttons)
+        {
+            String cssClassString = button.getAttribute("class");
+            if (cssClassString.contains(action.buttonCls()))
+            {
+                // we've found the button for the action.
+                if (cssClassString.contains("x4-btn-disabled"))
+                    return ActionStatus.DISABLED;
+                else
+                    return ActionStatus.ENABLED;
+            }
+            else
+            {
+                log(cssClassString);
+            }
+        }
+        return ActionStatus.MISSING;
+    }
+
     public enum BrowserAction
     {
         FOLDER_TREE("sitemap", "Toggle Folder Tree", "folderTreeToggle"),
@@ -749,6 +771,12 @@ public class FileBrowserHelper extends WebDriverWrapper
         {
             return button().containing(_buttonText);
         }
+    }
+
+    public enum ActionStatus{
+        ENABLED,
+        DISABLED,
+        MISSING
     }
 
     /**


### PR DESCRIPTION
#### Rationale
This adds component support for testing of file upload in assays with FileField results fields.

It introduces two components classes for some otherwise-familiar UI, 
FileAttachmentContainer:
<img width="596" alt="image" src="https://github.com/LabKey/testAutomation/assets/16809856/783cb82a-492b-4176-aeae-2325f12fdd31">
and FileAttachmentEntry: 
<img width="99" alt="image" src="https://github.com/LabKey/testAutomation/assets/16809856/f4a441a6-6b0c-4dd4-b81b-779ac9cd46f6">

Our existing component, `FileUploadPanel`, wraps [FileAttachmentForm](https://github.com/LabKey/labkey-ui-components/blob/fb_assayResultsFiles/packages/components/src/public/files/FileAttachmentForm.tsx) but FileUploadPanel assumes (based on long evidence) that there will only be one [FileAttachmentContainer](https://github.com/LabKey/labkey-ui-components/blob/fb_assayResultsFiles/packages/components/src/internal/components/files/FileAttachmentContainer.tsx) in it. But, the related feature work puts two of them there: 
<img width="623" alt="image" src="https://github.com/LabKey/testAutomation/assets/16809856/1dd57389-543f-4e50-991c-0e62a8e61c3e">
This change adds a method to `FileUploadPanel `to allow tests to get a `FileAttachmentContainer `based on its input name so it can interact with the second one while making no changes to any existing methods in `FileUploadPanel`. 


It also makes a change to AttachmentCardFinder to distinguish finding it by its title attribute from finding it by the file name. (in most situations, the title is the file name but in others, the title can include its location: 
<img width="440" alt="image" src="https://github.com/LabKey/testAutomation/assets/16809856/9262839f-db06-4ca7-8e9a-7ae0b2269782">)
Previously the withFile method used the title attribute to find the card, on the assumption file and title would always be the same. This change renames `withFile `to `withTitle `(usages are refactored) and adds a new method `withFileName` that finds the component based on the contents of its attachment-card__name element.

Prior to this, there wasn't support for updating file fields in `EntityBulkUpdateDialog`. This adds support for interacting with file fields in it: 
<img width="458" alt="image" src="https://github.com/LabKey/testAutomation/assets/16809856/88a989d7-be29-4be0-ac0e-681574bcf0fa">




#### Related Pull Requests
https://github.com/LabKey/limsModules/pull/302

#### Changes

- [x] New component wrappers, `FileAttachmentContainer`, `FileAttachmentEntry`
- [x] Update `FileUploadPanel `to give tests the ability to reference another `FileAttachmentContainer` but no functional changes to any other part of `FileUploadPanel`
- [x] Add file-field support to `EntityBulkUpdateDialog`
- [x] Rename finder method on AttachmentCard, refactor usages, add finder method to find by file name
