### PR TITLE
Make DataReportsTest.doAdvancedViewTest work on trial

### DIFF
--- a/src/org/labkey/test/tests/DataReportsTest.java
+++ b/src/org/labkey/test/tests/DataReportsTest.java
@@ -304,15 +304,12 @@ public class DataReportsTest extends ReportTest
     @Test
     public void doAdvancedViewTest()
     {
-        // Note: Enabling this feature flag requires a server restart, so just skip the test if not already enabled
-        if (!OptionalFeatureHelper.isOptionalFeatureEnabled(createDefaultConnection(), "enableExternalReport"))
-            return;
-
         clickAndWait(Locator.linkWithText("DEM-1: Demographics"));
         DataRegionTable dataRegion = DataRegionTable.DataRegion(getDriver()).find();
         String create_advanced_report = "Create Advanced Report";
 
-        if (TestProperties.isPrimaryUserAppAdmin())
+        // Note: Enabling this feature flag requires a server restart
+        if (TestProperties.isPrimaryUserAppAdmin() || !OptionalFeatureHelper.isOptionalFeatureEnabled(createDefaultConnection(), "enableExternalReport"))
         {
             BootstrapMenu reportMenu = dataRegion.getReportMenu();
             reportMenu.expand();


### PR DESCRIPTION
#### Rationale
This test is failing on trial instance because app admin users can't check whether optional features are enabled. They also can't create advanced reports so we can just use the existing alternate verification that was added to allow this test to run on trial.
```
Caused by: org.labkey.remoteapi.CommandException: User does not have permission to perform this operation.
  at app//org.labkey.remoteapi.Command.throwError(Command.java:406)
  at app//org.labkey.remoteapi.Command.checkThrowError(Command.java:366)
  at app//org.labkey.remoteapi.Command.executeRequest(Command.java:352)
  at app//org.labkey.remoteapi.Command._execute(Command.java:321)
  at app//org.labkey.remoteapi.Command.execute(Command.java:185)
  at app//org.labkey.test.util.OptionalFeatureHelper.isOptionalFeatureEnabled(OptionalFeatureHelper.java:77)
```

#### Related Pull Requests
* #1998 

#### Changes
* Make DataReportsTest.doAdvancedViewTest work on trial
