### PR TITLE
Restore old test browser window size

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -315,8 +315,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         getDriver().manage().timeouts().pageLoadTimeout(Duration.ofMillis(defaultWaitForPage));
         try
         {
-            // Similar dimensions to what is on TeamCity. A little bit shorter than most dev machines.
-            getDriver().manage().window().setSize(new Dimension(1280, 900));
+            getDriver().manage().window().setSize(new Dimension(1280, 1024));
         }
         catch (WebDriverException ex)
         {

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -315,7 +315,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         getDriver().manage().timeouts().pageLoadTimeout(Duration.ofMillis(defaultWaitForPage));
         try
         {
-            getDriver().manage().window().setSize(new Dimension(1280, 1024));
+            getDriver().manage().window().setSize(new Dimension(TestProperties.getBrowserWidth(), TestProperties.getBrowserHeight()));
         }
         catch (WebDriverException ex)
         {

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -164,26 +164,12 @@ public abstract class TestProperties
 
     public static double getTimeoutMultiplier()
     {
-        try
-        {
-            return Math.max(0, Double.parseDouble(System.getProperty("webtest.timeout.multiplier", "")));
-        }
-        catch (NumberFormatException badProp)
-        {
-            return 1.0;
-        }
+        return Math.max(0, getDoubleProperty("webtest.timeout.multiplier", 1.0));
     }
 
     public static Duration getCrawlerTimeout()
     {
-        try
-        {
-            return Duration.ofSeconds(Integer.parseInt(System.getProperty("crawlerTimeout")));
-        }
-        catch (NumberFormatException ignore)
-        {
-            return Duration.ofSeconds(90);
-        }
+        return Duration.ofSeconds(getIntegerProperty("crawlerTimeout", 90));
     }
 
     public static boolean isCloudPipelineEnabled()
@@ -194,6 +180,16 @@ public abstract class TestProperties
     public static String getCloudPipelineBucketName()
     {
         return System.getProperty("cloud.pipeline.bucket");
+    }
+
+    public static int getBrowserWidth()
+    {
+        return getIntegerProperty("webtest.browser.width", 1280);
+    }
+
+    public static int getBrowserHeight()
+    {
+        return getIntegerProperty("webtest.browser.height", 1024);
     }
 
     public static boolean isWebDriverLoggingEnabled()
@@ -258,15 +254,7 @@ public abstract class TestProperties
      */
     public static int getServerStartupTimeout()
     {
-        String property = System.getProperty("webtest.server.startup.timeout");
-        try
-        {
-            return Integer.parseInt(property);
-        }
-        catch (NumberFormatException nfe)
-        {
-            return 120;
-        }
+        return getIntegerProperty("webtest.server.startup.timeout", 120);
     }
 
     public static File getTomcatHome()
@@ -357,5 +345,53 @@ public abstract class TestProperties
         {
             return def;
         }
+    }
+
+    /**
+     * Interpret system property as an integer. If property is blank or unset, return the specified default value.
+     * Otherwise, parse property with {@link Integer#parseInt(String)}
+     * @param key System property name
+     * @param def Default value
+     * @return value of the specified property
+     */
+    private static int getIntegerProperty(String key, int def)
+    {
+        String prop = System.getProperty(key);
+        if (!StringUtils.isBlank(prop))
+        {
+            try
+            {
+                return Integer.parseInt(prop);
+            }
+            catch (NumberFormatException e)
+            {
+                TestLogger.warn("Invalid value for property %s: '%s'".formatted(key, prop), e);
+            }
+        }
+        return def;
+    }
+
+    /**
+     * Interpret system property as a double. If property is blank or unset, return the specified default value.
+     * Otherwise, parse property with {@link Double#parseDouble(String)}
+     * @param key System property name
+     * @param def Default value
+     * @return value of the specified property
+     */
+    private static double getDoubleProperty(String key, double def)
+    {
+        String prop = System.getProperty(key);
+        if (!StringUtils.isBlank(prop))
+        {
+            try
+            {
+                return Double.parseDouble(prop);
+            }
+            catch (NumberFormatException e)
+            {
+                TestLogger.warn("Invalid value for property %s: '%s'".formatted(key, prop), e);
+            }
+        }
+        return def;
     }
 }


### PR DESCRIPTION
#### Rationale
Changing the browser size revealed some minor test defects. Several tests/helpers are sensitive to browser size but it would require numerous changes to fix them all. For now, we will go back to 1280x1024 window size and make it customizable via system parameters.

#### Related Pull Requests
* #2050 

#### Changes
* Parameterize browser window size `webtest.browser.[height|width]`
* Revert default browser window size back to 1280x1024
