### PR TITLE
Add test to exercise site validators

### DIFF
--- a/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
+++ b/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
@@ -15,12 +15,14 @@
  */
 package org.labkey.test.tests;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.TestFileUtils;
+import org.labkey.test.TestProperties;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.BVT;
 import org.labkey.test.categories.CustomModules;
@@ -96,11 +98,12 @@ public class DatabaseDiagnosticsTest extends BaseWebDriverTest
 
         clickAndWait(Locator.lkButton("Data"));
 
+        assertNoLabKeyErrors();
         TextSearcher textSearcher = new TextSearcher(getText(Locators.bodyPanel()));
-        assertTextPresent(textSearcher, "Site Level Validation Results", "Folder Validation Results",
+        assertTextPresent(textSearcher,
+                "Site Level Validation Results", "Folder Validation Results",
                 "Module: Core", "Permissions Validator", "Display Format Validator",
                 "Module: Pipeline", "Pipeline Validator");
-        assertNoLabKeyErrors();
         assertTextNotPresent(textSearcher, "Error");
     }
 
@@ -116,6 +119,8 @@ public class DatabaseDiagnosticsTest extends BaseWebDriverTest
     @Test
     public void testTomcatLogs() throws Exception
     {
+        Assume.assumeFalse("Can't check log files on remote server", TestProperties.isServerRemote());
+
         File logDir = TestFileUtils.getServerLogDir();
         assertTrue("Server log directory does not exist: " + logDir, logDir.isDirectory());
         File[] logs = logDir.listFiles();
@@ -125,7 +130,7 @@ public class DatabaseDiagnosticsTest extends BaseWebDriverTest
                 file -> failureFiles.put(file.getName(), "line " + contaminatedLogs.get(file)));
 
         assertTrue(String.format("These tomcat logs (in %s) contained unwanted text [%s]:\n%s",
-                logDir.getAbsolutePath(), PasswordUtil.getPassword(), failureFiles.toString()),
+                logDir.getAbsolutePath(), PasswordUtil.getPassword(), failureFiles),
                 failureFiles.isEmpty());
     }
 

--- a/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
+++ b/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
@@ -97,9 +97,11 @@ public class DatabaseDiagnosticsTest extends BaseWebDriverTest
         clickAndWait(Locator.lkButton("Data"));
 
         TextSearcher textSearcher = new TextSearcher(getText(Locators.bodyPanel()));
-        assertTextPresent(textSearcher, "Site Level Validation Results", "Folder Validation Results", "Module: core", "Module: Pipeline");
+        assertTextPresent(textSearcher, "Site Level Validation Results", "Folder Validation Results",
+                "Module: Core", "Permissions Validator", "Display Format Validator",
+                "Module: Pipeline", "Pipeline Validator");
         assertNoLabKeyErrors();
-        assertTextNotPresent(textSearcher, "Error", "Warning");
+        assertTextNotPresent(textSearcher, "Error");
     }
 
     @Test

--- a/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
+++ b/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
@@ -70,7 +70,7 @@ public class DatabaseDiagnosticsTest extends BaseWebDriverTest
     }
 
     @Test
-    public void siteValidatorTest()
+    public void testSiteValidator()
     {
         goToAdminConsole().goToSettingsSection();
 


### PR DESCRIPTION
#### Rationale
Add a simple test for site validators. Just run them all and check for errors.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5841

#### Changes
* Add test to exercise site validators `DatabaseDiagnosticsTest.testSiteValidators`
