### PR TITLE
Test coverage for plate reformatting

### DIFF
--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -541,7 +541,9 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
 
         public BaseReactSelectFinder<Select> withId(String id)
         {
-            _locator = Locators.containerWithDescendant(Locator.tagWithId("div", id));
+            Locator.XPathLocator idElementLoc = Locator.XPathLocator.union(
+                    Locator.tagWithId("div", id), Locator.tagWithId("input", id));
+            _locator = Locators.containerWithDescendant(idElementLoc);
             return this;
         }
 

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -541,9 +541,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
 
         public BaseReactSelectFinder<Select> withId(String id)
         {
-            Locator.XPathLocator idElementLoc = Locator.XPathLocator.union(
-                    Locator.tagWithId("div", id), Locator.tagWithId("input", id));
-            _locator = Locators.containerWithDescendant(idElementLoc);
+            _locator = Locators.containerWithDescendant(Locator.id(id));
             return this;
         }
 


### PR DESCRIPTION
#### Rationale
This change updates `BaseReactSelect.BaseReactSelectFinder.withId` to find a select with its id on an input, in addition to on a div.

At this point, the use cases that depend on this are in `ReformatModalDialog.java`
If we would prefer not to change the existing method's behavior and think it would be better to add a new method named withInputId, that would be a simple change.  If we would like to stop adding finder methods like this, perhaps adding a .locatedBy(locator) method (to this class, also perhaps to the component template finder class) would allow callers to provide their own component locators more flexibly.

#### Related Pull Requests
https://github.com/LabKey/limsModules/pull/529 <- related test coverage here

#### Changes

- [x] find with id on input _and_ div
