### PR TITLE
Automation for Calculated Columns - Support for calculated columns in LKS

### DIFF
--- a/src/org/labkey/test/components/list/AdvancedListSettingsDialog.java
+++ b/src/org/labkey/test/components/list/AdvancedListSettingsDialog.java
@@ -214,7 +214,7 @@ public class AdvancedListSettingsDialog extends ModalDialog
             return collapsibleFieldLoc(checkboxLabelText).waitForElement(this, 2000);
         }
 
-        final ReactSelect titleColumnSelector = ReactSelect.finder(getDriver()).findWhenNeeded(this);
+        final ReactSelect titleColumnSelector = ReactSelect.finder(getDriver()).withName("titleColumn").findWhenNeeded(this);
     }
 
     public enum SearchIncludeOptions

--- a/src/org/labkey/test/components/list/AdvancedListSettingsDialog.java
+++ b/src/org/labkey/test/components/list/AdvancedListSettingsDialog.java
@@ -11,6 +11,8 @@ import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.openqa.selenium.WebElement;
 
+import java.util.List;
+
 public class AdvancedListSettingsDialog extends ModalDialog
 {
     private final EditListDefinitionPage _page;
@@ -159,6 +161,11 @@ public class AdvancedListSettingsDialog extends ModalDialog
         return _page;
     }
 
+    public List<String> getTitleColumnOptions()
+    {
+        return elementCache().titleColumnSelector.getOptions();
+    }
+
     @Override
     protected ElementCache newElementCache()
     {
@@ -206,6 +213,8 @@ public class AdvancedListSettingsDialog extends ModalDialog
         {
             return collapsibleFieldLoc(checkboxLabelText).waitForElement(this, 2000);
         }
+
+        final ReactSelect titleColumnSelector = ReactSelect.finder(getDriver()).findWhenNeeded(this);
     }
 
     public enum SearchIncludeOptions

--- a/src/org/labkey/test/pages/study/DatasetDesignerPage.java
+++ b/src/org/labkey/test/pages/study/DatasetDesignerPage.java
@@ -258,6 +258,10 @@ public class DatasetDesignerPage extends DomainDesigner<DatasetDesignerPage.Elem
     // find ptid column select
     // find visit column select
 
+    public List<String> getKeyPropertyNameOptions()
+    {
+        return elementCache().keyPropertyName.getOptions();
+    }
 
     @Override
     protected ElementCache newElementCache()
@@ -282,6 +286,7 @@ public class DatasetDesignerPage extends DomainDesigner<DatasetDesignerPage.Elem
 
         private WebElement rowUniquenessContainer = Locator.tagWithClass("div", "dataset_data_row_uniqueness_container")
                 .findWhenNeeded(propertiesPanel);
+        final ReactSelect keyPropertyName = ReactSelect.finder(getDriver()).withName("keyPropertyName").findWhenNeeded(this);
         protected Locator dataRowRadioBtn(Integer index)
         {
             return Locator.tag("label").child(Locator.input("dataRowSetting")


### PR DESCRIPTION
#### Rationale
[Spec](https://docs.google.com/document/d/1MXQfaz8mI75yLQcVfBniPqT9j8YyjdNmFzUKJmezS0Q/edit#heading=h.om4t96kajd8u)
[Github epic](https://github.com/LabKey/limsModules/issues/70)

1. Verify that the calculated field shows up in the row details view 
2. Verify calc field does not show in LKS insert or edit form
3. Study dataset - calculated fields can’t be used as the 3rd key
4. List - calculated fields can’t be used as title column in advanced settings
5. Verify for all domain types that support calc fields (sample type, data class, study dataset, list, assay (Batch, Run, Results)) Simple smoke test for each data type (add, save and re-edit).

#### Related Pull Requests
https://github.com/LabKey/premiumModules/pull/52

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
