### PR TITLE
Set window size for new browser

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -310,7 +310,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
         SingletonWebDriver.getInstance().setUpWebDriver(this);
 
-        initWebDriverTimeoutsAndSize();
+        initWebDriverTimeouts();
         closeExtraWindows();
 
         if (!TestProperties.isCspCheckSkipped() && cspFailFast())
@@ -320,29 +320,12 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     }
 
     @LogMethod
-    private void initWebDriverTimeoutsAndSize()
+    private void initWebDriverTimeouts()
     {
         TestLogger.debug("set script timeout");
         getDriver().manage().timeouts().scriptTimeout(Duration.ofMillis(WAIT_FOR_PAGE));
         TestLogger.debug("page load timeout set");
         getDriver().manage().timeouts().pageLoadTimeout(Duration.ofMillis(defaultWaitForPage));
-
-        TestProperties.getWindowSize().ifPresent(dimension -> {
-            try
-            {
-                TestLogger.info("set window size");
-                getDriver().manage().window().setSize(dimension);
-            }
-            catch (WebDriverException ex)
-            {
-                TestLogger.debug("failed to set window size");
-                // Ignore occasional error from attempting to resize maximized window
-                if (!ex.getMessage().contains("current state is maximized"))
-                {
-                    throw ex;
-                }
-            }
-        });
     }
 
     /**

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -186,8 +186,8 @@ public abstract class TestProperties
 
     public static Optional<Dimension> getWindowSize()
     {
-        String dimensionStr = System.getProperty("webtest.window.size");
-        if (dimensionStr != null)
+        String dimensionStr = System.getProperty("webtest.window.size", "1280x1024");
+        if (!dimensionStr.isEmpty())
         {
             String[] dimensionParts = dimensionStr.split("x", 2);
             int browserWidth = Integer.parseInt(dimensionParts[0]);

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -403,6 +403,14 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
         if (newWebDriver != null)
         {
+
+            Optional<Dimension> windowSize = TestProperties.getWindowSize();
+            if (windowSize.isPresent())
+            {
+                TestLogger.info("Set window size: " + windowSize.get());
+                newWebDriver.manage().window().setSize(windowSize.get());
+            }
+
             Capabilities caps = ((HasCapabilities) newWebDriver).getCapabilities();
             String browserName = caps.getBrowserName();
             String browserVersion = caps.getBrowserVersion();


### PR DESCRIPTION
#### Rationale
Leaving the default browser size resulted in too many test failures. We can get most of the perf improvement by only setting the window size when we initially launch the browser.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2118

#### Changes
- Set window size when launching new browser instance