### PR TITLE
Update MultiMenu for issue 50901

### DIFF
--- a/src/org/labkey/test/components/react/MultiMenu.java
+++ b/src/org/labkey/test/components/react/MultiMenu.java
@@ -49,6 +49,8 @@ public class MultiMenu extends BootstrapMenu
      */
     public WebElement getMenuItem(String menuItem)
     {
+        expand();
+        waitForData();
         return Locators.menuItem().withText(menuItem).waitForElement(getMenuList(), _menuWaitTmeout);
     }
 
@@ -91,7 +93,6 @@ public class MultiMenu extends BootstrapMenu
     @LogMethod(quiet = true)
     public void doMenuAction(@LoggedParam String menuAction)
     {
-        expand();
         var item = getMenuItem(menuAction);
         getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(item));
         item.click();
@@ -104,7 +105,6 @@ public class MultiMenu extends BootstrapMenu
      */
     public void doMenuAction(@LoggedParam String toggleText, @LoggedParam String menuAction)
     {
-        expand();
         clickMenuItemUnderToggle(toggleText, menuAction);
     }
 
@@ -213,6 +213,7 @@ public class MultiMenu extends BootstrapMenu
     public WebElement expandToggle(String toggle)
     {
         expand();
+        waitForData();
         int listItemCount = getListItems().size();
 
         // find the toggle-item; it may be expanded already
@@ -326,8 +327,6 @@ public class MultiMenu extends BootstrapMenu
      */
     protected List<WebElement> getMenuItemsUnderToggle(String toggle)
     {
-        expand();
-        waitForData();
         expandToggle(toggle);
 
         List<WebElement> itemsUnderToggle = new ArrayList<>();

--- a/src/org/labkey/test/components/react/MultiMenu.java
+++ b/src/org/labkey/test/components/react/MultiMenu.java
@@ -59,7 +59,7 @@ public class MultiMenu extends BootstrapMenu
      */
     public boolean isMenuItemDisabled(String menuItem)
     {
-        return !getMenuItem(menuItem).isEnabled();
+        return getMenuItem(menuItem).getAttribute("class").contains("disabled");
     }
 
     /**
@@ -70,7 +70,7 @@ public class MultiMenu extends BootstrapMenu
      */
     public boolean isMenuItemUnderToggleDisabled(String toggle, String menuItem)
     {
-        return !getMenuItemUnderToggle(toggle, menuItem).isEnabled();
+        return getMenuItemUnderToggle(toggle, menuItem).getAttribute("class").contains("disabled");
     }
 
     /**

--- a/src/org/labkey/test/components/react/MultiMenu.java
+++ b/src/org/labkey/test/components/react/MultiMenu.java
@@ -327,8 +327,8 @@ public class MultiMenu extends BootstrapMenu
     protected List<WebElement> getMenuItemsUnderToggle(String toggle)
     {
         expand();
-        expandToggle(toggle);
         waitForData();
+        expandToggle(toggle);
 
         List<WebElement> itemsUnderToggle = new ArrayList<>();
 

--- a/src/org/labkey/test/components/react/MultiMenu.java
+++ b/src/org/labkey/test/components/react/MultiMenu.java
@@ -4,19 +4,19 @@
  */
 package org.labkey.test.components.react;
 
-import org.junit.Assert;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -40,48 +40,73 @@ public class MultiMenu extends BootstrapMenu
         return Locator.tagWithClass("ul", "dropdown-menu").findElement(this);
     }
 
+    /*
+        finds the first menu item with the specified text
+     */
     public WebElement getMenuItem(String text)
     {
-        return Locator.tag("li").withChild(Locator.tagWithAttribute("a", "role", "menuitem")
-                    .withText(text)).waitForElement(getMenuList(), _menuWaitTmeout);
+        return Locators.menuItem().withText(text).waitForElement(getMenuList(), _menuWaitTmeout);
     }
 
+    /**
+     * Find the first item with specified text under the path of the
+     * @param menuText Text of the menu to expand
+     * @param itemText  Text of the item to find under its path
+     * @return
+     */
+    public WebElement getMenuItem(String menuText, String itemText)
+    {
+        return getItemUnderToggle(menuText, itemText);
+    }
+
+    /**
+     * Checks whether the specified menu item is disabled
+     * @param text Text of the menu item
+     * @return  true if class contains 'disabled'
+     */
     public boolean isMenuItemDisabled(String text)
     {
         return getMenuItem(text).getAttribute("class").toLowerCase().contains("disabled");
     }
 
+    public boolean isMenuItemDisabled(String menuText, String itemText)
+    {
+        return getItemUnderToggle(menuText, itemText).getAttribute("class").toLowerCase().contains("disabled");
+    }
+
     /**
-     * Send in a list of menu text to click, they will be clicked in the order given.
+     * gets all list-items currently appearing in the menu.  This includes header and separator items,
+     * which are special and don't have links
+     * @return
+     */
+    protected List<WebElement> getListItems()
+    {
+        return Locators.listItem().findElements(getMenuList());
+    }
+
+    /**
+     * Click a single top-level menu-item
      *
-     * @param pathToAction List of the menus to click
+     * @param menuAction The menu item to click
      **/
     @LogMethod(quiet = true)
-    public void doMenuAction(@LoggedParam List<String> pathToAction)
+    public void doMenuAction(@LoggedParam String menuAction)
     {
         expand();
+        var item = getMenuItem(menuAction);
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(item));
+        item.click();
+    }
 
-        for (int i = 0; i < pathToAction.size(); i++)
-        {
-            Assert.assertFalse("Menu item not enabled.", isMenuItemDisabled(pathToAction.get(i)));
-
-            WebElement menuItem = getMenuItem(pathToAction.get(i));
-
-            if (i < pathToAction.size() - 1)
-            {
-                // Everything in the pathToAction should contain a sub menu except possibly the last item.
-                Assert.assertTrue("Item in menu path '" + pathToAction.get(i) + "' does not contain a sub-menu.", menuItem.getAttribute("class").contains("dropdown-section-toggle"));
-                if(!Locator.byClass("fa").findElement(menuItem).getAttribute("class").contains("fa-chevron-up"))
-                {
-                    // This is a sub-menu item, but click it only if the sub-menu is not expanded.
-                    menuItem.click();
-                }
-            }
-            else // Last item+
-            {
-                menuItem.click();
-            }
-        }
+    /**
+     *  Click a menu item under a menu
+     * @param toggleText Text of the menu to expand
+     * @param menuAction Text of the menu item to click
+     */
+    public void doMenuAction(@LoggedParam String toggleText, @LoggedParam String menuAction)
+    {
+        expand();
+        clickItemUnderToggle(toggleText, menuAction);
     }
 
     private List<WebElement> waitForData()
@@ -165,11 +190,6 @@ public class MultiMenu extends BootstrapMenu
         }
     }
 
-    public void doMenuAction(String ... subMenuLabels)
-    {
-        doMenuAction(Arrays.asList(subMenuLabels));
-    }
-
     public List<String> getMenuText()
     {
         expandAll();
@@ -186,34 +206,182 @@ public class MultiMenu extends BootstrapMenu
         return menuText;
     }
 
-    public List<String> getItemsUnderHeading(String heading)
+    /*
+       Finds and expands (if it is collapsed) a menu's dropdown-section toggle.
+       (Expanding a collapsed dropdown-section-toggle causes items hidden while collapsed
+       to be shown as dom peers after it in the list)
+    */
+    public WebElement expandToggle(String label)
+    {
+        expand();
+        int listItemCount = getListItems().size();
+
+        // find the toggle-item; it may be expanded already
+        WebElement toggle = Locators.menuToggle(label).waitForElement(this, 1000);
+        if (Locators.menuToggleClosed().existsIn(toggle))
+        {
+            toggle.click(); // expand the toggle
+            WebDriverWrapper.waitFor(() ->
+                            Locator.tagWithClass("span", "fa-chevron-up").existsIn(toggle),
+                    "the toggle-item did not expand in time", 1000);
+            WebDriverWrapper.waitFor(()-> getListItems().size() > listItemCount,
+                    "the list-items did not appear in the list after expanding", 1000);
+        }
+
+        return toggle;
+    }
+
+    /**
+     * gets the names of dropdown-section__menu-items between a heading and the next divider
+     *
+     * @param heading
+     * @return
+     */
+    public List<String> getItemsUnderHeading(String heading, boolean collapse)
+    {
+        var itemTexts = getWrapper().getTexts(getItemsUnderHeading(heading));
+        if (collapse)
+            collapse();
+        return itemTexts;
+    }
+
+    /**
+     * gets the dropdown-section__menu-items between a heading and the next separator
+     *
+     * @param heading
+     * @return
+     */
+    protected List<WebElement> getItemsUnderHeading(String heading)
     {
         expandAll();
         boolean headingFound = false;
-        List<String> items = new ArrayList<>();
+        List<WebElement> itemsUnderHeading = new ArrayList<>();
         List<WebElement> listItems = Locator.tag("li").findElements(this);
+
+        for (WebElement item : listItems)
+        {
+            String className = item.getAttribute("class");
+            String role = item.getAttribute("role");
+            String text = item.getText().trim();
+
+            if (className.contains("dropdown-header") && text.equalsIgnoreCase(heading))
+                headingFound = true;
+
+            // Once we've found our header we know that all presentation elements belong to the heading
+            // we are interested in
+            if (headingFound && role.equals("presentation"))
+                itemsUnderHeading.add(item);
+
+            // Once we hit a divider we're done looking at menu items related to the heading, so we can stop iterating
+            if (headingFound && role.equals("separator"))
+                break;
+        }
+
+        return itemsUnderHeading;
+    }
+
+    private WebElement getItemUnderHeading(String toggleLabel, String label)
+    {
+        var itemsUnderHeading = getItemsUnderHeading(toggleLabel);
+        for (WebElement item : itemsUnderHeading)
+        {
+            if (item.getText().trim().equals(label))
+                return item;
+        }
+        throw new NoSuchElementException("No item '" + label + "' under toggle '" + toggleLabel + "' found.");
+    }
+
+    /**
+     * Clicks the specified item under the specified heading
+     *
+     * @param heading heading under which to find the item
+     * @param label   text of the item
+     */
+    public void clickItemUnderHeading(String heading, String label)
+    {
+        WebElement item = getItemUnderHeading(heading, label);
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(item));
+        item.click();
+    }
+
+    /**
+     * gets the names of dropdown-section__menu-items between a heading and the next divider
+     *
+     * @param heading The text of the heading
+     * @param collapse Whether to collapse the menu when finished
+     * @return
+     */
+    public List<String> getItemsUnderToggle(String heading, boolean collapse)
+    {
+        var itemTexts = getWrapper().getTexts(getItemsUnderToggle(heading));
+        if (collapse)
+            collapse();
+        return itemTexts;
+    }
+
+    /**
+     * Gets a list of dropdown-section__menu-items under a given toggle. For cases where the menu has duplicate
+     * menu-items and you need to select one under a specific toggle, use this to find it
+     *
+     * @param label Text of the toggle item
+     * @return A list of menu items under the specified toggle.
+     */
+    protected List<WebElement> getItemsUnderToggle(String label)
+    {
+        expand();
+        expandToggle(label);
+        waitForData();
+
+        List<WebElement> itemsUnderToggle = new ArrayList<>();
+
+        // iterate from the top and generate the list of items that follow it
+        List<WebElement> listItems = getListItems();
+        boolean headingFound = false;
 
         for (WebElement item : listItems)
         {
             String className = item.getAttribute("class");
             String text = item.getText().trim();
 
-            if (className.contains("dropdown-header") && text.equalsIgnoreCase(heading))
+            if (className.contains("dropdown-section-toggle") && text.equalsIgnoreCase(label))
                 headingFound = true;
 
-            // Once we've found our header we know that all dropdown-section__menu-item elements belong to the heading
+            // Once we've found our toggle we know that all dropdown-section__menu-item elements belong to the heading
             // we are interested in
             if (headingFound && className.contains("dropdown-section__menu-item"))
-                items.add(text);
+                itemsUnderToggle.add(item);
 
-            // Once we hit a divider we're done looking at menu items related to the heading, so we can stop iterating
-            if (headingFound && className.contains("divider"))
+            // Once we hit another divider or another toggle we're done looking at menu items related to the toggle, so we can stop iterating
+            if (headingFound && !text.equalsIgnoreCase(label) && className.contains("dropdown-section-toggle"))
                 break;
         }
 
-        collapse();
+        return itemsUnderToggle;
+    }
 
-        return items;
+    private WebElement getItemUnderToggle(String toggleLabel, String label)
+    {
+        waitForData();
+        var itemsUnderToggle = getItemsUnderToggle(toggleLabel);
+        for (WebElement item : itemsUnderToggle)
+        {
+            if (item.getText().trim().equals(label))
+                return item;
+        }
+        throw new NoSuchElementException("No item '" + label + "' under toggle '" + toggleLabel + "' found.");
+    }
+
+    /**
+     * clicks the dropdown-section__menu_item under the specified toggle
+     *
+     * @param toggleLabel text of the toggle under which to find the item
+     * @param label       text of the item to click
+     */
+    protected void clickItemUnderToggle(String toggleLabel, String label)
+    {
+        var item = getItemUnderToggle(toggleLabel, label);
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(item));
+        item.click();
     }
 
     public String getButtonText()
@@ -230,7 +398,44 @@ public class MultiMenu extends BootstrapMenu
 
         static public Locator.XPathLocator menuContainer(String text)
         {
-            return menuContainer().withChild(BootstrapMenu.Locators.dropdownToggle().withText(text));
+            return menuContainer().withChild(dropdownToggle().withText(text));
+        }
+
+        // finds the toggle to expand/collapse the root menu
+        public static Locator.XPathLocator dropdownToggle()
+        {
+            return Locator.byClass("dropdown-toggle");
+        }
+
+        public static Locator.XPathLocator dropdownHeader()
+        {
+            return Locator.tagWithClass("li", "dropdown-header");
+        }
+
+        // finds a menu-item
+        public static Locator.XPathLocator menuItem()
+        {
+            return Locator.tag("li").withChild(Locator.tagWithAttribute("a", "role", "menuitem"));
+        }
+
+        // finds any list-item (includes separators and header items)
+        public static Locator.XPathLocator listItem()
+        {
+            return Locator.tag("li");
+        }
+
+        // finds a menu-item that is also an expand/collapse, by name
+        public static Locator.XPathLocator menuToggle(String text)
+        {
+            return Locator.tagWithClass("li", "dropdown-section-toggle")
+                    .withDescendant(Locator.tagWithClass("span", "dropdown-section-toggle__text")
+                            .withText(text));
+        }
+
+        // finds the chevron-down span in a menuToggle, if present
+        public static Locator.XPathLocator menuToggleClosed()
+        {
+            return Locator.tagWithClass("span", "fa-chevron-down");
         }
     }
 

--- a/src/org/labkey/test/components/ui/grids/GridBar.java
+++ b/src/org/labkey/test/components/ui/grids/GridBar.java
@@ -205,7 +205,10 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
 
         if(found)
         {
-            multiMenu.doMenuAction(menuActions);
+            if (menuActions.size() == 1)
+                multiMenu.doMenuAction(menuActions.get(0));
+            else
+                multiMenu.doMenuAction(menuActions.get(0), menuActions.get(1));
         }
         else
         {

--- a/src/org/labkey/test/components/ui/grids/GridBar.java
+++ b/src/org/labkey/test/components/ui/grids/GridBar.java
@@ -207,8 +207,10 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
         {
             if (menuActions.size() == 1)
                 multiMenu.doMenuAction(menuActions.get(0));
-            else
+            else if (menuActions.size() == 2)
                 multiMenu.doMenuAction(menuActions.get(0), menuActions.get(1));
+            else
+                throw new IllegalArgumentException("There should be either 1 or 2 menu actions, but was:" + menuActions);
         }
         else
         {


### PR DESCRIPTION
#### Rationale
This change updates `MultiMenu `to be able to click list-items under a given heading, or under a given menu-item path.

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50901)
[github issue](https://github.com/LabKey/testAutomation/issues/2003)

#### Related Pull Requests
https://github.com/LabKey/limsModules/pull/569


#### Changes

- [x] Add method to get item under menu-item, like `getItemsUnderHeading`
- [x] Refactor `doMenuActions `into 2 methods that take 1 or 2 strings, instead of params string
- [x] Refactor usage of params/list doMenuActions to call the new doMenuActions signatures
- [ ] consider implementing waitForReady method for codepaths that don't include expandAll/waitForData
