### PR TITLE
Issue 49830: Update inferColumnInfo to force fields of type File to use ExpDataFileConverter

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -1494,12 +1494,12 @@ public class SampleTypeTest extends BaseWebDriverTest
         drt = importSampleTypeFilePathData(sampleTypeName, fileFieldName, "Test3", propFile.getAbsolutePath());
         checker().verifyEquals("Sample name in data row not as expected", "Test3", drt.getDataAsText(0, "Name"));
         String actualValue = drt.getDataAsText(0, fileFieldName);
-        checker().verifyTrue("File field should contain file name", " ".equals(actualValue) || actualValue.contains("file (unavailable)"));
+        checker().verifyTrue("File field should not be valid", " ".equals(actualValue) || actualValue.contains("properties (unavailable)"));
 
         // try an import with an invalid file path
         drt = importSampleTypeFilePathData(sampleTypeName, fileFieldName, "Test4", "invalid/path/to/file");
         checker().verifyEquals("Sample name in data row not as expected", "Test4", drt.getDataAsText(0, "Name"));
-        checker().verifyTrue("File field should contain file name", drt.getDataAsText(0, fileFieldName).contains("file (unavailable)"));
+        checker().verifyTrue("File field should not be valid", drt.getDataAsText(0, fileFieldName).contains("file (unavailable)"));
     }
 
     private DataRegionTable importSampleTypeFilePathData(String sampleTypeName, String fileFieldName, String sampleName, String filePath)

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -1491,14 +1491,15 @@ public class SampleTypeTest extends BaseWebDriverTest
 
         // try an import with a valid file that isn't accessible from this container
         File propFile = new File(TestFileUtils.getTestRoot(), "test.properties");
-        drt = importSampleTypeFilePathData(sampleTypeName, fileFieldName, "Test3", propFile.getCanonicalPath());
+        drt = importSampleTypeFilePathData(sampleTypeName, fileFieldName, "Test3", propFile.getAbsolutePath());
         checker().verifyEquals("Sample name in data row not as expected", "Test3", drt.getDataAsText(0, "Name"));
-        checker().verifyEquals("File field should contain file name", " ", drt.getDataAsText(0, fileFieldName));
+        String actualValue = drt.getDataAsText(0, fileFieldName);
+        checker().verifyTrue("File field should contain file name", " ".equals(actualValue) || actualValue.contains("file (unavailable)"));
 
         // try an import with an invalid file path
         drt = importSampleTypeFilePathData(sampleTypeName, fileFieldName, "Test4", "invalid/path/to/file");
         checker().verifyEquals("Sample name in data row not as expected", "Test4", drt.getDataAsText(0, "Name"));
-        checker().verifyEquals("File field should contain file name", " invalid/path/to/file (unavailable)", drt.getDataAsText(0, fileFieldName));
+        checker().verifyTrue("File field should contain file name", drt.getDataAsText(0, fileFieldName).contains("file (unavailable)"));
     }
 
     private DataRegionTable importSampleTypeFilePathData(String sampleTypeName, String fileFieldName, String sampleName, String filePath)

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -1461,7 +1461,7 @@ public class SampleTypeTest extends BaseWebDriverTest
     }
 
     @Test // Issue 49830
-    public void testFilePathOnBulkImport()
+    public void testFilePathOnBulkImport() throws IOException
     {
         projectMenu().navigateToFolder(PROJECT_NAME, FOLDER_NAME);
 
@@ -1491,7 +1491,7 @@ public class SampleTypeTest extends BaseWebDriverTest
 
         // try an import with a valid file that isn't accessible from this container
         File propFile = new File(TestFileUtils.getTestRoot(), "test.properties");
-        drt = importSampleTypeFilePathData(sampleTypeName, fileFieldName, "Test3", propFile.getAbsolutePath());
+        drt = importSampleTypeFilePathData(sampleTypeName, fileFieldName, "Test3", propFile.getCanonicalPath());
         checker().verifyEquals("Sample name in data row not as expected", "Test3", drt.getDataAsText(0, "Name"));
         checker().verifyEquals("File field should contain file name", " ", drt.getDataAsText(0, fileFieldName));
 


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=49830

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5676

#### Changes
- SampleTypeTest.testFilePathOnBulkImport test case for issue 49830
