### PR TITLE
Update API key tests to use ApiKeyPanel and ApiKeyDialog

### DIFF
--- a/src/org/labkey/test/components/core/ApiKeyDialog.java
+++ b/src/org/labkey/test/components/core/ApiKeyDialog.java
@@ -1,10 +1,11 @@
-package org.labkey.test.credentials;
+package org.labkey.test.components.core;
 
 import org.labkey.test.Locator;
 import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.components.html.Input;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
@@ -27,7 +28,10 @@ public class ApiKeyDialog extends ModalDialog
     public ApiKeyDialog generateApiKey()
     {
         elementCache().generateApiKeyButton.click();
-        return new ApiKeyDialog(getDriver(), _title);
+        getWrapper().shortWait().until(ExpectedConditions.invisibilityOf(elementCache().descriptionInput.getComponentElement()));
+        clearElementCache();
+        getWrapper().shortWait().until(ExpectedConditions.visibilityOf(elementCache().inputField.getComponentElement()));
+        return this;
     }
 
     public ApiKeyDialog copyKey()
@@ -109,8 +113,8 @@ public class ApiKeyDialog extends ModalDialog
 
     protected class ElementCache extends ModalDialog.ElementCache
     {
-        Input descriptionInput = Input.Input(Locator.tagWithId("input", "keyDescription"), getDriver()).refindWhenNeeded(this);
-        WebElement descriptionDisplay = Locator.tagWithClassContaining("div", "api-key__description").refindWhenNeeded(this);
+        Input descriptionInput = Input.Input(Locator.tagWithId("input", "keyDescription"), getDriver()).findWhenNeeded(this);
+        WebElement descriptionDisplay = Locator.tagWithClassContaining("div", "api-key__description").findWhenNeeded(this);
         WebElement generateApiKeyButton = Locator.tagWithText("button", "Generate API Key").findWhenNeeded(this);
         Input inputField = Input.Input(Locator.tagWithClass("input", "api-key__input"), getDriver()).findWhenNeeded(this);
         WebElement copyKeyButton = Locator.tagWithName("button", "copy_apikey_token").findWhenNeeded(this);

--- a/src/org/labkey/test/components/core/ApiKeyPanel.java
+++ b/src/org/labkey/test/components/core/ApiKeyPanel.java
@@ -1,0 +1,94 @@
+package org.labkey.test.components.core;
+
+import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
+import org.labkey.test.BootstrapLocators;
+import org.labkey.test.Locator;
+import org.labkey.test.components.bootstrap.Panel;
+import org.labkey.test.components.ui.grids.QueryGrid;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class ApiKeyPanel extends Panel<ApiKeyPanel.ElementCache>
+{
+    protected ApiKeyPanel(WebElement element, WebDriver driver)
+    {
+        super(element, driver);
+    }
+
+    public static SimpleWebDriverComponentFinder<ApiKeyPanel> panelFinder(WebDriver driver)
+    {
+        return new Panel.PanelFinder(driver).withTitle("API Keys").wrap(ApiKeyPanel::new);
+    }
+
+    public String generateApiKey(@Nullable String description)
+    {
+        ApiKeyDialog apiKeyDialog = clickGenerateApiKey();
+        if (description != null)
+        {
+            apiKeyDialog.setDescription(description);
+        }
+        apiKeyDialog.generateApiKey();
+        Assert.assertEquals("API Key discription", description == null ? "" : description, apiKeyDialog.getDescription());
+        String inputFieldValue = apiKeyDialog.getInputFieldValue();
+        apiKeyDialog.clickDone();
+        return inputFieldValue;
+    }
+
+    public String generateApiKey()
+    {
+        return generateApiKey(null);
+    }
+    public ApiKeyDialog clickGenerateApiKey()
+    {
+        elementCache().generateApiKeyButton.click();
+        return new ApiKeyDialog(getDriver(), ApiKeyDialog.API_KEY_TITLE);
+    }
+
+    public String generateSessionKey()
+    {
+        ApiKeyDialog apiKeyDialog = clickGenerateSessionKey();
+        String inputFieldValue = apiKeyDialog.getInputFieldValue();
+        apiKeyDialog.clickDone();
+        return inputFieldValue;
+    }
+
+    public ApiKeyDialog clickGenerateSessionKey()
+    {
+        elementCache().generateSessionKeyButton.click();
+        return new ApiKeyDialog(getDriver(), ApiKeyDialog.SESSION_KEY_TITLE);
+    }
+
+    public QueryGrid getGrid()
+    {
+        return new QueryGrid.QueryGridFinder(getDriver()).findWhenNeeded();
+    }
+
+
+    public boolean isGenerateApiKeyButtonEnabled()
+    {
+        return elementCache().generateApiKeyButton.isEnabled();
+    }
+
+    public boolean isGenerateApiKeyButtonDisplayed()
+    {
+        return elementCache().generateApiKeyButton.isDisplayed();
+    }
+
+    public boolean hasDisabledMessage()
+    {
+        return BootstrapLocators.warningBanner.containing("not enabled").existsIn(this);
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends Panel<ElementCache>.ElementCache
+    {
+        WebElement generateApiKeyButton = Locator.tagWithText("button", "Generate API Key").findWhenNeeded(this);
+        WebElement generateSessionKeyButton = Locator.tagWithText("button", "Generate Session Key").findWhenNeeded(this);
+    }
+}

--- a/src/org/labkey/test/tests/ApiKeyTest.java
+++ b/src/org/labkey/test/tests/ApiKeyTest.java
@@ -40,8 +40,8 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.bootstrap.ModalDialog;
+import org.labkey.test.components.core.ApiKeyPanel;
 import org.labkey.test.components.ui.grids.QueryGrid;
-import org.labkey.test.credentials.ApiKeyDialog;
 import org.labkey.test.pages.core.admin.CustomizeSitePage;
 import org.labkey.test.util.Maps;
 import org.labkey.test.util.TestUser;
@@ -373,27 +373,13 @@ public class ApiKeyTest extends BaseWebDriverTest
     private String generateSessionKey()
     {
         goToExternalToolPage();
-        waitForText("API keys are used to authorize");
-        clickButton("Generate Session Key", 0);
-        ApiKeyDialog dialog = new ApiKeyDialog(this.getDriver(), ApiKeyDialog.SESSION_KEY_TITLE);
-        waitForFormElementToNotEqual(Locator.inputByNameContaining("session_token"), "");
-        String key = Locator.inputByNameContaining("session_token").findElement(getDriver()).getAttribute("value");
-        dialog.clickDone();
-        return key;
+        return ApiKeyPanel.panelFinder(getDriver()).find().generateSessionKey();
     }
 
     private String generateAPIKey(@Nullable String description)
     {
         goToExternalToolPage();
-        clickButton("Generate API Key", 0);
-        ApiKeyDialog dialog = new ApiKeyDialog(this.getDriver(), ApiKeyDialog.API_KEY_TITLE);
-        if (description != null)
-            dialog.setDescription(description);
-        dialog = dialog.generateApiKey();
-        waitForFormElementToNotEqual(Locator.inputByNameContaining("apikey_token"), "");
-        String key = Locator.inputByNameContaining("apikey_token").findElement(getDriver()).getAttribute("value");
-        dialog.clickDone();
-        return key;
+        return ApiKeyPanel.panelFinder(getDriver()).find().generateApiKey(description);
     }
 
     private String generateAPIKeyAndRecord(List<Map<String, Object>> _generatedApiKeys) throws IOException


### PR DESCRIPTION
#### Rationale
Tests should use shared components when able. `ApiKeyPanel` should live in `testAutomation` since it isn't specific to sample manager.

#### Related Pull Requests
* https://github.com/LabKey/nlp/pull/251
* https://github.com/LabKey/limsModules/pull/816

#### Changes
* Update API key tests to use ApiKeyPanel and ApiKeyDialog
* Relocate ApiKeyPanel and ApiKeyDialog to `org.labkey.test.components.core`