### PR TITLE
Make TabbedGridPanel.isSelected public.

### DIFF
--- a/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
+++ b/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
@@ -75,8 +75,7 @@ public class TabbedGridPanel extends WebDriverComponent<TabbedGridPanel.ElementC
         return counts;
     }
 
-
-    private boolean isSelected(String tabText)
+    public boolean isSelected(String tabText)
     {
         String tabClass = elementCache().navTab(tabText).getAttribute("class");
         return tabClass.toLowerCase().contains("active");


### PR DESCRIPTION
#### Rationale
Some test fixes in 24.7. Primarily for MSSQL / Windows failures.

#### Related Pull Requests
* https://github.com/LabKey/limsModules/pull/489

#### Changes
* Make TabbedGridPanel.isSelected public.
