### PR TITLE
Add page state validation to list helpers

### DIFF
--- a/src/org/labkey/test/pages/list/BeginPage.java
+++ b/src/org/labkey/test/pages/list/BeginPage.java
@@ -30,6 +30,12 @@ public class BeginPage extends LabKeyPage<BeginPage.ElementCache>
         super(driver);
     }
 
+    @Override
+    protected void waitForPage()
+    {
+        waitFor(() -> elementCache().listsGrid.getComponentElement().isDisplayed(), "List grid is not displayed", WAIT_FOR_JAVASCRIPT);
+    }
+
     public static BeginPage beginAt(WebDriverWrapper driver)
     {
         return beginAt(driver, driver.getCurrentContainerPath());
@@ -49,6 +55,14 @@ public class BeginPage extends LabKeyPage<BeginPage.ElementCache>
                 .clickImport();
     }
 
+    public ImportListArchivePage importListArchiveExpectingError(File listArchive)
+    {
+        return getGrid()
+                .clickImportArchive()
+                .setZipFile(listArchive)
+                .clickImportExpectingError();
+    }
+
     public ManageListsGrid getGrid()
     {
         return elementCache().listsGrid;
@@ -60,7 +74,7 @@ public class BeginPage extends LabKeyPage<BeginPage.ElementCache>
         return new ElementCache();
     }
 
-    protected class ElementCache extends LabKeyPage.ElementCache
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
         private final ManageListsGrid listsGrid = new ManageListsGrid(getDriver());
     }

--- a/src/org/labkey/test/pages/list/ConfirmDeletePage.java
+++ b/src/org/labkey/test/pages/list/ConfirmDeletePage.java
@@ -15,7 +15,7 @@ public class ConfirmDeletePage extends LabKeyPage<ConfirmDeletePage.ElementCache
 
     public BeginPage confirmDelete()
     {
-        elementCache().deleteButton.click();
+        clickAndWait(elementCache().deleteButton);
         return new BeginPage(getDriver());
     }
 
@@ -25,7 +25,7 @@ public class ConfirmDeletePage extends LabKeyPage<ConfirmDeletePage.ElementCache
         return new ElementCache();
     }
 
-    protected class ElementCache extends LabKeyPage.ElementCache
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
         WebElement deleteButton = Locator.lkButton("Confirm Delete").findWhenNeeded(this);
     }

--- a/src/org/labkey/test/pages/list/GridPage.java
+++ b/src/org/labkey/test/pages/list/GridPage.java
@@ -62,7 +62,7 @@ public class GridPage extends LabKeyPage<GridPage.ElementCache>
         return new ElementCache();
     }
 
-    protected class ElementCache extends LabKeyPage.ElementCache
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
         private final DataRegionTable table = new DataRegionTable("query", getDriver());
     }

--- a/src/org/labkey/test/pages/list/ImportListArchivePage.java
+++ b/src/org/labkey/test/pages/list/ImportListArchivePage.java
@@ -51,7 +51,16 @@ public class ImportListArchivePage extends LabKeyPage<ImportListArchivePage.Elem
     public BeginPage clickImport()
     {
         clickAndWait(elementCache().importButton);
+        assertNoLabKeyErrors();
         return new BeginPage(getDriver());
+    }
+
+    public ImportListArchivePage clickImportExpectingError()
+    {
+        clickAndWait(elementCache().importButton);
+        assertLabKeyErrorPresent();
+        clearCache();
+        return this;
     }
 
     @Override
@@ -60,7 +69,7 @@ public class ImportListArchivePage extends LabKeyPage<ImportListArchivePage.Elem
         return new ElementCache();
     }
 
-    protected class ElementCache extends LabKeyPage.ElementCache
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
         WebElement zipInput = Locator.input("listZip").findWhenNeeded(this);
         WebElement importButton = Locator.lkButton("Import List Archive").findWhenNeeded(this);

--- a/src/org/labkey/test/pages/list/SetDefaultValuesListPage.java
+++ b/src/org/labkey/test/pages/list/SetDefaultValuesListPage.java
@@ -72,7 +72,7 @@ public class SetDefaultValuesListPage extends LabKeyPage<SetDefaultValuesListPag
         return new ElementCache();
     }
 
-    protected class ElementCache extends LabKeyPage.ElementCache
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
         private Map<String, FormItem> formItems = new HashMap<>();
         protected WebElement saveButton = Locator.lkButton("Save Defaults").findWhenNeeded(this);

--- a/src/org/labkey/test/tests/ListArchiveImportTest.java
+++ b/src/org/labkey/test/tests/ListArchiveImportTest.java
@@ -70,7 +70,7 @@ public class ListArchiveImportTest extends BaseWebDriverTest
         log("Import list and test for expected validation error");
         goToProjectHome();
 
-        goToManageLists().importListArchive(new ZipUtil(listArchive).tempZip());
+        goToManageLists().importListArchiveExpectingError(new ZipUtil(listArchive).tempZip());
 
         String expectedError = "File: Could not find referenced file People.xls";
         String actualError = Locators.labkeyError.findOptionalElement(getDriver()).map(WebElement::getText).orElse(null);


### PR DESCRIPTION
#### Rationale
List import was failing for a particular test but didn't cause any problems until later in the test. Helpers should catch these errors when they happen so that the problem is obvious.

#### Related Pull Requests
* N/A

#### Changes
 - Check for errors after importing a list archive
 - Add method to import a list archive expecting errors
 - Define `list.BeginPage.waitForPage`
