### PR TITLE
Update ExternalSchemaTest to explicitly show system schemas

### DIFF
--- a/src/org/labkey/test/pages/query/InsertExternalSchemaPage.java
+++ b/src/org/labkey/test/pages/query/InsertExternalSchemaPage.java
@@ -39,9 +39,22 @@ public class InsertExternalSchemaPage extends LabKeyPage<InsertExternalSchemaPag
         return this;
     }
 
+    public InsertExternalSchemaPage showSystemSchemas()
+    {
+        elementCache().systemSchemasCheckbox.check();
+        return this;
+    }
+
     public InsertExternalSchemaPage setDataSource(String dataSourceName)
     {
         _extHelper.selectComboBoxItem("Data Source:", dataSourceName);
+        return this;
+    }
+
+    public InsertExternalSchemaPage setSourceSystemSchema(String sourceSchemaName)
+    {
+        showSystemSchemas();
+        _extHelper.selectComboBoxItem("Database Schema Name :", sourceSchemaName);
         return this;
     }
 
@@ -88,6 +101,7 @@ public class InsertExternalSchemaPage extends LabKeyPage<InsertExternalSchemaPag
     {
         Input userSchemaNameInput = Input.Input(Locator.name("userSchemaName"), getDriver()).findWhenNeeded();
         Input metaDataInput = Input.Input(Locator.name("metaData"), getDriver()).findWhenNeeded();
+        Checkbox systemSchemasCheckbox = Checkbox.Checkbox(Locator.id("myincludeSystem")).findWhenNeeded(this);
         Checkbox editableCheckbox = Checkbox.Checkbox(Locator.id("myeditable")).findWhenNeeded(this);
         WebElement createButton = Locator.button("Create").findWhenNeeded(this);
         WebElement updateButton = Locator.button("Update").findWhenNeeded(this);

--- a/src/org/labkey/test/tests/ExternalSchemaTest.java
+++ b/src/org/labkey/test/tests/ExternalSchemaTest.java
@@ -195,7 +195,7 @@ public class ExternalSchemaTest extends BaseWebDriverTest
             clickAndWait(Locator.linkWithText("new external schema"));
             new InsertExternalSchemaPage(getDriver())
                 .setName(USER_SCHEMA_NAME)
-                .setSourceSchema(DB_SCHEMA_NAME)
+                .setSourceSystemSchema(DB_SCHEMA_NAME)
                 .setMetadata(TestFileUtils.getFileContents("server/modules/platform/core/resources/schemas/test.xml"))
                 .clickCreate();
         }


### PR DESCRIPTION
#### Rationale
ExternalSchemaTest was just typing the name of the schema it wanted without checking the checkbox to make it visible. When I updated `InsertExternalSchemaPage` to use the combo box, the test started failing. Just need to make the `test` schema visible in the combo box by checking the appropriate checkbox.

#### Related Pull Requests
* #2027

#### Changes
* Add system schema checkbox to `InsertExternalSchemaPage`
* Update `ExternalSchemaTest` accordingly
