### PR TITLE
Make sure portal menu is closed

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -56,11 +56,11 @@ import org.labkey.test.pages.core.admin.ShowAdminPage;
 import org.labkey.test.pages.user.UserDetailsPage;
 import org.labkey.test.util.APIUserHelper;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.LabKeyExpectedConditions;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.Maps;
+import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.PipelineStatusTable;
 import org.labkey.test.util.PortalHelper;
@@ -1092,13 +1092,6 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
     public void goToExternalToolPage()
     {
         clickUserMenuItem("External Tool Access");
-    }
-
-    protected WebElement openMenu(String menuText)
-    {
-        WebElement menu = Locator.menuBarItem(menuText).findElement(getDriver());
-        menu.click();
-        return menu;
     }
 
     private static Map<String, Boolean> _originalFeatureFlags = new HashMap<>();

--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -747,14 +747,6 @@ public abstract class Locator extends By
         return tag("a").child(tag("span").withAttributeContaining("class", "menu-item-text").withText(text)).notHidden();
     }
 
-    public static XPathLocator menuBarItem(String text)
-    {
-        return tagWithClass("div", "navbar-header")
-                .childTag("ul")
-                .childTag("li").withClass("dropdown")
-                .childTag("a").withText(text);
-    }
-
     public static XPathLocator linkWithTitle(String title)
     {
         return tag("a").withAttribute("title", title);

--- a/src/org/labkey/test/tests/MenuBarTest.java
+++ b/src/org/labkey/test/tests/MenuBarTest.java
@@ -99,9 +99,9 @@ public class MenuBarTest extends BaseWebDriverTest
 
         //Make sure that the menus are shown, but the content is not yet loaded.
         assertElementPresent(Locator.tagWithClass("div", "navbar-header"));
-        assertElementPresent(Locator.menuBarItem("Assays"));
-        assertElementPresent(Locator.menuBarItem("Studies"));
-        assertElementPresent(Locator.menuBarItem(WIKI_PAGE_TITLE));
+        assertElementPresent(menuBarItem("Assays"));
+        assertElementPresent(menuBarItem("Studies"));
+        assertElementPresent(menuBarItem(WIKI_PAGE_TITLE));
 
         log("Assert wiki, assay, and study portals not loaded");
         assertTextNotPresent(WIKI_PAGE_CONTENT);
@@ -195,9 +195,10 @@ public class MenuBarTest extends BaseWebDriverTest
 
         clickFolder(DEM_STUDY_FOLDER);
         assertTextPresent("Demo Study", "Study Overview");
-        openMenu("Folders");
+        menu = openMenu("Folders");
         waitForElement(Locator.linkWithText(DEM_STUDY_FOLDER));
         assertElementPresent(Locator.linkWithText(STUDY_FOLDER));
+        menu.click(); // close menu
 
         // Issue 47841: verify that menu config comes through with folder export/import (via create from template)
         UIContainerHelper uiContainerHelper = new UIContainerHelper(this);
@@ -208,6 +209,21 @@ public class MenuBarTest extends BaseWebDriverTest
         openMenu("Wiki Render Types");
         openMenu("Participant Reports");
         openMenu("Folders");
+    }
+
+    protected WebElement openMenu(String menuText)
+    {
+        WebElement menu = menuBarItem(menuText).findElement(getDriver());
+        menu.click();
+        return menu;
+    }
+
+    public static Locator.XPathLocator menuBarItem(String text)
+    {
+        return Locator.id("nav_dropdowns")
+                .childTag("ul")
+                .childTag("li").withClass("dropdown")
+                .childTag("a").withText(text);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Been seeing intermittent failures since updating to Firefox 128. A custom portal menu reopens when the test tries to click the admin menu without closing it first.

```
org.openqa.selenium.ElementNotInteractableException: Element <a id="popupMenuView02cf8" href="/admin-createFolder.view?returnUrl=%2FMenuBarVerifyProject%2FDemStudyFolder%2Fproject-begin.view"> could not be scrolled into view
[...]
  at app//org.labkey.test.util.UIContainerHelper.doCreateProject(UIContainerHelper.java:61)
  at app//org.labkey.test.util.UIContainerHelper.createProjectFromTemplate(UIContainerHelper.java:53)
  at app//org.labkey.test.tests.MenuBarTest.testSteps(MenuBarTest.java:204)
```

#### Related Pull Requests
* N/A

#### Changes
* Close portal menu after checking it
