### PR TITLE
Stop testing deprecated hasPermission() function

### DIFF
--- a/modules/simpletest/resources/scripts/validationTest/securityTest.js
+++ b/modules/simpletest/resources/scripts/validationTest/securityTest.js
@@ -25,7 +25,7 @@ function doTest()
     });
 
     // LABKEY.Security.currentUser
-    if(!currentUser.isSystemAdmin)
+    if (!currentUser.isSystemAdmin)
         errors[errors.length] = Error("Security.currentUser = " + Ext.util.JSON.encode(currentUser));
 
     //LABKEY.Security.createContainer()
@@ -33,16 +33,16 @@ function doTest()
         name: containerPath,
         containerPath: '/'
     });
-    if( container.path !== "/" + containerPath )
-        errors[errors.length] = new Error("Security.createContainer() = "+Ext.util.JSON.encode(container));
+    if (container.path !== "/" + containerPath)
+        errors[errors.length] = new Error("Security.createContainer() = " + Ext.util.JSON.encode(container));
 
     // LABKEY.Security.createGroup()
     var group = LABKEY.Security.createGroup({
         groupName: groupName,
         containerPath: containerPath
     });
-    if( group.name !== groupName )
-        errors[errors.length] = new Error("Security.createGroup() = "+Ext.util.JSON.encode(group));
+    if (group.name !== groupName)
+        errors[errors.length] = new Error("Security.createGroup() = " + Ext.util.JSON.encode(group));
 
     // LABKEY.Security.createNewUser()
     var user = LABKEY.Security.createNewUser({
@@ -50,8 +50,8 @@ function doTest()
         sendEmail: false,
         containerPath: containerPath
     });
-    if( user.email !== userEmail )
-        errors[errors.length] = new Error("Security.createNewUser() = "+Ext.util.JSON.encode(user));
+    if (user.email !== userEmail)
+        errors[errors.length] = new Error("Security.createNewUser() = " + Ext.util.JSON.encode(user));
 
     // LABKEY.Security.addGroupMembers()
     result = LABKEY.Security.addGroupMembers({
@@ -59,8 +59,8 @@ function doTest()
         principalIds: [user.userId],
         containerPath: containerPath
     });
-    if(result.added != user.userId )
-        errors[errors.length] = new Error("Security.addGroupMembers() = "+Ext.util.JSON.encode(result));
+    if (result.added !== user.userId )
+        errors[errors.length] = new Error("Security.addGroupMembers() = " + Ext.util.JSON.encode(result));
 
     // LABKEY.Security.getFolderTypes()
     result = LABKEY.Security.getFolderTypes({});
@@ -70,16 +70,16 @@ function doTest()
     result = LABKEY.Security.getSecurableResources({
         containerPath: containerPath
     });
-    if( typeof result === undefined )
-        errors[errors.length] = new Error("Security.getSecurableResources() = "+Ext.util.JSON.encode(result));
+    if (typeof result === undefined)
+        errors[errors.length] = new Error("Security.getSecurableResources() = " + Ext.util.JSON.encode(result));
 
     // LABKEY.Security.getGroupsForCurrentUser()
     result = LABKEY.Security.getGroupsForCurrentUser({
         containerPath: containerPath
     });
 
-    if( !result.groups || result.groups.length < 3) // User should be in at least 3 groups (id): Guests (-3), All Site Users (-2), and Site Administrators (-1)
-        errors[errors.length] = new Error("Security.getGroupsForCurrentUser() = "+Ext.util.JSON.encode(result));
+    if (!result.groups || result.groups.length < 3) // User should be in at least 3 groups (id): Guests (-3), All Site Users (-2), and Site Administrators (-1)
+        errors[errors.length] = new Error("Security.getGroupsForCurrentUser() = " + Ext.util.JSON.encode(result));
     else
     {
         var success = false;
@@ -99,46 +99,38 @@ function doTest()
         }
 
         if (!success)
-            errors[errors.length] = new Error("Security.getGroupsForCurrentUser() = "+Ext.util.JSON.encode(result));
+            errors[errors.length] = new Error("Security.getGroupsForCurrentUser() = " + Ext.util.JSON.encode(result));
     }
 
     // LABKEY.Security.getContainers()
     result = LABKEY.Security.getContainers({
         containerPath: containerPath
     });
-    if( !result.id )
-        errors[errors.length] = new Error("Security.getContainers() = "+Ext.util.JSON.encode(result));
+    if (!result.id)
+        errors[errors.length] = new Error("Security.getContainers() = " + Ext.util.JSON.encode(result));
 
     // LABKEY.Security.getGroupPermissions()
     result = LABKEY.Security.getGroupPermissions({
         containerPath: containerPath
     });
-    if( !result.container || !result.container.groups )
-        errors[errors.length] = new Error("Security.getGroupPermissions() = "+Ext.util.JSON.encode(result));
+    if (!result.container || !result.container.groups)
+        errors[errors.length] = new Error("Security.getGroupPermissions() = " + Ext.util.JSON.encode(result));
 
     // LABKEY.Security.getUsers()
     result = LABKEY.Security.getUsers({
         groupId: group.id,
         containerPath: containerPath
     });
-    if( !result.users )
-        errors[errors.length] = new Error("Security.getUsers() = "+Ext.util.JSON.encode(result));
+    if (!result.users)
+        errors[errors.length] = new Error("Security.getUsers() = " + Ext.util.JSON.encode(result));
 
     // LABKEY.Security.getUserPermissions()
     var permissions = LABKEY.Security.getUserPermissions({
         userEmail: userEmail,
         containerPath: containerPath
     });
-    if( !permissions.container || !permissions.user || permissions.user.userId!=user.userId )
-        errors[errors.length] = new Error("Security.getUserPermissions() = "+Ext.util.JSON.encode(permissions));
-
-    // LABKEY.Security.hasPermission()
-    result = LABKEY.Security.hasPermission({
-        perms: permissions.container.permissions,
-        perm: LABKEY.Security.permissions.read
-    });
-    if ( result !== 0 )
-        errors[errors.length] = new Error("Security.hasPermission() = "+Ext.util.JSON.encode(result));
+    if (!permissions.container || !permissions.user || permissions.user.userId !== user.userId)
+        errors[errors.length] = new Error("Security.getUserPermissions() = " + Ext.util.JSON.encode(permissions));
 
     // LABKEY.Security.getRoles()
     result = LABKEY.Security.getRoles({});
@@ -151,8 +143,8 @@ function doTest()
         principalIds: [user.userId],
         containerPath: containerPath
     });
-    if( !result.removed )
-        errors[errors.length] = new Error("Security.removeGroupMembers() = "+Ext.util.JSON.encode(result));
+    if (!result.removed)
+        errors[errors.length] = new Error("Security.removeGroupMembers() = " + Ext.util.JSON.encode(result));
 
     // LABKEY.Security.renameGroup()
     result = LABKEY.Security.renameGroup({
@@ -160,24 +152,24 @@ function doTest()
         newName: groupName + "Renamed",
         containerPath: containerPath
     });
-    if( !result.success )
-        errors[errors.length] = new Error("Security.renameGroup() = "+Ext.util.JSON.encode(result));
+    if (!result.success)
+        errors[errors.length] = new Error("Security.renameGroup() = " + Ext.util.JSON.encode(result));
 
     // LABKEY.Security.deleteGroup()
     result = LABKEY.Security.deleteGroup({
         groupId: group.id,
         containerPath: containerPath
     });
-    if( !result.deleted )
-        errors[errors.length] = new Error("Security.deleteGroup() = "+Ext.util.JSON.encode(result));
+    if (!result.deleted)
+        errors[errors.length] = new Error("Security.deleteGroup() = " + Ext.util.JSON.encode(result));
 
     // LABKEY.Security.deleteContainer()
     result = LABKEY.Security.deleteContainer({
         containerPath: containerPath
     });
-    if( Ext.util.JSON.encode(result) !== Ext.util.JSON.encode({}) )
-        errors[errors.length] = new Error("Security.deleteContainer() = "+Ext.util.JSON.encode(result));
+    if (Ext.util.JSON.encode(result) !== Ext.util.JSON.encode({}))
+        errors[errors.length] = new Error("Security.deleteContainer() = " + Ext.util.JSON.encode(result));
 
-    if( errors.length > 0 )
+    if (errors.length > 0)
         throw errors;
 }

--- a/modules/simpletest/resources/scripts/validationTest/securityTest.js
+++ b/modules/simpletest/resources/scripts/validationTest/securityTest.js
@@ -59,7 +59,7 @@ function doTest()
         principalIds: [user.userId],
         containerPath: containerPath
     });
-    if (result.added !== user.userId )
+    if (result.added[0] !== user.userId)
         errors[errors.length] = new Error("Security.addGroupMembers() = " + Ext.util.JSON.encode(result));
 
     // LABKEY.Security.getFolderTypes()

--- a/modules/simpletest/resources/scripts/validationTest/securityTest.js
+++ b/modules/simpletest/resources/scripts/validationTest/securityTest.js
@@ -61,7 +61,7 @@ function doTest()
         principalIds: [user.userId],
         containerPath: containerPath
     });
-    if (result.added[0] !== user.userId)
+    if (result.added.length !== 1 || result.added[0] !== user.userId)
         errors[errors.length] = new Error("Security.addGroupMembers() = " + Ext.util.JSON.encode(result));
 
     // LABKEY.Security.getFolderTypes()

--- a/modules/simpletest/resources/scripts/validationTest/securityTest.js
+++ b/modules/simpletest/resources/scripts/validationTest/securityTest.js
@@ -4,6 +4,8 @@
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
 
+// Note: This is exercised by RhinoService$TestCase
+
 var console = require("console");
 console.log("** evaluating: " + this['javax.script.filename']);
 var LABKEY = require("labkey");


### PR DESCRIPTION
#### Rationale
`LABKEY.Security.hasPermission()` has been deprecated and is no longer useful, since bitmask-based permissions are no longer returned by the server.

Also, remove warnings, address styling inconsistencies, and fix broken `addGroupMembers()` check.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5711