### PR TITLE
Update test to attempt delete using RowId

### DIFF
--- a/src/org/labkey/test/tests/FolderTest.java
+++ b/src/org/labkey/test/tests/FolderTest.java
@@ -372,14 +372,14 @@ public class FolderTest extends BaseWebDriverTest
             SelectRowsCommand sr = new SelectRowsCommand("core", "workbooks");
             sr.setColumns(Arrays.asList("EntityId"));
             SelectRowsResponse srr = sr.execute(cn, getProjectName() + "/WorkbookParent");
-            Object entityId = srr.getRows().get(0).get("EntityId");
+            Object rowId = srr.getRows().get(0).get("RowId");
 
             DeleteRowsCommand drc = new DeleteRowsCommand("core", "workbooks");
             Map<String, Object> row1 = new HashMap<>();
-            row1.put("EntityId", entityId);
+            row1.put("RowId", rowId);
             drc.addRow(row1);
 
-            SaveRowsResponse resp = drc.execute(new Connection(WebTestHelper.getBaseURL(), PasswordUtil.getUsername(), PasswordUtil.getPassword()), getContainerId());
+            SaveRowsResponse resp = drc.execute(cn, getContainerId());
 
             throw new Exception("That command should have failed");
         }


### PR DESCRIPTION
#### Rationale
`RowId` is now the primary key of `core.Containers`, but `FolderTest` didn't get the memo

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5952
