### PR TITLE
check whether remove-field button is present

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -201,6 +201,11 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         }
     }
 
+    public boolean isRemoveFieldBtnPresent()
+    {
+        return elementCache().removeFieldLoc.existsIn(this);
+    }
+
     public DomainFieldRow setAdvancedSettings(List<AdvancedFieldSetting> settings)
     {
         if (!settings.isEmpty())


### PR DESCRIPTION
#### Rationale
This change allows DomainFieldRow to check whether or not the remove field button is present

#### Related Pull Requests
https://github.com/LabKey/limsModules/pull/582

#### Changes

