### PR TITLE
Allow tests to ignore DatabaseNotSupportedException

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -466,7 +466,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             protected void skipped(AssumptionViolatedException e, Description description)
             {
                 super.skipped(e, description);
-                succeeded(description);
+                getCurrentTest().checker().reportResults();
             }
 
             @Override

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -465,7 +465,6 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             @Override
             protected void skipped(AssumptionViolatedException e, Description description)
             {
-                super.skipped(e, description);
                 getCurrentTest().checker().reportResults();
             }
 
@@ -792,6 +791,12 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                 if (_testFailed)
                     resetErrors(); // Clear errors from a previously failed test
                 _testFailed = false;
+            }
+
+            @Override
+            protected void skipped(AssumptionViolatedException e, Description description)
+            {
+                succeeded(description);
             }
 
             @Override

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -463,6 +463,13 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             }
 
             @Override
+            protected void skipped(AssumptionViolatedException e, Description description)
+            {
+                super.skipped(e, description);
+                succeeded(description);
+            }
+
+            @Override
             protected void succeeded(Description description)
             {
                 getCurrentTest().checker().reportResults();

--- a/src/org/labkey/test/Runner.java
+++ b/src/org/labkey/test/Runner.java
@@ -58,6 +58,7 @@ import org.labkey.test.util.DevModeOnlyTest;
 import org.labkey.test.util.ExportDiagnosticsPseudoTest;
 import org.labkey.test.util.NonWindowsTest;
 import org.labkey.test.util.PostgresOnlyTest;
+import org.labkey.test.util.ProductionModeOnlyTest;
 import org.labkey.test.util.SqlserverOnlyTest;
 import org.labkey.test.util.TestLogger;
 import org.labkey.test.util.Timer;
@@ -443,17 +444,22 @@ public class Runner extends TestSuite
                     continue;
                 }
 
-                if(interfaces.contains(DevModeOnlyTest.class) && !TestProperties.isDevModeEnabled())
+                if (interfaces.contains(DevModeOnlyTest.class) && !TestProperties.isDevModeEnabled())
                 {
                     LOG.warn("** Skipping " + testClass.getSimpleName() + ": server must be in dev mode");
                     continue;
                 }
-                else if(interfaces.contains(WindowsOnlyTest.class) && !SystemUtils.IS_OS_WINDOWS)
+                else if (interfaces.contains(ProductionModeOnlyTest.class) && TestProperties.isDevModeEnabled())
+                {
+                    LOG.warn("** Skipping " + testClass.getSimpleName() + ": server must be in production mode");
+                    continue;
+                }
+                else if (interfaces.contains(WindowsOnlyTest.class) && !SystemUtils.IS_OS_WINDOWS)
                 {
                     LOG.warn("** Skipping " + testClass.getSimpleName() + " test for unsupported operating system: " + SystemUtils.OS_NAME);
                     continue;
                 }
-                else if(interfaces.contains(NonWindowsTest.class) && SystemUtils.IS_OS_WINDOWS)
+                else if (interfaces.contains(NonWindowsTest.class) && SystemUtils.IS_OS_WINDOWS)
                 {
                     LOG.warn("** Skipping " + testClass.getSimpleName() + " test for unsupported operating system: " + SystemUtils.OS_NAME);
                     continue;

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -247,6 +247,11 @@ public abstract class TestProperties
         return "true".equals(System.getProperty("webtest.productFeature." + feature.toLowerCase(), "true"));
     }
 
+    public static boolean ignoreDatabaseNotSupportedException()
+    {
+        return "true".equals(System.getProperty("webtest.ignoreDatabaseNotSupportedException"));
+    }
+
     /**
      * Parses system property 'webtest.server.startup.timeout' to determine maximum allowed server startup time.
      * If property is not defined or is not an integer, it defaults to 60 seconds.

--- a/src/org/labkey/test/util/ProductionModeOnlyTest.java
+++ b/src/org/labkey/test/util/ProductionModeOnlyTest.java
@@ -1,0 +1,8 @@
+package org.labkey.test.util;
+
+/**
+ * Marker interface for tests that can only run with devMode=false
+ */
+public interface ProductionModeOnlyTest
+{
+}


### PR DESCRIPTION
#### Rationale
Tests running in production mode have been failing because we can't undeploy SQL Server only modules on embedded tomcat. We can configure the test harness to ignore these errors.

#### Related Pull Requests
* N/A

#### Changes
* Add flag to allow tests to ignore DatabaseNotSupportedException
* Make sure test postamble runs even if test is skipped
