### PR TITLE
wait for the save button to be ready before clicking

### DIFF
--- a/src/org/labkey/test/tests/CrossSiteScriptingForDeleteTest.java
+++ b/src/org/labkey/test/tests/CrossSiteScriptingForDeleteTest.java
@@ -9,6 +9,7 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.pages.reports.ManageViewsPage;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.Collections;
 import java.util.List;
@@ -60,7 +61,9 @@ public class CrossSiteScriptingForDeleteTest extends BaseWebDriverTest
         goToManageViews().clickAddReport("Link Report");
         setFormElement(Locator.name("viewName"), REPORT_NAME);
         setFormElement(Locator.name("linkUrl"), WebTestHelper.getContextPath() + LINK_REPORT_URL);
-        waitAndClickAndWait(Locator.linkWithText("Save"));
+        var saveBtn = Locator.linkWithText("Save").waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT);
+        shortWait().until(ExpectedConditions.elementToBeClickable(saveBtn));
+        clickAndWait(saveBtn);
         waitForText("Manage Views");
 
         log("Clicking on the report - No XSS");

--- a/src/org/labkey/test/tests/CrossSiteScriptingForDeleteTest.java
+++ b/src/org/labkey/test/tests/CrossSiteScriptingForDeleteTest.java
@@ -60,7 +60,7 @@ public class CrossSiteScriptingForDeleteTest extends BaseWebDriverTest
         goToManageViews().clickAddReport("Link Report");
         setFormElement(Locator.name("viewName"), REPORT_NAME);
         setFormElement(Locator.name("linkUrl"), WebTestHelper.getContextPath() + LINK_REPORT_URL);
-        clickButton("Save");
+        waitAndClickAndWait(Locator.linkWithText("Save"));
         waitForText("Manage Views");
 
         log("Clicking on the report - No XSS");


### PR DESCRIPTION
#### Rationale
Yesterday (and recently), [CrossSiteScriptingForDeleteTest.verifyReportNameIsEncoded](https://teamcity.labkey.org/viewLog.html?buildId=3110547&tab=buildResultsDiv&buildTypeId=LabKey_247Release_Community_DailySuites_DailyASqlserver#testNameId-1213030100997127121) has failed in a way that seems likely to be due to clicking the 'save' button before it was ready- the most-recent failure waited for navigation for the default page timeout.  This one-line change will hopefully address this.

#### Related Pull Requests
n/a

#### Changes
wait for the 'save' button before clicking 
