### PR TITLE
Test coverage for Issue 39496

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -535,7 +535,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         public FilteringReactSelect findSelect(String fieldCaption)
         {
             WebElement container = Locator.tag("td").withAttribute("data-caption", fieldCaption).findElement(this);
-            return FilteringReactSelect.finder(_driver).find(container);
+            return FilteringReactSelect.finder(_driver).timeout(_readyTimeout).waitFor(container);
         }
     }
 

--- a/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
+++ b/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
@@ -10,7 +10,6 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.admin.ExportFolderPage;
-import org.labkey.test.pages.samplemanagement.assay.AssayResultsPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.assay.GeneralAssayDesign;
 import org.labkey.test.tests.MissingValueIndicatorsTest;

--- a/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
+++ b/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
@@ -264,6 +264,12 @@ public class AssayMissingValuesTest extends MissingValueIndicatorsTest
         var dataRegion = DataRegionTable.DataRegion(getDriver()).waitFor();
 
         // expect 3 rows in this assay, p2 and p3 should get mv indicators in the count column
+        Map<String, List<String>> expectedData = new HashMap<>();
+        expectedData.put("Participant ID", List.of("p1", "p2", "p3"));
+        expectedData.put("Visit ID", List.of("1", "1", "1"));
+        expectedData.put("Count", List.of("4", "N", "Q"));
+        checkDataregionData(dataRegion, expectedData);
+
         Map<String, List<Integer>> expectedMVIndicators = new HashMap<>();
         expectedMVIndicators.put("Count", List.of(1, 2));
         checkMvIndicatorPresent(dataRegion, expectedMVIndicators);

--- a/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
+++ b/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
@@ -1,13 +1,18 @@
 package org.labkey.test.tests.assay;
 
+import org.intellij.lang.annotations.Language;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.domain.PropertyDescriptor;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.admin.ExportFolderPage;
+import org.labkey.test.pages.samplemanagement.assay.AssayResultsPage;
+import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.assay.GeneralAssayDesign;
 import org.labkey.test.tests.MissingValueIndicatorsTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
@@ -215,6 +220,54 @@ public class AssayMissingValuesTest extends MissingValueIndicatorsTest
         multiExpectedMVIndicators.put("Sex", List.of(2, 5, 8, 11));
         checkMvIndicatorPresent(dataRegion, multiExpectedMVIndicators);
         testMvFiltering(List.of("age", "sex"));
+    }
+
+    /**
+     * provides regression coverage for Issue 39496
+     * @throws Exception there was an exception creating the assay for this test
+     */
+    @Test
+    public void testSaveBatchAPIMissingValues() throws Exception
+    {
+        // create the assay
+        String assayName = "missingValueSaveBatchAPIAssay";
+        List<PropertyDescriptor> dataFields = List.of(
+                new FieldDefinition("ParticipantId", FieldDefinition.ColumnType.String),
+                new FieldDefinition("VisitId", FieldDefinition.ColumnType.Integer),
+                new FieldDefinition("Count", FieldDefinition.ColumnType.Integer).setMvEnabled(true));
+
+        var serverProtocol = new GeneralAssayDesign(assayName)
+                .setBatchFields(List.of(new FieldDefinition("batchData", FieldDefinition.ColumnType.String)), false)
+                .setDataFields(dataFields, false)
+                .createAssay(getProjectName(), createDefaultConnection());
+
+        @Language("JavaScript") String saveBatch = """
+                LABKEY.Experiment.saveBatch({
+                    assayId: %protocolId%,
+                    batch: {
+                        runs: [{
+                            name: 'js api',
+                            dataRows : [
+                                {participantId : 'p1', visitId : 1, count : 4.0},
+                                {participantId : 'p2', visitId : 1, count : 'N'},
+                                {participantId : 'p3', visitId : 1, count : 5, countMVIndicator : 'Q'}
+                            ]
+                        }]
+                    }
+                });
+                """.replace("%protocolId%", serverProtocol.getProtocolId().toString());
+        executeScript(saveBatch);
+
+        // navigate to the results view
+        goToProjectHome();
+        clickAndWait(Locator.linkWithText(assayName));
+        clickAndWait(Locator.linkWithText("view results"));
+        var dataRegion = DataRegionTable.DataRegion(getDriver()).waitFor();
+
+        // expect 3 rows in this assay, p2 and p3 should get mv indicators in the count column
+        Map<String, List<Integer>> expectedMVIndicators = new HashMap<>();
+        expectedMVIndicators.put("Count", List.of(1, 2));
+        checkMvIndicatorPresent(dataRegion, expectedMVIndicators);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
This adds regression coverage for Issue 39496, which verifies that missing values written to an assay via the `SaveBatch `API are handled as expected.

On a related note, this test sets up a simple way to verify whether or not missingValue indicators should be exported or not; [Issue 37610](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=37610) tracks this question and is a very stale issue; current behavior is to export empty values (not showing missing-value indicators as they appear in the dataregion) and in the years this issue has been around, nobody has asked for a fix.  (so, this might be an opportune time to decide whether or not to expect missingValue indicators to be exported)

It also attempts to address the intermittent test failure in [BiologicsSampleTimelineTest.testEditSampleDetailCausesTimelineEvent](https://teamcity.labkey.org/viewLog.html?buildId=3226197&buildTypeId=LabKey_2410Release_Premium_ProductSuites_Biologics_LimsStarter_LimsStarterB&fromSakuraUI=true#testNameId-6192646934553344580), which seems to be caused by a race condition in which the test looks for a select in `DetailTableEdit `before it is rendered, without waiting for it to appear.

#### Related Pull Requests
n/a

#### Changes

- [ ] add a new test case
- [ ] try to fix intermittent test failure 
