### PR TITLE
Issue 50569: Add ability for users to supply descriptions with API keys

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,7 +2,7 @@
 <!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->
 
 #### Related Pull Requests
-* <!-- list of links to related pull requests (replace this comment) -->
+- <!-- list of links to related pull requests (replace this comment) -->
 
 #### Changes
-* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
+- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

--- a/src/org/labkey/test/credentials/ApiKeyDialog.java
+++ b/src/org/labkey/test/credentials/ApiKeyDialog.java
@@ -1,0 +1,119 @@
+package org.labkey.test.credentials;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.bootstrap.ModalDialog;
+import org.labkey.test.components.html.Input;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.awt.*;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.IOException;
+
+public class ApiKeyDialog extends ModalDialog
+{
+    public static final String API_KEY_TITLE = "API Key";
+    public static final String SESSION_KEY_TITLE = "Session Key";
+
+    private final String _title;
+
+    public ApiKeyDialog(WebDriver driver, String title)
+    {
+        super(new ModalDialogFinder(driver).withTitle(title));
+        _title = title;
+    }
+
+    public ApiKeyDialog generateApiKey()
+    {
+        elementCache().generateApiKeyButton.click();
+        return new ApiKeyDialog(getDriver(), _title);
+    }
+
+    public ApiKeyDialog copyKey()
+    {
+        elementCache().copyKeyButton.click();
+        return this;
+    }
+
+    public String getClipboardContent() throws IOException, UnsupportedFlavorException
+    {
+        return  (String) Toolkit.getDefaultToolkit().getSystemClipboard()
+                .getData(DataFlavor.stringFlavor);
+    }
+
+    public boolean isCopyButtonDisplayed()
+    {
+        return elementCache().copyKeyButton.isDisplayed();
+    }
+
+    public boolean isCopyButtonEnabled()
+    {
+        return elementCache().copyKeyButton.isEnabled();
+    }
+
+    public boolean isGenerateButtonEnabled()
+    {
+        return elementCache().generateApiKeyButton.isEnabled();
+    }
+
+    public boolean isGenerateButtonDisplayed()
+    {
+        return elementCache().generateApiKeyButton.isDisplayed();
+    }
+
+    public boolean isInputFieldEnabled()
+    {
+        return elementCache().inputField.getComponentElement().isEnabled();
+    }
+
+    public boolean isInputFieldDisplayed()
+    {
+        return elementCache().inputField.getComponentElement().isDisplayed();
+    }
+
+    public boolean isDescriptionFieldDisplayed() { return elementCache().descriptionInput.getComponentElement().isDisplayed(); }
+
+    public void clickDone()
+    {
+        elementCache().doneButton.click();
+    }
+
+    public ApiKeyDialog setDescription(String description)
+    {
+        elementCache().descriptionInput.getComponentElement().sendKeys(description);
+        return this;
+    }
+
+    public String getDescription()
+    {
+        return elementCache().descriptionDisplay.getText();
+    }
+
+    public String getInputFieldValue()
+    {
+        return elementCache().inputField.getValue();
+    }
+
+    @Override
+    protected ApiKeyDialog.ElementCache newElementCache()
+    {
+        return new ApiKeyDialog.ElementCache();
+    }
+
+    @Override
+    protected ApiKeyDialog.ElementCache elementCache()
+    {
+        return (ApiKeyDialog.ElementCache) super.elementCache();
+    }
+
+    protected class ElementCache extends ModalDialog.ElementCache
+    {
+        Input descriptionInput = Input.Input(Locator.tagWithId("input", "keyDescription"), getDriver()).refindWhenNeeded(this);
+        WebElement descriptionDisplay = Locator.tagWithClassContaining("div", "api-key__description").refindWhenNeeded(this);
+        WebElement generateApiKeyButton = Locator.tagWithText("button", "Generate API Key").findWhenNeeded(this);
+        Input inputField = Input.Input(Locator.tagWithClass("input", "api-key__input"), getDriver()).findWhenNeeded(this);
+        WebElement copyKeyButton = Locator.tagWithName("button", "copy_apikey_token").findWhenNeeded(this);
+        WebElement doneButton = Locator.tagWithText("button", "Done").findWhenNeeded(this);
+    }
+}


### PR DESCRIPTION
#### Rationale
Issue [50569](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50569) - Sometimes users generate multiple API keys and want to add a description for when or how each is being used. The server-side addition of these fields has already been done. This PR and its relatives add the client-side changes.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5917
* https://github.com/LabKey/limsModules/pull/798

#### Changes
* Add `ApiKeyDialog` component
* Update `ApiKeyTest` for new UI for generating and copying keys
