### PR TITLE
EditableGrid: remove dependence on QueryModel

### DIFF
--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -1096,6 +1096,9 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
         public WebElement inputCell()
         {
+            // Wait for the input to appear because there are some cases where we type into a cell to trigger the input
+            // to appear, and then immediately try to type into the input and it may not be there.
+            Locators.inputCell.waitForElement(table, WAIT_FOR_JAVASCRIPT);
             return Locators.inputCell.findElement(table);
         }
 


### PR DESCRIPTION
#### Rationale
See rationale in ui-components

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1534
- https://github.com/LabKey/labkey-ui-premium/pull/470
- https://github.com/LabKey/platform/pull/5687
- https://github.com/LabKey/limsModules/pull/469
- https://github.com/LabKey/testAutomation/pull/2016

#### Changes
* EditableGrid: wait for input cells