### PR TITLE
Fix tests to handle deprecated feature flags

### DIFF
--- a/src/org/labkey/test/tests/DataReportsTest.java
+++ b/src/org/labkey/test/tests/DataReportsTest.java
@@ -36,6 +36,7 @@ import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.PermissionsHelper;
 import org.labkey.test.util.RReportHelper;
 import org.openqa.selenium.WebElement;
@@ -303,6 +304,10 @@ public class DataReportsTest extends ReportTest
     @Test
     public void doAdvancedViewTest()
     {
+        // Note: Enabling this feature flag requires a server restart, so just skip the test if not already enabled
+        if (!OptionalFeatureHelper.isOptionalFeatureEnabled(createDefaultConnection(), "enableExternalReport"))
+            return;
+
         clickAndWait(Locator.linkWithText("DEM-1: Demographics"));
         DataRegionTable dataRegion = DataRegionTable.DataRegion(getDriver()).find();
         String create_advanced_report = "Create Advanced Report";

--- a/src/org/labkey/test/tests/SecurityApiTest.java
+++ b/src/org/labkey/test/tests/SecurityApiTest.java
@@ -24,6 +24,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.util.APITestHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
+import org.labkey.test.util.OptionalFeatureHelper;
 
 import java.io.File;
 import java.util.Arrays;
@@ -143,10 +144,12 @@ public class SecurityApiTest extends BaseWebDriverTest
     @Test
     public void testApiUserRolesAndPermissions() throws Exception
     {
+        boolean previous = OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "effectivePermissions");
         APITestHelper apiTester = new APITestHelper(this);
         apiTester.setTestFiles(getTestFiles());
         apiTester.setIgnoredElements(getIgnoredElements());
         apiTester.runApiTests(ADMIN_USER);
+        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "effectivePermissions", previous);
     }
 
     @Override

--- a/src/org/labkey/test/tests/SecurityApiTest.java
+++ b/src/org/labkey/test/tests/SecurityApiTest.java
@@ -144,12 +144,12 @@ public class SecurityApiTest extends BaseWebDriverTest
     @Test
     public void testApiUserRolesAndPermissions() throws Exception
     {
-        boolean previous = OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "effectivePermissions");
+        boolean previous = OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "restoreUseOfAcls");
         APITestHelper apiTester = new APITestHelper(this);
         apiTester.setTestFiles(getTestFiles());
         apiTester.setIgnoredElements(getIgnoredElements());
         apiTester.runApiTests(ADMIN_USER);
-        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "effectivePermissions", previous);
+        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "restoreUseOfAcls", previous);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Advanced reports and bitmask-based permissions are deprecated and no longer enabled by default

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5711