### PR TITLE
Issue 51225: Allow calculation fields to be created via API in tests

### DIFF
--- a/data/api/rlabkey-api-list.xml
+++ b/data/api/rlabkey-api-list.xml
@@ -3,7 +3,7 @@
         <url>
             <![CDATA[
                 library(Rlabkey)
-                df <- data.frame(intKey=c(1:3), customInt=c(1:3), customString=c("aaa", "bbb", "ccc"))
+                df <- data.frame(intKey=c(1:3), customInt=c(1:3), customString=c("aaa", "bbb", "ccc"), customDec=c(1.1, 2.2, 3.3))
                 fields <- labkey.domain.inferFields(baseUrl=labkey.url.base, folderPath="%projectName%", df)
                 indices = labkey.domain.createIndices(list("intKey", "customInt"), TRUE)
                 indices = labkey.domain.createIndices(list("customInt"), FALSE, indices)
@@ -26,7 +26,8 @@
                 library(Rlabkey)
                 newrow <- data.frame(
                     customInt=1
-                    , customString="custom string value")
+                    , customString="custom string value"
+                    , customDec="1.234E-5") # issue 51160
 
                 print(labkey.insertRows(baseUrl=labkey.url.base, folderPath="%projectName%", schemaName="lists", queryName="test list", toInsert=newrow))
             ]]>
@@ -41,6 +42,8 @@
                 [1] 1
                 $rows[[1]]$customString
                 [1] "custom string value"
+                $rows[[1]]$customDec
+                [1] 1.234e-05
             ]]>
         </response>
     </test>

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -735,6 +735,11 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         return "on".equals(fieldRow.getAttribute("unselectable"));
     }
 
+    public WebElement getColumn(String fieldKey)
+    {
+        return expandPivots(fieldKey.split("/"));
+    }
+
     /** Check that a column is present and not hidden. Assumes that the 'show hidden columns' is unchecked. */
     public boolean isColumnVisible(String fieldKey)
     {

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -219,6 +219,12 @@ public class FieldDefinition extends PropertyDescriptor
         return this;
     }
 
+    public FieldDefinition setValueExpression(String valueExpression)
+    {
+        setFieldProperty("valueExpression", valueExpression);
+        return this;
+    }
+
     public Integer getScale()
     {
         return (Integer) getFieldProperty("scale");


### PR DESCRIPTION
#### Rationale
Issue [51225](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51225): Add the ability to create an entity with a calculated column using the API

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/850

#### Changes
- add `FieldDefinition. setValueExpression`
