### PR TITLE
Fix missing import in test distribution

### DIFF
--- a/distributions/teamcity/build.gradle
+++ b/distributions/teamcity/build.gradle
@@ -1,3 +1,4 @@
+import org.labkey.gradle.plugin.Distribution
 import org.labkey.gradle.plugin.FileModule
 import org.labkey.gradle.task.ModuleDistribution
 import org.labkey.gradle.util.BuildUtils
@@ -15,12 +16,13 @@ dist.description = "Distribution that includes all modules, for use in the conti
 
 project.tasks.register("distribution", ModuleDistribution) {
     ModuleDistribution dist ->
-        dist.group = GroupNames.DISTRIBUTION
         dist.description = "Make a LabKey modules distribution for 'test'"
 
         dist.subDirName = "test"
         dist.extraFileIdentifier = '-test'
         dist.versionPrefix = 'Test'
+
+        dist.extraProperties = [supportedDatabases: "pgsql, mssql"]
 }
 
 

--- a/distributions/teamcity/build.gradle
+++ b/distributions/teamcity/build.gradle
@@ -16,13 +16,12 @@ dist.description = "Distribution that includes all modules, for use in the conti
 
 project.tasks.register("distribution", ModuleDistribution) {
     ModuleDistribution dist ->
+        dist.group = GroupNames.DISTRIBUTION
         dist.description = "Make a LabKey modules distribution for 'test'"
 
         dist.subDirName = "test"
         dist.extraFileIdentifier = '-test'
         dist.versionPrefix = 'Test'
-
-        dist.extraProperties = [supportedDatabases: "pgsql, mssql"]
 }
 
 


### PR DESCRIPTION
#### Rationale
IntelliJ accidentally removed a gradle import from the teamcity distribution.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2080

#### Changes
- Revert accidental import removal
