### PR TITLE
Don't change browser window size during test setup

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -309,8 +309,20 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             doTearDown();
         }
 
-        SingletonWebDriver.getInstance().setUp(this);
+        SingletonWebDriver.getInstance().setUpWebDriver(this);
 
+        initWebDriverTimeoutsAndSize();
+        closeExtraWindows();
+
+        if (!TestProperties.isCspCheckSkipped() && cspFailFast())
+        {
+            addPageLoadListener(_cspCheckPageLoadListener);
+        }
+    }
+
+    @LogMethod
+    private void initWebDriverTimeoutsAndSize()
+    {
         getDriver().manage().timeouts().scriptTimeout(Duration.ofMillis(WAIT_FOR_PAGE));
         getDriver().manage().timeouts().pageLoadTimeout(Duration.ofMillis(defaultWaitForPage));
         try
@@ -322,12 +334,6 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             // Ignore occasional error from attempting to resize maximized window
             if (!ex.getMessage().contains("current state is maximized"))
                 throw ex;
-        }
-        closeExtraWindows();
-
-        if (!TestProperties.isCspCheckSkipped() && cspFailFast())
-        {
-            addPageLoadListener(_cspCheckPageLoadListener);
         }
     }
 
@@ -365,6 +371,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         return BROWSER_TYPE;
     }
 
+    @LogMethod
     private static void doTearDown()
     {
         boolean closeWindow = !_testFailed || isRunWebDriverHeadless() || Boolean.parseBoolean(System.getProperty("close.on.fail", "true"));
@@ -2766,7 +2773,8 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             return _downloadDir;
         }
 
-        private void setUp(BaseWebDriverTest test)
+        @LogMethod
+        private void setUpWebDriver(BaseWebDriverTest test)
         {
             WebDriver oldWebDriver = getWebDriver();
             File newDownloadDir = new File(ArtifactCollector.ensureDumpDir(test.getClass().getSimpleName()), "downloads");

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -324,16 +324,20 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     private void initWebDriverTimeoutsAndSize()
     {
         getDriver().manage().timeouts().scriptTimeout(Duration.ofMillis(WAIT_FOR_PAGE));
+        TestLogger.info("script timeout set");
         getDriver().manage().timeouts().pageLoadTimeout(Duration.ofMillis(defaultWaitForPage));
+        TestLogger.info("page load timeout set");
         try
         {
             getDriver().manage().window().setSize(new Dimension(TestProperties.getBrowserWidth(), TestProperties.getBrowserHeight()));
+            TestLogger.info("size set");
         }
         catch (WebDriverException ex)
         {
             // Ignore occasional error from attempting to resize maximized window
             if (!ex.getMessage().contains("current state is maximized"))
                 throw ex;
+            TestLogger.info("failed to set window size");
         }
     }
 

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -94,7 +94,6 @@ import org.labkey.test.util.query.QueryUtils;
 import org.labkey.test.util.search.SearchAdminAPIHelper;
 import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.By;
-import org.openqa.selenium.Dimension;
 import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TimeoutException;
@@ -323,22 +322,27 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     @LogMethod
     private void initWebDriverTimeoutsAndSize()
     {
+        TestLogger.debug("set script timeout");
         getDriver().manage().timeouts().scriptTimeout(Duration.ofMillis(WAIT_FOR_PAGE));
-        TestLogger.info("script timeout set");
+        TestLogger.debug("page load timeout set");
         getDriver().manage().timeouts().pageLoadTimeout(Duration.ofMillis(defaultWaitForPage));
-        TestLogger.info("page load timeout set");
-        try
-        {
-            getDriver().manage().window().setSize(new Dimension(TestProperties.getBrowserWidth(), TestProperties.getBrowserHeight()));
-            TestLogger.info("size set");
-        }
-        catch (WebDriverException ex)
-        {
-            // Ignore occasional error from attempting to resize maximized window
-            if (!ex.getMessage().contains("current state is maximized"))
-                throw ex;
-            TestLogger.info("failed to set window size");
-        }
+
+        TestProperties.getWindowSize().ifPresent(dimension -> {
+            try
+            {
+                TestLogger.info("set window size");
+                getDriver().manage().window().setSize(dimension);
+            }
+            catch (WebDriverException ex)
+            {
+                TestLogger.debug("failed to set window size");
+                // Ignore occasional error from attempting to resize maximized window
+                if (!ex.getMessage().contains("current state is maximized"))
+                {
+                    throw ex;
+                }
+            }
+        });
     }
 
     /**

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -18,6 +18,7 @@ package org.labkey.test;
 import org.apache.commons.lang3.StringUtils;
 import org.labkey.serverapi.reader.Readers;
 import org.labkey.test.util.TestLogger;
+import org.openqa.selenium.Dimension;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -182,14 +184,20 @@ public abstract class TestProperties
         return System.getProperty("cloud.pipeline.bucket");
     }
 
-    public static int getBrowserWidth()
+    public static Optional<Dimension> getWindowSize()
     {
-        return getIntegerProperty("webtest.browser.width", 1280);
-    }
-
-    public static int getBrowserHeight()
-    {
-        return getIntegerProperty("webtest.browser.height", 1024);
+        String dimensionStr = System.getProperty("webtest.window.size");
+        if (dimensionStr != null)
+        {
+            String[] dimensionParts = dimensionStr.split("x", 2);
+            int browserWidth = Integer.parseInt(dimensionParts[0]);
+            int browserHeight = Integer.parseInt(dimensionParts[1]);
+            return Optional.of(new Dimension(browserWidth, browserHeight));
+        }
+        else
+        {
+            return Optional.empty();
+        }
     }
 
     public static boolean isWebDriverLoggingEnabled()

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1008,6 +1008,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
         }
     }
 
+    @LogMethod
     protected void closeExtraWindows()
     {
         List<String> windows = new ArrayList<>(getDriver().getWindowHandles());

--- a/test.properties.template
+++ b/test.properties.template
@@ -86,6 +86,8 @@ selenium.reuseWebDriver=true
 #webtest.webdriver.logging=false
 ## Run test browser in headless mode (experimental)
 #webtest.webdriver.headless=false
+## Customize browser window size
+#webtest.window.size=1280x1024
 
 
 #==============================================================================


### PR DESCRIPTION
#### Rationale
`BaseWebDriverTest.setUp` current resets the browser window size before each test method. With Firefox 128, doing so takes around five seconds. This can add significant execution time to our test suites, especially with classes with numerous small test methods.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2043

#### Changes
- Don't change browser window size unless `webtest.window.size` is set
- Combine window height and width properties into one
