### PR TITLE
Fix filter to exclude search index from test artifacts

### DIFF
--- a/src/org/labkey/test/util/ArtifactCollector.java
+++ b/src/org/labkey/test/util/ArtifactCollector.java
@@ -329,8 +329,9 @@ public class ArtifactCollector
     private ArrayList<File> listFilesRecursive(File path, final FileFilter filter)
     {
         FileFilter directoryOrArtifactFilter = pathname ->
-                pathname.isDirectory() && !pathname.isHidden() && !pathname.getName().equals("@labkey_full_text_index") ||
-               pathname.lastModified() > _testStart && filter.accept(pathname);
+                pathname.isDirectory()
+                        ? !pathname.isHidden() && !pathname.getName().equals("@labkey_full_text_index")
+                        : pathname.lastModified() > _testStart && filter.accept(pathname);
 
         File[] files = path.listFiles(directoryOrArtifactFilter);
         ArrayList<File> allFiles = new ArrayList<>();


### PR DESCRIPTION
#### Rationale
The previous attempt to exclude the Lucene search index from being uploaded to TeamCity didn't account for the possibility that the directory might might be created after the test starts. 

#### Related Pull Requests
* #1939 

#### Changes
* Don't upload search index directory to TeamCity
