### PR TITLE
Test coverage for Issue 51117

### DIFF
--- a/src/org/labkey/test/tests/FileAttachmentColumnTest.java
+++ b/src/org/labkey/test/tests/FileAttachmentColumnTest.java
@@ -31,6 +31,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.pages.admin.FolderManagementPage;
 import org.labkey.test.pages.assay.AssayRunsPage;
 import org.labkey.test.pages.files.FileContentPage;
 import org.labkey.test.pages.study.CreateStudyPage;
@@ -395,6 +396,30 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
 
         log("validate dataset data in import location");
         validateDatasetData(STUDY_DATASET_NAME, IMPORT_PROJECT_NAME, SAMPLE_FILES);
+
+        /*
+            Regression coverage for Issue 51117
+         */
+        log("rename export folder to verify file and attachment fields still resolve");
+        String newFolderName = "ExportFolder_Renamed";
+        String newFolderPath = String.format("%s/%s", getProjectName(), newFolderName);
+        var folderManagementPage = FolderManagementPage.beginAt(this, EXPORT_FOLDER_PATH);
+        folderManagementPage.clickFolderRename()
+                .setProjectName(newFolderName)
+                .save();
+
+        log("validate list attachment data in renamed export location");
+        validateListData(LIST_NAME, newFolderPath, SAMPLE_FILES);
+
+        log("validate sample file field data in renamed export location");
+        validateSampleData(EXPORT_SAMPLETYPE_NAME, newFolderPath, SAMPLE_FILES);
+
+        log("validate assay file field data in renamed export location");
+        validateAssayRun(EXPORT_ASSAY_NAME, newFolderPath, "firstRun", runFile, expectedResultTexts,
+                expectedResultFiles, expectedOtherFiles);
+
+        log("validate dataset data in renamed export location");
+        validateDatasetData(STUDY_DATASET_NAME, newFolderPath, SAMPLE_FILES);
     }
 
     private void createListWithData(String containerPath)


### PR DESCRIPTION
#### Rationale
This adds regression coverage for [Issue 51117](https://www.labkey.org/home/Developer/issues/issues-update.view?issueId=51117).
This change uses the export folder in FileAttachmentColumnTest after the export is done and validated; it's convenient because it has a list, sampletype, assay, and dataset with file and field attachments in it, plus validation for them.

#### Related Pull Requests


#### Changes
Add to `FileAttachmentColumnTest.testExportImportData` after the export/import parts are done
