### PR TITLE
await select in edit mode

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -535,7 +535,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         public FilteringReactSelect findSelect(String fieldCaption)
         {
             WebElement container = Locator.tag("td").withAttribute("data-caption", fieldCaption).findElement(this);
-            return FilteringReactSelect.finder(_driver).find(container);
+            return FilteringReactSelect.finder(_driver).timeout(_readyTimeout).waitFor(container);
         }
     }
 


### PR DESCRIPTION
#### Rationale
Recently, [BiologicsSampleTimelineTest.testEditSampleDetailCausesTimelineEvent](https://teamcity.labkey.org/viewLog.html?buildId=3247197&buildTypeId=LabKey_247Release_Premium_ProductSuites_Biologics_LimsStarter_LimsStarterB&fromSakuraUI=true#testNameId-6192646934553344580) has failed in 24.7 because the 'status' select was not found (but was present in the after-failure screenshot) when the test attempted to edit a sample's status in order to verify that doing so would cause a timeline event.

This change backports the fix for this intermittent failure from develop; the test will now await the select as it does in  develop

#### Related Pull Requests
n/a

#### Changes
one-line backport from develop
