### PR TITLE
New wait for search indexer fails if the search module isn't present

### DIFF
--- a/src/org/labkey/test/util/ApiBootstrapHelper.java
+++ b/src/org/labkey/test/util/ApiBootstrapHelper.java
@@ -16,7 +16,6 @@ import org.labkey.test.WebTestHelper;
 
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.AccessDeniedException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/org/labkey/test/util/ApiBootstrapHelper.java
+++ b/src/org/labkey/test/util/ApiBootstrapHelper.java
@@ -16,6 +16,7 @@ import org.labkey.test.WebTestHelper;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.AccessDeniedException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -156,7 +157,8 @@ public class ApiBootstrapHelper
         }
         while (!timer.isTimedOut());
 
-        throw new RuntimeException("Server didn't finish starting.", lastException);
+        if (!(lastException.getCause() instanceof CommandException && lastException.getMessage().contains("Not Found")))
+            throw new RuntimeException("Server didn't finish starting.", lastException);
     }
 
     public Connection createDefaultConnection()


### PR DESCRIPTION
#### Rationale
New wait for search indexer fails if the search module isn't present

https://teamcity.labkey.org/buildConfiguration/LabKey_247Release_Premium_GitExtraPostgres/3127873?buildTab=tests&status=failed&expandedTest=build%3A%28id%3A3127860%29%2Cid%3A2000000017


#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/1989

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
