### PR TITLE
Test updates for Admin console link test

### DIFF
--- a/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
@@ -70,10 +70,8 @@ public class AdminConsoleNavigationTest extends BaseWebDriverTest
     {
         Set<String> ignoredLinks = Collections.newSetFromMap(new CaseInsensitiveHashMap<>());
         ignoredLinks.addAll(List.of(
-                "LDAP Sync Admin",                  // An HTML view -- difficult to customize navtrail
                 "Authentication",                   // Slow to load
                 "Change User Properties",           // Generic domain action -- difficult to customize navtrail
-                "Puppeteer Service",                // An HTML view -- difficult to customize navtrail
                 "Dump Heap",                        // Undesired consequences
                 "Reset Site Errors",                // No nav trail
                 "Memory Usage",                     // Slow to load

--- a/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
@@ -117,9 +117,6 @@ public class AdminConsoleNavigationTest extends BaseWebDriverTest
     {
         Set<String> ignoredLinks = Collections.newSetFromMap(new CaseInsensitiveHashMap<>());
         ignoredLinks.addAll(List.of(
-                "SignUp",                   //Issue 51100: SignUp link from admin console shows up to the troubleshooter but throws 403 while accessing it.
-                "Notebook Settings",        //Issue 51099: Notebook Settings and Puppeteer Service admin console link show up for troubleshooter but throws 403 while accessing it.
-                "Puppeteer Service",
                 "Dump Heap",                // Undesired consequences
                 "Profiler"                  //Profiler can be edited by the troubleshooter
         ));


### PR DESCRIPTION
#### Rationale
Removing couple of links from ignore list after following issues were fixed.

1. Issue 51100: SignUp link from admin console shows up to the troubleshooter but throws 403 while accessing it.
2. Issue 51099: Notebook Settings and Puppeteer Service admin console link show up for troubleshooter but throws 403  while accessing it. 
3. Issue 49129: Troubleshooters see error page for Notebook Settings and Puppeteer Service from admin console 

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/2017	

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
