### PR TITLE
Issue 50131: Kill DB queries when pipeline job is canceled

### DIFF
--- a/modules/ETLtest/module.properties
+++ b/modules/ETLtest/module.properties
@@ -1,2 +1,2 @@
 Name: ETLtest
-SchemaVersion: 24.000
+SchemaVersion: 24.001

--- a/modules/ETLtest/resources/ETLs/SProcSlowNoTransaction.xml
+++ b/modules/ETLtest/resources/ETLs/SProcSlowNoTransaction.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>Stored Proc - Slow without Transaction</name>
+    <description>Does a slow stored proc call</description>
+    <transforms>
+        <transform id="step1" type="StoredProcedure">
+            <procedure schemaName="etltest" procedureName="etltest" useTransaction="false">
+                <parameter name="@testMode" value="9"/>
+                <parameter name="@testInOutParam" value="before" noWorkValue="${testInOutParam}"/>
+            </procedure>
+        </transform>
+    </transforms>
+</etl>

--- a/modules/ETLtest/resources/ETLs/SProcSlowTransaction.xml
+++ b/modules/ETLtest/resources/ETLs/SProcSlowTransaction.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>Stored Proc - Slow with Transaction</name>
+    <description>Does a slow stored proc call</description>
+    <transforms>
+        <transform id="step1" type="StoredProcedure">
+            <procedure schemaName="etltest" procedureName="etltest">
+                <parameter name="@testMode" value="9"/>
+                <parameter name="@testInOutParam" value="before" noWorkValue="${testInOutParam}"/>
+            </procedure>
+        </transform>
+    </transforms>
+</etl>

--- a/modules/ETLtest/resources/ETLs/giantCTE.xml
+++ b/modules/ETLtest/resources/ETLs/giantCTE.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>Giant CTE</name>
+    <description>Processes a million rows, so it's gonna take a long time</description>
+    <transforms>
+        <transform id="step1" type="org.labkey.di.pipeline.TransformTask">
+            <description>Copy to target</description>
+            <source schemaName="etltest" queryName="giantCTE" />
+            <destination schemaName="lists" queryName="Target" targetOption="merge">
+            </destination>
+        </transform>
+    </transforms>
+    <schedule>
+        <poll interval="15s" />
+    </schedule>
+</etl>

--- a/modules/ETLtest/resources/queries/etltest/giantCTE.sql
+++ b/modules/ETLtest/resources/queries/etltest/giantCTE.sql
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2017-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+WITH cte AS (SELECT 1 AS Key UNION ALL SELECT Key + 1 AS Key FROM cte WHERE Key < 1000000)
+
+SELECT Key FROM cte

--- a/modules/ETLtest/resources/schemas/dbscripts/postgresql/etltest-24.000-24.001.sql
+++ b/modules/ETLtest/resources/schemas/dbscripts/postgresql/etltest-24.000-24.001.sql
@@ -1,0 +1,148 @@
+CREATE OR REPLACE FUNCTION etltest.etltest
+  (IN transformrunid integer
+    , IN containerid entityid DEFAULT NULL::character varying
+    , INOUT rowsinserted integer DEFAULT 0
+    , INOUT rowsdeleted integer DEFAULT 0
+    , INOUT rowsmodified integer DEFAULT 0
+    , INOUT returnmsg character varying DEFAULT 'default message'::character varying
+    , IN debug character varying DEFAULT ''::character varying
+    , IN filterrunid integer DEFAULT NULL::integer
+    , INOUT filterstarttimestamp timestamp without time zone DEFAULT NULL::timestamp without time zone
+    , INOUT filterendtimestamp timestamp without time zone DEFAULT NULL::timestamp without time zone
+    , INOUT previousfilterrunid integer DEFAULT (-1)
+    , INOUT previousfilterstarttimestamp timestamp without time zone DEFAULT NULL::timestamp without time zone
+    , INOUT previousfilterendtimestamp timestamp without time zone DEFAULT NULL::timestamp without time zone
+    --, INOUT procVersion decimal DEFAULT 0
+    , IN testmode integer DEFAULT (-1)
+    , INOUT testinoutparam character varying DEFAULT ''::character varying
+    , INOUT runcount integer DEFAULT 1
+    , OUT return_status integer)
+  RETURNS record AS
+$BODY$
+
+/*
+	Test modes
+	1	normal operation
+	2	return code > 0
+	3	raise error
+	4	input/output parameter persistence
+	5	override of persisted input/output parameter
+	6	Run filter strategy, require filterRunId. Test persistence.
+    7   Modified since filter strategy, no source, require filterStartTimeStamp & filterEndTimeStamp,
+		populated from output of previous run
+    8	Modified since filter strategy with source, require filterStartTimeStamp & filterEndTimeStamp
+		populated from the filter strategy IncrementalStartTime & IncrementalEndTime
+    9	Sleep for 2 minutes before finishing
+
+*/
+BEGIN
+
+  IF testMode IS NULL
+  THEN
+    returnMsg := 'No testMode set';
+    return_status := 1;
+    RETURN;
+END IF;
+
+  IF runCount IS NULL
+  THEN
+    runCount := 1;
+ELSE
+    runCount := runCount + 1;
+END IF;
+
+  IF testMode = 1
+  THEN
+    RAISE NOTICE '%', 'Test print statement logging';
+    rowsInserted := 1;
+    rowsDeleted := 2;
+    rowsModified := 4;
+    returnMsg := 'Test returnMsg logging';
+    return_status := 0;
+    RETURN;
+END IF;
+
+  IF testMode = 2 THEN return_status := 1; RETURN; END IF;
+
+  IF testMode = 3
+  THEN
+    returnMsg := 'Intentional SQL Exception From Inside Proc';
+    RAISE EXCEPTION '%', returnMsg;
+END IF;
+
+  IF testMode = 4 AND testInOutParam != 'after' AND runCount > 1
+  THEN
+    returnMsg := 'Expected value "after" for testInOutParam on run count = ' || runCount || ', but was ' || testInOutParam;
+    return_status := 1;
+    RETURN;
+END IF;
+
+  IF testMode = 5 AND testInOutParam != 'before' AND runCount > 1
+  THEN
+    returnMsg := 'Expected value "before" for testInOutParam on run count = ' || runCount || ', but was ' || testInOutParam;
+    return_status := 1;
+    RETURN;
+END IF;
+
+  IF testMode = 6
+  THEN
+    IF filterRunId IS NULL
+    THEN
+      returnMsg := 'Required filterRunId value not supplied';
+      return_status := 1;
+      RETURN;
+END IF;
+    IF runCount > 1 AND (previousFilterRunId IS NULL OR previousFilterRunId >= filterRunId)
+    THEN
+      returnMsg := 'Required filterRunId was not persisted from previous run.';
+      return_status := 1;
+      RETURN;
+END IF;
+    previousFilterRunId := filterRunId;
+END IF;
+
+  IF testMode = 7
+  THEN
+    IF runCount > 1 AND (filterStartTimeStamp IS NULL AND filterEndTimeStamp IS NULL)
+    THEN
+      returnMsg := 'Required filterStartTimeStamp or filterEndTimeStamp were not persisted from previous run.';
+      return_status := 1;
+      RETURN;
+END IF;
+    filterStartTimeStamp := localtimestamp;
+    filterEndTimeStamp := localtimestamp;
+END IF;
+
+  IF testMode = 8
+  THEN
+    IF runCount > 1 AND ((previousFilterStartTimeStamp IS NULL AND previousFilterEndTimeStamp IS NULL)
+                         OR (filterStartTimeStamp IS NULL AND filterEndTimeStamp IS NULL))
+    THEN
+      returnMsg := 'Required filterStartTimeStamp or filterEndTimeStamp were not persisted from previous run.';
+      return_status := 1;
+      RETURN;
+END IF;
+    previousFilterStartTimeStamp := coalesce(filterStartTimeStamp, localtimestamp);
+    previousFilterEndTimeStamp := coalesce(filterEndTimeStamp, localtimestamp);
+END IF;
+
+  IF testMode = 9
+  THEN
+      -- Sleep for 2 minutes
+     SELECT pg_sleep(120);
+      return_status := 1;
+      RETURN;
+END IF;
+
+  -- set value for persistence tests
+  IF testInOutParam != ''
+  THEN
+    testInOutParam := 'after';
+END IF;
+
+  return_status := 0;
+  RETURN;
+
+END;
+$BODY$
+LANGUAGE plpgsql;

--- a/modules/ETLtest/resources/schemas/dbscripts/sqlserver/etltest-24.000-24.001.sql
+++ b/modules/ETLtest/resources/schemas/dbscripts/sqlserver/etltest-24.000-24.001.sql
@@ -1,0 +1,129 @@
+ALTER PROCEDURE etltest.etlTest
+    @transformRunId int,
+    @containerId entityid = NULL OUTPUT,
+    @rowsInserted int = 0 OUTPUT,
+    @rowsDeleted int = 0 OUTPUT,
+    @rowsModified int = 0 OUTPUT,
+    @returnMsg varchar(100) = 'default message' OUTPUT,
+    @debug varchar(1000) = '',
+    @filterRunId int = null,
+    @filterStartTimeStamp datetime = null OUTPUT,
+    @filterEndTimeStamp datetime = null OUTPUT,
+    @testMode int,
+    @testInOutParam varchar(10) = null OUTPUT,
+    @runCount int = 1 OUTPUT,
+    @previousFilterRunId int = -1 OUTPUT,
+    @previousFilterStartTimeStamp datetime = null OUTPUT,
+    @previousFilterEndTimeStamp datetime = null OUTPUT
+    AS
+BEGIN
+
+/*
+	Test modes
+	1	normal operation
+	2	return code > 0
+	3	raise error
+	4	input/output parameter persistence
+	5	override of persisted input/output parameter
+	6	Run filter strategy, require filterRunId. Test persistence.
+    7   Modified since filter strategy, no source, require filterStartTimeStamp & filterEndTimeStamp,
+		populated from output of previous run
+    8	Modified since filter strategy with source, require filterStartTimeStamp & filterEndTimeStamp
+		populated from the filter strategy IncrementalStartTime & IncrementalEndTime
+    9	Sleep for 2 minutes before finishing
+*/
+
+IF @testMode IS NULL
+BEGIN
+	SET @returnMsg = 'No testMode set'
+	RETURN 1
+END
+
+IF @runCount IS NULL
+    SET @runCount = 1;
+ELSE
+    SET @runCount = @runCount + 1;
+
+IF @testMode = 1
+BEGIN
+	print 'Test print statement logging'
+	SET @rowsInserted = 1
+	SET @rowsDeleted = 2
+	SET @rowsModified = 4
+	SET @returnMsg = 'Test returnMsg logging'
+	RETURN 0
+END
+
+IF @testMode = 2 RETURN 1
+
+IF @testMode = 3
+BEGIN
+	SET @returnMsg = 'Intentional SQL Exception From Inside Proc'
+	RAISERROR(@returnMsg, 11, 1)
+END
+
+IF @testMode = 4 AND @testInOutParam != 'after' AND @runCount > 1
+BEGIN
+	SET @returnMsg = 'Expected value "after" for @testInOutParam on run count = ' + convert(varchar, @runCount) + ', but was ' + @testInOutParam
+	RETURN 1
+END
+
+IF @testMode = 5 AND @testInOutParam != 'before' AND @runCount > 1
+BEGIN
+	SET @returnMsg = 'Expected value "before" for @testInOutParam on run count = ' + convert(varchar, @runCount) + ', but was ' + @testInOutParam
+	RETURN 1
+END
+
+IF @testMode = 6
+BEGIN
+	IF @filterRunId IS NULL
+BEGIN
+		SET @returnMsg = 'Required @filterRunId value not supplied'
+		RETURN 1
+END
+	IF @runCount > 1 AND (@previousFilterRunId IS NULL OR @previousFilterRunId >= @filterRunId)
+BEGIN
+		SET @returnMsg = 'Required @filterRunId was not persisted from previous run.'
+		RETURN 1
+END
+	SET @previousFilterRunId = @filterRunId
+END
+
+IF @testMode = 7
+BEGIN
+    IF @runCount > 1 AND (@filterStartTimeStamp IS NULL AND @filterEndTimeStamp IS NULL)
+BEGIN
+      SET @returnMsg = 'Required filterStartTimeStamp or filterEndTimeStamp were not persisted from previous run.';
+RETURN 1;
+END;
+    SET @filterStartTimeStamp = CURRENT_TIMESTAMP;
+    SET @filterEndTimeStamp = CURRENT_TIMESTAMP;
+END;
+
+IF @testMode = 8
+
+BEGIN
+    IF @runCount > 1 AND ((@previousFilterStartTimeStamp IS NULL AND @previousFilterEndTimeStamp IS NULL)
+                         OR (@filterStartTimeStamp IS NULL AND @filterEndTimeStamp IS NULL))
+BEGIN
+      SET @returnMsg = 'Required filterStartTimeStamp or filterEndTimeStamp were not persisted from previous run.';
+RETURN 1;
+END;
+    SET @previousFilterStartTimeStamp = coalesce(@filterStartTimeStamp, CURRENT_TIMESTAMP);
+    SET @previousFilterEndTimeStamp = coalesce(@filterEndTimeStamp, CURRENT_TIMESTAMP);
+END;
+
+IF @testMode = 9
+BEGIN
+    -- Sleep for 2 minutes
+    WAITFOR DELAY '00:02'
+    RETURN 1;
+END;
+
+-- set value for persistence tests
+IF @testInOutParam IS NOT NULL AND @testInOutParam != '' SET @testInOutParam = 'after'
+
+RETURN 0
+
+END
+GO


### PR DESCRIPTION
#### Rationale
To help test canceling a pipeline job that's running queries, it's helpful to have some ETLs that take long enough to run to be easily cancellable.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5892

#### Changes
* Three ETL variants (one normal source/target ETL, two stored proc variants) that take a while to run, with related resources
* A new version of the `etltest` stored proc that sleeps for two minutes
