### PR TITLE
Issue 50861: Pass around properly encoded WebDav URLs

### DIFF
--- a/src/org/labkey/test/pages/files/CustomizeFilesWebPartPage.java
+++ b/src/org/labkey/test/pages/files/CustomizeFilesWebPartPage.java
@@ -18,10 +18,15 @@ package org.labkey.test.pages.files;
 import org.labkey.test.Locator;
 import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.selenium.LazyWebElement;
+import org.labkey.test.util.FileBrowserHelper;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.labkey.test.Locators.pageSignal;
+import static org.labkey.test.util.FileBrowserHelper.FILE_LIST_SIGNAL_NAME;
+import static org.labkey.test.util.FileBrowserHelper.encodeFileNodeIdPart;
 
 /**
  * Created by susanh on 9/20/17.
@@ -31,6 +36,7 @@ public class CustomizeFilesWebPartPage extends LabKeyPage<CustomizeFilesWebPartP
     public CustomizeFilesWebPartPage(WebDriver driver)
     {
         super(driver);
+        waitForElement(pageSignal(FILE_LIST_SIGNAL_NAME));
     }
 
     public String getTitle()
@@ -51,12 +57,10 @@ public class CustomizeFilesWebPartPage extends LabKeyPage<CustomizeFilesWebPartP
         return getText(selectedNodeLoc);
     }
 
-    public CustomizeFilesWebPartPage setFileRoot(String... nodeParts)
+    public void setFileRoot(String... nodeParts)
     {
         selectFileRoot(true, nodeParts);
         submit();
-        sleep(3000);
-        return this;
     }
 
     public CustomizeFilesWebPartPage selectFileRoot(boolean nodeExist, String... nodeParts)
@@ -64,26 +68,32 @@ public class CustomizeFilesWebPartPage extends LabKeyPage<CustomizeFilesWebPartP
         if (isExtTreeNodeSelected(nodeParts[nodeParts.length - 1]))
             return this;
 
-        String nodeWithParents = "";
+        StringBuilder nodeId = new StringBuilder();
+        StringBuilder nodeWithParents = new StringBuilder();
         String separator = "";
         for (String node : nodeParts)
         {
-            nodeWithParents += separator + node;
-            separator = ".";
+            nodeWithParents.append(separator).append(node);
+            separator = "/";
 
-            Locator.XPathLocator loc = Locators.fileRootTreeNode(node);
+            nodeId.append(encodeFileNodeIdPart(node));
+            if (!node.isEmpty())
+            {
+                nodeId.append('/');
+            }
+            WebElement nodeEl = Locators.fileRootTreeNode(nodeId.toString()).findWhenNeeded(getDriver());
 
             if (!nodeExist)
             {
                 sleep(1000);
-                if (!isElementPresent(loc))
+                if (!nodeEl.isDisplayed())
                     return this;
             }
 
-            shortWait().until(ExpectedConditions.elementToBeClickable(loc));
+            shortWait().until(ExpectedConditions.elementToBeClickable(nodeEl));
             Locator.XPathLocator selectedNode = Locator.xpath("//tr").withClass("x4-grid-row-selected").append("/td/div/span").withText(node);
 
-            if (isElementPresent(selectedNode))
+            if (nodeEl.getDomAttribute("class").contains("selected"))
                 continue; // already selected
 
             log("Selecting node " + nodeWithParents + " ...");
@@ -91,15 +101,15 @@ public class CustomizeFilesWebPartPage extends LabKeyPage<CustomizeFilesWebPartP
             // select/expand tree node
             try
             {
-                scrollIntoView(loc);
+                scrollIntoView(nodeEl);
             }
-            catch (StaleElementReferenceException ignore)
+            catch (StaleElementReferenceException log)
             {
-                log(ignore.getMessage());
+                log(log.getMessage());
             }
 
-            click(loc);
-            waitForElement(selectedNode, 2000);
+            doAndWaitForPageSignal(nodeEl::click, FILE_LIST_SIGNAL_NAME);
+            waitFor(() -> nodeEl.getDomAttribute("class").contains("selected"), "Node note selected: " + nodeWithParents, 2000);
         }
 
         if (!nodeExist)
@@ -108,10 +118,10 @@ public class CustomizeFilesWebPartPage extends LabKeyPage<CustomizeFilesWebPartP
         return this;
     }
 
-    public CustomizeFilesWebPartPage submit()
+    public void submit()
     {
         clickAndWait(elementCache().submitButton);
-        return new CustomizeFilesWebPartPage(getDriver());
+        new FileBrowserHelper(this).waitForFileGridReady();
     }
 
     public void verifyFileRootNodePresent(String... nodeParts)
@@ -130,17 +140,18 @@ public class CustomizeFilesWebPartPage extends LabKeyPage<CustomizeFilesWebPartP
         return new ElementCache();
     }
 
-    protected class ElementCache extends LabKeyPage.ElementCache
+    protected class ElementCache extends LabKeyPage<ElementCache>.ElementCache
     {
-        protected WebElement title = new LazyWebElement(Locator.tagWithName("input", "title"), this);
+        protected WebElement title = new LazyWebElement<>(Locator.tagWithName("input", "title"), this);
         protected WebElement submitButton = Locator.lkButton("Submit").findWhenNeeded(this);
     }
 
     public static class Locators
     {
-        public static Locator.XPathLocator fileRootTreeNode(String nodeName)
+        public static Locator.XPathLocator fileRootTreeNode(String nodeId)
         {
-            return Locator.tag("tr").withClass("x4-grid-row").append("/td/div/span").withText(nodeName);
+            Locator.XPathLocator fBrowser = Locator.tagWithClass("div", "fbrowser");
+            return fBrowser.append(Locator.tag("tr").withPredicate("starts-with(@id, 'treeview')").attributeEndsWith("data-recordid", nodeId));
         }
     }
 }

--- a/src/org/labkey/test/pages/files/WebDavPage.java
+++ b/src/org/labkey/test/pages/files/WebDavPage.java
@@ -25,7 +25,7 @@ import org.openqa.selenium.WebElement;
 
 public class WebDavPage extends LabKeyPage<WebDavPage.ElementCache>
 {
-    private FileBrowserHelper _fileBrowserHelper;
+    private final FileBrowserHelper _fileBrowserHelper;
     public WebDavPage(WebDriver driver)
     {
         super(driver);
@@ -43,9 +43,14 @@ public class WebDavPage extends LabKeyPage<WebDavPage.ElementCache>
         return _fileBrowserHelper;
     }
 
-    public String getWebDavUrl()
+    public WebElement getWebDavUrl()
     {
-        return elementCache().webDavUrlElement.getText();
+        return elementCache().webDavUrlElement;
+    }
+
+    public String getAbsolutePath()
+    {
+        return elementCache().absolutePathElement.getText();
     }
 
     @Override
@@ -54,12 +59,14 @@ public class WebDavPage extends LabKeyPage<WebDavPage.ElementCache>
         return new ElementCache();
     }
 
-    protected class ElementCache extends LabKeyPage.ElementCache
+    protected class ElementCache extends LabKeyPage<ElementCache>.ElementCache
     {
         WebElement htmlViewButton = Locator.button("HTML View").findWhenNeeded(this);
 
         WebElement fbDetailsTable = Locator.tagWithClass("table", "fb-details").findWhenNeeded(this);
-        WebElement webDavUrlElement = Locator.tagWithText("th", "WebDav URL:").followingSibling("a")
+        WebElement webDavUrlElement = Locator.tagWithText("th", "WebDav URL:").followingSibling("td").childTag("a")
                 .findWhenNeeded(fbDetailsTable);
+        WebElement absolutePathElement = Locator.tagWithText("th", "Absolute Path:").followingSibling("td")
+            .findWhenNeeded(fbDetailsTable);
     }
 }

--- a/src/org/labkey/test/pages/files/WebFilesHtmlViewPage.java
+++ b/src/org/labkey/test/pages/files/WebFilesHtmlViewPage.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.pages.files;
 
+import org.eclipse.jetty.util.URIUtil;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
@@ -36,7 +37,7 @@ public class WebFilesHtmlViewPage extends LabKeyPage<WebFilesHtmlViewPage.Elemen
 
     public static WebFilesHtmlViewPage beginAt(WebDriverWrapper driver, String containerPath)
     {
-        driver.beginAt(WebTestHelper.getBaseURL() + "/_webfiles/" + containerPath + "/?listing=html");
+        driver.beginAt(WebTestHelper.getBaseURL() + "/_webfiles/" + URIUtil.encodePath(containerPath) + "/?listing=html");
         return new WebFilesHtmlViewPage(driver.getDriver());
     }
 

--- a/src/org/labkey/test/tests/WebDavTest.java
+++ b/src/org/labkey/test/tests/WebDavTest.java
@@ -67,7 +67,7 @@ public class WebDavTest extends BaseWebDriverTest
     @Override
     protected String getProjectName()
     {
-        return "WebDavTest Project";
+        return "WebDavTest Project" + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
     }
 
     @BeforeClass

--- a/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
@@ -16,6 +16,8 @@
 
 package org.labkey.test.tests.filecontent;
 
+import org.apache.hc.client5.http.utils.URIUtils;
+import org.eclipse.jetty.util.URIUtil;
 import org.hamcrest.CoreMatchers;
 import org.jetbrains.annotations.NotNull;
 import org.junit.BeforeClass;
@@ -46,10 +48,13 @@ import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SearchHelper;
 import org.labkey.test.util.Timer;
+import org.labkey.test.util.core.webdav.WebDavUtils;
 import org.openqa.selenium.WebElement;
 
 import java.io.File;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -92,7 +97,7 @@ public class FileContentUploadTest extends BaseWebDriverTest
     {
         // Use a special exotic character in order to make sure we don't break
         // i18n. See https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=5369
-        return "File Content T\u017Dst Project";
+        return "File Content T\u017Dst Project" + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
     }
 
     @BeforeClass
@@ -245,8 +250,7 @@ public class FileContentUploadTest extends BaseWebDriverTest
         assertThat("Absolute file path for file", absolutePath, CoreMatchers.containsString(s + "@files" + s + filename));
 
         log("Check Absolute File Path in WebDav");
-        URL webdavURL = new URL(WebTestHelper.getBaseURL() + "/_webdav" + getCurrentContainerPath() + "/@files");
-        goToURL(webdavURL, 5000);
+        beginAt(WebDavUtils.buildBaseWebDavUrl(getCurrentContainerPath()));
         waitForText("WebDav URL");
         absolutePath = Locator.byClass("fb-details")
                 .append(Locator.tagWithText("th", "Absolute Path:").followingSibling("td"))

--- a/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
@@ -287,7 +287,7 @@ public class FileContentUploadTest extends BaseWebDriverTest
     @Test
     public void testFileNameCharacters() throws IOException
     {
-        String folderName = "Test folder names";
+        String folderName = "Test file name characters";
 
         goToProjectHome();
         goToModule("FileContent");

--- a/src/org/labkey/test/tests/filecontent/FilesWebpartFileRootTest.java
+++ b/src/org/labkey/test/tests/filecontent/FilesWebpartFileRootTest.java
@@ -90,7 +90,6 @@ public class FilesWebpartFileRootTest extends BaseWebDriverTest
         CustomizeFilesWebPartPage customizePage = new CustomizeFilesWebPartPage(getDriver());
         Assert.assertEquals("Default webpart file root should be set at @files", "@files", customizePage.getFileRoot());
         customizePage.setFileRoot("@files", folderName);
-        _fileBrowserHelper.selectFileBrowserRoot();
         Assert.assertEquals("File in custom file root", List.of(testFile.getName()), _fileBrowserHelper.getFileList());
 
         goToProjectHome();

--- a/src/org/labkey/test/tests/filecontent/FilesWebpartFileRootTest.java
+++ b/src/org/labkey/test/tests/filecontent/FilesWebpartFileRootTest.java
@@ -30,6 +30,7 @@ import org.labkey.test.pages.files.CustomizeFilesWebPartPage;
 import org.labkey.test.util.FileBrowserHelper;
 import org.labkey.test.util.PortalHelper;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
@@ -50,7 +51,8 @@ public class FilesWebpartFileRootTest extends BaseWebDriverTest
     @Override
     protected @Nullable String getProjectName()
     {
-        return "FilesWebpartFileRootProject";
+        // TODO: Add tricky characters
+        return "FilesWebpartFileRootProject";// + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
     }
 
     @BeforeClass
@@ -78,9 +80,19 @@ public class FilesWebpartFileRootTest extends BaseWebDriverTest
     @Test
     public void testCustomFileRoot()
     {
+        String folderName = "Folder " + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
+        File testFile = TestFileUtils.getSampleData("fileTypes/sample.txt");
+
+        _fileBrowserHelper.createFolder(folderName);
+        _fileBrowserHelper.selectFileBrowserItem(folderName + "/");
+        _fileBrowserHelper.uploadFile(testFile);
+
         portalHelper.clickWebpartMenuItem("Files", true, "Customize");
         CustomizeFilesWebPartPage customizePage = new CustomizeFilesWebPartPage(getDriver());
         Assert.assertEquals("Default webpart file root should be set at @files", "@files", customizePage.getFileRoot());
+        customizePage.setFileRoot("@files", folderName);
+        _fileBrowserHelper.selectFileBrowserRoot();
+        Assert.assertEquals("File in custom file root", List.of(testFile.getName()), _fileBrowserHelper.getFileList());
 
         goToProjectHome();
 

--- a/src/org/labkey/test/tests/filecontent/FilesWebpartFileRootTest.java
+++ b/src/org/labkey/test/tests/filecontent/FilesWebpartFileRootTest.java
@@ -51,8 +51,7 @@ public class FilesWebpartFileRootTest extends BaseWebDriverTest
     @Override
     protected @Nullable String getProjectName()
     {
-        // TODO: Add tricky characters
-        return "FilesWebpartFileRootProject";// + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
+        return "FilesWebpartFileRoot Project" + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
     }
 
     @BeforeClass

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -251,7 +251,8 @@ public class FileBrowserHelper extends WebDriverWrapper
         }
     }
 
-    public void selectSingleFile(String fileName)
+    @LogMethod (quiet = true)
+    public void selectSingleFile(@LoggedParam String fileName)
     {
         WebElement row = scrollToGridRow(encodeFileNodeIdPart(fileName));
         WebElement nameCell = Locator.tagWithAttribute("td", "role", "gridcell").withText(fileName).findElement(row);

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -121,7 +121,7 @@ public class FileBrowserHelper extends WebDriverWrapper
 
         for (int i = 0; i < parts.length; i++)
         {
-            parts[i] = URLEncoder.encode(parts[i], StandardCharsets.UTF_8).replace("+", "%20");
+            parts[i] = encodeFileNodeIdPart(parts[i]);
             nodeId.append(parts[i]);
             if (!parts[i].isEmpty())
             {
@@ -810,6 +810,11 @@ public class FileBrowserHelper extends WebDriverWrapper
         }
     }
 
+    private static String encodeFileNodeIdPart(String rawIdPart)
+    {
+        return URLEncoder.encode(rawIdPart, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
     public static abstract class Locators
     {
         static Locator.XPathLocator fBrowser = Locator.tagWithClass("div", "fbrowser");
@@ -840,7 +845,7 @@ public class FileBrowserHelper extends WebDriverWrapper
 
         public static Locator.XPathLocator gridRow(String fileName)
         {
-            return gridRowWithNodeId("/" + fileName);
+            return gridRowWithNodeId("/" + encodeFileNodeIdPart(fileName));
         }
 
         public static Locator.XPathLocator gridRowWithNodeId(String nodeIdEndsWith)

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -38,6 +38,8 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.io.File;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -119,8 +121,9 @@ public class FileBrowserHelper extends WebDriverWrapper
 
         for (int i = 0; i < parts.length; i++)
         {
+            parts[i] = URLEncoder.encode(parts[i], StandardCharsets.UTF_8).replace("+", "%20");
             nodeId.append(parts[i]);
-            if (!parts[i].equals(""))
+            if (!parts[i].isEmpty())
             {
                 nodeId.append('/');
             }
@@ -181,7 +184,7 @@ public class FileBrowserHelper extends WebDriverWrapper
         final Locator.XPathLocator folderTreeNodeLoc = fBrowser.append(Locator.tag("tr").withPredicate("starts-with(@id, 'treeview')").attributeEndsWith("data-recordid", nodeId));
 
         final WebElement folderTreeNode = waitForElement(folderTreeNodeLoc);
-        waitForElementToDisappear(Locator.xpath("//tbody[starts-with(@id, 'treeview')]/tr[not(starts-with(@id, 'treeview'))]")); // temoporary row exists during expansion animation
+        waitForElementToDisappear(Locator.xpath("//tbody[starts-with(@id, 'treeview')]/tr[not(starts-with(@id, 'treeview'))]")); // temporary row exists during expansion animation
 
         boolean atRoot = !isElementPresent(fBrowser.append(Locator.byClass("x4-grid-row-selected"))); // Root node is not initially highlighted
         if (atRoot && "0".equals(folderTreeNode.getAttribute("data-recordindex")))
@@ -296,7 +299,7 @@ public class FileBrowserHelper extends WebDriverWrapper
         selectFileBrowserItem(currentName);
         doAndWaitForFileListRefresh(() -> {
             clickFileBrowserButton(BrowserAction.RENAME);
-            Window renameWindow = Window(getDriver()).withTitle("Rename").waitFor();
+            Window<?> renameWindow = Window(getDriver()).withTitle("Rename").waitFor();
             setFormElement(Locator.name("renameText-inputEl").findElement(renameWindow), newName);
             renameWindow.clickButton("Rename", WAIT_FOR_EXT_MASK_TO_DISSAPEAR);
         });
@@ -308,7 +311,7 @@ public class FileBrowserHelper extends WebDriverWrapper
         selectFileBrowserItem(fileName);
         doAndWaitForFileListRefresh(() -> {
             clickFileBrowserButton(BrowserAction.MOVE);
-            Window moveWindow = Window(getDriver()).withTitle("Choose Destination").waitFor();
+            Window<?> moveWindow = Window(getDriver()).withTitle("Choose Destination").waitFor();
             //NOTE:  this doesn't yet support nested folders
             WebElement folder = Locator.tagWithClass("span", "x4-tree-node-text").withText(destinationPath).waitForElement(moveWindow, 1000);
             shortWait().until(LabKeyExpectedConditions.animationIsDone(folder));
@@ -390,7 +393,7 @@ public class FileBrowserHelper extends WebDriverWrapper
     public void setDescription(String fileName, String description)
     {
         doAndWaitForFileListRefresh(() -> {
-            Window propWindow = editProperty(fileName);
+            Window<?> propWindow = editProperty(fileName);
             setFormElement(Locator.name("Flag/Comment"), description);
             propWindow.clickButton("Save", true);
             _ext4Helper.waitForMaskToDisappear();
@@ -403,7 +406,7 @@ public class FileBrowserHelper extends WebDriverWrapper
         return Locators.gridRow(fileName).childTag("td").position(7).refindWhenNeeded(getDriver()).getText();
     }
 
-    public Window editProperty(String fileName)
+    public Window<?> editProperty(String fileName)
     {
         selectFileBrowserItem(fileName);
         clickFileBrowserButton(BrowserAction.EDIT_PROPERTIES);
@@ -468,7 +471,7 @@ public class FileBrowserHelper extends WebDriverWrapper
     public DomainDesignerPage goToEditProperties()
     {
         goToAdminMenu();
-        Window window = Window.Window(getDriver()).withTitle("Manage File Browser Configuration").waitFor();
+        Window<?> window = Window.Window(getDriver()).withTitle("Manage File Browser Configuration").waitFor();
         Ext4Checkbox().locatedBy(Locator.id("importAction-inputEl")).waitFor(window).check();
 
         waitAndClick(Ext4Helper.Locators.ext4Tab("File Properties"));
@@ -477,7 +480,7 @@ public class FileBrowserHelper extends WebDriverWrapper
         return new DomainDesignerPage(getDriver());
     }
 
-    public Window clickImportData()
+    public Window<?> clickImportData()
     {
         doAndWaitForPageSignal(() -> clickFileBrowserButton(BrowserAction.IMPORT_DATA), IMPORT_SIGNAL_NAME);
         return Window(getDriver()).withTitle("Import Data").waitFor();
@@ -485,7 +488,7 @@ public class FileBrowserHelper extends WebDriverWrapper
 
     public void selectImportDataAction(@LoggedParam String actionName)
     {
-        Window importWindow = clickImportData();
+        Window<?> importWindow = clickImportData();
         RadioButton actionRadioButton = RadioButton().withLabelContaining(actionName).find(importWindow);
         actionRadioButton.check();
         if (!actionRadioButton.isSelected())
@@ -529,7 +532,7 @@ public class FileBrowserHelper extends WebDriverWrapper
 
         openUploadPanel();
 
-        waitFor(() -> getFormElement(Locator.xpath("//label[text() = 'Choose a File:']/../..//input[contains(@class, 'x4-form-field')]")).equals(""),
+        waitFor(() -> getFormElement(Locator.xpath("//label[text() = 'Choose a File:']/../..//input[contains(@class, 'x4-form-field')]")).isEmpty(),
                 "Upload field did not clear after upload.", WAIT_FOR_JAVASCRIPT);
 
         setFormElement(Locator.css(".single-upload-panel input:last-of-type[type=file]"), file);
@@ -545,7 +548,7 @@ public class FileBrowserHelper extends WebDriverWrapper
 
             if (replace)
             {
-                Window confirmation = Window(getDriver()).withTitle("File Conflict:").waitFor();
+                Window<?> confirmation = Window(getDriver()).withTitle("File Conflict:").waitFor();
                 assertTrue("Unexpected confirmation message.", confirmation.getBody().contains("Would you like to replace it?"));
                 confirmation.clickButton("Yes", true);
             }
@@ -557,9 +560,9 @@ public class FileBrowserHelper extends WebDriverWrapper
         if (description != null)
             waitForElement(fileGridCell.withText(description));
 
-        if (fileProperties != null && fileProperties.size() > 0)
+        if (fileProperties != null && !fileProperties.isEmpty())
         {
-            Window propWindow = Window(getDriver()).withTitle("Extended File Properties").waitFor();
+            Window<?> propWindow = Window(getDriver()).withTitle("Extended File Properties").waitFor();
             waitForText("File (1 of ");
             for (FileBrowserExtendedProperty prop : fileProperties)
             {

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -839,7 +839,6 @@ public class FileBrowserHelper extends WebDriverWrapper
     private static final Map<String, String> DECODE_UNRESERVED_MARKS = Map.of(
         "!", "%21",
         "~", "%7E",
-        "'", "%27",
         "(", "%28",
         ")", "%29"
     );

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.util;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.Mutable;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.jetbrains.annotations.Nullable;
@@ -44,6 +45,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -833,9 +835,24 @@ public class FileBrowserHelper extends WebDriverWrapper
         }
     }
 
+    // See PageFlowUtil.encodeURIComponent()
+    private static final Map<String, String> DECODE_UNRESERVED_MARKS = Map.of(
+        "!", "%21",
+        "~", "%7E",
+        "'", "%27",
+        "(", "%28",
+        ")", "%29"
+    );
+
+    // See PageFlowUtil.encodeURIComponent()
     public static String encodeFileNodeIdPart(String rawIdPart)
     {
-        return URLEncoder.encode(rawIdPart, StandardCharsets.UTF_8).replace("+", "%20");
+        String encoded = URLEncoder.encode(rawIdPart, StandardCharsets.UTF_8).replace("+", "%20");
+
+        for (var entry : DECODE_UNRESERVED_MARKS.entrySet())
+            encoded = StringUtils.replace(encoded, entry.getValue(), entry.getKey());
+
+        return encoded;
     }
 
     public static abstract class Locators

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -324,7 +324,7 @@ public class FileBrowserHelper extends WebDriverWrapper
             clickFileBrowserButton(BrowserAction.MOVE);
             Window<?> moveWindow = Window(getDriver()).withTitle("Choose Destination").waitFor();
             //NOTE:  this doesn't yet support nested folders
-            WebElement folder = Locator.tagWithClass("span", "x4-tree-node-text").withText(destinationPath).waitForElement(moveWindow, 1000);
+            WebElement folder = Locator.tagWithClass("span", "x4-tree-node-text").withText(destinationPath).waitForElement(moveWindow, 2000);
             shortWait().until(LabKeyExpectedConditions.animationIsDone(folder));
             sleep(500);
             folder.click();

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -49,6 +49,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.Locators.pageSignal;
 import static org.labkey.test.components.ext4.Checkbox.Ext4Checkbox;
 import static org.labkey.test.components.ext4.RadioButton.RadioButton;
 import static org.labkey.test.components.ext4.Window.Window;
@@ -56,7 +57,7 @@ import static org.labkey.test.components.ext4.Window.Window;
 public class FileBrowserHelper extends WebDriverWrapper
 {
     private static final String IMPORT_SIGNAL_NAME = "import-actions-updated";
-    private static final String FILE_LIST_SIGNAL_NAME = "file-list-updated";
+    public static final String FILE_LIST_SIGNAL_NAME = "file-list-updated";
 
     public static final String ABSOLUTE_FILE_PATH_COLUMN_ID = "10";
     private static final Locator fileGridCell = Locator.tagWithClass("div", "labkey-filecontent-grid").append(Locator.tagWithClass("div", "x4-grid-cell-inner"));
@@ -805,10 +806,15 @@ public class FileBrowserHelper extends WebDriverWrapper
      */
     public int waitForFileGridReady()
     {
-        waitForElement(org.labkey.test.Locators.pageSignal(IMPORT_SIGNAL_NAME));
-        String signalValue = waitForElement(org.labkey.test.Locators.pageSignal(FILE_LIST_SIGNAL_NAME)).getAttribute("value");
+        String signalValue = waitForBrowserSignals();
         waitForGrid();
         return Integer.parseInt(signalValue);
+    }
+
+    public String waitForBrowserSignals()
+    {
+        waitForElement(pageSignal(IMPORT_SIGNAL_NAME));
+        return waitForElement(pageSignal(FILE_LIST_SIGNAL_NAME)).getAttribute("value");
     }
 
     public void openFolderTree()
@@ -827,7 +833,7 @@ public class FileBrowserHelper extends WebDriverWrapper
         }
     }
 
-    private static String encodeFileNodeIdPart(String rawIdPart)
+    public static String encodeFileNodeIdPart(String rawIdPart)
     {
         return URLEncoder.encode(rawIdPart, StandardCharsets.UTF_8).replace("+", "%20");
     }

--- a/src/org/labkey/test/util/core/webdav/WebDavUtils.java
+++ b/src/org/labkey/test/util/core/webdav/WebDavUtils.java
@@ -19,6 +19,7 @@ import com.github.sardine.Sardine;
 import com.github.sardine.SardineFactory;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jetty.util.URIUtil;
 import org.labkey.test.TestProperties;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.util.LogMethod;
@@ -65,7 +66,7 @@ public class WebDavUtils
     public static String buildBaseWebDavUrl(String containerPath, String webDavDir)
     {
         return WebTestHelper.getBaseURL() + "/_webdav/"
-                + StringUtils.strip(containerPath, "/").replace(" ", "%20") + "/"
+                + URIUtil.encodePath(StringUtils.strip(containerPath, "/")) + "/"
                 + StringUtils.strip(webDavDir, "/") + "/";
     }
 
@@ -77,7 +78,7 @@ public class WebDavUtils
     public static String buildBaseWebfilesUrl(String containerPath)
     {
         return WebTestHelper.getBaseURL() + "/_webfiles/"
-                + StringUtils.strip(containerPath, "/").replace(" ", "%20") + "/";
+                + URIUtil.encodePath(StringUtils.strip(containerPath, "/")) + "/";
     }
 
     @LogMethod


### PR DESCRIPTION
#### Rationale
We are inconsistently encoding URIs in Strings and passing them around. Many codepaths end up double-encoding and then selectively decoding specific characters.

We can do better by using `URI` on the server and properly encoding throughout.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5961

#### Changes
- Switch to `URI` to make it clear what's being passed around
- Return encoded values in JSON and other responses
- Expect encoded URIs in HTML attributes