### PR TITLE
add regression coverage for Issue 22743

### DIFF
--- a/src/org/labkey/test/tests/FileAttachmentColumnTest.java
+++ b/src/org/labkey/test/tests/FileAttachmentColumnTest.java
@@ -276,7 +276,6 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
         var otherResultFileTexts = resultsPage.getDataTable().getColumnDataAsText(OTHER_RESULT_FILE_COL);
         var runFileTexts = resultsPage.getDataTable().getColumnDataAsText("Run/runFile");
         var expectedRunFileLinkTexts = resultFiles.stream().map(File::getName).toList();
-        var expectedOtherResultFiles = SAMPLE_FILES.stream().map(File::getName).toList();
 
         checker().withScreenshot("unexpected_results_texts")
                 .wrapAssertion(()-> Assertions.assertThat(resultTxts)
@@ -295,7 +294,7 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
                 .wrapAssertion(()-> Assertions.assertThat(otherResultFileTexts.stream().map(String::trim).toList())
                         .as("expect other results files to have resolved")
                         .containsExactlyInAnyOrder("csv_sample.csv", "pdf_sample.pdf",
-                                "pdf_sample_with+%$@+%%+#-+=.pdf", "tif_sample.tif"));
+                                "pdf_sample_with+%$@+%%+#-+=.pdf", "tif_sample.tif", ""));  // empty value is for jpg, which doesn't get text/is rendered inline
         checker().withScreenshot("unexpected_run_file_links")
                 .wrapAssertion(()-> Assertions.assertThat(runFileTexts.stream().map(String::trim).toList())
                         .as("expect complete run files")

--- a/src/org/labkey/test/tests/FileAttachmentColumnTest.java
+++ b/src/org/labkey/test/tests/FileAttachmentColumnTest.java
@@ -110,6 +110,11 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
         createListWithData(EXPORT_FOLDER_PATH);
 
         //create sample types with file columns
+        WebDavUploadHelper uploadHelper = new WebDavUploadHelper(EXPORT_FOLDER_PATH);
+        for (File file : DATAFILE_DIRECTORY.listFiles())
+        {
+            uploadHelper.uploadFile(file);
+        }
         createSampleTypeWithData(EXPORT_SAMPLETYPE_NAME, EXPORT_FOLDER_PATH);
 
         // create an assay in the export folder
@@ -378,7 +383,7 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
         for (File file : DATAFILE_DIRECTORY.listFiles())
         {
             sampleFileData.add(Map.of("Name", file.getName(), "Color", "green",
-                    "File", String.format("\"%s\"",file.getAbsolutePath())));
+                    "File", file.getName()));
         }
 
         SampleTypeHelper sampleHelper = new SampleTypeHelper(this);

--- a/src/org/labkey/test/tests/FileAttachmentColumnTest.java
+++ b/src/org/labkey/test/tests/FileAttachmentColumnTest.java
@@ -15,47 +15,111 @@
  */
 package org.labkey.test.tests;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.assay.ImportRunCommand;
+import org.labkey.remoteapi.assay.Protocol;
+import org.labkey.remoteapi.domain.PropertyDescriptor;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.pages.experiment.UpdateSampleTypePage;
+import org.labkey.test.pages.files.FileContentPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
+import org.labkey.test.params.assay.GeneralAssayDesign;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
+import org.labkey.test.util.APIAssayHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
+import org.labkey.test.util.TestDataUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class FileAttachmentColumnTest extends BaseWebDriverTest
 {
-    private final String FOLDER_NAME = "TestFolder";
+    private final String PROJECT_NAME = "FileAndAttachmentColumns Project";
+    private final String EXPORT_FOLDER_NAME = "ExportFolder";
+    private final String EXPORT_FOLDER_PATH = String.format("%s/%s", PROJECT_NAME, EXPORT_FOLDER_NAME);
+    private final String IMPORT_FOLDER_NAME = "ImportFolder";
+    private final String IMPORT_FOLDER_PATH = String.format("%s/%s", PROJECT_NAME, IMPORT_FOLDER_NAME);
+    private final String SUBFOLDER_A = "SubFolderA";
+    private final String SUBFOLDER_A_PATH = String.format("%s/%s", PROJECT_NAME, SUBFOLDER_A);
+    private final String SUB_A_ASSAY = "Sub_A_Assay";
     private final String LIST_NAME = "TestList";
     private final String LIST_KEY = "TestListId";
-    private final String SAMPLESET_NAME = "FileSamples";
+    private final String SAMPLETYPE_NAME = "FileSamples";
+    private final String ASSAY_NAME = "FileSampleAssay";
     private final File DATAFILE_DIRECTORY = TestFileUtils.getSampleData("fileTypes");
     private final File SAMPLE_CSV = new File(DATAFILE_DIRECTORY, "csv_sample.csv");
     private final File SAMPLE_JPG = new File(DATAFILE_DIRECTORY, "jpg_sample.jpg");
+    private final File SAMPLE_TRICKY_PDF = new File(DATAFILE_DIRECTORY, "pdf_sample_with+%$@+%%+#-+=.pdf");
     private final File SAMPLE_PDF = new File(DATAFILE_DIRECTORY, "pdf_sample.pdf");
     private final File SAMPLE_TIF = new File(DATAFILE_DIRECTORY, "tif_sample.tif");
+    private final File SAMPLE_ZIP = new File(DATAFILE_DIRECTORY, "zip_sample.zip");
+    private final List<File> SAMPLE_FILES = List.of(SAMPLE_CSV, SAMPLE_JPG, SAMPLE_TRICKY_PDF, SAMPLE_PDF, SAMPLE_TIF, SAMPLE_ZIP);
 
+    @Override
+    protected void doCleanup(boolean afterTest) throws TestTimeoutException
+    {
+        _containerHelper.deleteProject(getProjectName(), afterTest);
+    }
+
+    @BeforeClass
+    public static void setupProject() throws Exception
+    {
+        FileAttachmentColumnTest init = (FileAttachmentColumnTest)getCurrentTest();
+        init.doSetup();
+    }
+
+    private void doSetup() throws Exception
+    {
+        _containerHelper.createProject(getProjectName(), "Custom");
+        _containerHelper.createSubfolder(getProjectName(), EXPORT_FOLDER_NAME);
+        _containerHelper.enableModules(Arrays.asList("Experiment", "Pipeline", "Portal"));
+        _containerHelper.createSubfolder(getProjectName(), IMPORT_FOLDER_NAME);
+        _containerHelper.enableModules(Arrays.asList("Experiment", "Pipeline", "Portal"));
+        _containerHelper.createSubfolder(getProjectName(), SUBFOLDER_A);
+        _containerHelper.enableModules(Arrays.asList("Experiment", "Pipeline", "Portal"));
+
+        //create list with attachment columns
+        createListWithData(EXPORT_FOLDER_PATH);
+
+        //create sample type with file columns
+        createSampleTypeWithData(EXPORT_FOLDER_PATH);
+
+        // create an assay in the test folder
+        List<PropertyDescriptor> runFields = List.of(
+                new FieldDefinition("runTxt", FieldDefinition.ColumnType.String),
+                new FieldDefinition("runFile", ColumnType.File));
+        List<PropertyDescriptor> dataFields = List.of(
+                new FieldDefinition("resultTxt", FieldDefinition.ColumnType.String),
+                new FieldDefinition("resultFile", ColumnType.File));
+        var protocol = makeGeneralAssay(ASSAY_NAME, runFields, dataFields, EXPORT_FOLDER_PATH);
+        //addRunData(protocol.getProtocolId(), EXPORT_FOLDER_PATH);
+        // issue 51176, addRunData isn't resolving files
+
+        // make another in a different folder with the same fields
+        makeGeneralAssay(SUB_A_ASSAY, runFields, dataFields, SUBFOLDER_A_PATH);
+    }
+
+    // list
     @Test
     public void verifyFileDownloadOnClick()
     {
@@ -73,65 +137,153 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
         mouseOut();
     }
 
-    @Override
-    protected void doCleanup(boolean afterTest) throws TestTimeoutException
+    // sampleType
+    @Test
+    public void verifySampleFileFields()
     {
-        _containerHelper.deleteProject(getProjectName(), afterTest);
+        // give the sampleType actual files via editing
+
+        SampleTypeHelper.beginAtSampleTypesList(this, EXPORT_FOLDER_PATH);
+        clickAndWait(Locator.linkWithText(SAMPLETYPE_NAME));
+        DataRegionTable samplesRegion = new DataRegionTable("Material", getDriver());
+        List<String> fileNames = SAMPLE_FILES.stream().map(File::getName).toList();
+
+        for (File file : SAMPLE_FILES)
+        {
+            int rowIndex = samplesRegion.getRowIndexStrict("Name", file.getName());
+            var fileFieldText = samplesRegion.getRowDataAsText(rowIndex, "File").get(0);
+
+            // due to the current state of file import via file, expect no content in the File field
+            checker().withScreenshot("unexpected_file_state")
+                    .wrapAssertion(()-> Assertions.assertThat(fileFieldText)
+                            .as("expect bulk-imported file to be empty: Issue 51176")
+                            .isEqualTo(" "));
+
+            // now edit the row to remove the broken/imported file and replace it via row edit
+            var queryUpdatePage = samplesRegion.clickEditRow(rowIndex);
+            queryUpdatePage.setField("file", file)
+                    .submit();
+
+            if (file == SAMPLE_JPG) // jpg don't appear to get name shown as text, just thumbnail
+            {
+                checker().withScreenshot("unexpected_file_state")
+                        .verifyTrue("expect jpg to be visible",
+                                Locator.tagWithAttribute("img", "title",
+                                        String.format("sampletype%s%s", File.separatorChar, file.getName())).existsIn(getDriver()));
+            }
+            else
+            {
+                checker().withScreenshot("unexpected_file_state")
+                        .awaiting(Duration.ofSeconds(2),
+                                () -> Assertions.assertThat(samplesRegion.getRowDataAsText(rowIndex, "File").get(0))
+                                        .as("expect the uploaded file to be fixed")
+                                        .endsWith(String.format("sampletype%s%s", File.separatorChar, file.getName())));
+            }
+        }
+
+        // verify file download behavior for csv, pdf
+        doAndWaitForDownload(()->click(Locator.linkContainingText(String.format("sampletype%s%s", File.separatorChar, SAMPLE_CSV.getName()))));
+        doAndWaitForDownload(()->click(Locator.linkContainingText(String.format("sampletype%s%s", File.separatorChar, SAMPLE_PDF.getName()))));
+
+        // verify popup/sprite for jpeg
+        mouseOver(Locator.tagWithAttribute("img", "title", String.format("sampletype%s%s", File.separatorChar, SAMPLE_JPG.getName())));
+        shortWait().until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div/span[contains(text(),'" + SAMPLE_JPG.getName() + "')]")));
+        mouseOut();
+
+        var fileContentPage = FileContentPage.beginAt(this, EXPORT_FOLDER_PATH);
+        fileContentPage.fileBrowserHelper().expandFileBrowserRootNode();
+        fileContentPage.fileBrowserHelper().selectFileBrowserItem("/sampletype/csv_sample.csv");
+        var files = fileContentPage.fileBrowserHelper().getFileList(true);
+        checker().withScreenshot("unexpected_davfile_state")
+                .wrapAssertion(()-> Assertions.assertThat(files)
+                        .as("expect edited files to be present in dav locaiton")
+                        .containsExactlyInAnyOrderElementsOf(fileNames));
     }
 
-    @BeforeClass
-    public static void setupProject()
+    // assay
+    @Test
+    public void testAssayFileFieldsUI() throws Exception
     {
-        FileAttachmentColumnTest init = (FileAttachmentColumnTest)getCurrentTest();
-        init.doSetup();
+        String runName = "assay_run.tsv";
+
+        // generate some resultFiles
+        var resultFiles = new ArrayList<File>();
+        Random r = new Random();
+        List<Map<String, Object>> importData = new ArrayList<>();
+        for (int i = 0; i < 5; i++)
+        {
+            String fileName = String.format("field_file_for_results_domain-%d.tsv", i);
+            String result = String.format("result-%d", i);
+            String fileText = "resultTxt\tresultFile\n"+result+"\t\""+TestFileUtils.getTestTempDir() + File.separatorChar + fileName+"\"\n";
+            var fieldFile = TestFileUtils.writeTempFile(fileName, fileText);
+            resultFiles.add(fieldFile);
+
+            importData.add(Map.of("resultText", result, "resultFile", fieldFile.getPath()));
+        }
+
+        // generate a run file, referencing the result files
+        String importDataFileContents = TestDataUtils.tsvStringFromRowMaps(importData,
+                List.of("resultText", "resultFile"), true);
+        File importFile = TestFileUtils.writeTempFile(runName, importDataFileContents);
+
+        beginAt(SUBFOLDER_A_PATH + "/project-begin.view");
+        goToModule("Assay");
+        clickAndWait(Locator.linkContainingText(SUB_A_ASSAY));
+        clickButton("Import Data");
+        clickButton("Next");    // batch properties
+
+        // run properties
+        setFormElement(Locator.input("name"), runName);
+        setFormElement(Locator.input("runTxt"), "run text");
+        setFormElement(Locator.input("runFile"), importFile);
+        checkRadioButton(Locator.inputById("Fileupload"));
+        int addIndex = 0;
+        for (File file : resultFiles)
+        {
+            if (addIndex > 0)
+            {
+                sleep(500);
+                var plusIcon = Locator.tagWithClass("a", "labkey-file-add-icon-enabled")
+                        .waitForElement(getDriver(), 1000);
+                scrollIntoView(plusIcon, true);
+                shortWait().until(ExpectedConditions.elementToBeClickable(plusIcon));
+                plusIcon.click();
+                setFormElement(Locator.input("__primaryFile__" + addIndex), file);
+            }
+            else
+            {   // insert the first one, its name doesn't have an index
+                setFormElement(Locator.input("__primaryFile__"), file);
+            }
+            addIndex ++;
+        }
+
+        clickButton("Save and Finish");
+
+        log("foo");
     }
 
-    private void doSetup()
+    private void createListWithData(String containerPath)
     {
-        _containerHelper.createProject(getProjectName(), "Custom");
-        _containerHelper.createSubfolder(getProjectName(), FOLDER_NAME);
-        _containerHelper.enableModules(Arrays.asList("Experiment", "Pipeline", "Portal"));
-
-        //create list with attachment columns
-        createList();
-
-        //create sample type with file columns
-        createSampleType();
-    }
-
-    private void createList()
-    {
-        beginAt(getProjectName() + "/" + FOLDER_NAME + "/project-begin.view");
+        beginAt(containerPath + "/project-begin.view");
         clickTab("Portal");
 
         ListHelper listHelper = new ListHelper(getDriver());
-        listHelper.createList(getProjectName() + "/" + FOLDER_NAME, LIST_NAME, LIST_KEY,
+        listHelper.createList(getProjectName() + "/" + EXPORT_FOLDER_NAME, LIST_NAME, LIST_KEY,
                 new FieldDefinition("Name", ColumnType.String),
                 new FieldDefinition("File", ColumnType.Attachment));
         goToManageLists();
         listHelper.click(Locator.linkContainingText(LIST_NAME));
-        // todo: import actual data here
-        Map<String, String> csvRow = new HashMap<>();
-        csvRow.put("Name", "csv file");
-        csvRow.put("File", SAMPLE_CSV.getAbsolutePath());
-        Map<String, String> jpgRow = new HashMap<>();
-        jpgRow.put("Name", "jpeg file");
-        jpgRow.put("File", SAMPLE_JPG.getAbsolutePath());
-        Map<String, String> pdfRow = new HashMap<>();
-        pdfRow.put("Name", "pdf file");
-        pdfRow.put("File", SAMPLE_PDF.getAbsolutePath());
-        Map<String, String> tifRow = new HashMap<>();
-        tifRow.put("Name", "tif file");
-        tifRow.put("File", SAMPLE_TIF.getAbsolutePath());
-        listHelper.insertNewRow(csvRow, false);
-        listHelper.insertNewRow(jpgRow, false);
-        listHelper.insertNewRow(pdfRow, false);
-        listHelper.insertNewRow(tifRow, false);
+
+        for (File file : SAMPLE_FILES)
+        {
+            Map<String, String> fileRow = Map.of("Name", file.getName(), "File", file.getAbsolutePath());
+            listHelper.insertNewRow(fileRow, false);
+        }
     }
 
-    private void createSampleType()
+    private void createSampleTypeWithData(String containerPath)
     {
-        beginAt(getProjectName() + "/" + FOLDER_NAME + "/project-begin.view");
+        beginAt(containerPath + "/project-begin.view");
         clickTab("Portal");
 
         PortalHelper portalHelper = new PortalHelper(getDriver());
@@ -139,29 +291,74 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
 
         log("adding sample type with file column");
 
-        SampleTypeHelper sampleHelper = new SampleTypeHelper(this);
-        sampleHelper.createSampleType(new SampleTypeDefinition(SAMPLESET_NAME).setFields(List.of(new FieldDefinition("color", ColumnType.String))), Collections.singletonList(Map.of("Name", "ed", "color", "green")));
-
-        // add a 'file' column
-        log("editing fields for sample type");
-        clickFolder(FOLDER_NAME);
-        UpdateSampleTypePage updatePage = sampleHelper.goToEditSampleType(SAMPLESET_NAME);
-        updatePage.addFields(List.of(new FieldDefinition("File", ColumnType.File)));
-        updatePage.clickSave();
-
-        StringBuilder sb = new StringBuilder("Name\tcolor\tfile\n");
+        List<Map<String, String>> sampleFileData = new ArrayList<>();
         for (File file : DATAFILE_DIRECTORY.listFiles())
         {
-            String newRow = file.getName() + "\tred\t\"" + file.getPath() + "\"\n";
-            sb.append(newRow);
+            sampleFileData.add(Map.of("Name", file.getName(), "Color", "green",
+                    "File", String.format("\"%s\"",file.getAbsolutePath())));
         }
-        sampleHelper.bulkImport(sb.toString());
+
+        SampleTypeHelper sampleHelper = new SampleTypeHelper(this);
+        SampleTypeDefinition sampleTypeDefinition = new SampleTypeDefinition(SAMPLETYPE_NAME)
+                .setFields(List.of(new FieldDefinition("color", ColumnType.String),
+                        new FieldDefinition("file", ColumnType.File)));
+        sampleHelper.createSampleType(sampleTypeDefinition, sampleFileData);
+    }
+
+    private Protocol makeGeneralAssay(String assayName, List<PropertyDescriptor> runFields, List<PropertyDescriptor> dataFields,
+                                      String folderPath) throws Exception
+    {
+        var assayDesign =  new GeneralAssayDesign(assayName)
+                .setBatchFields(List.of(new FieldDefinition("batchData", FieldDefinition.ColumnType.String)), false)
+                .setRunFields(runFields, false)
+                .setDataFields(dataFields, false);
+
+
+        var protocol = assayDesign.createAssay(folderPath, createDefaultConnection());
+        var updateProtocol = protocol.setEditableRuns(true).setEditableResults(true);
+        return assayDesign.updateProtocol(folderPath, createDefaultConnection(), updateProtocol);
+    }
+
+    private void addRunData(Integer protocolId, String folderPath) throws Exception
+    {
+        var resultFiles = new ArrayList<File>();
+        Random r = new Random();
+        List<Map<String, Object>> importData = new ArrayList<>();
+        String tempDirPath = String.format("%s%s", TestFileUtils.getTestTempDir(), File.separatorChar);
+        for (int i = 0; i < 5; i++)
+        {
+            String fileName = String.format("results_file-%d.tsv", i);
+            String result = String.format("result-%d", i);
+            String fileText = "runTxt\trunFile\tresultTxt\tresultFile\n" +
+                    "runText\t" + tempDirPath + "runFile.tsv\t" +result + "\t\""+tempDirPath+fileName+"\"\n";
+            var fieldFile = TestFileUtils.writeTempFile(fileName, fileText);
+            resultFiles.add(fieldFile);
+
+            importData.add(Map.of("resultText", result, "resultFile", fieldFile.getPath()));
+        }
+
+        // generate a run file, referencing the result files
+        String importDataFileContents = TestDataUtils.tsvStringFromRowMaps(importData,
+                List.of("resultText", "resultFile"), true);
+        File runFile = TestFileUtils.writeTempFile("runFile.tsv", importDataFileContents);
+
+        // build the import data
+        List<Map<String, Object>> runRecords = new ArrayList<>();
+        for (File file : resultFiles)
+        {
+            runRecords.add(Map.of("runTxt", "\""+runFile.getName()+"\"", "runFile", runFile,
+                    "resultTxt", "\""+file.getName()+"\"", "resultFile", file));
+        }
+
+        ImportRunCommand importRunCommand = new ImportRunCommand(protocolId, runRecords);
+        importRunCommand.setName("firstRun");
+        importRunCommand.execute(createDefaultConnection(), folderPath);
     }
 
     @Before
     public void preTest()
     {
-        beginAt(getProjectName() + "/" + FOLDER_NAME + "/project-begin.view");
+        beginAt(getProjectName() + "/" + EXPORT_FOLDER_NAME + "/project-begin.view");
     }
 
     @Override
@@ -173,7 +370,7 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
     @Override
     protected String getProjectName()
     {
-        return "FileAndAttachmentColumns Project";
+        return PROJECT_NAME;
     }
 
     @Override

--- a/src/org/labkey/test/tests/FileAttachmentColumnTest.java
+++ b/src/org/labkey/test/tests/FileAttachmentColumnTest.java
@@ -393,12 +393,13 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
             resultFiles.add(resultFile);
 
             importData.add(Map.of(RESULT_TXT_COL, result, RESULT_FILE_COL, resultFile.getName(),
-                    OTHER_RESULT_FILE_COL, otherResultFile.getName()));
+                    OTHER_RESULT_FILE_COL, otherResultFile.getName(),
+                    RUN_TXT_COL,"run text", RUN_FILE_COL, "runFile.tsv"));
         }
 
         // generate a run file, referencing the result files
         String importDataFileContents = TestDataUtils.tsvStringFromRowMaps(importData,
-                List.of(RESULT_TXT_COL, RESULT_FILE_COL, OTHER_RESULT_FILE_COL), true);
+                List.of(RUN_TXT_COL, RUN_FILE_COL, RESULT_TXT_COL, RESULT_FILE_COL, OTHER_RESULT_FILE_COL), true);
         File runFile = TestFileUtils.writeTempFile("runFile.tsv", importDataFileContents);
         uploadHelper.uploadFile(runFile);
 

--- a/src/org/labkey/test/tests/FileAttachmentColumnTest.java
+++ b/src/org/labkey/test/tests/FileAttachmentColumnTest.java
@@ -58,10 +58,9 @@ import java.util.Random;
 public class FileAttachmentColumnTest extends BaseWebDriverTest
 {
     private final String PROJECT_NAME = "FileAndAttachmentColumns Project";
+    private final String IMPORT_PROJECT_NAME = "FileAndAttachmentColumns Import Project";
     private final String EXPORT_FOLDER_NAME = "ExportFolder";
     private final String EXPORT_FOLDER_PATH = String.format("%s/%s", PROJECT_NAME, EXPORT_FOLDER_NAME);
-    private final String IMPORT_FOLDER_NAME = "ImportFolder";
-    private final String IMPORT_FOLDER_PATH = String.format("%s/%s", PROJECT_NAME, IMPORT_FOLDER_NAME);
     private final String SUBFOLDER_A = "SubFolderA";
     private final String SUBFOLDER_A_PATH = String.format("%s/%s", PROJECT_NAME, SUBFOLDER_A);
     private final String SUB_A_ASSAY = "Sub_A_Assay";
@@ -87,6 +86,7 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
         _containerHelper.deleteProject(getProjectName(), afterTest);
+        _containerHelper.deleteProject(IMPORT_PROJECT_NAME, afterTest);
     }
 
     @BeforeClass
@@ -98,11 +98,11 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
 
     private void doSetup() throws Exception
     {
+        _containerHelper.createProject(IMPORT_PROJECT_NAME);
+        _containerHelper.enableModules(Arrays.asList("Experiment", "Pipeline", "Portal"));
         _containerHelper.createProject(getProjectName(), "Custom");
         _containerHelper.createSubfolder(getProjectName(), EXPORT_FOLDER_NAME);
         _containerHelper.enableModules(Arrays.asList("Experiment", "Pipeline", "Portal"));
-        _containerHelper.createSubfolder(getProjectName(), IMPORT_FOLDER_NAME);
-        //_containerHelper.enableModules(Arrays.asList("Experiment", "Pipeline", "Portal"));
         _containerHelper.createSubfolder(getProjectName(), SUBFOLDER_A);
         _containerHelper.enableModules(Arrays.asList("Experiment", "Pipeline", "Portal"));
 
@@ -320,7 +320,7 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
 
     // exportImport
     /*
-        exports a folder with a list, sampletype, assay, and imports them to the import folder
+        exports a folder with a list, sampletype, assay, and imports them to the import project
         Then, validates expected data in source and destination
      */
     @Test
@@ -331,14 +331,13 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
                 .goToExportTab()
                 .includeFiles(true)
                 .exportToBrowserAsZipFile();
-        beginAt(IMPORT_FOLDER_PATH + "/project-begin.view");
+        beginAt(IMPORT_PROJECT_NAME + "/project-begin.view");
         goToFolderManagement()
                 .goToImportTab()
                 .selectLocalZipArchive()
                 .chooseFile(exportZip)
                 .clickImportFolder();
         waitForPipelineJobsToFinish(1);
-
         // validate list items
 
         // samples
@@ -431,8 +430,8 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
         List<Map<String, Object>> runRecords = new ArrayList<>();
         for (File resultFile : resultFiles)
         {
-            runRecords.add(Map.of(RUN_TXT_COL, runFile.getName(), RUN_FILE_COL, runFile.getName(),
-                    RESULT_TXT_COL, resultFile.getName(), RESULT_FILE_COL, resultFile.getName()));
+            runRecords.add(Map.of(RUN_TXT_COL, runFile.getName(), RUN_FILE_COL, runFile,
+                    RESULT_TXT_COL, resultFile.getName(), RESULT_FILE_COL, resultFile));
         }
 
         ImportRunCommand importRunCommand = new ImportRunCommand(protocolId, runRecords);

--- a/src/org/labkey/test/tests/FileAttachmentColumnTest.java
+++ b/src/org/labkey/test/tests/FileAttachmentColumnTest.java
@@ -74,12 +74,12 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
     private final String SUBA_SAMPLETYPE_NAME = "SubASamples";
     private final String EXPORT_ASSAY_NAME = "Export Assay";
     private final File DATAFILE_DIRECTORY = TestFileUtils.getSampleData("fileTypes");
-    private final File SAMPLE_CSV = FileUtil.appendPath(DATAFILE_DIRECTORY, Path.parse("csv_sample.csv"));
-    private final File SAMPLE_JPG = FileUtil.appendPath(DATAFILE_DIRECTORY, Path.parse("jpg_sample.jpg"));
-    private final File SAMPLE_TRICKY_PDF = FileUtil.appendPath(DATAFILE_DIRECTORY, Path.parse("pdf_sample_with+%$@+%%+#-+=.pdf"));
-    private final File SAMPLE_PDF = FileUtil.appendPath(DATAFILE_DIRECTORY, Path.parse("pdf_sample.pdf"));
-    private final File SAMPLE_TIF = FileUtil.appendPath(DATAFILE_DIRECTORY, Path.parse("tif_sample.tif"));
-    private final File SAMPLE_ZIP = FileUtil.appendPath(DATAFILE_DIRECTORY, Path.parse("zip_sample.zip"));
+    private final File SAMPLE_CSV = new File(DATAFILE_DIRECTORY, "csv_sample.csv");
+    private final File SAMPLE_JPG = new File(DATAFILE_DIRECTORY, "jpg_sample.jpg");
+    private final File SAMPLE_TRICKY_PDF = new File(DATAFILE_DIRECTORY, "pdf_sample_with+%$@+%%+#-+=.pdf");
+    private final File SAMPLE_PDF = new File(DATAFILE_DIRECTORY, "pdf_sample.pdf");
+    private final File SAMPLE_TIF = new File(DATAFILE_DIRECTORY, "tif_sample.tif");
+    private final File SAMPLE_ZIP = new File(DATAFILE_DIRECTORY, "zip_sample.zip");
     private final List<File> SAMPLE_FILES = List.of(SAMPLE_CSV, SAMPLE_JPG, SAMPLE_TRICKY_PDF, SAMPLE_PDF, SAMPLE_TIF, SAMPLE_ZIP);
     private final String RUN_TXT_COL = "runTxt";
     private final String RUN_FILE_COL = "runFile";


### PR DESCRIPTION
#### Rationale
This adds test coverage for Issue 22743, which is essentially that there isn't adequate/comprehensive test coverage for file and attachment columns in various domain kinds

#### Related Pull Requests
n/a

#### Changes

- [x] test for list, samples, assay, dataset with files/attachments, export and import
- [x] test for sample file fields, ui
- [x] test for assay run and result domain file fields, ui
