### PR TITLE
make menu item wait configurable

### DIFF
--- a/src/org/labkey/test/components/react/MultiMenu.java
+++ b/src/org/labkey/test/components/react/MultiMenu.java
@@ -22,13 +22,18 @@ import java.util.Optional;
 
 public class MultiMenu extends BootstrapMenu
 {
-    private int _menuWaitTmeout = 500;
+    private int _menuWaitTmeout = 2000;
 
     protected MultiMenu(WebElement element, WebDriver driver)
     {
         super(driver, element);
     }
 
+    /**
+     * Sets the amount of time the component will wait for menu or toggle items to appear when interacting with them
+     * @param menuWait time in milliseconds to wait for menu items or toggle items to appear
+     * @return the current instance
+     */
     public MultiMenu setMenuWait(int menuWait)
     {
         _menuWaitTmeout = menuWait;
@@ -217,7 +222,7 @@ public class MultiMenu extends BootstrapMenu
         int listItemCount = getListItems().size();
 
         // find the toggle-item; it may be expanded already
-        WebElement toggleElement = Locators.menuToggle(toggle).waitForElement(this, 1000);
+        WebElement toggleElement = Locators.menuToggle(toggle).waitForElement(this, _menuWaitTmeout);
         if (Locators.menuToggleClosed().existsIn(toggleElement))
         {
             toggleElement.click(); // expand the toggle

--- a/src/org/labkey/test/components/react/MultiMenu.java
+++ b/src/org/labkey/test/components/react/MultiMenu.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 
 public class MultiMenu extends BootstrapMenu
 {
-    private int _menuWaitTmeout = 2000;
+    private int _menuWaitTimeout = 500;
 
     protected MultiMenu(WebElement element, WebDriver driver)
     {
@@ -36,7 +36,7 @@ public class MultiMenu extends BootstrapMenu
      */
     public MultiMenu setMenuWait(int menuWait)
     {
-        _menuWaitTmeout = menuWait;
+        _menuWaitTimeout = menuWait;
         return this;
     }
 
@@ -56,7 +56,7 @@ public class MultiMenu extends BootstrapMenu
     {
         expand();
         waitForData();
-        return Locators.menuItem().withText(menuItem).waitForElement(getMenuList(), _menuWaitTmeout);
+        return Locators.menuItem().withText(menuItem).waitForElement(getMenuList(), _menuWaitTimeout);
     }
 
     /**
@@ -222,7 +222,7 @@ public class MultiMenu extends BootstrapMenu
         int listItemCount = getListItems().size();
 
         // find the toggle-item; it may be expanded already
-        WebElement toggleElement = Locators.menuToggle(toggle).waitForElement(this, _menuWaitTmeout);
+        WebElement toggleElement = Locators.menuToggle(toggle).waitForElement(this, _menuWaitTimeout);
         if (Locators.menuToggleClosed().existsIn(toggleElement))
         {
             toggleElement.click(); // expand the toggle

--- a/src/org/labkey/test/components/react/MultiMenu.java
+++ b/src/org/labkey/test/components/react/MultiMenu.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 
 public class MultiMenu extends BootstrapMenu
 {
-    private int _menuWaitTimeout = 500;
+    private int _menuWaitTimeout = 2000;
 
     protected MultiMenu(WebElement element, WebDriver driver)
     {


### PR DESCRIPTION
#### Rationale
Recently, [RegistryRollupTest.testProtSeqRollup](https://teamcity.labkey.org/viewLog.html?buildId=3174687&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_LimsStarter_LimsStarterB&fromSakuraUI=true#testNameId-1936760145919715826) has been failing intermittently because the 'Create Samples' menu toggle item under the Protein Sequence overview page's Manage Menu has taken more than a second to be present (but it's present in the artifacts)

This change updates the way MultiMenu finds toggles to align with the way it finds menuItems- waiting for them for the duration of _menuWaitTimeout

#### Related Pull Requests
n/a

#### Changes
use menuWaitTimeout when finding toggles
