### PR TITLE
Update Editable Grid Test Component

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -16,6 +16,7 @@ import org.labkey.test.components.ui.ontology.ConceptPickerDialog;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.LabKeyExpectedConditions;
 import org.openqa.selenium.ElementNotInteractableException;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebDriver;
@@ -983,21 +984,21 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
             expand();
 
         getWrapper().setFormElement(elementCache().expressionInput, expression);
+        WebDriverWrapper.sleep(500);
+
+        // Remove focus from the input, this should cause the status message to update.
+        elementCache().expressionInput.sendKeys(Keys.TAB);
+
         return this;
     }
 
     public String getValueExpressionStatusMessage()
     {
-        // Need to remove focus from the expression field to have the updated status message show up.
-        getWrapper().fireEvent(elementCache().expressionInput, WebDriverWrapper.SeleniumEvent.blur);
-        WebDriverWrapper.sleep(500);
-
         String statusMsg = "";
         if(waitFor(elementCache().expressionStatusMsg::isDisplayed, 1_000))
         {
             statusMsg = elementCache().expressionStatusMsg.getText();
         }
-
         return statusMsg;
     }
 

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -984,7 +984,6 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
             expand();
 
         getWrapper().setFormElement(elementCache().expressionInput, expression);
-        WebDriverWrapper.sleep(500);
 
         // Remove focus from the input, this should cause the status message to update.
         elementCache().expressionInput.sendKeys(Keys.TAB);

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -478,11 +478,30 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         {
             String beforeText = gridCell.getText();
 
-            new Actions(getDriver()).sendKeys(" ").perform(); // Type into no particular element to activate input
+            activateCell(gridCell);
 
             String str = value.toString();
             WebElement inputCell = elementCache().inputCell();
-            inputCell.sendKeys(Keys.BACK_SPACE, str, Keys.RETURN); // Add the RETURN to close the inputCell.
+
+            // Select any text that is present.
+            new Actions(getDriver()).sendKeys(Keys.HOME)
+                    .keyDown(Keys.SHIFT)
+                    .sendKeys(Keys.END)
+                    .keyDown(Keys.UP)
+                    .perform();
+
+            if(!str.isEmpty())
+            {
+                inputCell.sendKeys(str); // Add the RETURN to close the inputCell.
+            }
+            else
+            {
+                new Actions(getDriver()).sendKeys(Keys.DELETE)
+                        .perform();
+
+            }
+
+            new Actions(getDriver()).sendKeys(Keys.RETURN).perform(); // Finish the edit.
 
             getWrapper().shortWait().until(ExpectedConditions.stalenessOf(inputCell));
 
@@ -521,9 +540,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
         WebElement textArea = activateCellUsingDoubleClick(row, columnName);
 
-        // Using setFormElement won't call the blur even to remove focus and set the field.
-        getWrapper().setFormElementJS(textArea, value);
-        getWrapper().fireEvent(textArea, WebDriverWrapper.SeleniumEvent.blur);
+        textArea.sendKeys(value, Keys.RETURN); // Add the RETURN to close the inputCell.
 
         waitFor(()->getWrapper().shortWait().until(ExpectedConditions.stalenessOf(textArea)),
                 "TextArea did not go away.", 500);
@@ -691,7 +708,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         int initialRowCount = getRowCount();
         WebElement gridCell = getCell(row, columnName);
         String indexValue = gridCell.getText();
-        selectCell(gridCell);
+        activateCell(gridCell);
 
         getWrapper().actionPaste(null, pasteText);
 

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -487,21 +487,19 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
             new Actions(getDriver()).sendKeys(Keys.HOME)
                     .keyDown(Keys.SHIFT)
                     .sendKeys(Keys.END)
-                    .keyDown(Keys.UP)
+                    .keyUp(Keys.SHIFT)
                     .perform();
 
             if(!str.isEmpty())
             {
-                inputCell.sendKeys(str); // Add the RETURN to close the inputCell.
+                inputCell.sendKeys(str, Keys.TAB); // Add the TAB to close the inputCell.
             }
             else
             {
                 new Actions(getDriver()).sendKeys(Keys.DELETE)
+                        .sendKeys(Keys.TAB)
                         .perform();
-
             }
-
-            new Actions(getDriver()).sendKeys(Keys.RETURN).perform(); // Finish the edit.
 
             getWrapper().shortWait().until(ExpectedConditions.stalenessOf(inputCell));
 

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -483,23 +483,23 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
             String str = value.toString();
             WebElement inputCell = elementCache().inputCell();
 
-            // Select any text that is present.
-            new Actions(getDriver()).sendKeys(Keys.HOME)
-                    .keyDown(Keys.SHIFT)
-                    .sendKeys(Keys.END)
-                    .keyUp(Keys.SHIFT)
-                    .perform();
+            // Remove the text that is there.
+            inputCell.clear();
+
+            // If the cell had text calling '.clear()' requires a reactivation of the cell.
+            if(!inputCell.isDisplayed())
+            {
+                gridCell.click();
+                activateCell(gridCell);
+                inputCell = elementCache().inputCell();
+            }
 
             if(!str.isEmpty())
             {
-                inputCell.sendKeys(str, Keys.TAB); // Add the TAB to close the inputCell.
+                inputCell.sendKeys(str);
             }
-            else
-            {
-                new Actions(getDriver()).sendKeys(Keys.DELETE)
-                        .sendKeys(Keys.TAB)
-                        .perform();
-            }
+
+            inputCell.sendKeys(Keys.RETURN); // Close the inputCell.
 
             getWrapper().shortWait().until(ExpectedConditions.stalenessOf(inputCell));
 
@@ -706,7 +706,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         int initialRowCount = getRowCount();
         WebElement gridCell = getCell(row, columnName);
         String indexValue = gridCell.getText();
-        activateCell(gridCell);
+        selectCell(gridCell);
 
         getWrapper().actionPaste(null, pasteText);
 
@@ -1111,7 +1111,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
         public WebElement inputCell()
         {
-            return Locators.inputCell.findElement(table);
+            return Locators.inputCell.refindWhenNeeded(table);
         }
 
         public ReactSelect lookupSelect(WebElement cell)

--- a/src/org/labkey/test/components/ui/grids/GridBar.java
+++ b/src/org/labkey/test/components/ui/grids/GridBar.java
@@ -9,7 +9,6 @@ import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
-import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.react.MultiMenu;
 import org.labkey.test.components.ui.Pager;
@@ -197,25 +196,26 @@ public class GridBar extends WebDriverComponent<GridBar.ElementCache>
             }
             catch (NoSuchElementException nse)
             {
-                getWrapper().log("Couldn't find menu button with caption '" + buttonText + "', trying again.");
                 tries++;
                 sleep(500);
             }
         }
 
-        if(found)
+        // If the button still wasn't found try the 'More' button.
+        if(!found)
         {
-            if (menuActions.size() == 1)
-                multiMenu.doMenuAction(menuActions.get(0));
-            else if (menuActions.size() == 2)
-                multiMenu.doMenuAction(menuActions.get(0), menuActions.get(1));
-            else
-                throw new IllegalArgumentException("There should be either 1 or 2 menu actions, but was:" + menuActions);
+            multiMenu = elementCache().findMenu("More");
+            Assert.assertTrue(String.format("Could not find a menu button '%s' or 'More', don't know what to click.", buttonText),
+                    multiMenu.getComponentElement().isDisplayed());
+            getWrapper().log(String.format("Couldn't find menu button '%s', clicking the 'More' menu button.", buttonText));
         }
+
+        if (menuActions.size() == 1)
+            multiMenu.doMenuAction(menuActions.get(0));
+        else if (menuActions.size() == 2)
+            multiMenu.doMenuAction(menuActions.get(0), menuActions.get(1));
         else
-        {
-            throw new NoSuchElementException("Couldn't find menu button with caption '" + buttonText + "'.");
-        }
+            throw new IllegalArgumentException("There should be either 1 or 2 menu actions, but was:" + menuActions);
     }
 
     public List<String> getMenuButtonsText()


### PR DESCRIPTION
#### Rationale
Addressing some failures because of changes in the editable grid behavior. Previously the way the text field was activated in the editable grid would clear the existing text (click the field and then send a 'space' key). That doesn't work the same as before. This change uses the input.clear() method to clear the text.

Some of the calculated columns test were failing because the validation msg wasn't getting updated. The message shows up after a expression is entered and the input control loses focus. This change changes the set method to remove focus when done.

#### Related Pull Requests
* https://github.com/LabKey/limsModules/pull/701

#### Changes
* Fixing how the editable grid clears a text field before setting the value.
* Have the grid bar allow for a 'More' menu.
* Update the DomainFieldRow.setValueExpression to lose focus after setting the value.
