### PR TITLE
Fix EditableGridTest.testFillCellValidation

### DIFF
--- a/src/org/labkey/test/components/ui/search/FilterFacetedPanel.java
+++ b/src/org/labkey/test/components/ui/search/FilterFacetedPanel.java
@@ -93,11 +93,23 @@ public class FilterFacetedPanel extends WebDriverComponent<FilterFacetedPanel.El
 
     public FilterFacetedPanel filterValues(String filterStr)
     {
+
+        List<WebElement> checkBoxes = elementCache().checkboxLabelLoc.findElements(this);
+
         if (StringUtils.isEmpty(filterStr))
             elementCache().filterInput.set("");
         else
             elementCache().filterInput.setWithPaste(filterStr);
-        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().checkboxLabelLoc.waitForElement(this, 5_000)));
+
+        // If there were options before, wait until they are removed.
+        if (!checkBoxes.isEmpty())
+        {
+            getWrapper().shortWait().until(ExpectedConditions.stalenessOf(checkBoxes.get(0)));
+        }
+
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache()
+                .checkboxLabelLoc.waitForElement(this, 5_000)));
+
         return this;
     }
 

--- a/src/org/labkey/test/tests/component/EditableGridTest.java
+++ b/src/org/labkey/test/tests/component/EditableGridTest.java
@@ -1554,8 +1554,11 @@ public class EditableGridTest extends BaseWebDriverTest
         testGrid.selectCell(0, STR_FIELD_NAME);
         actionPaste(null, rowsToString(clipRows));
 
+        // Scroll one column to the right into view, this will help ensure the REQ_LOOKUP_FIELD_NAME is within the viewport.
+        var index = testGrid.getColumnNames().indexOf(REQ_LOOKUP_FIELD_NAME + " *") + 1;
+        scrollIntoView(testGrid.getCell(0, testGrid.getColumnNames().get(index)));
+
         WebElement fillFrom = testGrid.getCell(0, REQ_LOOKUP_FIELD_NAME + " *");
-        scrollIntoView(fillFrom);
         WebElement fillTo = testGrid.getCell(2, REQ_LOOKUP_FIELD_NAME + " *");
         testGrid.dragFill(fillFrom, fillTo);
 

--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-
 @Category({Daily.class})
 public class GridPanelTest extends GridPanelBaseTest
 {
@@ -739,7 +738,7 @@ public class GridPanelTest extends GridPanelBaseTest
      * Issue 47247: LKSM: Filtering values >250 doesn't save selection
      */
     @Test
-    public void testFilterWithMaxDistinctValues() throws IOException, CommandException
+    public void testFilterWithMaxDistinctValues()
     {
         QueryGrid grid = beginAtQueryGrid(FILTER_SAMPLE_TYPE);
         checker().verifyEquals("Unfiltered grid row count not as expected", 300, grid.getRecordCount());


### PR DESCRIPTION
#### Rationale
Fix EditableGridTest.testFillCellValidation to scroll a little farther.

#### Related Pull Requests
* https://github.com/LabKey/limsModules/pull/490

#### Changes
* Have the test scroll just a bit farther to the right to be entirely in the view port.
