### PR TITLE
longer wait for file download

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -2342,7 +2342,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
                     final File[] files = downloadDir.listFiles(tempFilesFilter);
                     return files != null && files.length == 0;
                 },
-                "Temp files remain in download dir: " + downloadDir, WAIT_FOR_JAVASCRIPT);
+                "Temp files remain in download dir: " + downloadDir, WAIT_FOR_PAGE);
 
         MutableInt downloadSize = new MutableInt(-1);
         MutableInt stabilityDuration = new MutableInt(0);


### PR DESCRIPTION
#### Rationale
[UploadLargeExcelAssayTest.testUpload200kRows](https://teamcity.labkey.org/viewLog.html?buildId=3101989&buildTypeId=LabkeyTrunk_DailyCSqlserver2014&fromSakuraUI=true#testNameId3537965916196401765) is failing on 24.7 sql because it takes more than 10 seconds to complete downloading the large excel file the test exports.

This change gives it more time to complete downloading
Once this is passing in 24.7, I will want to merge this change (along with https://github.com/LabKey/testAutomation/pull/1978) forward to develop - hopefully that will get `UploadLargeExcelAssayTest `passing 

#### Related Pull Requests


#### Changes
use WAIT_FOR_PAGE (60 seconds) instead of WAIT_FOR_JAVASCRIPT (10 seconds) as download timeout
