### PR TITLE
Rename Project to Folder in apps

### DIFF
--- a/src/org/labkey/test/components/ui/FolderDeleteConfirmationDialog.java
+++ b/src/org/labkey/test/components/ui/FolderDeleteConfirmationDialog.java
@@ -10,16 +10,14 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 
-public class ProjectDeleteConfirmationDialog<SourcePage extends LabKeyPage, ConfirmPage extends LabKeyPage> extends DeleteConfirmationDialog<SourcePage, ConfirmPage>
+public class FolderDeleteConfirmationDialog<SourcePage extends LabKeyPage, ConfirmPage extends LabKeyPage> extends DeleteConfirmationDialog<SourcePage, ConfirmPage>
 {
-
-
-    public ProjectDeleteConfirmationDialog(@NotNull SourcePage sourcePage)
+    public FolderDeleteConfirmationDialog(@NotNull SourcePage sourcePage)
     {
        super(sourcePage, null);
     }
 
-    public ProjectDeleteConfirmationDialog(@NotNull SourcePage sourcePage, Supplier<ConfirmPage> confirmPageSupplier)
+    public FolderDeleteConfirmationDialog(@NotNull SourcePage sourcePage, Supplier<ConfirmPage> confirmPageSupplier)
     {
         super(sourcePage, confirmPageSupplier);
     }
@@ -28,7 +26,7 @@ public class ProjectDeleteConfirmationDialog<SourcePage extends LabKeyPage, Conf
     public Map<String, String> getConfirmationData()
     {
         Map<String, String> data = new CaseInsensitiveHashMap<>();
-        WebElement tableEl = Locator.tagWithClass("table", "delete-project-modal__table")
+        WebElement tableEl = Locator.tagWithClass("table", "delete-folder-modal__table")
                 .waitForElement(this, 2000);
         var rows = Locator.tag("tbody").child("tr").findElements(tableEl);
         for (WebElement row : rows)

--- a/src/org/labkey/test/components/ui/navigation/apps/ChangeTargetFolderDialog.java
+++ b/src/org/labkey/test/components/ui/navigation/apps/ChangeTargetFolderDialog.java
@@ -10,7 +10,7 @@ public class ChangeTargetFolderDialog extends ModalDialog
     private final UpdatesTargetFolder _updatingComponent;
     public ChangeTargetFolderDialog(WebDriver driver, UpdatesTargetFolder updatingComponent)
     {
-        super(new ModalDialogFinder(driver).withTitle("Change projects and reset form?"));
+        super(new ModalDialogFinder(driver).withTitle("Change folders and reset form?"));
         this._updatingComponent = updatingComponent;
     }
 
@@ -20,10 +20,10 @@ public class ChangeTargetFolderDialog extends ModalDialog
         dismiss("Cancel");
     }
 
-    public void clickChangeProjects()
+    public void clickChangeFolders()
     {
         _updatingComponent.doAndWaitForFolderUpdate(()->
-                dismiss("Change Projects"));
+                dismiss("Change Folders"));
 
     }
 


### PR DESCRIPTION
#### Rationale
Using Project in the apps to label LKS Folders causes confusion internally and the word "Folder" resonates with clients, so we are switching our terminology in the applications. This brings about changes in class names, variable name, constants, etc. Most cases changed Project to Folder, but I've left Project when we are clearly referencing the LKS project and changed to container (sometimes) when it can be either a LKS Project or LKS Folder.  Names of experimental feature flags have not been updated and some metric names have also intentionally not been updated.


#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5883

#### Changes
* `ProjectDeleteConfirmationDialog` changed to `FolderDeleteConfirmationDialog`
* Update text in `ChangeTargetFolderDialog`.
