### PR TITLE
Update Version Referenced in testAutomation/gradle.properties.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ jettyVersion=12.0.4
 seleniumVersion=4.18.0
 mockserverNettyVersion=5.15.0
 
-labkeySchemasTestVersion=23.11-SNAPSHOT
+labkeySchemasTestVersion=24.11-SNAPSHOT


### PR DESCRIPTION
#### Rationale
Should be referencing a more recent version of the published APIs.
Changes to CPUTimer in platform are not getting picked up by TeamCity when building the tests in this branch. This was causing build failures and needed to be fixed.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/812

#### Changes
- Update to reference version 24.11 of the LabKey APIs.
