### PR TITLE
Adjust build.gradle for new Artifactory Plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -198,7 +198,6 @@ if (project.hasProperty('doPublishing'))
                                 username = artifactory_user
                                 password = artifactory_password
                             }
-                            maven = true
                         }
                         defaults
                                 {


### PR DESCRIPTION
#### Rationale
The newest Artifactory Plugin version doesn't support the `maven` property

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/220
* https://github.com/LabKey/server/pull/907