### PR TITLE
Add method for choosing a value from a selection list based on index

### DIFF
--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -346,6 +346,21 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
     }
 
     /**
+     * Opens the select menu and gets the web elements corresponding to the items in the dropdown list.
+     *
+     * @return List of web elements for the options in the opened select menu
+     */
+    public List<WebElement> getOptionElements()
+    {
+        boolean alreadyOpened = isExpanded();
+
+        // Can only get the list of items once the list has been opened.
+        if (!alreadyOpened)
+            open();
+        return Locators.listItems.findElements(getComponentElement());
+    }
+
+    /**
      * Get the items that are in the dropdown list. That is the items that may be selected.
      *
      * @return List of strings for the values in the list.

--- a/src/org/labkey/test/components/react/ReactSelect.java
+++ b/src/org/labkey/test/components/react/ReactSelect.java
@@ -101,7 +101,7 @@ public class ReactSelect extends BaseReactSelect<ReactSelect>
                     // clear any value that may have been entered in the text box, this should protect against that as well.
                     enterValueInTextbox(option);
 
-                    // Don't know if this is will work as expected. It may take a moment for the list to populate
+                    // Don't know if this will work as expected. It may take a moment for the list to populate
                     // after typing in a value.
                     waitFor(()->!getOptions().contains("Loading..."), 1_000);
 
@@ -128,7 +128,7 @@ public class ReactSelect extends BaseReactSelect<ReactSelect>
         }
 
         assertTrue("Expected '" + option + "' to be displayed.", optionEl.isDisplayed());
-        sleep(500); // either react or the test is moving to fast/slow for one another
+        sleep(500); // either react or the test is moving too fast/slow for one another
         TestLogger.debug("optionEl is displayed, clicking");
         optionEl.click();
 

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -373,6 +373,24 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 
     /**
      * <p>
+     *     For a given column, 'columnNameToSet', set the lookup cell in the first row where the value in column 'columnNameToSearch'
+     *     equals 'valueToSearch'. The value chosen will be at the specified index in the lookup options. Supply a 'value' in order to
+     *     filter the set of options shown.
+     * </p>
+     *
+     * @param columnNameToSearch The name of the column to check if a row should be updated or not.
+     * @param valueToSearch The value to check for in 'columnNameToSearch' to see if the row should be updated.
+     * @param columnNameToSet The column to update in a row.
+     * @param value Optional value to supply for filtering lookup options before selection
+     * @param index The 0-based index of the option to choose from the possibly filtered list of options.
+     */
+    public void setCellValueForLookup(String columnNameToSearch, String valueToSearch, String columnNameToSet, @Nullable String value, int index)
+    {
+        setCellValueForLookup(getRowIndex(columnNameToSearch, valueToSearch), columnNameToSet, value, index);
+    }
+
+    /**
+     * <p>
      *     For a given column, 'columnNameToSet', set the cell in the row if value in column 'columnNameToSearch'
      *     equals 'valueToSearch'.
      * </p>
@@ -412,6 +430,34 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
     public WebElement setCellValue(int row, String columnName, Object value)
     {
         return setCellValue(row, columnName, value, true);
+    }
+
+    /**
+     * <p>
+     * For the identified row set the value in the identified lookup column by selecting the given index in the lookup list.
+     * </p>
+     *
+     * @param row        Index of the row (0 based).
+     * @param columnName Name of the column to update.
+     * @param value      Optional value to type in to filter the options shown
+     * @param index      The index of the option to select for the lookup
+     * @return cell WebElement
+     */
+    public WebElement setCellValueForLookup(int row, String columnName, @Nullable String value, int index)
+    {
+        WebElement gridCell = selectCell(row, columnName);
+
+        ReactSelect lookupSelect = elementCache().lookupSelect(gridCell);
+
+        lookupSelect.open();
+        if (value != null)
+            lookupSelect.enterValueInTextbox(value);
+
+        List<WebElement> elements = lookupSelect.getOptionElements();
+        if (elements.size() < index)
+            throw new NotFoundException("Could not select option at index " + index + " in lookup for " + columnName + ". Only " + elements.size() + " options found.");
+        elements.get(index).click();
+        return gridCell;
     }
 
     /**


### PR DESCRIPTION
#### Rationale
With our selection dropdowns now possibly including identifying field data, the selection based on exact match for the text of the option will not work. This PR adds some utility methods for choosing from a lookup based on the expected index of the option. 

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/841

#### Changes
- Add `getOptionElements` method to `BaseReactSelect`
- Add a couple of `setCellValueForLookup` methods that accept integer indexes for the option to be chosen
