### PR TITLE
Update EditableGrid Test Component

### DIFF
--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -521,9 +521,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
         WebElement textArea = activateCellUsingDoubleClick(row, columnName);
 
-        // Using setFormElement won't call the blur even to remove focus and set the field.
-        getWrapper().setFormElementJS(textArea, value);
-        getWrapper().fireEvent(textArea, WebDriverWrapper.SeleniumEvent.blur);
+        textArea.sendKeys(value, Keys.RETURN); // Add the RETURN to close the inputCell.
 
         waitFor(()->getWrapper().shortWait().until(ExpectedConditions.stalenessOf(textArea)),
                 "TextArea did not go away.", 500);


### PR DESCRIPTION
#### Rationale
This looks to be an issue with the React 18 update. Changing EditableGrid.setMultiLineCellValue to use sendKeys appears to work.

#### Related Pull Requests
* None

#### Changes
* Change EditableGrid.setMultiLineCellValue to use sendKeys.
