### PR TITLE
DetailPopover: collapse popover by mousing over app header icon

### DIFF
--- a/src/org/labkey/test/components/domain/DetailPopover.java
+++ b/src/org/labkey/test/components/domain/DetailPopover.java
@@ -32,7 +32,8 @@ public class DetailPopover extends WebDriverComponent<DetailPopover.ElementCache
 
     public DetailPopover collapse()
     {
-        getWrapper().mouseOut();
+        // mouseOver the app header icon, instead of calling geWrapper.mouseOut() as that does not always work
+        getWrapper().mouseOver(Locator.byClass("navbar-left-icon").findElement(getDriver()));
         clearElementCache();
         return this;
     }


### PR DESCRIPTION
#### Rationale
For some reason on my branch the detail popover is not collapsing when we try `getWrapper().mouseOut()`, so I made it mouse over our app icon instead. This seems to work.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/525
- https://github.com/LabKey/limsModules/pull/692
- https://github.com/LabKey/testAutomation/pull/2051

#### Changes
* DetailPopover: mouse over app icon to close detail popover