### PR TITLE
Test updates for Firefox 128

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -92,6 +92,7 @@ import org.labkey.test.util.core.webdav.WebDavUploadHelper;
 import org.labkey.test.util.ext4cmp.Ext4FieldRef;
 import org.labkey.test.util.query.QueryUtils;
 import org.labkey.test.util.search.SearchAdminAPIHelper;
+import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.ElementClickInterceptedException;
@@ -803,6 +804,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             protected void succeeded(Description description)
             {
                 closeExtraWindows();
+                dismissAllAlerts();
                 checker().withScreenshot(description.getMethodName() + "_serverErrors").wrapAssertion(() -> checkErrors());
                 checker().reportResults();
             }
@@ -1011,8 +1013,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                     }
                     catch (MalformedURLException e)
                     {
-                        log("Unable to construct debug URL");
-                        e.printStackTrace();
+                        TestLogger.log().error("Unable to construct debug URL", e);
                     }
                 }
             }
@@ -1054,7 +1055,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                     }
                     catch (UnhandledAlertException alert)
                     {
-                        TestLogger.warn("Alert was triggered by iframe: " + alert.getAlertText());
+                        TestLogger.warn("Alert was triggered by iframe: " + WebDriverUtils.getUnhandledAlertText(alert, getDriver()));
                     }
                 }
                 // Don't take screenshots if error was deferred and any screenshots were taken

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -134,8 +134,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
 
         if (!Locator.tagWithName("form", "login").existsIn(getDriver()) || !Locator.name("email").existsIn(getDriver()))
         {
-            executeScript("window.onbeforeunload = null;"); // Just get logged in, ignore 'unload' alerts
-            beginAt(buildURL("login", "login"));
+            beginAtAcceptingAlerts(buildURL("login", "login"));
             waitForAnyElement("Should be on login or Home portal", Locator.id("email"), SiteNavBar.Locators.userMenu,
                     UserMenu.appUserMenu());
         }
@@ -1423,7 +1422,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
 
     public void goToHome()
     {
-        beginAt(buildURL("project", "home", "begin"));
+        beginAtAcceptingAlerts(buildURL("project", "home", "begin"));
         waitFor(this::onLabKeyPage, "Home project didn't seem to load. JavaScript 'LABKEY' namespace not found.", 10000);
     }
 

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test;
 
+import org.apache.commons.lang3.StringUtils;
 import org.labkey.serverapi.reader.Readers;
 import org.labkey.test.util.TestLogger;
 
@@ -81,27 +82,27 @@ public abstract class TestProperties
 
     public static boolean isTestCleanupSkipped()
     {
-        return "false".equals(System.getProperty("clean", "false"));
+        return !getBooleanProperty("clean", false);
     }
 
     public static boolean isLinkCheckEnabled()
     {
-        return "true".equals(System.getProperty("linkCheck", "false")) || isInjectionCheckEnabled();
+        return getBooleanProperty("linkCheck", false) || isInjectionCheckEnabled();
     }
 
     public static boolean isInjectionCheckEnabled()
     {
-        return "true".equals(System.getProperty("injectCheck", "false"));
+        return getBooleanProperty("injectCheck", false);
     }
 
     public static boolean isScriptCheckEnabled()
     {
-        return "true".equals(System.getProperty("scriptCheck", "true"));
+        return getBooleanProperty("scriptCheck", true);
     }
 
     public static boolean isDevModeEnabled()
     {
-        return "true".equals(System.getProperty("devMode", "true"));
+        return getBooleanProperty("devMode", true);
     }
 
     public static boolean isTestRunningOnTeamCity()
@@ -113,33 +114,32 @@ public abstract class TestProperties
 
     public static boolean isServerRemote()
     {
-        return "true".equals(System.getProperty("webtest.server.remote", "false"));
+        return getBooleanProperty("webtest.server.remote", false);
     }
 
     public static boolean isLeakCheckSkipped()
     {
-        return "false".equals(System.getProperty("memCheck", "true"));
+        return !getBooleanProperty("memCheck", true);
     }
 
     public static boolean isQueryCheckSkipped()
     {
-        return "false".equals(System.getProperty("queryCheck", "true"));
+        return !getBooleanProperty("queryCheck", true);
     }
 
     public static boolean isCspCheckSkipped()
     {
-        // Skip by default
-        return "false".equals(System.getProperty("webtest.cspCheck", "false"));
+        return !getBooleanProperty("webtest.cspCheck", false);
     }
 
     public static boolean isNewWebDriverForEachTest()
     {
-        return !"true".equals(System.getProperty("selenium.reuseWebDriver", "false"));
+        return !getBooleanProperty("selenium.reuseWebDriver", false);
     }
 
     public static boolean isViewCheckSkipped()
     {
-        return "false".equals(System.getProperty("viewCheck", "true"));
+        return !getBooleanProperty("viewCheck", true);
     }
 
     public static boolean isSystemMaintenanceDisabled()
@@ -149,22 +149,22 @@ public abstract class TestProperties
 
     public static boolean isHeapDumpCollectionEnabled()
     {
-        return "true".equals(System.getProperty("webtest.enable.heap.dump"));
+        return getBooleanProperty("webtest.enable.heap.dump", false);
     }
 
     public static boolean isDiagnosticsExportEnabled()
     {
-        return "true".equals(System.getProperty("webtest.enable.export.diagnostics"));
+        return getBooleanProperty("webtest.enable.export.diagnostics", false);
     }
 
     public static boolean isRunWebDriverHeadless()
     {
-        return "true".equals(System.getProperty("webtest.webdriver.headless"));
+        return getBooleanProperty("webtest.webdriver.headless", false);
     }
 
     public static boolean isDumpBrowserConsole()
     {
-        return "true".equals(System.getProperty("webtest.dump.browser.console"));
+        return getBooleanProperty("webtest.dump.browser.console", false);
     }
 
     public static double getTimeoutMultiplier()
@@ -193,7 +193,7 @@ public abstract class TestProperties
 
     public static boolean isCloudPipelineEnabled()
     {
-        return "true".equals(System.getProperty("use.cloud.pipeline"));
+        return getBooleanProperty("use.cloud.pipeline", false);
     }
 
     public static String getCloudPipelineBucketName()
@@ -203,37 +203,37 @@ public abstract class TestProperties
 
     public static boolean isWebDriverLoggingEnabled()
     {
-        return "true".equals(System.getProperty("webtest.webdriver.logging"));
+        return getBooleanProperty("webtest.webdriver.logging", true);
     }
 
     public static boolean isTroubleshootingStacktracesEnabled()
     {
-        return "true".equals(System.getProperty("webtest.troubleshooting.stacktraces"));
+        return getBooleanProperty("webtest.troubleshooting.stacktraces", false);
     }
 
     public static boolean isDebugLoggingEnabled()
     {
-        return "true".equals(System.getProperty("webtest.logging.debug"));
+        return getBooleanProperty("webtest.logging.debug", false);
     }
 
     public static boolean isPrimaryUserAppAdmin()
     {
-        return "true".equals(System.getProperty("webtest.primary.app.admin"));
+        return getBooleanProperty("webtest.primary.app.admin", false);
     }
 
     public static boolean isWithoutTestModules()
     {
-        return "true".equals(System.getProperty("webtest.without.test.modules"));
+        return getBooleanProperty("webtest.without.test.modules", false);
     }
 
     public static boolean isTrialServer()
     {
-        return "true".equals(System.getProperty("webtest.server.trial"));
+        return getBooleanProperty("webtest.server.trial", false);
     }
 
     public static boolean isEmbeddedTomcat()
     {
-        return !System.getProperty("useEmbeddedTomcat", "false").equals("false") || new File(TestFileUtils.getDefaultDeployDir(), "embedded").isDirectory();
+        return getBooleanProperty("useEmbeddedTomcat", false) || new File(TestFileUtils.getDefaultDeployDir(), "embedded").isDirectory();
     }
 
     public static boolean isCheckerFatal()
@@ -342,5 +342,25 @@ public abstract class TestProperties
             TestLogger.log("Using " + dumpDir + " to store test output");
         }
         return dumpDir;
+    }
+
+    /**
+     * Interpret system property as boolean. If property is blank or unset, return the specified default value.
+     * Otherwise, parse property with {@link Boolean#parseBoolean(String)}
+     * @param key System property name
+     * @param def Default value
+     * @return value of the specified property
+     */
+    private static boolean getBooleanProperty(String key, boolean def)
+    {
+        String prop = System.getProperty(key);
+        if (!StringUtils.isBlank(prop))
+        {
+            return Boolean.parseBoolean(prop);
+        }
+        else
+        {
+            return def;
+        }
     }
 }

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -38,6 +38,10 @@ public abstract class TestProperties
 
     static
     {
+        if (System.getenv("FIREFOX128") != null)
+        {
+            System.setProperty("selenium.firefox.binary", System.getenv("FIREFOX128"));
+        }
 
         final File propFile = new File(TestFileUtils.getTestRoot(), "test.properties");
         final File propFileTemplate = new File(TestFileUtils.getTestRoot(), "test.properties.template");

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -39,11 +39,6 @@ public abstract class TestProperties
 
     static
     {
-        if (System.getenv("FIREFOX128") != null)
-        {
-            System.setProperty("selenium.firefox.binary", System.getenv("FIREFOX128"));
-        }
-
         final File propFile = new File(TestFileUtils.getTestRoot(), "test.properties");
         final File propFileTemplate = new File(TestFileUtils.getTestRoot(), "test.properties.template");
         if (!propFile.exists())

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1129,7 +1129,17 @@ public abstract class WebDriverWrapper implements WrapsDriver
         return beginAt(url, defaultWaitForPage);
     }
 
+    public long beginAtAcceptingAlerts(String url)
+    {
+        return beginAt(url, defaultWaitForPage, true);
+    }
+
     public long beginAt(String url, int millis)
+    {
+        return beginAt(url, millis, false);
+    }
+
+    public long beginAt(String url, int millis, boolean acceptAlerts)
     {
         String relativeURL = makeRelativeUrl(url);
         String logMessage = "";
@@ -1155,6 +1165,19 @@ public abstract class WebDriverWrapper implements WrapsDriver
                 catch (TimeoutException ex)
                 {
                     throw new TestTimeoutException(ex); // Triggers thread dump.
+                }
+                catch (UnhandledAlertException uae)
+                {
+                    Alert alert;
+                    if (acceptAlerts && (alert = getAlertIfPresent()) != null)
+                    {
+                        TestLogger.warn("Unhandled alert: " + alert.getText());
+                        alert.accept();
+                    }
+                    else
+                    {
+                        throw uae;
+                    }
                 }
             }, expectPageLoad ? millis : 0);
             logMessage += TestLogger.formatElapsedTime(elapsedTime);

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -368,9 +368,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
             nodePath += "/";
         }
 
-        WebElement tr = Locator.tag("tr").withClass("x4-grid-data-row").withAttribute("data-recordid", fieldKey).findElement(getComponentElement());
-        Locator.byClass("x4-tree-node-text").findElement(tr).click();
-        return tr;
+        return Locator.tag("tr").withClass("x4-grid-data-row").withAttribute("data-recordid", fieldKey).findElement(getComponentElement());
     }
 
     private void addItem(String[] fieldKeyParts, String columnName, ViewItemType type)
@@ -383,7 +381,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         // Expand all nodes necessary to reveal the desired node.
         WebElement fieldRow = expandPivots(fieldKeyParts);
         WebElement checkbox = Locator.css("input[type=button]").findElement(fieldRow);
-        WebElement rowLabel = Locator.css("span").findElement(fieldRow);
+        WebElement rowLabel = Locator.byClass("x4-tree-node-text").findElement(fieldRow);
         rowLabel.click();
         new Checkbox(checkbox).check();
         itemXPath(type, fieldKeyParts).waitForElement(this, 2_000);

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -369,7 +369,8 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         }
 
         WebElement tr = Locator.tag("tr").withClass("x4-grid-data-row").withAttribute("data-recordid", fieldKey).findElement(getComponentElement());
-        return _driver.scrollIntoView(tr, false);
+        Locator.byClass("x4-tree-node-text").findElement(tr).click();
+        return tr;
     }
 
     private void addItem(String[] fieldKeyParts, String columnName, ViewItemType type)

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -382,7 +382,9 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         // Expand all nodes necessary to reveal the desired node.
         WebElement fieldRow = expandPivots(fieldKeyParts);
         WebElement checkbox = Locator.css("input[type=button]").findElement(fieldRow);
+        getWrapper().scrollIntoView(checkbox);
         new Checkbox(checkbox).check();
+        itemXPath(type, fieldKeyParts).waitForElement(this, 2_000);
     }
 
     public void addColumn(String[] fieldKeyParts, String label)

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -369,7 +369,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         }
 
         WebElement tr = Locator.tag("tr").withClass("x4-grid-data-row").withAttribute("data-recordid", fieldKey).findElement(getComponentElement());
-        return _driver.scrollIntoView(tr, false);
+        return _driver.scrollIntoView(tr, true);
     }
 
     private void addItem(String[] fieldKeyParts, String columnName, ViewItemType type)
@@ -382,7 +382,6 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         // Expand all nodes necessary to reveal the desired node.
         WebElement fieldRow = expandPivots(fieldKeyParts);
         WebElement checkbox = Locator.css("input[type=button]").findElement(fieldRow);
-        getWrapper().scrollIntoView(checkbox);
         new Checkbox(checkbox).check();
         itemXPath(type, fieldKeyParts).waitForElement(this, 2_000);
     }

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -369,7 +369,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         }
 
         WebElement tr = Locator.tag("tr").withClass("x4-grid-data-row").withAttribute("data-recordid", fieldKey).findElement(getComponentElement());
-        return _driver.scrollIntoView(tr, true);
+        return _driver.scrollIntoView(tr, false);
     }
 
     private void addItem(String[] fieldKeyParts, String columnName, ViewItemType type)
@@ -382,6 +382,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         // Expand all nodes necessary to reveal the desired node.
         WebElement fieldRow = expandPivots(fieldKeyParts);
         WebElement checkbox = Locator.css("input[type=button]").findElement(fieldRow);
+        getWrapper().mouseOver(checkbox);
         new Checkbox(checkbox).check();
         itemXPath(type, fieldKeyParts).waitForElement(this, 2_000);
     }

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -382,7 +382,8 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         // Expand all nodes necessary to reveal the desired node.
         WebElement fieldRow = expandPivots(fieldKeyParts);
         WebElement checkbox = Locator.css("input[type=button]").findElement(fieldRow);
-        getWrapper().mouseOver(checkbox);
+        WebElement rowLabel = Locator.css("span").findElement(fieldRow);
+        rowLabel.click();
         new Checkbox(checkbox).check();
         itemXPath(type, fieldKeyParts).waitForElement(this, 2_000);
     }

--- a/src/org/labkey/test/components/ext4/Checkbox.java
+++ b/src/org/labkey/test/components/ext4/Checkbox.java
@@ -93,6 +93,14 @@ public class Checkbox extends org.labkey.test.components.html.Checkbox
                     {
                         return Locator.tagWithClass("img", Ext4Helper.getCssPrefix() + "grid-checkcolumn");
                     }
+                },
+        TREE
+                {
+                    @Override
+                    protected Locator.XPathLocator itemLoc()
+                    {
+                        return Locator.tagWithClass("input", Ext4Helper.getCssPrefix() + "tree-checkbox");
+                    }
                 };
 
         protected abstract Locator.XPathLocator itemLoc();

--- a/src/org/labkey/test/pages/StartImportPage.java
+++ b/src/org/labkey/test/pages/StartImportPage.java
@@ -17,6 +17,8 @@ package org.labkey.test.pages;
 
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.components.ext4.Checkbox.CheckboxFinder;
+import org.labkey.test.components.ext4.Checkbox.CheckboxType;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.util.FileBrowserHelper;
@@ -102,6 +104,21 @@ public class StartImportPage extends LabKeyPage<StartImportPage.ElementCache>
     {
         elementCache().applyToMultipleFoldersCheckbox.set(check);
         shortWait().until(LabKeyExpectedConditions.visibilityOf(elementCache().applyMultiplePanel, check));
+    }
+
+    public void checkTargetFolders(String... folders)
+    {
+        for (String folder : folders)
+        {
+            WebElement rowEl = Locator.tagWithClass("tr", "x4-grid-row")
+                    .withDescendant(Locator.tagWithClass("span", "x4-tree-node-text").withText(folder))
+                    .findElement(elementCache().applyMultiplePanel);
+            shortWait().until(LabKeyExpectedConditions.animationIsDone(rowEl));
+            Locator.tag("span").findElement(rowEl).click(); // get row into view
+            Checkbox checkbox = new CheckboxFinder(CheckboxType.TREE).refindWhenNeeded(rowEl); // Checkbox goes stale sometimes
+            checkbox.check();
+            shortWait().until(ignored -> checkbox.isChecked());
+        }
     }
 
     public boolean isMultipleFolderImportAvailable()

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -767,6 +767,7 @@ public class FieldDefinition extends PropertyDescriptor
             super.setTableType(lookupType);
         }
 
+        @Deprecated (since = "22.10")
         @Override
         public LookupInfo setTableType(ColumnType tableType)
         {

--- a/src/org/labkey/test/selenium/ReclickingWebElement.java
+++ b/src/org/labkey/test/selenium/ReclickingWebElement.java
@@ -99,11 +99,6 @@ public class ReclickingWebElement extends WebElementDecorator
                 {
                     actionClick();
                 }
-                else if (e.getRawMessage().contains("could not be scrolled into view"))
-                {
-                    // Add some information to help test developer find a better element.
-                    throw new ElementNotInteractableException("Click failed; try clicking a child element. Firefox doesn't like clicking certain wrapping elements\n" + e.getRawMessage(), e);
-                }
                 else
                 {
                     throw e;

--- a/src/org/labkey/test/tests/AdvancedImportOptionsTest.java
+++ b/src/org/labkey/test/tests/AdvancedImportOptionsTest.java
@@ -352,20 +352,7 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest
         Locator.tagWithClass("span", "x4-tree-node-text").notHidden().withText(IMPORT_FOLDER_MULTI01).waitForElement(shortWait());
 
         log("Select sub folders to import into");
-        /* new UI behavior: clicking on the text doesn't toggle the box, but clicking the checkbox does.
-         * Also, using a checkbox to wrap this has issues; checkBox.get() always returns false, so
-         * set(true) unchecks the box.  Todo: salvage this logic into a component someplace.
-          * Todo: wonder if being already-selected here is a problem.*/
-        WebElement checkbox01 = Locator.tagWithClass("span", "x4-tree-node-text").withText(IMPORT_FOLDER_MULTI01)
-                .precedingSibling("input").waitForElement(new WebDriverWait(getDriver(), Duration.ofSeconds(5)));
-        if (checkbox01.getAttribute("aria-checked") == null || !checkbox01.getAttribute("aria-checked").equals("true"))
-            checkbox01.click();
-        sleep(250);
-        WebElement checkBox03 = Locator.tagWithClass("span", "x4-tree-node-text").withText(IMPORT_FOLDER_MULTI03)
-                .precedingSibling("input").waitForElement(new WebDriverWait(getDriver(), Duration.ofSeconds(5)));
-        if (checkBox03.getAttribute("aria-checked") == null || !checkBox03.getAttribute("aria-checked").equals("true"))
-            checkBox03.click();
-        sleep(250);
+        importPage.checkTargetFolders(IMPORT_FOLDER_MULTI01, IMPORT_FOLDER_MULTI03);
 
         log("Start the import and verify the confirmation dialog");
         importPage.clickStartImport("The import archive will be applied to 2 selected target folders. A separate pipeline import job will be created for each. This action cannot be undone.\n\nWould you like to proceed?");

--- a/src/org/labkey/test/tests/CrawlerTest.java
+++ b/src/org/labkey/test/tests/CrawlerTest.java
@@ -16,6 +16,7 @@ import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.Crawler;
 import org.labkey.test.util.CspLogUtil;
 import org.labkey.test.util.PermissionsHelper.MemberType;
+import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.UnhandledAlertException;
 
 import java.time.Duration;
@@ -80,7 +81,7 @@ public class CrawlerTest extends BaseWebDriverTest
         }
         catch (UnhandledAlertException alert)
         {
-            if (!alert.getMessage().contains(Crawler.injectedAlert))
+            if (!WebDriverUtils.getUnhandledAlertText(alert, getDriver()).contains(Crawler.injectedAlert))
             {
                 throw alert; // Wrong alert
             }
@@ -92,7 +93,7 @@ public class CrawlerTest extends BaseWebDriverTest
         }
         catch (UnhandledAlertException alert)
         {
-            if (!alert.getMessage().contains(Crawler.injectedAlert))
+            if (!WebDriverUtils.getUnhandledAlertText(alert, getDriver()).contains(Crawler.injectedAlert))
             {
                 throw alert; // Wrong alert
             }

--- a/src/org/labkey/test/tests/FolderExportTest.java
+++ b/src/org/labkey/test/tests/FolderExportTest.java
@@ -18,6 +18,7 @@ package org.labkey.test.tests;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlOptions;
+import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -195,7 +196,8 @@ public class FolderExportTest extends BaseWebDriverTest
         goToModule("FileContent");
         _fileBrowserHelper.selectFileBrowserItem(dir + "/" + uploadFileName);
         File downloadedFile = _fileBrowserHelper.downloadSelectedFiles();
-        assertEquals("Expected file '" + uploadFileName + "' did not get downloaded", uploadFileName, downloadedFile.getName());
+        Assertions.assertThat(downloadedFile.getName()).as("Downloaded file with special characters")
+                .isIn(uploadFileName, uploadFileName.replace("%", "_")); // Firefox 128+ replaces '%'s in downloaded file name
 
         log("Test Drag and Drop zip folder '" + sourceZip.getName() + "'");
         _fileBrowserHelper.dragDropUpload(sourceZip);

--- a/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
@@ -478,8 +478,8 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         DataRegionTable sourceTable = new SampleTypeHelper(this).getSamplesDataRegionTable();
         CustomizeView cv = sourceTable.openCustomizeGrid();
         cv.showHiddenItems();
-        cv.addColumn("INPUTS/MATERIALS/PARENTSAMPLES");
-        cv.addColumn("INPUTS/DATA/PARENTDATACLASS");
+        cv.addColumn("Inputs/Materials/parentSamples");
+        cv.addColumn("Inputs/Data/parentDataClass");
         cv.clickSave().save();
         List<Map<String, String>> sourceRowData = sourceTable.getTableData();
 
@@ -502,11 +502,11 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         // we expect the sample types and experiment runs webparts to come across along with the folder import
         clickAndWait(Locator.linkWithText(testSamples));
         DataRegionTable destSamplesTable = new SampleTypeHelper(this).getSamplesDataRegionTable();
-        CustomizeView cv2 = destSamplesTable.openCustomizeGrid();
-        cv2.showHiddenItems();
-        cv2.addColumn("INPUTS/MATERIALS/PARENTSAMPLES");
-        cv.addColumn("INPUTS/DATA/PARENTDATACLASS");
-        cv2.clickSave().save();
+        cv = destSamplesTable.openCustomizeGrid();
+        cv.showHiddenItems();
+        cv.addColumn("Inputs/Materials/parentSamples");
+        cv.addColumn("Inputs/Data/parentDataClass");
+        cv.clickSave().save();
 
         // capture the data in the exported sampleType
         List<Map<String, String>> destRowData = destSamplesTable.getTableData();

--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -310,8 +310,8 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         CustomizeView customizeView = samplesTable.getCustomizeView();
         customizeView.openCustomizeViewPanel();
         customizeView.showHiddenItems();
-        customizeView.addColumn("INPUTS/MATERIALS/BLOOD/VisitDate");
-        customizeView.addColumn("INPUTS/MATERIALS/BLOOD/ParticipantId");
+        customizeView.addColumn("Inputs/Materials/Blood/VisitDate");
+        customizeView.addColumn("Inputs/Materials/Blood/ParticipantId");
         customizeView.saveCustomView();
         samplesTable.checkCheckbox(samplesTable.getRowIndex("Name", derivedSampleName));
         samplesTable.clickHeaderButtonAndWait("Link to Study");
@@ -617,9 +617,9 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         CustomizeView customizeView = samplesTable.getCustomizeView();
         customizeView.openCustomizeViewPanel();
         customizeView.showHiddenItems();
-        customizeView.addColumn("INPUTS/MATERIALS/" + parentSampleType + "/VisitId");
-        customizeView.addColumn("INPUTS/MATERIALS/" + parentSampleType + "/VisitDate");
-        customizeView.addColumn("INPUTS/MATERIALS/" + parentSampleType + "/ParticipantId");
+        customizeView.addColumn("Inputs/Materials/" + parentSampleType + "/VisitId");
+        customizeView.addColumn("Inputs/Materials/" + parentSampleType + "/VisitDate");
+        customizeView.addColumn("Inputs/Materials/" + parentSampleType + "/ParticipantId");
         customizeView.saveCustomView();
 
         log("Bulk importing in the child sample");

--- a/src/org/labkey/test/tests/SampleTypeRemoteAPITest.java
+++ b/src/org/labkey/test/tests/SampleTypeRemoteAPITest.java
@@ -470,7 +470,7 @@ public class SampleTypeRemoteAPITest extends BaseWebDriverTest
         DataRegionTable assayList = DataRegionTable.DataRegion(getDriver()).withName("AssayList").waitFor();
         CustomizeView customizeView = assayList.openCustomizeGrid();
         customizeView.showHiddenItems();
-        customizeView.addColumn("ROWID");
+        customizeView.addColumn("RowId");
         customizeView.clickSave().save();   // make this the default view
         String assayIdStringValue = assayList.getRowDataAsMap(0).get("RowId");
 
@@ -606,7 +606,7 @@ public class SampleTypeRemoteAPITest extends BaseWebDriverTest
         DataRegionTable assayList = DataRegionTable.DataRegion(getDriver()).withName("AssayList").waitFor();
         CustomizeView customizeView = assayList.openCustomizeGrid();
         customizeView.showHiddenItems();
-        customizeView.addColumn("ROWID");
+        customizeView.addColumn("RowId");
         customizeView.clickSave().save();   // make this the default view
         String assayIdStringValue = assayList.getRowDataAsMap(0).get("RowId");
 

--- a/src/org/labkey/test/tests/api/CustomizeGridPermissionsTest.java
+++ b/src/org/labkey/test/tests/api/CustomizeGridPermissionsTest.java
@@ -50,7 +50,7 @@ public class CustomizeGridPermissionsTest extends BaseWebDriverTest
     private static final String LIST_NAME = "NIMHDemographics";
 
     private static final String VIEW_NAME = "My View";
-    private static final String COLUMN_NAME = "Container";
+    private static final String COLUMN_NAME = "container";
     private static final String COLUMN_LABEL = "Folder";
 
     @Override

--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -71,7 +71,7 @@ public class GridPanelTest extends GridPanelBaseTest
     private static final String VIEW_EXTRA_COLUMNS = "Extra_Columns";
     private static final String VIEW_FEWER_COLUMNS = "Fewer_Columns";
     private static final String VIEW_FILTERED_COLUMN = "Filtered_Column";
-    private static final List<String> extraColumnsNames = Arrays.asList("IsAliquot", "GenId"); // Special case for adding the columns to the view and calling getRows api.
+    private static final List<String> extraColumnsNames = Arrays.asList("IsAliquot", "genId"); // Special case for adding the columns to the view and calling getRows api.
     private static final List<String> extraColumnsHeaders = Arrays.asList("Is Aliquot", "Gen Id"); // The column headers as they appear in the UI and exported file.
     private static final List<String> removedColumns = Arrays.asList(FILTER_BOOL_COL);
 

--- a/src/org/labkey/test/tests/filecontent/FileContentActionButtonsTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentActionButtonsTest.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.tests.filecontent;
 
+import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -231,7 +232,8 @@ public class FileContentActionButtonsTest extends BaseWebDriverTest
         log("Downloading file '" + renamedFile + "'");
         _fileBrowserHelper.selectFileBrowserItem("/" + folderName2 + "/" + renamedFile);
         File download = _fileBrowserHelper.downloadSelectedFiles();
-        assertEquals(renamedFile, download.getName());
+        Assertions.assertThat(download.getName()).as("Downloaded file with special characters")
+                .isIn(uploadFileName, uploadFileName.replace("%", "_")); // Firefox 128+ replaces '%'s in downloaded file name
 
         log("Setting description " + fileDescription + " for '" + renamedFile + "'");
         _fileBrowserHelper.setDescription(renamedFile, fileDescription);

--- a/src/org/labkey/test/tests/filecontent/FileContentActionButtonsTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentActionButtonsTest.java
@@ -233,7 +233,7 @@ public class FileContentActionButtonsTest extends BaseWebDriverTest
         _fileBrowserHelper.selectFileBrowserItem("/" + folderName2 + "/" + renamedFile);
         File download = _fileBrowserHelper.downloadSelectedFiles();
         Assertions.assertThat(download.getName()).as("Downloaded file with special characters")
-                .isIn(uploadFileName, uploadFileName.replace("%", "_")); // Firefox 128+ replaces '%'s in downloaded file name
+                .isIn(renamedFile, renamedFile.replace("%", "_")); // Firefox 128+ replaces some characters in downloaded file name
 
         log("Setting description " + fileDescription + " for '" + renamedFile + "'");
         _fileBrowserHelper.setDescription(renamedFile, fileDescription);

--- a/src/org/labkey/test/tests/list/CrossFolderListTest.java
+++ b/src/org/labkey/test/tests/list/CrossFolderListTest.java
@@ -9,7 +9,6 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Data;
 import org.labkey.test.categories.Hosting;
 import org.labkey.test.pages.LabkeyErrorPage;
-import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.pages.list.GridPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.list.IntListDefinition;
@@ -220,7 +219,7 @@ public class CrossFolderListTest extends BaseWebDriverTest
         var customizeView = subFolderListPage.getGrid().openCustomizeGrid();
         customizeView.showHiddenItems();
         customizeView.addColumn("Key");
-        customizeView.addColumn("Container");   // fun fact: the label is 'Folder'
+        customizeView.addColumn("container");   // fun fact: the label is 'Folder'
         customizeView.saveDefaultView();
 
         // now ensure we got the metadata

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -41,7 +41,7 @@ import org.labkey.test.TestProperties;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.core.ProjectMenu;
-import org.openqa.selenium.Alert;
+import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriverException;
@@ -1263,26 +1263,9 @@ public class Crawler
         }
         catch (UnhandledAlertException ex)
         {
-            String alertText = ex.getAlertText();
-            if (alertText == null)
-                alertText = test.cancelAlert();
-            else if (alertText.isBlank())
-                alertText = ex.getMessage();
+            String alertText = WebDriverUtils.getUnhandledAlertText(ex, test.getDriver());
 
             checkForJavaScriptInjection(alertText);
-
-            checkForSqlInjection(test);
-
-            throw ex;
-        }
-        catch (Exception ex)
-        {
-            Alert alert;
-            while (null != (alert = test.getAlertIfPresent()))
-            {
-                checkForJavaScriptInjection(alert.getText());
-                alert.dismiss();
-            }
 
             checkForSqlInjection(test);
 


### PR DESCRIPTION
#### Rationale
There are several problems that popped up when running tests on Firefox 128

`UnhandledAlertException.getAlertText` no longer contains the alert text. Configuring `setUnhandledPromptBehaviour(UnexpectedAlertBehaviour.IGNORE)` will allow tests to get alert text with `getDriver().switchTo().alert().getText()` when encountering an `UnhandledAlertException`. The default behavior was to dismiss those alerts, so I've also updated several base navigation/cleanup methods explicitly close the alerts (`beginAtAcceptingAlerts`).

`CustomizeView.addColumn` was sometimes failing to add columns. There was no validation that the operation completed successfully, so tests failed log after the actual error occurred. In addition to fixing the `addColumn` functionality, I added some validation to `CustomizeView.addItem`. That validation revealed that many tests were using incorrectly cased fieldKeys (the left panel has all-caps fieldKeys but the right panel does not).

Firefox 128 replaces `%`s in downloaded file names with `_`s. A couple of test required updates to handle that.

Checkboxes on `StartImportPage` weren't getting reliably checked in `AdvancedImportOptionsTest`. I moved that checkbox functionality out of the test into `StartImportPage.checkTargetFolders(String... folders)` to handle UI animation and ensuring the checkboxes are checked.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Handle new behavior of `UnhandledAlertException`
* Add validation to `CustomizeView.addItem`
* Add helper to parse boolean test properties
* Handle Firefox download file name changes
* Handle checkboxes on multi folder import