### PR TITLE
New wait for search indexer fails if the search module isn't present

### DIFF
--- a/src/org/labkey/test/util/ApiBootstrapHelper.java
+++ b/src/org/labkey/test/util/ApiBootstrapHelper.java
@@ -16,7 +16,6 @@ import org.labkey.test.WebTestHelper;
 
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.AccessDeniedException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/org/labkey/test/util/ApiBootstrapHelper.java
+++ b/src/org/labkey/test/util/ApiBootstrapHelper.java
@@ -13,15 +13,16 @@ import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.LabKeySiteWrapper;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
+import org.labkey.test.util.search.SearchAdminAPIHelper;
 
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static org.labkey.test.WebTestHelper.getBaseURL;
+import static org.labkey.test.WebTestHelper.getRemoteApiConnection;
 
 /**
  * Bootstrap a server without the initial user validation done by {@link LabKeySiteWrapper#signIn()}
@@ -38,6 +39,11 @@ public class ApiBootstrapHelper
             createInitialUser();
             waitForBootstrap();
             new APIUserHelper(this::createDefaultConnection).setInjectionDisplayName(PasswordUtil.getUsername());
+            /*
+                    Waiting for search service to boot up
+                    Issue 50601: PDF indexing is slow on first file after server startup on Windows
+            */
+            SearchAdminAPIHelper.waitForSearchServiceBootstrap(getRemoteApiConnection());
         }
         else
         {
@@ -129,12 +135,6 @@ public class ApiBootstrapHelper
     {
         Connection cn = WebTestHelper.getRemoteApiConnection(false);
         SimpleGetCommand command = new SimpleGetCommand("admin", "startupStatus");
-        /*
-            Waiting for search service to boot up
-            Issue 50601: PDF indexing is slow on first file after server startup on Windows
-         */
-        SimpleGetCommand searchCmd = new SimpleGetCommand("search", "json");
-        searchCmd.setParameters(Map.of("q", "pinging to check server is started", "scope", "All"));
         Exception lastException = null;
 
         Timer timer = new Timer(Duration.ofMinutes(5));
@@ -143,8 +143,7 @@ public class ApiBootstrapHelper
             try
             {
                 CommandResponse response = command.execute(cn, null);
-                CommandResponse searchResponse = searchCmd.execute(cn, "/");
-                if ((Boolean) response.getParsedData().getOrDefault("startupComplete", false) && searchResponse.getStatusCode() == 200)
+                if ((Boolean) response.getParsedData().getOrDefault("startupComplete", false))
                 {
                     return;
                 }
@@ -156,8 +155,7 @@ public class ApiBootstrapHelper
         }
         while (!timer.isTimedOut());
 
-        if (!(lastException.getCause() instanceof CommandException && lastException.getMessage().contains("Not Found")))
-            throw new RuntimeException("Server didn't finish starting.", lastException);
+        throw new RuntimeException("Server didn't finish starting.", lastException);
     }
 
     public Connection createDefaultConnection()

--- a/src/org/labkey/test/util/ApiBootstrapHelper.java
+++ b/src/org/labkey/test/util/ApiBootstrapHelper.java
@@ -16,6 +16,7 @@ import org.labkey.test.WebTestHelper;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.AccessDeniedException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -156,7 +157,8 @@ public class ApiBootstrapHelper
         }
         while (!timer.isTimedOut());
 
-        throw new RuntimeException("Server didn't finish starting.", lastException);
+        if (!(lastException.getCause() instanceof CommandException && lastException.getMessage().contains("Not Found")))
+            throw new RuntimeException("Server didn't finish starting.", lastException);
     }
 
     public Connection createDefaultConnection()


### PR DESCRIPTION
Rationale
New wait for search indexer fails if the search module isn't present

https://teamcity.labkey.org/buildConfiguration/LabKey_247Release_Premium_GitExtraPostgres/3127873?buildTab=tests&status=failed&expandedTest=build%3A%28id%3A3127860%29%2Cid%3A2000000017

Related Pull Requests
https://github.com/LabKey/testAutomation/pull/1989

Changes