### PR TITLE
Remove useEmbeddedTomcat property and other support for standalone

### DIFF
--- a/distributions/teamcity/build.gradle
+++ b/distributions/teamcity/build.gradle
@@ -20,7 +20,6 @@ project.tasks.register("distribution", ModuleDistribution) {
         dist.description = "Make a LabKey modules distribution for 'test'"
 
         dist.subDirName = "test"
-        dist.embeddedArchiveType = "tar.gz"
         dist.extraFileIdentifier = '-test'
         dist.versionPrefix = 'Test'
 }

--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -159,14 +159,7 @@ public abstract class TestFileUtils
 
     public static File getServerLogDir()
     {
-        if (TestProperties.isEmbeddedTomcat())
-        {
-            return new File(getDefaultDeployDir(), "embedded/logs");
-        }
-        else
-        {
-            return new File(TestProperties.getTomcatHome(), "logs");
-        }
+        return new File(getDefaultDeployDir(), "embedded/logs");
     }
 
     public static File getTestRoot()
@@ -217,7 +210,7 @@ public abstract class TestFileUtils
         if (_modulesDir == null)
         {
             _modulesDir = new File(getDefaultDeployDir(), "modules");
-            if (TestProperties.isEmbeddedTomcat() && !_modulesDir.isDirectory())
+            if (!_modulesDir.isDirectory())
             {
                 // Module root when deploying from embedded distribution
                 _modulesDir = new File(getDefaultDeployDir(), "embedded/modules");

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -262,15 +262,6 @@ public abstract class TestProperties
         }
     }
 
-    public static File getTomcatHome()
-    {
-        String tomcatHome = System.getProperty("tomcat.home", System.getenv("CATALINA_HOME"));
-        if (tomcatHome != null && !tomcatHome.isEmpty())
-            return new File(tomcatHome);
-        else
-            return null;
-    }
-
     public static String getAdditionalPipelineTools()
     {
         return System.getProperty("additional.pipeline.tools");

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -224,11 +224,6 @@ public abstract class TestProperties
         return "true".equals(System.getProperty("webtest.server.trial"));
     }
 
-    public static boolean isEmbeddedTomcat()
-    {
-        return !System.getProperty("useEmbeddedTomcat", "false").equals("false") || new File(TestFileUtils.getDefaultDeployDir(), "embedded").isDirectory();
-    }
-
     public static boolean isCheckerFatal()
     {
         return "true".equals(System.getProperty("webtest.checker.fatal"));


### PR DESCRIPTION
#### Rationale
Support for the `useEmbeddedTomcat` property is being removed in the next Gradle Plugin version

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/216