### PR TITLE
Issue 51521: Add switch to disable Server HTTP header

### DIFF
--- a/src/org/labkey/test/pages/core/admin/CustomizeSitePage.java
+++ b/src/org/labkey/test/pages/core/admin/CustomizeSitePage.java
@@ -165,6 +165,11 @@ public class CustomizeSitePage extends LabKeyPage<CustomizeSitePage.ElementCache
         return this;
     }
 
+    public boolean isShowRibbonMessage()
+    {
+        return elementCache().showRibbonMessage.get();
+    }
+
     public CustomizeSitePage setRibbonMessage(String html)
     {
         elementCache().ribbonMessage.set(html);
@@ -193,6 +198,17 @@ public class CustomizeSitePage extends LabKeyPage<CustomizeSitePage.ElementCache
     {
         elementCache().XFrameOption.selectByValue(value.name());
         return this;
+    }
+
+    public CustomizeSitePage setEnableServerHttpHeader(boolean enable)
+    {
+        elementCache().enableServerHttpHeader.set(enable);
+        return this;
+    }
+
+    public boolean isEnableServerHttpHeader()
+    {
+        return elementCache().enableServerHttpHeader.get();
     }
 
     @Override
@@ -257,6 +273,7 @@ public class CustomizeSitePage extends LabKeyPage<CustomizeSitePage.ElementCache
         // HTTP Security Settings
         protected final Select CSRFCheck = Select(Locator.id("CSRFCheck")).findWhenNeeded(this);
         protected final Select XFrameOption = Select(Locator.id("XFrameOption")).findWhenNeeded(this);
+        protected final Checkbox enableServerHttpHeader = Checkbox(Locator.id("includeServerHttpHeader")).findWhenNeeded(this);
     }
 
     public enum ReportingLevel

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -26,6 +26,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.pages.core.admin.CustomizeSitePage;
 import org.labkey.test.pages.core.login.LoginConfigRow;
 import org.labkey.test.pages.core.login.LoginConfigurePage;
 import org.labkey.test.util.ApiPermissionsHelper;
@@ -58,25 +59,21 @@ public class AdminConsoleTest extends BaseWebDriverTest
     @Test
     public void testServerHttpHeaderSetting()
     {
-        goToAdminConsole().clickSiteSettings();
-        waitForElement(Locator.name("includeServerHttpHeader"));
-        WebElement checkbox = Locator.checkboxByName("includeServerHttpHeader").findElement(getDriver());
-
-        boolean originalValue = checkbox.isSelected();
+        CustomizeSitePage customizeSitePage = goToAdminConsole().clickSiteSettings();
+        boolean originalValue = customizeSitePage.isEnableServerHttpHeader();
 
         // Try with the setting on
         if (!originalValue)
-            click(Locator.checkboxByName("includeServerHttpHeader"));
-        clickButton("Save");
+        {
+            customizeSitePage.setEnableServerHttpHeader(true).save();
+        }
 
         String serverHeader = getServerHeader();
         assertTrue("Expected to get a Server header, but got " + serverHeader, serverHeader != null && serverHeader.startsWith("LabKey/"));
 
         // Try with the setting off
-        goToAdminConsole().clickSiteSettings();
-        waitForElement(Locator.name("includeServerHttpHeader"));
-        click(Locator.checkboxByName("includeServerHttpHeader"));
-        clickButton("Save");
+        customizeSitePage = goToAdminConsole().clickSiteSettings();
+        customizeSitePage.setEnableServerHttpHeader(false).save();
 
         serverHeader = getServerHeader();
         assertNull("Expected to get no Server header, but got " + serverHeader, serverHeader);
@@ -84,10 +81,8 @@ public class AdminConsoleTest extends BaseWebDriverTest
         if (originalValue)
         {
             // Turn the setting back on
-            goToAdminConsole().clickSiteSettings();
-            waitForElement(Locator.name("includeServerHttpHeader"));
-            click(Locator.checkboxByName("includeServerHttpHeader"));
-            clickButton("Save");
+            customizeSitePage = goToAdminConsole().clickSiteSettings();
+            customizeSitePage.setEnableServerHttpHeader(true).save();
         }
     }
 
@@ -127,30 +122,26 @@ public class AdminConsoleTest extends BaseWebDriverTest
     @Test
     public void testRibbonBar()
     {
-        goToAdminConsole().clickSiteSettings();
-        waitForElement(Locator.name("showRibbonMessage"));
-        Locator.name("ribbonMessage").findElement(getDriver()).clear();
-
-        WebElement checkbox = Locator.checkboxByName("showRibbonMessage").findElement(getDriver());
+        CustomizeSitePage customizeSitePage = goToAdminConsole().clickSiteSettings();
+        customizeSitePage.setRibbonMessage(null);
 
         //only select if not already checked
-        if (!checkbox.isSelected())
-            click(Locator.checkboxByName("showRibbonMessage"));
+        if (!customizeSitePage.isShowRibbonMessage())
+            customizeSitePage.setShowRibbonMessage(true);
 
-        clickButton("Save");
+        customizeSitePage.save();
 
         waitForElement(Locator.xpath("//div[contains(text(), 'Cannot enable the ribbon message without providing a message to show')]"));
 
         String linkText = "and also click this...";
         String html = "READ ME!!!  <a href='<%=contextPath%>" + "/home/project-begin.view'>" + linkText + "</a>";
 
+        customizeSitePage = new CustomizeSitePage(getDriver());
         //only check if not already checked
-        checkbox = Locator.checkboxByName("showRibbonMessage").findElement(getDriver());
-        if (!checkbox.isSelected())
-            click(Locator.checkboxByName("showRibbonMessage"));
+        if (!customizeSitePage.isShowRibbonMessage())
+            customizeSitePage.setShowRibbonMessage(true);
 
-        setFormElement(Locator.name("ribbonMessage"), html);
-        clickButton("Save");
+        customizeSitePage.setRibbonMessage(html).save();
 
         Locator ribbon = Locator.tagWithClass("div", "alert alert-warning").containing("READ ME!!!");
         waitForElement(ribbon);
@@ -167,10 +158,8 @@ public class AdminConsoleTest extends BaseWebDriverTest
         assertElementPresent(ribbonLink);
         stopImpersonating();
 
-        goToAdminConsole().clickSiteSettings();
-        waitForElement(Locator.name("showRibbonMessage"));
-        click(Locator.checkboxByName("showRibbonMessage"));
-        clickButton("Save");
+        customizeSitePage = goToAdminConsole().clickSiteSettings();
+        customizeSitePage.setShowRibbonMessage(false).save();
         assertElementNotPresent(ribbon);
         assertElementNotPresent(ribbonLink);
     }

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -126,7 +126,8 @@ public class AdminConsoleTest extends BaseWebDriverTest
             throw new RuntimeException("Failed to get Server HTTP response header", e);
         }
     }
-        @Test
+    
+    @Test
     public void testRibbonBar()
     {
         goToAdminConsole().clickSiteSettings();

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -19,7 +19,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
-import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.SimpleGetCommand;
 import org.labkey.test.BaseWebDriverTest;
@@ -32,14 +31,12 @@ import org.labkey.test.pages.core.login.LoginConfigurePage;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PermissionsHelper;
-import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.WebElement;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -65,7 +62,7 @@ public class AdminConsoleTest extends BaseWebDriverTest
         waitForElement(Locator.name("includeServerHttpHeader"));
         WebElement checkbox = Locator.checkboxByName("includeServerHttpHeader").findElement(getDriver());
 
-        boolean originalValue = "true".equals(checkbox.getAttribute("checked"));
+        boolean originalValue = checkbox.isSelected();
 
         // Try with the setting on
         if (!originalValue)
@@ -136,7 +133,7 @@ public class AdminConsoleTest extends BaseWebDriverTest
         WebElement checkbox = Locator.checkboxByName("showRibbonMessage").findElement(getDriver());
 
         //only select if not already checked
-        if (!("true".equals(checkbox.getAttribute("checked"))))
+        if (!checkbox.isSelected())
             click(Locator.checkboxByName("showRibbonMessage"));
 
         clickButton("Save");
@@ -148,7 +145,7 @@ public class AdminConsoleTest extends BaseWebDriverTest
 
         //only check if not already checked
         checkbox = Locator.checkboxByName("showRibbonMessage").findElement(getDriver());
-        if (!("true".equals(checkbox.getAttribute("checked"))))
+        if (!checkbox.isSelected())
             click(Locator.checkboxByName("showRibbonMessage"));
 
         setFormElement(Locator.name("ribbonMessage"), html);
@@ -247,7 +244,7 @@ public class AdminConsoleTest extends BaseWebDriverTest
         //authentication
         LoginConfigurePage configurePage = goToAdminConsole().clickAuthentication();
         List<LoginConfigRow> configRows = configurePage.getPrimaryConfigurations();
-        assertFalse("expect 'edit' links not to be available for auth configs", configRows.stream().anyMatch(a-> a.canEdit()));
+        assertFalse("expect 'edit' links not to be available for auth configs", configRows.stream().anyMatch(LoginConfigRow::canEdit));
         assertFalse("expect 'add configuration' menu to be absent for AppAdmin", configurePage.canAddConfiguration());
         clickButton("Done");
         assertElementPresent("expect to return to admin console", siteAdminLoc, 1);


### PR DESCRIPTION
#### Rationale
Some organizations don't like having the product and version identified in HTTP headers. We can make it optional.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5989

#### Changes
- Test the presence and absence of the header when toggling the setting
