### PR TITLE
Wait for Search Service to boot up before tests start running

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -33,6 +33,7 @@ import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.apache.hc.core5.http.protocol.HttpContext;
+import org.awaitility.Awaitility;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.junit.Assert;
@@ -727,19 +728,25 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                 SimpleGetCommand command = new SimpleGetCommand("search", "json");
                 command.setParameters(Map.of("q", "pinging to check server is started", "scope", "All"));
                 CommandResponse searchResponse;
-                try
+                do
                 {
-                    do
+                    try
                     {
+                        sleep(10); // to poll the re-request
                         searchResponse = command.execute(connection, "/");
                     }
-                    while (searchResponse.getStatusCode() != 200);
+                    catch (IOException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (CommandException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                }
+                while (searchResponse.getStatusCode() != 200);
 
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+
             }
             else // Just upgrading
             {

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -723,17 +723,19 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                     customizeSitePage.save();
                 }
 
-                //Waiting for search service to boot up
+                /*
+                    Waiting for search service to boot up
+                    Issue 50601: PDF indexing is slow on first file after server startup on Windows
+                 */
                 Connection connection = createDefaultConnection();
                 SimpleGetCommand command = new SimpleGetCommand("search", "json");
                 command.setParameters(Map.of("q", "pinging to check server is started", "scope", "All"));
                 long searchEndTime = System.currentTimeMillis() + 180000; // Wait for maximum of 3 mins.
-                CommandResponse searchResponse = null;
                 do
                 {
                     try
                     {
-                        searchResponse = command.execute(connection, "/");
+                        command.execute(connection, "/");
                     }
                     catch (IOException e)
                     {
@@ -741,10 +743,10 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                     }
                     catch (CommandException e)
                     {
-                        sleep(500); // Retry and to poll the re-request
+                        sleep(500); //poll the re-request
                     }
                 }
-                while ((searchResponse != null) && (searchResponse.getStatusCode() != 200) && (System.currentTimeMillis() < searchEndTime));
+                while (System.currentTimeMillis() < searchEndTime);
             }
             else // Just upgrading
             {

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -720,6 +720,26 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                     // Note: leave the self-report setting unchanged
                     customizeSitePage.save();
                 }
+
+                //Waiting for search service to boot up
+                Connection connection = createDefaultConnection();
+
+                SimpleGetCommand command = new SimpleGetCommand("search", "json");
+                command.setParameters(Map.of("q", "pinging to check server is started", "scope", "All"));
+                CommandResponse searchResponse;
+                try
+                {
+                    do
+                    {
+                        searchResponse = command.execute(connection, "/");
+                    }
+                    while (searchResponse.getStatusCode() != 200);
+
+                }
+                catch (Exception e)
+                {
+                    throw new RuntimeException(e);
+                }
             }
             else // Just upgrading
             {

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -730,14 +730,14 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                 Connection connection = createDefaultConnection();
                 SimpleGetCommand command = new SimpleGetCommand("search", "json");
                 command.setParameters(Map.of("q", "pinging to check server is started", "scope", "All"));
-                long searchEndTime = System.currentTimeMillis() + 180000; // Wait for maximum of 3 mins.
+                Timer timer = new Timer(Duration.ofMinutes(3));
                 do
                 {
                     try
                     {
                         CommandResponse response = command.execute(connection, "/");
                         if (response.getStatusCode() == 200) break; // Server is up, we can exit the loop
-                        else throw new RuntimeException("Search server did not start properly");
+                        else throw new RuntimeException("Search service did not start properly");
                     }
                     catch (IOException e)
                     {
@@ -748,7 +748,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                         sleep(500); //poll the re-request
                     }
                 }
-                while (System.currentTimeMillis() < searchEndTime);
+                while (!timer.isTimedOut());
             }
             else // Just upgrading
             {

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -735,7 +735,9 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                 {
                     try
                     {
-                        command.execute(connection, "/");
+                        CommandResponse response = command.execute(connection, "/");
+                        if (response.getStatusCode() == 200) break; // Server is up, we can exit the loop
+                        else throw new RuntimeException("Search server did not start properly");
                     }
                     catch (IOException e)
                     {

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -727,8 +727,8 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                 Connection connection = createDefaultConnection();
                 SimpleGetCommand command = new SimpleGetCommand("search", "json");
                 command.setParameters(Map.of("q", "pinging to check server is started", "scope", "All"));
-                CommandResponse searchResponse = null;
                 long searchEndTime = System.currentTimeMillis() + 180000; // Wait for maximum of 3 mins.
+                CommandResponse searchResponse = null;
                 do
                 {
                     try
@@ -744,7 +744,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                         sleep(500); // Retry and to poll the re-request
                     }
                 }
-                while (searchResponse.getStatusCode() != 200 && System.currentTimeMillis() < searchEndTime);
+                while ((searchResponse != null) && (searchResponse.getStatusCode() != 200) && (System.currentTimeMillis() < searchEndTime));
             }
             else // Just upgrading
             {

--- a/src/org/labkey/test/util/ApiBootstrapHelper.java
+++ b/src/org/labkey/test/util/ApiBootstrapHelper.java
@@ -3,7 +3,6 @@ package org.labkey.test.util;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
-import org.json.JSONObject;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
@@ -11,18 +10,16 @@ import org.labkey.remoteapi.GuestCredentialsProvider;
 import org.labkey.remoteapi.PostCommand;
 import org.labkey.remoteapi.SimpleGetCommand;
 import org.labkey.remoteapi.SimplePostCommand;
-import org.labkey.test.ExtraSiteWrapper;
 import org.labkey.test.LabKeySiteWrapper;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.components.core.login.SetPasswordForm;
-import org.openqa.selenium.WebDriver;
 
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.labkey.test.WebTestHelper.getBaseURL;
 
@@ -132,6 +129,12 @@ public class ApiBootstrapHelper
     {
         Connection cn = WebTestHelper.getRemoteApiConnection(false);
         SimpleGetCommand command = new SimpleGetCommand("admin", "startupStatus");
+        /*
+            Waiting for search service to boot up
+            Issue 50601: PDF indexing is slow on first file after server startup on Windows
+         */
+        SimpleGetCommand searchCmd = new SimpleGetCommand("search", "json");
+        searchCmd.setParameters(Map.of("q", "pinging to check server is started", "scope", "All"));
         Exception lastException = null;
 
         Timer timer = new Timer(Duration.ofMinutes(5));
@@ -140,7 +143,8 @@ public class ApiBootstrapHelper
             try
             {
                 CommandResponse response = command.execute(cn, null);
-                if ((Boolean) response.getParsedData().getOrDefault("startupComplete", false))
+                CommandResponse searchResponse = searchCmd.execute(cn, "/");
+                if ((Boolean) response.getParsedData().getOrDefault("startupComplete", false) && searchResponse.getStatusCode() == 200)
                 {
                     return;
                 }
@@ -149,7 +153,8 @@ public class ApiBootstrapHelper
             {
                 lastException = e;
             }
-        } while (!timer.isTimedOut());
+        }
+        while (!timer.isTimedOut());
 
         throw new RuntimeException("Server didn't finish starting.", lastException);
     }


### PR DESCRIPTION
#### Rationale
Recently tests have started failing on SQL Sever on windows machine caused due to slower search service. This fix should wait for search service to start before running any tests.

Link to test failures
https://teamcity.labkey.org/buildConfiguration/LabKey_247Release_Community_DailySqlServer?mode=branches#all-projects

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
