### PR TITLE
Stop building distributions for standalone Tomcat

### DIFF
--- a/distributions/teamcity/build.gradle
+++ b/distributions/teamcity/build.gradle
@@ -20,7 +20,6 @@ project.tasks.register("distribution", ModuleDistribution) {
         dist.description = "Make a LabKey modules distribution for 'test'"
 
         dist.subDirName = "test"
-        dist.includeTarGZArchive = true
         dist.embeddedArchiveType = "tar.gz"
         dist.extraFileIdentifier = '-test'
         dist.versionPrefix = 'Test'

--- a/src/org/labkey/test/tests/AdvancedImportOptionsTest.java
+++ b/src/org/labkey/test/tests/AdvancedImportOptionsTest.java
@@ -319,7 +319,7 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
         pushLocation();
         impersonate(LIMITED_USER);
         clickFolder(IMPORT_FOLDER_MULTI01);
-        log("Get to the import page and validate that is looks as expected.");
+        log("Get to the import page and validate that it looks as expected.");
         StartImportPage importPage = StartImportPage.startImportFromFile(this, zipFile, false);
         importPage.setSelectSpecificImportOptions(true);
         importPage.setApplyToMultipleFoldersCheckBox(true);


### PR DESCRIPTION
#### Rationale
We no longer support standalone Tomcat

#### Related Pull Requests
* https://github.com/LabKey/distributions/pull/473