### PR TITLE
Ignore errors caused by cancelling a pipeline job

### DIFF
--- a/src/org/labkey/test/ClientErrorAssertionError.java
+++ b/src/org/labkey/test/ClientErrorAssertionError.java
@@ -1,8 +1,12 @@
 package org.labkey.test;
 
-public class ClientErrorAssertionError extends AssertionError
+/**
+ * Indicates that a client-side error was found in the server's error log
+ * Requires the 'javascriptErrorServerLogging' optional feature to be enabled on the server
+ */
+public class ClientErrorAssertionError extends ServerErrorAssertionError
 {
-    public ClientErrorAssertionError(Object detailMessage)
+    public ClientErrorAssertionError(String detailMessage)
     {
         super(detailMessage);
     }

--- a/src/org/labkey/test/ClientErrorAssertionError.java
+++ b/src/org/labkey/test/ClientErrorAssertionError.java
@@ -1,0 +1,9 @@
+package org.labkey.test;
+
+public class ClientErrorAssertionError extends AssertionError
+{
+    public ClientErrorAssertionError(Object detailMessage)
+    {
+        super(detailMessage);
+    }
+}

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -953,9 +953,9 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                 beginAt(buildURL("admin", "showErrorsSinceMark"));
                 resetErrors();
                 if (errorLogContents.toLowerCase().contains(CLIENT_SIDE_ERROR.toLowerCase()))
-                    fail("There were client-side errors during the test run. Check labkey.log and/or labkey-errors.log for details.");
+                    throw new ClientErrorAssertionError("There were client-side errors during the test run. Check labkey.log and/or labkey-errors.log for details.");
                 else
-                    fail("There were server-side errors during the test run. Check labkey.log and/or labkey-errors.log for details.");
+                    throw new ServerErrorAssertionError("There were server-side errors during the test run. Check labkey.log and/or labkey-errors.log for details.");
             }
         }
         log("No new errors found.");

--- a/src/org/labkey/test/ServerErrorAssertionError.java
+++ b/src/org/labkey/test/ServerErrorAssertionError.java
@@ -1,8 +1,11 @@
 package org.labkey.test;
 
+/**
+ * Indicates that an error was found in the server's error log
+ */
 public class ServerErrorAssertionError extends AssertionError
 {
-    public ServerErrorAssertionError(Object detailMessage)
+    public ServerErrorAssertionError(String detailMessage)
     {
         super(detailMessage);
     }

--- a/src/org/labkey/test/ServerErrorAssertionError.java
+++ b/src/org/labkey/test/ServerErrorAssertionError.java
@@ -1,0 +1,9 @@
+package org.labkey.test;
+
+public class ServerErrorAssertionError extends AssertionError
+{
+    public ServerErrorAssertionError(Object detailMessage)
+    {
+        super(detailMessage);
+    }
+}

--- a/src/org/labkey/test/tests/PipelineCancelTest.java
+++ b/src/org/labkey/test/tests/PipelineCancelTest.java
@@ -68,7 +68,7 @@ public class PipelineCancelTest  extends BaseWebDriverTest
         }
         catch (ServerErrorAssertionError error)
         {
-            log("Ignoring server errors cause by cancelling pipeline job");
+            log("Ignoring server errors caused by cancelling the folder import pipeline job");
         }
     }
 

--- a/src/org/labkey/test/tests/PipelineCancelTest.java
+++ b/src/org/labkey/test/tests/PipelineCancelTest.java
@@ -18,6 +18,7 @@ package org.labkey.test.tests;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.ServerErrorAssertionError;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestProperties;
 import org.labkey.test.categories.Daily;
@@ -52,10 +53,23 @@ public class PipelineCancelTest  extends BaseWebDriverTest
         startImportStudyFromZip(STUDY_ZIP);
 
         log("Cancel import");
-        new PipelineStatusTable(this).clickStatusLink(0).clickCancel();
+        new PipelineStatusTable(this).clickStatusLink(0)
+            .clickCancel()
+            .assertLogTextContains(
+                "Interrupting job by sending interrupt request.",
+                "Failed to complete task");
 
         goToProjectHome();
         assertTextPresent("This folder does not contain a study."); //part of the import will be done, but it shouldn't have gotten to participants.
+
+        try
+        {
+            checkErrors();
+        }
+        catch (ServerErrorAssertionError error)
+        {
+            log("Ignoring server errors cause by cancelling pipeline job");
+        }
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Recent changes made cancelling pipeline jobs more aggressive, which can cause some server-side errors.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5892

#### Changes
- Ignore errors caused by cancelling a pipeline job 
