### PR TITLE
Remove code to test API support of JSON based plate metadata

### DIFF
--- a/src/org/labkey/test/AssayAPITest.java
+++ b/src/org/labkey/test/AssayAPITest.java
@@ -15,28 +15,19 @@
  */
 package org.labkey.test;
 
-import org.json.JSONObject;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.assay.Batch;
 import org.labkey.remoteapi.assay.GetProtocolCommand;
-import org.labkey.remoteapi.assay.ImportRunCommand;
 import org.labkey.remoteapi.assay.ImportRunResponse;
 import org.labkey.remoteapi.assay.Protocol;
 import org.labkey.remoteapi.assay.ProtocolResponse;
-import org.labkey.remoteapi.assay.Run;
-import org.labkey.remoteapi.assay.SaveAssayBatchCommand;
 import org.labkey.remoteapi.assay.SaveProtocolCommand;
-import org.labkey.remoteapi.query.Filter;
-import org.labkey.remoteapi.query.SelectRowsCommand;
-import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.ReactAssayDesignerPage;
-import org.labkey.test.pages.assay.plate.PlateDesignerPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.APIAssayHelper;
 import org.labkey.test.util.DataRegionTable;
@@ -69,19 +60,6 @@ public class AssayAPITest extends BaseWebDriverTest
     protected final static File CREST_2_FILE = TestFileUtils.getSampleData("InlineImages/crest-2.png");
     protected final static String SUBFOLDER_1 = "Sub1";
 
-    private final static String PLATE_METADATA = "{\n" +
-            "      \"control\" : {\n" +
-            "        \"positive\" : {\"dilution\":  0.005},\n" +
-            "        \"negative\" : {\"dilution\":  1.01}\n" +
-            "      },\n" +
-            "      \"sample\" : {\n" +
-            "        \"SA01\" : {\"dilution\": 1.05, \"Barcode\" : \"BC_111\", \"Concentration\" : 0.0125},\n" +
-            "        \"SA02\" : {\"dilution\": 2.05, \"Barcode\" : \"BC_222\"},\n" +
-            "        \"SA03\" : {\"dilution\": 3.05, \"Barcode\" : \"BC_333\"},\n" +
-            "        \"SA04\" : {\"dilution\": 4.05, \"Barcode\" : \"BC_444\"}\n" +
-            "      }\n" +
-            "    }";
-
     @Override
     protected String getProjectName()
     {
@@ -101,8 +79,6 @@ public class AssayAPITest extends BaseWebDriverTest
         initTest._fileBrowserHelper.uploadFile(CREST_FILE);
         initTest._fileBrowserHelper.uploadFile(SCREENSHOT_FILE);
         initTest._fileBrowserHelper.uploadFile(FOO_XLS_FILE);
-
-        initTest.createPlateTemplate();
     }
 
     @Test
@@ -367,172 +343,5 @@ public class AssayAPITest extends BaseWebDriverTest
     public List<String> getAssociatedModules()
     {
         return Arrays.asList("assay");
-    }
-
-    @Test
-    public void testGpatSaveBatchWithPlate() throws Exception
-    {
-        goToProjectHome();
-
-        String assayName = "GPAT-SaveBatch-Plate";
-        ((APIAssayHelper) _assayHelper).createAssayWithPlateSupport(assayName);
-
-        String runName = "created-via-saveBatch";
-        String folderPath = "/" + getProjectName();
-
-        // get the plate lsid
-        String lsid = ((APIAssayHelper) _assayHelper).getPlateTemplateLsid(folderPath);
-
-        log("create run via saveBatch");
-        Run run = new Run();
-        run.setName(runName);
-        run.setProperties(Maps.of("PlateTemplate", lsid));
-
-        List<Map<String, Object>> resultRows = new ArrayList<>();
-        resultRows.add(Maps.of("ptid", "188438418", "visitId", "111"));
-        run.setResultData(resultRows);
-
-        Batch batch = new Batch();
-        batch.setRuns(List.of(run));
-
-        int assayId = ((APIAssayHelper)_assayHelper).getIdFromAssayName(assayName, getProjectName());
-        SaveAssayBatchCommand cmd = new SaveAssayBatchCommand(assayId, batch);
-        checkErrors();
-
-        try
-        {
-            // verify that plate metadata JSON is required
-            cmd.execute(createDefaultConnection(), folderPath);
-        }
-        catch (CommandException e)
-        {
-            assertTrue("Expecting a failure because of missing plate metadata", e.getResponseText().contains("Unable to locate the ExpData with the plate metadata"));
-        }
-        resetErrors();
-
-        run.setPlateMetadata(new JSONObject(PLATE_METADATA));
-
-        try
-        {
-            // verify that the well location property is required
-            cmd.execute(createDefaultConnection(), folderPath);
-        }
-        catch (CommandException e)
-        {
-            assertTrue("Expecting a failure because of missing plate metadata", e.getResponseText().contains("Imported data must contain a WellLocation column to support plate metadata integration"));
-        }
-        resetErrors();
-
-        resultRows.clear();
-        resultRows.add(Maps.of("ptid", "111", "visitId", "111", "wellLocation", "A11"));
-        resultRows.add(Maps.of("ptid", "222", "visitId", "111", "wellLocation", "H12"));
-        resultRows.add(Maps.of("ptid", "333", "visitId", "111", "wellLocation", "A1"));
-        resultRows.add(Maps.of("ptid", "444", "visitId", "111", "wellLocation", "B5"));
-        resultRows.add(Maps.of("ptid", "555", "visitId", "111", "wellLocation", "E8"));
-        resultRows.add(Maps.of("ptid", "666", "visitId", "111", "wellLocation", "G10"));
-
-        cmd.execute(createDefaultConnection(), folderPath);
-
-        SelectRowsCommand selectRowsCmd = new SelectRowsCommand("assay.General." + assayName, "Data");
-        selectRowsCmd.addFilter("run/name", runName, Filter.Operator.EQUAL);
-        SelectRowsResponse resp = selectRowsCmd.execute(createDefaultConnection(), folderPath);
-
-        List<Map<String, Object>> expectedRows = new ArrayList<>();
-        expectedRows.add(Maps.of("wellLocation", "A11", "plateData/dilution", 0.005));
-        expectedRows.add(Maps.of("wellLocation", "H12", "plateData/dilution", 1.01));
-        expectedRows.add(Maps.of("wellLocation", "A1", "plateData/dilution", 1.05, "plateData/barcode", "BC_111", "plateData/concentration", 0.0125));
-        expectedRows.add(Maps.of("wellLocation", "B5", "plateData/dilution", 2.05, "plateData/barcode", "BC_222"));
-        expectedRows.add(Maps.of("wellLocation", "E8", "plateData/dilution", 3.05, "plateData/barcode", "BC_333"));
-        expectedRows.add(Maps.of("wellLocation", "G10", "plateData/dilution", 4.05, "plateData/barcode", "BC_444"));
-
-        verifyPlateMetadata(resp, expectedRows);
-    }
-
-    private void verifyPlateMetadata(SelectRowsResponse resp, List<Map<String, Object>> expectedRows)
-    {
-        assertTrue("Wrong number of data rows returned", resp.getRowCount().intValue() == expectedRows.size());
-
-        int i = 0;
-        for (Map<String, Object> row : resp.getRows())
-        {
-            for (Map.Entry<String, Object> expected : expectedRows.get(i++).entrySet())
-            {
-                Object value = row.get(expected.getKey());
-
-                assertTrue("Expected property: " + expected.getKey() + " not found", value != null);
-                assertTrue("Expected property value : " + expected.getValue() + " not found", expected.getValue().equals(value));
-            }
-        }
-    }
-
-    @Test
-    public void testGpatImportRunWithPlate() throws Exception
-    {
-        goToProjectHome();
-
-        String assayName = "GPAT-ImportRun-Plate";
-        ((APIAssayHelper) _assayHelper).createAssayWithPlateSupport(assayName);
-
-        String runName = "created-via-importRun";
-        String folderPath = "/" + getProjectName();
-
-        // get the plate lsid
-        String lsid =  ((APIAssayHelper) _assayHelper).getPlateTemplateLsid(folderPath);
-        int assayId = ((APIAssayHelper)_assayHelper).getIdFromAssayName(assayName, getProjectName());
-
-        log("create run via importRun");
-        List<Map<String, Object>> resultRows = new ArrayList<>();
-        resultRows.add(Maps.of("ptid", "111", "visitId", "111", "wellLocation", "H11"));
-        resultRows.add(Maps.of("ptid", "222", "visitId", "111", "wellLocation", "A12"));
-        resultRows.add(Maps.of("ptid", "333", "visitId", "111", "wellLocation", "A3"));
-        resultRows.add(Maps.of("ptid", "444", "visitId", "111", "wellLocation", "B6"));
-        resultRows.add(Maps.of("ptid", "555", "visitId", "111", "wellLocation", "E7"));
-        resultRows.add(Maps.of("ptid", "666", "visitId", "111", "wellLocation", "G9"));
-
-        ImportRunCommand cmd = new ImportRunCommand(assayId, resultRows);
-        cmd.setProperties(Maps.of("PlateTemplate", lsid));
-        cmd.setPlateMetadata(new JSONObject(PLATE_METADATA));
-        cmd.setName(runName);
-        cmd.execute(createDefaultConnection(), folderPath);
-
-        SelectRowsCommand selectRowsCmd = new SelectRowsCommand("assay.General." + assayName, "Data");
-        selectRowsCmd.addFilter("run/name", runName, Filter.Operator.EQUAL);
-        SelectRowsResponse resp = selectRowsCmd.execute(createDefaultConnection(), folderPath);
-
-        List<Map<String, Object>> expectedRows = new ArrayList<>();
-        expectedRows.add(Maps.of("wellLocation", "H11", "plateData/dilution", 0.005));
-        expectedRows.add(Maps.of("wellLocation", "A12", "plateData/dilution", 1.01));
-        expectedRows.add(Maps.of("wellLocation", "A3", "plateData/dilution", 1.05, "plateData/barcode", "BC_111", "plateData/concentration", 0.0125));
-        expectedRows.add(Maps.of("wellLocation", "B6", "plateData/dilution", 2.05, "plateData/barcode", "BC_222"));
-        expectedRows.add(Maps.of("wellLocation", "E7", "plateData/dilution", 3.05, "plateData/barcode", "BC_333"));
-        expectedRows.add(Maps.of("wellLocation", "G9", "plateData/dilution", 4.05, "plateData/barcode", "BC_444"));
-
-        verifyPlateMetadata(resp, expectedRows);
-    }
-
-    public void createPlateTemplate()
-    {
-        PlateDesignerPage.PlateDesignerParams params = new PlateDesignerPage.PlateDesignerParams(8, 12);
-        params.setTemplateType("blank");
-        params.setAssayType("Standard");
-        PlateDesignerPage plateDesigner = PlateDesignerPage.beginAt(this,params);
-
-        // create the sample well groups
-        plateDesigner.createWellGroup("SAMPLE", "SA01");
-        plateDesigner.createWellGroup("SAMPLE", "SA02");
-        plateDesigner.createWellGroup("SAMPLE", "SA03");
-        plateDesigner.createWellGroup("SAMPLE", "SA04");
-
-        // mark the regions on the plate to use the well groups
-        plateDesigner.selectWellsForWellgroup("CONTROL", "Positive", "A11", "H11");
-        plateDesigner.selectWellsForWellgroup("CONTROL", "Negative", "A12", "H12");
-
-        plateDesigner.selectWellsForWellgroup("SAMPLE", "SA01", "A1", "H3");
-        plateDesigner.selectWellsForWellgroup("SAMPLE", "SA02", "A4", "H6");
-        plateDesigner.selectWellsForWellgroup("SAMPLE", "SA03", "A7", "H8");
-        plateDesigner.selectWellsForWellgroup("SAMPLE", "SA04", "A9", "H10");
-
-        plateDesigner.setName("GPAT");
-        plateDesigner.save();
     }
 }


### PR DESCRIPTION
#### Rationale
This removes API testing for the JSON based plate metadata, since it was removed from the server earlier. I left the code in the assay helper to create an assay with plate support since it could be used in a LKB folder.