### PR TITLE
Test non-standard date and time formats

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -417,17 +417,14 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
             throw new UnsupportedOperationException("Setting the format for Date, Time or DateTime fields not supported in this method.");
         }
 
-        if (!StringUtils.isEmpty(dataType))
+        if (elementCache().formatInput.getComponentElement().isDisplayed())
         {
-            if (elementCache().formatInput.getComponentElement().isDisplayed())
-            {
-                elementCache().formatInput.setValue(formatString);
-            }
-            else if (elementCache().charScaleInput.getComponentElement().isDisplayed())
-            {
-                // Formatting of Boolean types use the scale input.
-                elementCache().charScaleInput.setValue(formatString);
-            }
+            elementCache().formatInput.setValue(formatString);
+        }
+        else if (elementCache().charScaleInput.getComponentElement().isDisplayed())
+        {
+            // Formatting of Boolean types use the scale input.
+            elementCache().charScaleInput.setValue(formatString);
         }
         else
         {

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -1329,7 +1329,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
     {
         String date = getDateTimeFormatDate();
         String time = getDateTimeFormatTime();
-        if ("<none>".equals(time) || StringUtils.isEmpty(time))
+        if (TIME_FORMAT.none.toString().equals(time) || StringUtils.isEmpty(time))
             return date;
 
         return date + " " + time;

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -1329,9 +1329,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
     {
         String date = getDateTimeFormatDate();
         String time = getDateTimeFormatTime();
-        if ("<none>".equals(time))
-            time = null;
-        if (StringUtils.isEmpty(time))
+        if ("<none>".equals(time) || StringUtils.isEmpty(time))
             return date;
 
         return date + " " + time;

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -15,10 +15,11 @@ import org.labkey.test.components.html.RadioButton;
 import org.labkey.test.components.html.SelectWrapper;
 import org.labkey.test.components.react.FilteringReactSelect;
 import org.labkey.test.components.ui.ontology.ConceptPickerDialog;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.DATE_FORMAT;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.TIME_FORMAT;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.LabKeyExpectedConditions;
 import org.openqa.selenium.ElementNotInteractableException;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebDriver;
@@ -146,12 +147,8 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
     public ModalDialog setTypeWithDialog(FieldDefinition.ColumnType columnType)
     {
         elementCache().fieldTypeSelectInput.selectByVisibleText(columnType.getLabel());
-
-        ModalDialog confirmDialog = new ModalDialog.ModalDialogFinder(getDriver())
+        return new ModalDialog.ModalDialogFinder(getDriver())
                 .withTitle("Confirm Data Type Change").timeout(1000).waitFor();
-
-        return confirmDialog;
-
     }
 
     public boolean getRequiredField()
@@ -412,32 +409,25 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
     {
         expand();
 
+
+        if (FieldDefinition.ColumnType.DateAndTime.getRangeURI().equals(dataType) ||
+                FieldDefinition.ColumnType.Date.getRangeURI().equals(dataType) ||
+                (FieldDefinition.ColumnType.Time.getRangeURI().equals(dataType)))
+        {
+            throw new UnsupportedOperationException("Setting the format for Date, Time or DateTime fields not supported in this method.");
+        }
+
         if (!StringUtils.isEmpty(dataType))
         {
-            if (FieldDefinition.ColumnType.DateAndTime.getRangeURI().equals(dataType))
+            if (elementCache().formatInput.getComponentElement().isDisplayed())
             {
-                setDateTimeFormat(formatString);
-                return this;
+                elementCache().formatInput.setValue(formatString);
             }
-            if (FieldDefinition.ColumnType.Date.getRangeURI().equals(dataType))
+            else if (elementCache().charScaleInput.getComponentElement().isDisplayed())
             {
-                setDateFormat(formatString);
-                return this;
+                // Formatting of Boolean types use the scale input.
+                elementCache().charScaleInput.setValue(formatString);
             }
-            if (FieldDefinition.ColumnType.Time.getRangeURI().equals(dataType))
-            {
-                setTimeFormat(formatString);
-                return this;
-            }
-        }
-        if(elementCache().formatInput.getComponentElement().isDisplayed())
-        {
-            elementCache().formatInput.setValue(formatString);
-        }
-        else if(elementCache().charScaleInput.getComponentElement().isDisplayed())
-        {
-            // Formatting of Boolean types use the scale input.
-            elementCache().charScaleInput.setValue(formatString);
         }
         else
         {
@@ -1308,7 +1298,14 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         return getFormatWithoutExample(elementCache().dateTimeFormatDateSelect.getValue());
     }
 
-    public DomainFieldRow setDateTimeFormatDate(String dateFormat)
+    public DomainFieldRow setDateTimeFormat(DATE_FORMAT date, TIME_FORMAT time)
+    {
+        setDateTimeFormat(date);
+        setDateTimeFormat(time);
+        return this;
+    }
+
+    public DomainFieldRow setDateTimeFormat(DATE_FORMAT dateFormat)
     {
         expand();
         if (isDateTimeInherited())
@@ -1317,12 +1314,12 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         return this;
     }
 
-    public DomainFieldRow setDateTimeFormatTime(String timeFormat)
+    public DomainFieldRow setDateTimeFormat(TIME_FORMAT timeFormat)
     {
         expand();
         if (isDateTimeInherited())
             setDateTimeInherited(false);
-        elementCache().dateTimeFormatTimeSelect.typeAheadSelect(timeFormat + " (");
+        elementCache().dateTimeFormatTimeSelect.typeAheadSelect("<none>".equals(timeFormat) ? timeFormat.toString() : timeFormat + " (");
         return this;
     }
 
@@ -1343,29 +1340,6 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         return date + " " + time;
     }
 
-    public DomainFieldRow setDateTimeFormat(String dateTime)
-    {
-        expand();
-        if (isDateTimeInherited())
-            setDateTimeInherited(false);
-
-        String[] parts = dateTime.split("\\s+", 2);
-        if (parts.length == 2)
-            return setDateTimeFormat(parts[0], parts[1]);
-        return setDateTimeFormat(parts[0], "<none>");
-    }
-
-    public DomainFieldRow setDateTimeFormat(String date, String time)
-    {
-        expand();
-        if (isDateTimeInherited())
-            setDateTimeInherited(false);
-
-        elementCache().dateTimeFormatDateSelect.typeAheadSelect(date + " (");
-        elementCache().dateTimeFormatTimeSelect.typeAheadSelect("<none>".equals(time) ? time : time + " (");
-        return this;
-    }
-
     public DomainFieldRow setDateInherited(boolean check)
     {
         expand();
@@ -1383,7 +1357,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         return getFormatWithoutExample(elementCache().dateFormatSelect.getValue());
     }
 
-    public DomainFieldRow setDateFormat(String dateFormat)
+    public DomainFieldRow setDateFormat(DATE_FORMAT dateFormat)
     {
         expand();
         if (isDateInherited())
@@ -1409,7 +1383,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         return getFormatWithoutExample(elementCache().timeFormatSelect.getValue());
     }
 
-    public DomainFieldRow setTimeFormat(String timeFormat)
+    public DomainFieldRow setTimeFormat(TIME_FORMAT timeFormat)
     {
         expand();
         if (isTimeInherited())

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -1290,11 +1290,6 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         return elementCache().dateTimeInheritedCheckbox.get();
     }
 
-    public String getDateTimeFormatDate()
-    {
-        return getFormatWithoutExample(elementCache().dateTimeFormatDateSelect.getValue());
-    }
-
     public DomainFieldRow setDateTimeFormat(DATE_FORMAT date, TIME_FORMAT time)
     {
         setDateTimeFormat(date);
@@ -1320,9 +1315,46 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         return this;
     }
 
+    public String getDateTimeFormatDate()
+    {
+        String formatValue;
+
+        if(elementCache().dateTimeFormatDateSelect.isInteractive())
+        {
+            formatValue = getFormatWithoutExample(elementCache().dateTimeFormatDateSelect.getValue());
+        }
+        else
+        {
+            formatValue = getFormatWithoutExample(elementCache().disabledDateTimeDateFormat.getText());
+        }
+
+        return formatValue;
+    }
+
+    public boolean isDateTimeFormatDateEnabled()
+    {
+        return elementCache().dateTimeFormatDateSelect.isInteractive();
+    }
+
     public String getDateTimeFormatTime()
     {
-        return getFormatWithoutExample(elementCache().dateTimeFormatTimeSelect.getValue());
+        String formatValue;
+
+        if(elementCache().dateTimeFormatTimeSelect.isInteractive())
+        {
+            formatValue = getFormatWithoutExample(elementCache().dateTimeFormatTimeSelect.getValue());
+        }
+        else
+        {
+            formatValue = getFormatWithoutExample(elementCache().disabledDateTimeTimeFormat.getText());
+        }
+
+        return formatValue;
+    }
+
+    public boolean isDateTimeFormatTimeEnabled()
+    {
+        return elementCache().dateTimeFormatTimeSelect.isInteractive();
     }
 
     public String getDateTimeFormat()
@@ -1349,7 +1381,23 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
     public String getDateFormat()
     {
-        return getFormatWithoutExample(elementCache().dateFormatSelect.getValue());
+        String formatValue;
+
+        if(elementCache().dateFormatSelect.isInteractive())
+        {
+            formatValue = getFormatWithoutExample(elementCache().dateFormatSelect.getValue());
+        }
+        else
+        {
+            formatValue = getFormatWithoutExample(elementCache().disabledDateFormat.getText());
+        }
+
+        return formatValue;
+    }
+
+    public boolean isDateFormatEnabled()
+    {
+        return elementCache().dateFormatSelect.isInteractive();
     }
 
     public DomainFieldRow setDateFormat(DATE_FORMAT dateFormat)
@@ -1375,7 +1423,23 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
     public String getTimeFormat()
     {
-        return getFormatWithoutExample(elementCache().timeFormatSelect.getValue());
+        String formatValue;
+
+        if(elementCache().timeFormatSelect.isInteractive())
+        {
+            formatValue = getFormatWithoutExample(elementCache().timeFormatSelect.getValue());
+        }
+        else
+        {
+            formatValue = getFormatWithoutExample(elementCache().disabledTimeFormat.getText());
+        }
+
+        return formatValue;
+    }
+
+    public boolean isTimeFormatEnabled()
+    {
+        return elementCache().timeFormatSelect.isInteractive();
     }
 
     public DomainFieldRow setTimeFormat(TIME_FORMAT timeFormat)
@@ -1385,6 +1449,16 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
             setTimeInherited(false);
         elementCache().timeFormatSelect.typeAheadSelect(timeFormat + " (");
         return this;
+    }
+
+    public boolean hasDomainWarningIcon()
+    {
+        return elementCache().domainWarningIcon.isDisplayed();
+    }
+
+    public WebElement getDomainWarningIcon()
+    {
+        return elementCache().domainWarningIcon;
     }
 
     public static class DomainFieldRowFinder extends WebDriverComponentFinder<DomainFieldRow, DomainFieldRowFinder>
@@ -1492,15 +1566,25 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         public final FilteringReactSelect dateTimeFormatDateSelect = FilteringReactSelect.finder(getDriver())
                 .withNamedInput("domainpropertiesrow-format_datedateTime")
                 .refindWhenNeeded(this);
+        public final WebElement disabledDateTimeDateFormat = Locator.tagWithAttributeContaining("div", "id", "domainpropertiesrow-format_datedateTime")
+                .descendant("div[contains(@class,'select-input__single-value--is-disabled')]").findWhenNeeded(this);
         public final FilteringReactSelect dateTimeFormatTimeSelect = FilteringReactSelect.finder(getDriver())
                 .withNamedInput("domainpropertiesrow-format_timedateTime")
                 .refindWhenNeeded(this);
+        public final WebElement disabledDateTimeTimeFormat = Locator.tagWithAttributeContaining("div", "id", "domainpropertiesrow-format_timedateTime")
+                .descendant("div[contains(@class,'select-input__single-value--is-disabled')]").findWhenNeeded(this);
         public final FilteringReactSelect dateFormatSelect = FilteringReactSelect.finder(getDriver())
                 .withNamedInput("domainpropertiesrow-format_datedate")
                 .refindWhenNeeded(this);
+        public final WebElement disabledDateFormat = Locator.tagWithAttributeContaining("div", "id", "domainpropertiesrow-format_datedate")
+                .descendant("div[contains(@class,'select-input__single-value--is-disabled')]").findWhenNeeded(this);
         public final FilteringReactSelect timeFormatSelect = FilteringReactSelect.finder(getDriver())
                 .withNamedInput("domainpropertiesrow-format_timetime")
                 .refindWhenNeeded(this);
+        public final WebElement disabledTimeFormat = Locator.tagWithAttributeContaining("div", "id", "domainpropertiesrow-format_timetime")
+                .descendant("div[contains(@class,'select-input__single-value--is-disabled')]").findWhenNeeded(this);
+        public final WebElement domainWarningIcon = Locator.tagWithClass("span", "domain-warning-icon")
+                .findWhenNeeded(this);
 
         // lookup field options
         public final Select lookupContainerSelect = SelectWrapper.Select(Locator.name("domainpropertiesrow-lookupContainer"))

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -1302,7 +1302,19 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         expand();
         if (isDateTimeInherited())
             setDateTimeInherited(false);
-        elementCache().dateTimeFormatDateSelect.typeAheadSelect(dateFormat + " (");
+
+        String txt;
+
+        if (dateFormat.equals(DATE_FORMAT.DATETIME))
+        {
+            txt = dateFormat.toString();
+        }
+        else
+        {
+            txt = dateFormat + " (";
+        }
+
+        elementCache().dateTimeFormatDateSelect.typeAheadSelect(txt);
         return this;
     }
 
@@ -1311,7 +1323,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         expand();
         if (isDateTimeInherited())
             setDateTimeInherited(false);
-        elementCache().dateTimeFormatTimeSelect.typeAheadSelect("<none>".equals(timeFormat) ? timeFormat.toString() : timeFormat + " (");
+        elementCache().dateTimeFormatTimeSelect.typeAheadSelect(TIME_FORMAT.none.equals(timeFormat) ? timeFormat.toString() : timeFormat + " (");
         return this;
     }
 
@@ -1405,7 +1417,18 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         expand();
         if (isDateInherited())
             setDateInherited(false);
-        elementCache().dateFormatSelect.typeAheadSelect(dateFormat + " (");
+
+        String txt;
+        if (dateFormat.equals(DATE_FORMAT.DATE))
+        {
+            txt = dateFormat.toString();
+        }
+        else
+        {
+            txt = dateFormat + " (";
+        }
+        elementCache().dateFormatSelect.typeAheadSelect(txt);
+
         return this;
     }
 
@@ -1447,7 +1470,19 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         expand();
         if (isTimeInherited())
             setTimeInherited(false);
-        elementCache().timeFormatSelect.typeAheadSelect(timeFormat + " (");
+
+        String txt;
+
+        if (timeFormat.equals(TIME_FORMAT.TIME))
+        {
+            txt = timeFormat.toString();
+        }
+        else
+        {
+            txt = timeFormat + " (";
+        }
+
+        elementCache().timeFormatSelect.typeAheadSelect(txt);
         return this;
     }
 

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -8,6 +8,8 @@ import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.react.ToggleButton;
 import org.labkey.test.components.ui.grids.ResponsiveGrid;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.DATE_FORMAT;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.TIME_FORMAT;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.selenium.WebElementWrapper;
 import org.openqa.selenium.TimeoutException;
@@ -124,7 +126,36 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
         if (fieldDefinition.getLabel() != null)
             fieldRow.setLabel(fieldDefinition.getLabel());
         if (fieldDefinition.getFormat() != null)
-            fieldRow.setFormat(fieldDefinition.getFormat(), fieldDefinition.getRangeURI());
+        {
+            if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.Date))
+            {
+                fieldRow.setDateFormat(DATE_FORMAT.get(fieldDefinition.getFormat()));
+            }
+            else if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.Time))
+            {
+                fieldRow.setTimeFormat(TIME_FORMAT.get(fieldDefinition.getFormat()));
+            }
+            else if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.DateAndTime))
+            {
+                String format = fieldDefinition.getFormat().trim();
+
+                int index = format.indexOf(" ");
+                if (index > 0)
+                {
+                    fieldRow.setDateTimeFormat(
+                            DATE_FORMAT.get(format.substring(0, index)),
+                            TIME_FORMAT.get(format.substring(index + 1)));
+                }
+                else
+                {
+                    fieldRow.setDateTimeFormat(DATE_FORMAT.get(format));
+                }
+            }
+            else
+            {
+                fieldRow.setFormat(fieldDefinition.getFormat(), fieldDefinition.getRangeURI());
+            }
+        }
         if (fieldDefinition.getScale() != null)
             fieldRow.setCharCount(fieldDefinition.getScale());
         if (fieldDefinition.getURL() != null)

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -138,10 +138,13 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
             }
             else if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.DateAndTime))
             {
-                String format = fieldDefinition.getFormat().trim();
 
-                int index = format.indexOf(" ");
-                if (index > 0)
+                // Identify the part of the format that is the date and the part that is the time. Take into account
+                // a data format may include spaces (time does not).
+                String format = fieldDefinition.getFormat().trim();
+                int index = format.lastIndexOf(" ");
+
+                if (format.substring(index + 1).contains(":"))
                 {
                     fieldRow.setDateTimeFormat(
                             DATE_FORMAT.get(format.substring(0, index)),

--- a/src/org/labkey/test/pages/admin/FolderFormatsPage.java
+++ b/src/org/labkey/test/pages/admin/FolderFormatsPage.java
@@ -239,6 +239,20 @@ public class FolderFormatsPage extends FolderManagementPage
         return elementCache().restrictChartingColsChk.isSelected();
     }
 
+    public FolderFormatsPage clickSave()
+    {
+        clickAndWait(elementCache().saveButton);
+        clearCache();
+        return this;
+    }
+
+    public FolderFormatsPage clickInheritAll()
+    {
+        clickAndWait(elementCache().inheritAll);
+        clearCache();
+        return this;
+    }
+
     @Override
     protected ElementCache newElementCache()
     {
@@ -276,6 +290,10 @@ public class FolderFormatsPage extends FolderManagementPage
         WebElement additionalParsingPatternTimes = Locator.inputByNameContaining("extraTimeParsingPattern").findElement(this);
         WebElement additionalParsingPatternDateAndTime = Locator.inputByNameContaining("extraDateTimeParsingPattern").findElement(this);
         WebElement restrictChartingColsChk = Locator.checkboxByName("restrictedColumnsEnabled").findWhenNeeded(this);
+
+        WebElement saveButton = Locator.lkButton("Save").findWhenNeeded(this);
+        WebElement inheritAll = Locator.lkButton("Inherit All").findWhenNeeded(this);
+
     }
 
 }

--- a/src/org/labkey/test/pages/admin/FolderFormatsPage.java
+++ b/src/org/labkey/test/pages/admin/FolderFormatsPage.java
@@ -1,0 +1,281 @@
+package org.labkey.test.pages.admin;
+
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.pages.core.admin.BaseSettingsPage;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.DATE_FORMAT;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class FolderFormatsPage extends FolderManagementPage
+{
+
+    public FolderFormatsPage(WebDriver driver)
+    {
+        super(driver);
+    }
+
+    public static FolderFormatsPage beginAt(WebDriverWrapper wrapper)
+    {
+        return beginAt(wrapper, wrapper.getCurrentContainerPath());
+    }
+
+    public static FolderFormatsPage beginAt(WebDriverWrapper wrapper, String containerPath)
+    {
+        wrapper.beginAt(WebTestHelper.buildURL("admin", containerPath, "folderSettings"));
+        return new FolderFormatsPage(wrapper.getDriver());
+    }
+
+    private Boolean getInherited(String name)
+    {
+        return elementCache().inheritedChk(name).isSelected();
+    }
+
+    private void setInherited(String name, boolean enable)
+    {
+        if (enable)
+            checkCheckbox(elementCache().inheritedChk(name));
+        else
+            uncheckCheckbox(elementCache().inheritedChk(name));
+    }
+
+    public boolean getDefaultDateDisplayInherited()
+    {
+        return getInherited("defaultDateFormatInherited");
+    }
+
+    public void setDefaultDateDisplayInherited(boolean enable)
+    {
+        setInherited("defaultDateFormatInherited", enable);
+    }
+
+    public String getDefaultDateDisplay()
+    {
+        return getSelectedOptionValue(elementCache().defaultDateFormat);
+    }
+
+    public void setDefaultDateDisplay(DATE_FORMAT dateFormat)
+    {
+        selectOptionByValue(elementCache().defaultDateFormat, dateFormat.toString());
+    }
+
+    public boolean defaultDateDisplayWarning()
+    {
+        return elementCache().nonStandardWarning(elementCache().defaultDateFormat).isDisplayed();
+    }
+
+    public void setDefaultDateTimeDisplay(BaseSettingsPage.DATE_FORMAT dateFormat, BaseSettingsPage.TIME_FORMAT timeFormat)
+    {
+        setDefaultDateTimeDateDisplay(dateFormat);
+        setDefaultDateTimeTimeDisplay(timeFormat);
+    }
+
+    public String getDefaultDateTimeDateDisplay()
+    {
+        return getSelectedOptionValue(elementCache().defaultDateTimeDateFormat);
+    }
+
+    public void setDefaultDateTimeDateDisplay(BaseSettingsPage.DATE_FORMAT dateFormat)
+    {
+        selectOptionByValue(elementCache().defaultDateTimeDateFormat, dateFormat.toString());
+    }
+
+    public boolean defaultDateTimeDateDisplayWarning()
+    {
+        return elementCache().nonStandardWarning(elementCache().defaultDateTimeDateFormat).isDisplayed();
+    }
+
+    public boolean getDefaultTimeDisplayInherited()
+    {
+        return getInherited("defaultTimeFormatInherited");
+    }
+
+    public void setDefaultTimeDisplayInherited(boolean enable)
+    {
+        setInherited("defaultTimeFormatInherited", enable);
+    }
+
+    public String getDefaultDateTimeTimeDisplay()
+    {
+        return getSelectedOptionValue(elementCache().defaultDateTimeTimeFormat);
+    }
+
+    public void setDefaultDateTimeTimeDisplay(BaseSettingsPage.TIME_FORMAT timeFormat)
+    {
+        selectOptionByValue(elementCache().defaultDateTimeTimeFormat, timeFormat.toString());
+    }
+
+    public boolean defaultDateTimeTimeDisplayWarning()
+    {
+        return elementCache().nonStandardWarning(elementCache().defaultDateTimeTimeFormat).isDisplayed();
+    }
+
+    public boolean getDefaultDateTimeDisplayInherited()
+    {
+        return getInherited("defaultDateTimeFormatInherited");
+    }
+
+    public void setDefaultDateTimeDisplayInherited(boolean enable)
+    {
+        setInherited("defaultDateTimeFormatInherited", enable);
+    }
+
+    public String getDefaultTimeDisplay()
+    {
+        return getSelectedOptionValue(elementCache().defaultTimeFormat);
+    }
+
+    public void setDefaultTimeDisplay(BaseSettingsPage.TIME_FORMAT timeFormat)
+    {
+        selectOptionByValue(elementCache().defaultTimeFormat, timeFormat.toString());
+    }
+
+    public boolean defaultTimeDisplayWarning()
+    {
+        return elementCache().nonStandardWarning(elementCache().defaultTimeFormat).isDisplayed();
+    }
+
+    public boolean getDefaultNumberDisplayInherited()
+    {
+        return getInherited("defaultNumberFormatInherited");
+    }
+
+    public void setDefaultNumberDisplayInherited(boolean enable)
+    {
+        setInherited("defaultNumberFormatInherited", enable);
+    }
+
+    public String getDefaultNumberDisplay()
+    {
+        return getFormElement(elementCache().defaultNumberFormat);
+    }
+
+    public void setDefaultNumberDisplay(String numberFormat)
+    {
+        setFormElement(elementCache().defaultNumberFormat, numberFormat);
+    }
+
+    public boolean getAdditionalParsingPatternDatesInherited()
+    {
+        return getInherited("extraDateParsingPatternInherited");
+    }
+
+    public void setAdditionalParsingPatternDatesInherited(boolean enable)
+    {
+        setInherited("extraDateParsingPatternInherited", enable);
+    }
+
+    public String getAdditionalParsingPatternDates()
+    {
+        return getFormElement(elementCache().additionalParsingPatternDates);
+    }
+
+    public void setAdditionalParsingPatternDates(String pattern)
+    {
+        setFormElement(elementCache().additionalParsingPatternDates, pattern);
+    }
+
+    public boolean getAdditionalParsingPatternDateAndTimeInherited()
+    {
+        return getInherited("extraDateTimeParsingPatternInherited");
+    }
+
+    public void setAdditionalParsingPatternDateAndTimeInherited(boolean enable)
+    {
+        setInherited("extraDateTimeParsingPatternInherited", enable);
+    }
+
+    public String getAdditionalParsingPatternDateAndTime()
+    {
+        return getFormElement(elementCache().additionalParsingPatternDateAndTime);
+    }
+
+    public void setAdditionalParsingPatternDateAndTime(String pattern)
+    {
+        setFormElement(elementCache().additionalParsingPatternDateAndTime, pattern);
+    }
+
+    public boolean getAdditionalParsingPatternTimesInherited()
+    {
+        return getInherited("extraTimeParsingPatternInherited");
+    }
+
+    public void setAdditionalParsingPatternTimesInherited(boolean enable)
+    {
+        setInherited("extraTimeParsingPatternInherited", enable);
+    }
+
+    public String getAdditionalParsingPatternTimes()
+    {
+        return getFormElement(elementCache().additionalParsingPatternTimes);
+    }
+
+    public void setAdditionalParsingPatternTimes(String pattern)
+    {
+        setFormElement(elementCache().additionalParsingPatternTimes, pattern);
+    }
+
+    public boolean getRestrictChartingColsInherited()
+    {
+        return getInherited("restrictedColumnsEnabledInherited");
+    }
+
+    public void setRestrictChartingColsInherited(boolean enable)
+    {
+        setInherited("restrictedColumnsEnabledInherited", enable);
+    }
+
+    public void setRestrictChartingCols(boolean restrict)
+    {
+        if (restrict)
+            checkCheckbox(elementCache().restrictChartingColsChk);
+        else
+            uncheckCheckbox(elementCache().restrictChartingColsChk);
+    }
+
+    public boolean getRestrictChartingCols()
+    {
+        return elementCache().restrictChartingColsChk.isSelected();
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+    protected class ElementCache extends FolderManagementPage.ElementCache
+    {
+        WebElement inheritedChk(String name)
+        {
+            return Locator.checkboxByName(name).findWhenNeeded(this);
+        }
+
+        WebElement defaultDateFormat = Locator.id("defaultDateFormat").findWhenNeeded(this);
+        WebElement defaultTimeFormat = Locator.id("defaultTimeFormat").findWhenNeeded(this);
+        WebElement defaultDateTimeDateFormat = Locator.id("dateSelect").findWhenNeeded(this);
+        WebElement defaultDateTimeTimeFormat = Locator.id("timeSelect").findWhenNeeded(this);
+        WebElement formatWarningBanner = Locator.tagWithId("div", "dateFormatWarning").findWhenNeeded(this);
+
+        WebElement nonStandardWarning(WebElement field)
+        {
+            String id = field.getAttribute("id");
+            String xpath = String.format("//select[@id='%s']/following-sibling::span[@class='has-warning']", id);
+            return Locator.xpath(xpath).findWhenNeeded(this);
+        }
+
+        WebElement defaultNumberFormat = Locator.inputByNameContaining("defaultNumberFormat").findWhenNeeded(this);
+        WebElement additionalParsingPatternDates = Locator.inputByNameContaining("extraDateParsingPattern").findElement(this);
+        WebElement additionalParsingPatternTimes = Locator.inputByNameContaining("extraTimeParsingPattern").findElement(this);
+        WebElement additionalParsingPatternDateAndTime = Locator.inputByNameContaining("extraDateTimeParsingPattern").findElement(this);
+        WebElement restrictChartingColsChk = Locator.checkboxByName("restrictedColumnsEnabled").findWhenNeeded(this);
+    }
+
+}

--- a/src/org/labkey/test/pages/admin/FolderManagementPage.java
+++ b/src/org/labkey/test/pages/admin/FolderManagementPage.java
@@ -59,7 +59,7 @@ public class FolderManagementPage extends LabKeyPage<FolderManagementPage.Elemen
 
     public FolderFormatsPage goToFormatsTab()
     {
-        selectTab("formats");
+        selectTab("settings");
         return new FolderFormatsPage(getDriver());
     }
 

--- a/src/org/labkey/test/pages/admin/FolderManagementPage.java
+++ b/src/org/labkey/test/pages/admin/FolderManagementPage.java
@@ -57,6 +57,12 @@ public class FolderManagementPage extends LabKeyPage<FolderManagementPage.Elemen
         return new FileRootsManagementPage(getDriver());
     }
 
+    public FolderFormatsPage goToFormatsTab()
+    {
+        selectTab("formats");
+        return new FolderFormatsPage(getDriver());
+    }
+
     public RConfigurationPage goToRConfigTab()
     {
         selectTab("rConfig");

--- a/src/org/labkey/test/pages/core/admin/BaseSettingsPage.java
+++ b/src/org/labkey/test/pages/core/admin/BaseSettingsPage.java
@@ -392,7 +392,7 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
         HH_mm("HH:mm"),
         HH_mm_ss_SSS("HH:mm:ss.SSS"),
         hh_mm_a("hh:mm a"),
-        none(""), // Valid only for a DateTime field.
+        none("<none>"), // Valid only for a DateTime field.
         Default("HH:mm:ss"),
         DTDefault("HH:mm");
 
@@ -417,13 +417,9 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
         }
 
         public static TIME_FORMAT get(String format) {
-
-            if(format.equalsIgnoreCase("none") ||
-                    format.equalsIgnoreCase("<none>"))
-                format = "";
-
             return lookup.get(format);
         }
+
     }
 
 }

--- a/src/org/labkey/test/pages/core/admin/BaseSettingsPage.java
+++ b/src/org/labkey/test/pages/core/admin/BaseSettingsPage.java
@@ -11,6 +11,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
 {
@@ -369,6 +371,19 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
         public String toString() {
             return this.format;
         }
+
+        private static final Map<String, DATE_FORMAT> lookup = new HashMap<>();
+
+        static {
+            for (DATE_FORMAT d : DATE_FORMAT.values()) {
+                lookup.put(d.toString(), d);
+            }
+        }
+
+        public static DATE_FORMAT get(String format) {
+            return lookup.get(format);
+        }
+
     }
 
     public enum TIME_FORMAT
@@ -377,6 +392,7 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
         HH_mm("HH:mm"),
         HH_mm_ss_SSS("HH:mm:ss.SSS"),
         hh_mm_a("hh:mm a"),
+        none(""), // Valid only for a DateTime field.
         Default("HH:mm:ss"),
         DTDefault("HH:mm");
 
@@ -390,6 +406,23 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
         @Override
         public String toString() {
             return this.format;
+        }
+
+        private static final Map<String, TIME_FORMAT> lookup = new HashMap<>();
+
+        static {
+            for (TIME_FORMAT t : TIME_FORMAT.values()) {
+                lookup.put(t.toString(), t);
+            }
+        }
+
+        public static TIME_FORMAT get(String format) {
+
+            if(format.equalsIgnoreCase("none") ||
+                    format.equalsIgnoreCase("<none>"))
+                format = "";
+
+            return lookup.get(format);
         }
     }
 

--- a/src/org/labkey/test/pages/core/admin/BaseSettingsPage.java
+++ b/src/org/labkey/test/pages/core/admin/BaseSettingsPage.java
@@ -183,7 +183,7 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
 
     public void setDefaultDateDisplay(DATE_FORMAT dateFormat)
     {
-        selectOptionByValue(elementCache().defaultDateFormat, dateFormat.format);
+        selectOptionByValue(elementCache().defaultDateFormat, dateFormat.toString());
     }
 
     public boolean defaultDateDisplayWarning()
@@ -204,7 +204,7 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
 
     public void setDefaultDateTimeDateDisplay(DATE_FORMAT dateFormat)
     {
-        selectOptionByValue(elementCache().defaultDateTimeDateFormat, dateFormat.format);
+        selectOptionByValue(elementCache().defaultDateTimeDateFormat, dateFormat.toString());
     }
 
     public boolean defaultDateTimeDateDisplayWarning()
@@ -219,7 +219,7 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
 
     public void setDefaultDateTimeTimeDisplay(TIME_FORMAT timeFormat)
     {
-        selectOptionByValue(elementCache().defaultDateTimeTimeFormat, timeFormat.format);
+        selectOptionByValue(elementCache().defaultDateTimeTimeFormat, timeFormat.toString());
     }
 
     public boolean defaultDateTimeTimeDisplayWarning()
@@ -234,7 +234,7 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
 
     public void setDefaultTimeDisplay(TIME_FORMAT timeFormat)
     {
-        selectOptionByValue(elementCache().defaultTimeFormat, timeFormat.format);
+        selectOptionByValue(elementCache().defaultTimeFormat, timeFormat.toString());
     }
 
     public boolean defaultTimeDisplayWarning()
@@ -305,6 +305,23 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
         setFormElement(elementCache().altLoginPageTxt,loginPage);
     }
 
+    /**
+     * If the warning banner is present return the text otherwise return an empty string.
+     *
+     * @return Text in warning banner, empty string if no banner is present.
+     */
+    public String getFormatWarningMessage()
+    {
+        if (elementCache().formatWarningBanner.isDisplayed())
+        {
+            return elementCache().formatWarningBanner.getText();
+        }
+        else
+        {
+            return "";
+        }
+    }
+
     public void save()
     {
         clickAndWait(elementCache().saveBtn);
@@ -347,6 +364,7 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
         WebElement defaultTimeFormat = Locator.id("defaultTimeFormat").findWhenNeeded(this);
         WebElement defaultDateTimeDateFormat = Locator.id("dateSelect").findWhenNeeded(this);
         WebElement defaultDateTimeTimeFormat = Locator.id("timeSelect").findWhenNeeded(this);
+        WebElement formatWarningBanner = Locator.tagWithId("div", "dateFormatWarning").findWhenNeeded(this);
 
         WebElement nonStandardWarning(WebElement field)
         {

--- a/src/org/labkey/test/pages/core/admin/BaseSettingsPage.java
+++ b/src/org/labkey/test/pages/core/admin/BaseSettingsPage.java
@@ -186,6 +186,11 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
         selectOptionByValue(elementCache().defaultDateFormat, dateFormat.format);
     }
 
+    public boolean defaultDateDisplayWarning()
+    {
+        return elementCache().nonStandardWarning(elementCache().defaultDateFormat).isDisplayed();
+    }
+
     public void setDefaultDateTimeDisplay(DATE_FORMAT dateFormat, TIME_FORMAT timeFormat)
     {
         setDefaultDateTimeDateDisplay(dateFormat);
@@ -202,6 +207,11 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
         selectOptionByValue(elementCache().defaultDateTimeDateFormat, dateFormat.format);
     }
 
+    public boolean defaultDateTimeDateDisplayWarning()
+    {
+        return elementCache().nonStandardWarning(elementCache().defaultDateTimeDateFormat).isDisplayed();
+    }
+
     public String getDefaultDateTimeTimeDisplay()
     {
         return getSelectedOptionValue(elementCache().defaultDateTimeTimeFormat);
@@ -212,6 +222,11 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
         selectOptionByValue(elementCache().defaultDateTimeTimeFormat, timeFormat.format);
     }
 
+    public boolean defaultDateTimeTimeDisplayWarning()
+    {
+        return elementCache().nonStandardWarning(elementCache().defaultDateTimeTimeFormat).isDisplayed();
+    }
+
     public String getDefaultTimeDisplay()
     {
         return getSelectedOptionValue(elementCache().defaultTimeFormat);
@@ -220,6 +235,11 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
     public void setDefaultTimeDisplay(TIME_FORMAT timeFormat)
     {
         selectOptionByValue(elementCache().defaultTimeFormat, timeFormat.format);
+    }
+
+    public boolean defaultTimeDisplayWarning()
+    {
+        return elementCache().nonStandardWarning(elementCache().defaultTimeFormat).isDisplayed();
     }
 
     public String getDefaultNumberDisplay()
@@ -327,6 +347,13 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
         WebElement defaultTimeFormat = Locator.id("defaultTimeFormat").findWhenNeeded(this);
         WebElement defaultDateTimeDateFormat = Locator.id("dateSelect").findWhenNeeded(this);
         WebElement defaultDateTimeTimeFormat = Locator.id("timeSelect").findWhenNeeded(this);
+
+        WebElement nonStandardWarning(WebElement field)
+        {
+            String id = field.getAttribute("id");
+            String xpath = String.format("//select[@id='%s']/following-sibling::span[@class='has-warning']", id);
+            return Locator.xpath(xpath).findWhenNeeded(this);
+        }
 
         WebElement defaultNumberFormat = Locator.inputByNameContaining("defaultNumberFormat").findWhenNeeded(this);
         WebElement additionalParsingPatternDates = Locator.inputByNameContaining("extraDateParsingPattern").findElement(this);

--- a/src/org/labkey/test/pages/core/admin/BaseSettingsPage.java
+++ b/src/org/labkey/test/pages/core/admin/BaseSettingsPage.java
@@ -398,12 +398,19 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
     {
         yyyy_MM_dd("yyyy-MM-dd"),
         yyyy_MMM_dd("yyyy-MMM-dd"),
+        yyyy_MM("yyyy-MM"),
         dd_MMM_yyyy("dd-MMM-yyyy"),
         dd_MMM_yy("dd-MMM-yy"),
+        dd_MM_yyyy("dd-MM-yyyy"),
         ddMMMyyyy("ddMMMyyyy"),
         ddMMMyy("ddMMMyy"),
+        MMddyyyy("MM/dd/yyyy"),
+        MM_dd_yyyy("MM-dd-yyyy"),
+        MMMM_dd_yyyy("MMMM dd yyyy"),
         Default("yyyy-MM-dd"),
-        DTDefault("yyyy-MM-dd");
+        DTDefault("yyyy-MM-dd"),
+        DATE("Date"), // Valid only in a domain designer.
+        DATETIME("DATETIME"); // Valid only in a domain designer and only for the date part of a DateTime field.
 
         private final String format;
 
@@ -439,7 +446,8 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
         hh_mm_a("hh:mm a"),
         none("<none>"), // Valid only for a DateTime field.
         Default("HH:mm:ss"),
-        DTDefault("HH:mm");
+        DTDefault("HH:mm"),
+        TIME("Time"); // Valid only in domain designer.
 
         private final String format;
 

--- a/src/org/labkey/test/tests/DataClassTest.java
+++ b/src/org/labkey/test/tests/DataClassTest.java
@@ -26,6 +26,8 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.domain.BaseDomainDesigner;
 import org.labkey.test.components.domain.DomainFormPanel;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.DATE_FORMAT;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.TIME_FORMAT;
 import org.labkey.test.pages.experiment.CreateDataClassPage;
 import org.labkey.test.pages.query.UpdateQueryRowPage;
 import org.labkey.test.params.FieldDefinition;
@@ -304,29 +306,26 @@ public class DataClassTest extends BaseWebDriverTest
         log("Add a date-time field.");
 
         String dateTimeField = "DateTime";
-        String dateTimeFormat = "ddMMMyyyy hh:mm a";
         DomainFormPanel domainFormPanel = createPage.getDomainEditor();
         domainFormPanel.manuallyDefineFields(dateTimeField)
                 .setType(FieldDefinition.ColumnType.DateAndTime)
-                .setDateTimeFormat(dateTimeFormat);
+                .setDateTimeFormat(DATE_FORMAT.ddMMMyyyy, TIME_FORMAT.hh_mm_a);
 
         log("Add a date-only field.");
 
         String dateField = "Date";
-        String dateFormat = "ddMMMyyyy";
         domainFormPanel = createPage.getDomainEditor();
         domainFormPanel.addField(dateField)
                 .setType(FieldDefinition.ColumnType.Date)
-                .setDateFormat(dateFormat);
+                .setDateFormat(DATE_FORMAT.ddMMMyyyy);
 
         log("Add a time-only field.");
 
         String timeField = "Time";
-        String timeFormat = "hh:mm a";
         domainFormPanel = createPage.getDomainEditor();
         domainFormPanel.addField(timeField)
                 .setType(FieldDefinition.ColumnType.Time)
-                .setTimeFormat(timeFormat);
+                .setTimeFormat(TIME_FORMAT.hh_mm_a);
 
         createPage.clickSave();
 

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -35,6 +35,8 @@ import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.domain.RangeValidatorDialog;
 import org.labkey.test.components.domain.RegexValidatorDialog;
 import org.labkey.test.components.domain.RegexValidatorPanel;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.DATE_FORMAT;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.TIME_FORMAT;
 import org.labkey.test.pages.experiment.CreateSampleTypePage;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.params.FieldDefinition;
@@ -311,7 +313,7 @@ public class DomainDesignerTest extends BaseWebDriverTest
         domainFormPanel.addField("addedField")
                 .setType(FieldDefinition.ColumnType.DateAndTime)
                 .expand()
-                .setDateTimeFormat("yyyy-MM-dd HH:mm")
+                .setDateTimeFormat(DATE_FORMAT.yyyy_MM_dd, TIME_FORMAT.HH_mm)
                 .setExcludeFromDateShifting(false)
                 .setDescription("simplest date format of all")
                 .setLabel("DateTime");

--- a/src/org/labkey/test/tests/ExpTest.java
+++ b/src/org/labkey/test/tests/ExpTest.java
@@ -27,7 +27,7 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.FileBrowser;
 import org.labkey.test.components.domain.DomainFieldRow;
 import org.labkey.test.components.ui.lineage.LineageGraph;
-import org.labkey.test.pages.core.admin.BaseSettingsPage;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.DATE_FORMAT;
 import org.labkey.test.pages.query.QueryMetadataEditorPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.PortalHelper;
@@ -140,7 +140,7 @@ public class ExpTest extends BaseWebDriverTest
         DomainFieldRow domainRow = designerPage.fieldsPanel().getField("Created");
         domainRow.setLabel("editedCreated");
         domainRow.setDateTimeInherited(false);
-        domainRow.setDateTimeFormatDate(BaseSettingsPage.DATE_FORMAT.ddMMMyyyy.toString());
+        domainRow.setDateTimeFormat(DATE_FORMAT.ddMMMyyyy);
         designerPage.clickSave();
 
         // Verify that it ended up in the XML version of the metadata

--- a/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
+++ b/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
@@ -41,14 +41,17 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
     private static final String PROJECT_NAME = "Non-Standard Date And Time Formats Test";
 
+    // No standard Date, Time and DateTime formats set at the project level.
     private static final String PROJECT_DATE_FORMAT = "dd/MM/yy";
     private static final String PROJECT_TIME_FORMAT = "K:m:s a Z";
     private static final String PROJECT_DATETIME_FORMAT = "EEEE MMMM dd D yyyy k:mm:s X";
 
+    // Warning shown on the Validation page for project settings.
     private static final List<String> PROJECT_WARNINGS = List.of(String.format("Project default display format for Dates: %s", PROJECT_DATE_FORMAT),
             String.format("Project default display format for DateTimes: %s", PROJECT_DATETIME_FORMAT),
             String.format("Project default display format for Times: %s", PROJECT_TIME_FORMAT));
 
+    // Tooltips shown on the various designer pages for non-standard formats.
     private static final String TT_NS_DATE = "Non-standard date format.";
     private static final String TT_NS_TIME = "Non-standard time format.";
     private static final String TT_NS_DATETIME = "Non-standard date-time format.";
@@ -80,6 +83,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         _containerHelper.createProject(PROJECT_NAME, null);
         goToProjectHome();
 
+        // Use the API to set non-standard formats for the project.
         new APIContainerHelper(this)
                 .setDateAndTimeFormats(createDefaultConnection(), PROJECT_NAME,
                         PROJECT_DATE_FORMAT, PROJECT_TIME_FORMAT, PROJECT_DATETIME_FORMAT);
@@ -114,6 +118,21 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         return BrowserType.CHROME;
     }
 
+    /**
+     * <p>
+     *     Test non-standard Date, Time and DateTime format settings at the project level. The non-standard formats are
+     *     set during project creation.
+     * </p>
+     * <p>
+     *     This test will:
+     *     <ul>
+     *         <li>Validate that the Date, Time and DateTime fields are not inherited.</li>
+     *         <li>Validate the formats are as expected (non-standard)</li>
+     *         <li>Validate the tooltip message.</li>
+     *         <li>Validate the Site Validate report show the project settings.</li>
+     *     </ul>
+     * </p>
+     */
     @Test
     public void testProjectSettingsPage()
     {
@@ -162,6 +181,25 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
     }
 
+    /**
+     * <p>
+     *     Test non-standard Date, Time and DateTime formats with lists.
+     * </p>
+     * <p>
+     *     This test will:
+     *     <ul>
+     *         <li>Create a list that has non-standard formats set for the fields.</li>
+     *         <li>Create a second list that has fields that inherit from the project settings.</li>
+     *         <li>Import data into the list to validate non-standard formats are used when display the data.</li>
+     *         <li>Validate the designer for fields that do not inherit from the project.</li>
+     *         <li>Validate the designer for fields that are inherited from the project (should see no warnings)</li>
+     *         <li>Check Site Validation report calls out the fields not inherited, but not the inherited fields.</li>
+     *     </ul>
+     * </p>
+     *
+     * @throws IOException Can be thrown by the API creation calls.
+     * @throws CommandException Can be thrown by the API creation calls.
+     */
     @Test
     public void testLists() throws IOException, CommandException
     {
@@ -303,6 +341,25 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
     }
 
+    /**
+     * <p>
+     *     Validate editing Date, Time and DateTime fields with non-standard formats.
+     * </p>
+     * <p>
+     *     This test will:
+     *     <ul>
+     *         <li>Create a list with a non-standard format.</li>
+     *         <li>Validate the list and fields are called out in the site validation.</li>
+     *         <li>Edit the various fields and change the formats to a standard format.</li>
+     *         <li>Cancel the edit and validate the at the non-standard format is retained.</li>
+     *         <li>Edit again and change the fields to a standard format.</li>
+     *         <li>Validate the list and fields are no longer called out in the Site Validation report.</li>
+     *     </ul>
+     * </p>
+     *
+     * @throws IOException Can be thrown by the API creation calls.
+     * @throws CommandException Can be thrown by the API creation calls.
+     */
     @Test
     public void testEdit() throws IOException, CommandException
     {
@@ -408,6 +465,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
     }
 
+    // Private helper that will create a list through the APIs. This allows the list to have non-standard formats.
     private void createListByAPI(String listName, List<FieldDefinition> fields) throws IOException, CommandException
     {
         Connection connection = createDefaultConnection();
@@ -420,6 +478,23 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         listDef.create(connection, getProjectName());
     }
 
+    /**
+     * <p>
+     *     Validate non-standard Date, Time and DateTime formats in a DataClass
+     * </p>
+     * <p>
+     *     This test will:
+     *     <ul>
+     *         <li>Create a DataClass with non-standard formats.</li>
+     *         <li>Create a DataClass that inherits non-standard formats from the project settings.</li>
+     *         <li>Add some data to both as a sanity validation that non-standard formats are used.</li>
+     *         <li>Validate the designer scenarios for both DataClasses.</li>
+     *     </ul>
+     * </p>
+     *
+     * @throws IOException Can be thrown by the API creation calls.
+     * @throws CommandException Can be thrown by the API creation calls.
+     */
     @Test
     public void testDataClass() throws IOException, CommandException
     {
@@ -564,6 +639,10 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
     }
 
+    // Private helper that validates Date, Time and DateTime fields in a domain designer.
+    // isInherited: Used to check the enabled / editable state of the field.
+    // columnType: Used to identify the expected field options and messages.
+    // expectedToolTipText: Used as a check for the warning icon. If null no warning icon is expected.
     private void checkField(DomainFormPanel domainEditor, String fieldName,
                             boolean isInherited, FieldDefinition.ColumnType columnType,
                             String expectedFormat, @Nullable String expectedToolTipText)
@@ -671,6 +750,8 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
     }
 
+    // Private helper to check the Site Validation report. Checks to see if the report should, or should not, contain
+    // the list of warnings.
     private void checkSiteValidation(List<String> expectedWarnings, boolean shouldContain)
     {
         List<String> actualWarnings = getProjectValidationWarnings();
@@ -735,14 +816,16 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         String xpath = String.format("//li[contains(text(),'Project: %s')]//li[contains(text(),'Warnings:')]//ul", getProjectName());
         WebElement ul = Locator.xpath(xpath).findWhenNeeded(getDriver());
 
+        int linkTextLength = " more info".length();
+
         if (ul.isDisplayed())
         {
             List<String> actualWarnings = ul.findElements(Locator.tag("li")).stream().map(WebElement::getText).toList();
 
             for(String warning : actualWarnings)
             {
-                // Trim off the MORE INFO text.
-                String temp = warning.trim().substring(0, warning.length() - 10);
+                // Trim off the MORE INFO link text.
+                String temp = warning.trim().substring(0, warning.length() - linkTextLength);
                 warnings.add(temp);
             }
         }

--- a/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
+++ b/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
@@ -14,7 +14,6 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.domain.DomainFieldRow;
 import org.labkey.test.components.domain.DomainFormPanel;
-import org.labkey.test.components.react.FilteringReactSelect;
 import org.labkey.test.pages.admin.FolderFormatsPage;
 import org.labkey.test.pages.admin.FolderManagementPage;
 import org.labkey.test.pages.core.admin.BaseSettingsPage;

--- a/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
+++ b/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
@@ -10,6 +10,7 @@ import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.domain.DomainFieldRow;
 import org.labkey.test.components.domain.DomainFormPanel;
@@ -100,6 +101,22 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         ((NonStandardDateAndTimeFormatTest) getCurrentTest()).resetSiteSettings();
     }
 
+    @Override
+    public void doCleanup(boolean afterTest) throws TestTimeoutException
+    {
+
+        super.doCleanup(afterTest);
+
+        try
+        {
+            ((NonStandardDateAndTimeFormatTest) getCurrentTest()).resetSiteSettings();
+        }
+        catch (IOException | CommandException rethrow)
+        {
+            throw new RuntimeException(rethrow);
+        }
+    }
+
     private void resetSiteSettings() throws IOException, CommandException
     {
         log("Reset site settings.");
@@ -150,7 +167,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         checker().verifyFalse("DateTime format field should not be shown as inherited.",
                 projectSettingsPage.getDefaultDateDisplayInherited());
 
-        log("Check that the values in the fields are as expected.");
+        log("Check that the format and warnings in the designer are as expected.");
 
         checker().verifyEquals("Format of Default Date is not as expected.",
                 PROJECT_DATE_FORMAT, projectSettingsPage.getDefaultDateDisplay());
@@ -229,7 +246,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                 new FieldDefinition(dateTimeCol02, FieldDefinition.ColumnType.DateAndTime).setFormat(String.format("%s %s", nsTimeFormat02, nsDateFormat02))
         );
 
-        createListByAPI(listFormat, listFields);
+        createListByAPI(getProjectName(), listFormat, listFields);
 
         log(String.format("Create a second list named '%s' that inherits formats from the project.", listInherit));
 
@@ -239,7 +256,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                 new FieldDefinition(dateTimeCol01, FieldDefinition.ColumnType.DateAndTime)
         );
 
-        createListByAPI(listInherit, listFields);
+        createListByAPI(getProjectName(), listInherit, listFields);
 
         log(String.format("Validate the design and data of list '%s' (does not inherit formats).", listFormat));
         goToProjectHome();
@@ -379,7 +396,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                 new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setFormat(String.format("%s %s", nsDateFormat, nsTimeFormat))
         );
 
-        createListByAPI(listEdit, listFields);
+        createListByAPI(getProjectName(), listEdit, listFields);
 
         log("Check that Site Validation tags the fields in the list.");
 
@@ -465,19 +482,6 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
     }
 
-    // Private helper that will create a list through the APIs. This allows the list to have non-standard formats.
-    private void createListByAPI(String listName, List<FieldDefinition> fields) throws IOException, CommandException
-    {
-        Connection connection = createDefaultConnection();
-        ListDefinition listDef = new IntListDefinition(listName, "Key");
-        for(FieldDefinition field : fields)
-        {
-            listDef.addField(field);
-        }
-
-        listDef.create(connection, getProjectName());
-    }
-
     /**
      * <p>
      *     Validate non-standard Date, Time and DateTime formats in a DataClass
@@ -515,13 +519,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
         log(String.format("Create a Data Class named '%s' with non-standard format fields.", dcFormat));
 
-        DataClassDefinition dataClass = new DataClassDefinition(dcFormat);
-        for(FieldDefinition field : fields)
-        {
-            dataClass.addField(field);
-        }
-
-        dataClass.create(createDefaultConnection(), getProjectName());
+        createDataClass(getProjectName(), dcFormat, fields);
 
         fields = List.of(
                 new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date),
@@ -531,18 +529,9 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
         log(String.format("Create a Data Class named '%s' that inherits non-standard format fields from the project.", dcFormat));
 
-        dataClass = new DataClassDefinition(dcInherit);
-        for(FieldDefinition field : fields)
-        {
-            dataClass.addField(field);
-        }
-
-        dataClass.create(createDefaultConnection(), getProjectName());
+        createDataClass(getProjectName(), dcInherit, fields);
 
         log("Add some data to both data classes as a sanity validation of the formats.");
-
-        goToProjectHome();
-        clickAndWait(Locator.linkWithText(dcFormat));
 
         String bulkData = String.format("%s\t%s\t%s\t%s\n", "Name", dateTimeCol, dateCol, timeCol)
                 + "A\t12/23/24 14:45\t12/23/24\t14:45\n";
@@ -557,18 +546,8 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                 dateCol, "23/12/24",
                 timeCol, "2:45:0 PM -0800", "Flag", "");
 
-        DataRegionTable dataTable = new DataRegionTable("query", getDriver());
-        dataTable.clickImportBulkData()
-                .setText(bulkData);
-        clickButton("Submit");
-
-        goToProjectHome();
-        clickAndWait(Locator.linkWithText(dcInherit));
-
-        dataTable = new DataRegionTable("query", getDriver());
-        dataTable.clickImportBulkData()
-                .setText(bulkData);
-        clickButton("Submit");
+        populateDataClass(getProjectName(), dcFormat, bulkData);
+        populateDataClass(getProjectName(), dcInherit, bulkData);
 
         log(String.format("Validate domain designer feedback for '%s'.", dcFormat));
 
@@ -594,7 +573,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
         log("Validate the data (make sure we still respect non-standard formats).");
 
-        dataTable = new DataRegionTable("query", getDriver());
+        DataRegionTable dataTable = new DataRegionTable("query", getDriver());
         Map<String, String> actualData = dataTable.getRowDataAsMap(0);
         checker().verifyEquals("Data with formatted fields is not as expected.",
                 expectedFormatData, actualData);
@@ -636,6 +615,132 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         actualData = dataTable.getRowDataAsMap(0);
         checker().verifyEquals("Data with inherited fields is not as expected.",
                 expectedInheritedData, actualData);
+
+    }
+
+    @Test
+    public void testChildFolder() throws IOException, CommandException
+    {
+
+        String folderProject = "Non-Standard Sub-Folder Test";
+        String subFolder = "SubFolder_01";
+        String subFolderPath = folderProject + "/" + subFolder;
+
+        String dcInParent = "DC In Parent Folder";
+        String dcInChild = "DC In Child Folder";
+        String dateCol = "Date";
+        String timeCol = "Time";
+        String dateTimeCol = "DateTime";
+
+        log(String.format("Create a project '%s' with standard formatting.", folderProject));
+
+        _containerHelper.deleteProject(folderProject, false);
+        _containerHelper.createProject(folderProject, null);
+
+        // Use the API to set the formats for the project.
+//        new APIContainerHelper(this)
+//                .setDateAndTimeFormats(createDefaultConnection(), folderProject,
+//                        DATE_FORMAT.Default.toString(), TIME_FORMAT.Default.toString(), String.format("%s %s", DATE_FORMAT.Default, TIME_FORMAT.DTDefault));
+
+        log(String.format("Create a child folder '%s'.", folderProject));
+        _containerHelper.createSubfolder(folderProject, subFolder);
+
+        // Use the API to set the formats for the project.
+//        new APIContainerHelper(this)
+//                .setDateAndTimeFormats(createDefaultConnection(), subFolderPath,
+//                        DATE_FORMAT.Default.toString(), TIME_FORMAT.Default.toString(), String.format("%s %s", DATE_FORMAT.Default, TIME_FORMAT.DTDefault));
+
+        log(String.format("In the parent folder create a DataClass named '%s' with various Date, Time and DateTime columns some with non-standard formatting.", dcInParent));
+
+        goToProjectHome(folderProject);
+        _portalHelper.addWebPart("Data Classes");
+
+        List<FieldDefinition> fields = List.of(
+                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date),
+                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time),
+                new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime)
+        );
+
+        createDataClass(folderProject, dcInParent, fields);
+
+        log("Add data to use for format validation.");
+        String bulkData = String.format("%s\t%s\t%s\t%s\n", "Name", dateTimeCol, dateCol, timeCol)
+                + "P1\t12/23/24 14:45\t12/23/24\t14:45\n";
+
+        populateDataClass(folderProject, dcInParent, bulkData);
+
+        log(String.format("In the child folder '%s' create a DataClass named '%s' with various Date, Time and DateTime columns.", subFolder, dcInChild));
+
+        navigateToFolder(folderProject, subFolder);
+        _portalHelper.addWebPart("Data Classes");
+
+        fields = List.of(
+                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date),
+                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time),
+                new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime)
+        );
+
+        createDataClass(subFolderPath, dcInChild, fields);
+
+        log("Add data to DataClass created in the subfolder as validation.");
+
+        bulkData = String.format("%s\t%s\t%s\t%s\n", "Name", dateTimeCol, dateCol, timeCol)
+                + "C1\t11/28/24 11:11\t11/28/24\t11:11\n";
+
+        populateDataClass(subFolderPath, dcInChild, bulkData);
+
+        log("In the subfolder add data to DataClass in the parent folder as validation.");
+
+        populateDataClass(subFolderPath, dcInParent, bulkData);
+
+        String nsDateFormat = "MMMM dd, yyyy";
+        String nsTimeFormat = "hh:mm a";
+
+        // Change the site setting to be non-standard and validate inheritance.
+        goToProjectSettings();
+        new APIContainerHelper(this)
+                .setDateAndTimeFormats(createDefaultConnection(), "/",
+                        nsDateFormat, nsTimeFormat, String.format("%s %s", nsDateFormat, nsTimeFormat));
+
+    }
+
+    // Private helper that will create a list through the APIs. This allows the list to have non-standard formats.
+    private void createListByAPI(String path, String listName, List<FieldDefinition> fields) throws IOException, CommandException
+    {
+        Connection connection = createDefaultConnection();
+        ListDefinition listDef = new IntListDefinition(listName, "Key");
+        for(FieldDefinition field : fields)
+        {
+            listDef.addField(field);
+        }
+
+        listDef.create(connection, path);
+    }
+
+    private void createDataClass(String path, String dcName, List<FieldDefinition> fields) throws IOException, CommandException
+    {
+        log(String.format("Create a Data Class named '%s' in '%s'.", dcName, path));
+
+        DataClassDefinition dataClass = new DataClassDefinition(dcName);
+        for(FieldDefinition field : fields)
+        {
+            dataClass.addField(field);
+        }
+
+        dataClass.create(createDefaultConnection(), path);
+
+    }
+
+    private void populateDataClass(String path, String dcName, String importData)
+    {
+        goToProjectHome(path);
+        clickAndWait(Locator.linkWithText(dcName));
+
+        DataRegionTable dataTable = new DataRegionTable("query", getDriver());
+        dataTable.clickImportBulkData()
+                .setText(importData);
+
+        clickButton("Submit");
 
     }
 

--- a/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
+++ b/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
@@ -325,7 +325,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
     /**
      * <p>
-     *     Validate editing Date, Time and DateTime fields with non-standard formats.
+     *     Validate editing Date-Time fields with non-standard formats to standard formats.
      * </p>
      * <p>
      *     This test will:
@@ -343,7 +343,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
      * @throws CommandException Can be thrown by the API creation calls.
      */
     @Test
-    public void testEdit() throws IOException, CommandException
+    public void testEditDomain() throws IOException, CommandException
     {
         String listEdit = "List Edit Non-Standard Formats";
         String dateCol = "Date";
@@ -590,7 +590,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
      * <p>
      *     This test will:
      *     <ul>
-     *         <li>Create a separate project with a subfolder.</li>
+     *         <li>Create a separate project with a subfolder. Project has standard formats.</li>
      *         <li>Create and populate a data class in the project.</li>
      *         <li>Create and populate a data class in the subfolder.</li>
      *         <li>From the subfolder add a record to the data class in the parent folder.</li>
@@ -603,7 +603,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
      *         <li>Validate the data in both data classes is formatted as expected in the subfolder.</li>
      *         <li>Reset the site settings.</li>
      *         <li>Validate the Site Validation does not call out the site settings but still calls out the subfolder.</li>
-     *         <li>Validate the 'Look and Feel' page is updated with the default formats.</li>
+     *         <li>Validate the 'Look and Feel' page is reset with the default formats.</li>
      *         <li>Validate the subfolder formats are unchanged.</li>
      *     </ul>
      *     Note: there are periodic checks that the data is formatted as expected at the various levels.
@@ -653,7 +653,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
         populateDataClass(folderProject, dcInParent, bulkData);
 
-        log(String.format("In the child folder '%s' create a DataClass named '%s' with various Date, Time and DateTime columns.", subFolder, dcInChild));
+        log(String.format("In the child folder '%s' create a DataClass named '%s' with Date & Time columns.", subFolder, dcInChild));
 
         navigateToFolder(folderProject, subFolder);
         _portalHelper.addWebPart("Data Classes");
@@ -677,10 +677,11 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
         populateDataClass(subFolderPath, dcInParent, bulkData);
 
+        log("Change the site setting to be non-standard.");
+
         String nsSiteDateFormat = "MMMM dd, yyyy";
         String nsSiteTimeFormat = "kk:mm z";
 
-        log("Change the site setting to be non-standard.");
         changeSiteDateAndTimeFormats(nsSiteDateFormat, nsSiteTimeFormat);
 
         goToProjectHome(folderProject);
@@ -727,23 +728,6 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                 true, String.format("%s %s", nsSiteDateFormat, nsSiteTimeFormat), "",
                 false, false);
 
-        log("Validate fields in the designer at the project level.");
-        goToProjectHome(folderProject);
-        clickAndWait(Locator.linkWithText(dcInParent));
-        clickAndWait(Locator.lkButton("Edit Data Class"));
-        CreateDataClassPage editPage = new CreateDataClassPage(getDriver());
-        DomainFormPanel domainEditor = editPage.getDomainEditor();
-
-        validateFieldsInDesigner(domainEditor, dateCol,
-                true, FieldDefinition.ColumnType.Date,
-                nsSiteDateFormat, TT_NS_DATE);
-        validateFieldsInDesigner(domainEditor, timeCol,
-                true, FieldDefinition.ColumnType.Time,
-                nsSiteTimeFormat, TT_NS_TIME);
-        validateFieldsInDesigner(domainEditor, dateTimeCol,
-                true, FieldDefinition.ColumnType.DateAndTime,
-                String.format("%s %s", nsSiteDateFormat, nsSiteTimeFormat), TT_NS_DATETIME);
-
         log(String.format("Validate subfolder settings for '%s' inherit the site settings.", subFolderPath));
         FolderFormatsPage.beginAt(this, subFolderPath);
         validateSettingsPage(true, nsSiteDateFormat, false,
@@ -755,18 +739,20 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         Map<String, String> expectedFormatData = Map.of("Name", "P1",
                 dateTimeCol, "December 23, 2024 14:45 PST",
                 dateCol, "December 23, 2024",
-                timeCol, "14:45 PST", "Flag", "");
+                timeCol, "14:45 PST",
+                "Flag", "");
 
         validateDataIsFormatted(folderProject, dcInParent, expectedFormatData);
 
         expectedFormatData = Map.of("Name", "C1",
                 dateTimeCol, "November 28, 2024 11:11 PST",
                 dateCol, "November 28, 2024",
-                timeCol, "11:11 PST", "Flag", "");
+                timeCol, "11:11 PST",
+                "Flag", "");
         validateDataIsFormatted(subFolderPath, dcInChild, expectedFormatData);
         validateDataIsFormatted(subFolderPath, dcInParent, expectedFormatData);
 
-        log("Change the format in the subFolder.");
+        log("Change the formats in the subFolder.");
         String nsSubDateFormat = "EEEE MMMM dd, yyyy";
         String nsSubTimeFormat = "kk:mm (z)";
 
@@ -785,11 +771,12 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         expectedFormatData = Map.of("Name", "C1",
                 dateTimeCol, "Thursday November 28, 2024 11:11 (PST)",
                 dateCol, "Thursday November 28, 2024",
-                timeCol, "11:11 (PST)", "Flag", "");
+                timeCol, "11:11 (PST)",
+                "Flag", "");
         validateDataIsFormatted(subFolderPath, dcInChild, expectedFormatData);
         validateDataIsFormatted(subFolderPath, dcInParent, expectedFormatData);
 
-        log("Check that the 'Site Validation' report includes the subfolder.");
+        log("Check that the 'Site Validation' report now includes the subfolder.");
         List<String> folderWarnings = List.of(String.format("Folder default display format for Dates: %s", nsSubDateFormat),
                 String.format("Folder default display format for Times: %s", nsSubTimeFormat),
                 String.format("Folder default display format for DateTimes: %s %s", nsSubDateFormat, nsSubTimeFormat));
@@ -921,8 +908,6 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         DomainFieldRow fieldRow = domainEditor.getField(fieldName);
         fieldRow.expand();
 
-        String actualFormat;
-
         if (FieldDefinition.ColumnType.Date.equals(columnType))
         {
             if(isInherited)
@@ -934,9 +919,8 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                         fieldRow.isDateFormatEnabled());
             }
 
-            actualFormat = fieldRow.getDateFormat();
             checker().verifyEquals(String.format("Date format for field '%s' not as expected.", fieldName),
-                    expectedFormat, actualFormat);
+                    expectedFormat, fieldRow.getDateFormat());
         }
         else if (FieldDefinition.ColumnType.Time.equals(columnType))
         {
@@ -950,9 +934,8 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                         fieldRow.isTimeFormatEnabled());
             }
 
-            actualFormat = fieldRow.getTimeFormat();
             checker().verifyEquals(String.format("Time format for field '%s' not as expected.", fieldName),
-                    expectedFormat, actualFormat);
+                    expectedFormat, fieldRow.getTimeFormat());
         }
         else
         {
@@ -987,13 +970,11 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                 expectedTimeFormat = expectedFormat.substring(index+1);
             }
 
-            actualFormat = fieldRow.getDateTimeFormatDate();
             checker().verifyEquals(String.format("DateTime Date format for field '%s' not as expected.", fieldName),
-                    expectedDateFormat, actualFormat);
+                    expectedDateFormat, fieldRow.getDateTimeFormatDate());
 
-            actualFormat = fieldRow.getDateTimeFormatTime();
             checker().verifyEquals(String.format("DateTime Time format for field '%s' not as expected.", fieldName),
-                    expectedTimeFormat, actualFormat);
+                    expectedTimeFormat, fieldRow.getDateTimeFormatTime());
         }
 
         // If expected tooltip text is not null treat the field as a non-standard format field.
@@ -1022,7 +1003,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
     }
 
-    // These controls are shared across multiple pages. It is easier to find them here in the test than to use
+    // These controls are shared across multiple setting pages. It is easier to find them here in the test than to use
     // the page objects.
     private String getFormatFromControl(String fieldId)
     {
@@ -1137,9 +1118,9 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         checker().screenShotIfNewError("Site_Validation_Error");
     }
 
+    // Private helper that gets the data from the Site Validation page, narrowed to the scope provided, and cleans it up a bit.
     private List<String> getProjectValidationWarnings(String scope)
     {
-        List<String> warnings = new ArrayList<>();
 
         URLBuilder urlBuilder = new URLBuilder("admin", "configureSiteValidation");
         String url = urlBuilder.buildRelativeURL();
@@ -1168,18 +1149,15 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         String xpath = String.format("//li[contains(text(),'%s')]//li[contains(text(),'Warnings:')]//ul", scope);
         WebElement ul = Locator.xpath(xpath).findWhenNeeded(getDriver());
 
+        List<String> warnings = new ArrayList<>();
         int linkTextLength = " more info".length();
 
         if (ul.isDisplayed())
         {
-            List<String> actualWarnings = ul.findElements(Locator.tag("li")).stream().map(WebElement::getText).toList();
-
-            for(String warning : actualWarnings)
-            {
-                // Trim off the MORE INFO link text.
-                String temp = warning.trim().substring(0, warning.length() - linkTextLength);
-                warnings.add(temp);
-            }
+            // Get the text of the warnings and trim off the 'More Info' link.
+            warnings = ul.findElements(Locator.tag("li"))
+                    .stream()
+                    .map(el->el.getText().trim().substring(0, el.getText().length() - linkTextLength)).toList();
         }
 
         return warnings;

--- a/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
+++ b/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
@@ -936,6 +936,15 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
         validateDataIsFormatted(folderProject, dcSetFormats, expectedFormatData);
 
+        log("Check that using the values DATE, TIME and DATETIME do not show up in the validation report.");
+        // Issue 51491
+        List<String> siteWarnings = List.of(String.format("Site default display format for Dates: %s", DATE_FORMAT.DATE),
+                String.format("Site default display format for Times: %s", TIME_FORMAT.TIME),
+                String.format("Site default display format for DateTimes: %s %s", DATE_FORMAT.DATETIME, TIME_FORMAT.none));
+
+        String scope = "Root: /";
+        validateSiteValidationReport(scope, siteWarnings, false);
+
         log(String.format("Go to sub-folder '%s' and validate the data here is formatted according to sub-folder settings.", subFolder));
 
         expectedFormatData = Map.of("Name", "C1",

--- a/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
+++ b/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
@@ -1,0 +1,348 @@
+package org.labkey.test.tests;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.Connection;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
+import org.labkey.test.categories.Daily;
+import org.labkey.test.components.domain.DomainFieldRow;
+import org.labkey.test.components.domain.DomainFormPanel;
+import org.labkey.test.pages.core.admin.BaseSettingsPage;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.TIME_FORMAT;
+import org.labkey.test.pages.core.admin.ProjectSettingsPage;
+import org.labkey.test.pages.list.EditListDefinitionPage;
+import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.list.IntListDefinition;
+import org.labkey.test.params.list.ListDefinition;
+import org.labkey.test.util.APIContainerHelper;
+import org.labkey.test.util.DataRegionTable;
+import org.openqa.selenium.WebElement;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Category({Daily.class})
+public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
+{
+
+    private static final String PROJECT_NAME = "Non-Standard Date And Time Formats Test";
+
+    private static final String PROJECT_DATE_FORMAT = "dd/MM/yy";
+    private static final String PROJECT_TIME_FORMAT = "K:m:s a Z";
+    private static final String PROJECT_DATETIME_FORMAT = "EEEE MMMM dd D yyyy k:mm:s X";
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Arrays.asList("list");
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return PROJECT_NAME;
+    }
+
+    @BeforeClass
+    public static void setupProject() throws IOException, CommandException
+    {
+        NonStandardDateAndTimeFormatTest init = (NonStandardDateAndTimeFormatTest)getCurrentTest();
+        init.doSetup();
+    }
+
+    private void doSetup() throws IOException, CommandException
+    {
+        resetSiteSettings();
+        _containerHelper.createProject(PROJECT_NAME, null);
+        goToProjectHome();
+
+        new APIContainerHelper(this)
+                .setDateAndTimeFormats(createDefaultConnection(), PROJECT_NAME,
+                        PROJECT_DATE_FORMAT, PROJECT_TIME_FORMAT, PROJECT_DATETIME_FORMAT);
+    }
+
+    @AfterClass
+    public static void afterClass() throws IOException, CommandException
+    {
+        ((NonStandardDateAndTimeFormatTest) getCurrentTest()).resetSiteSettings();
+    }
+
+    private void resetSiteSettings() throws IOException, CommandException
+    {
+        log("Reset site settings.");
+        BaseSettingsPage.resetSettings(createDefaultConnection(), "/");
+    }
+
+    @Before
+    public void preTest()
+    {
+        goToProjectHome();
+    }
+
+    @Override
+    protected BrowserType bestBrowser()
+    {
+        return BrowserType.CHROME;
+    }
+
+    @Test
+    public void testProjectSettingsPage()
+    {
+        goToProjectHome();
+        ProjectSettingsPage projectSettingsPage = ProjectSettingsPage.beginAt(this);
+
+        log("Check that the Date, Time and DateTime format fields are not inherited.");
+
+        checker().verifyFalse("Date format field should not be shown as inherited.",
+                projectSettingsPage.getDefaultDateDisplayInherited());
+
+        checker().verifyFalse("Time format field should not be shown as inherited.",
+                projectSettingsPage.getDefaultTimeDisplayInherited());
+
+        checker().verifyFalse("DateTime format field should not be shown as inherited.",
+                projectSettingsPage.getDefaultDateDisplayInherited());
+
+        log("Check that the values in the fields are as expected.");
+
+        checker().verifyEquals("Format of Default Date is not as expected.",
+                PROJECT_DATE_FORMAT, projectSettingsPage.getDefaultDateDisplay());
+
+        checker().verifyTrue("Default Date field should have a non-standard warning, it does not.",
+                projectSettingsPage.defaultDateDisplayWarning());
+
+        checker().verifyEquals("Format of Default Time is not as expected.",
+                PROJECT_TIME_FORMAT, projectSettingsPage.getDefaultTimeDisplay());
+
+        checker().verifyTrue("Default Time field should have a non-standard warning, it does not.",
+                projectSettingsPage.defaultTimeDisplayWarning());
+
+        checker().verifyEquals("Format of Default DateTime (Date) is not as expected.",
+                PROJECT_DATETIME_FORMAT, projectSettingsPage.getDefaultDateTimeDateDisplay());
+
+        checker().verifyTrue("Default DateTime Date field should have a non-standard warning, it does not.",
+                projectSettingsPage.defaultDateTimeDateDisplayWarning());
+
+        checker().verifyEquals("Format of Default DateTime (Time) is not as expected.",
+                "", projectSettingsPage.getDefaultDateTimeTimeDisplay());
+
+        checker().verifyFalse("Default DateTime Time field should not have a non-standard warning, it does.",
+                projectSettingsPage.defaultDateTimeTimeDisplayWarning());
+
+    }
+
+    @Test
+    public void testLists() throws IOException, CommandException
+    {
+
+        String listFormat = "Non-Standard Formats";
+        String listInherit = "Inherit Project Formats";
+        String dateCol01 = "Date01";
+        String dateCol02 = "Date02";
+        String timeCol01 = "Time01";
+        String timeCol02 = "Time02";
+        String dateTimeCol01 = "DateTime01";
+        String dateTimeCol02 = "DateTime02";
+
+        log(String.format("Create a list named '%s' with various Date, Time and DateTime columns.", listFormat));
+
+        String nsDateFormat01 = "MMMM dd, yyyy";
+        String nsDateFormat02 = "yyyy-w G";
+        String nsTimeFormat01 = "hh:mm:ss.ss a";
+        String nsTimeFormat02 = "K:mm a z";
+
+        List<FieldDefinition> listFields = List.of(
+                new FieldDefinition(dateCol01, FieldDefinition.ColumnType.Date).setFormat(nsDateFormat01),
+                new FieldDefinition(dateCol02, FieldDefinition.ColumnType.Date).setFormat(nsDateFormat02),
+                new FieldDefinition(timeCol01, FieldDefinition.ColumnType.Time).setFormat(nsTimeFormat01),
+                new FieldDefinition(timeCol02, FieldDefinition.ColumnType.Time).setFormat(nsTimeFormat02),
+                new FieldDefinition(dateTimeCol01, FieldDefinition.ColumnType.DateAndTime).setFormat(String.format("%s %s", nsDateFormat01, nsTimeFormat01)),
+                new FieldDefinition(dateTimeCol02, FieldDefinition.ColumnType.DateAndTime).setFormat(String.format("%s %s", nsTimeFormat02, nsDateFormat02))
+        );
+
+        createListByAPI(listFormat, listFields);
+
+        log(String.format("Create a second list named '%s' that inherits formats from the project.", listInherit));
+
+        listFields = List.of(
+                new FieldDefinition(dateCol01, FieldDefinition.ColumnType.Date),
+                new FieldDefinition(timeCol01, FieldDefinition.ColumnType.Time),
+                new FieldDefinition(dateTimeCol01, FieldDefinition.ColumnType.DateAndTime)
+        );
+
+        createListByAPI(listInherit, listFields);
+
+        log(String.format("Validate the design and data of list '%s' (does not inherit formats).", listFormat));
+        goToProjectHome();
+        _listHelper.goToList(listFormat);
+        _listHelper.insertNewRow(Map.of(dateCol01, "4/1/21",
+                dateCol02, "12/25/19",
+                timeCol01, "12:32 am",
+                timeCol02, "14:42",
+                dateTimeCol01, "May 1, 2005 6:32 pm",
+                dateTimeCol02, "6/1/24 10:00"), false);
+
+        Map<String, String> expectedRowValues = Map.of(dateCol01, "April 01, 2021",
+                dateCol02, "2019-52 AD",
+                timeCol01, "12:32:00.00 AM",
+                timeCol02, "2:42 PM PST",
+                dateTimeCol01, "May 01, 2005 06:32:00.00 PM",
+                dateTimeCol02, "10:00 AM PDT 2024-22 AD");
+
+        DataRegionTable table = new DataRegionTable("query", getDriver());
+
+        clickAndWait(table.getHeaderButton("Design"));
+        EditListDefinitionPage listDefinitionPage = new EditListDefinitionPage(getDriver());
+
+        checkField(listDefinitionPage, dateCol01, false, FieldDefinition.ColumnType.Date,
+                nsDateFormat01, "Non-standard date format.");
+        checkField(listDefinitionPage, dateCol02, false, FieldDefinition.ColumnType.Date,
+                nsDateFormat02, "Non-standard date format.");
+        checkField(listDefinitionPage, timeCol01, false, FieldDefinition.ColumnType.Time,
+                nsTimeFormat01, "Non-standard time format.");
+        checkField(listDefinitionPage, timeCol02, false, FieldDefinition.ColumnType.Time,
+                nsTimeFormat02, "Non-standard time format.");
+        checkField(listDefinitionPage, dateTimeCol01, false, FieldDefinition.ColumnType.DateAndTime,
+                String.format("%s %s", nsDateFormat01, nsTimeFormat01), "Non-standard date-time format.");
+        checkField(listDefinitionPage, dateTimeCol02, false, FieldDefinition.ColumnType.DateAndTime,
+                String.format("%s %s", nsTimeFormat02, nsDateFormat02), "Non-standard date-time format.");
+
+        listDefinitionPage.clickCancel();
+        table = new DataRegionTable("query", getDriver());
+        Map<String, String> actualRowValues = table.getRowDataAsMap(0);
+
+        checker().verifyEquals("Data in grid is not formatted as expected.",
+                expectedRowValues, actualRowValues);
+
+        log(String.format("Validate the design and data of list '%s' (does inherit formats).", listInherit));
+        goToProjectHome();
+        _listHelper.goToList(listInherit);
+        _listHelper.insertNewRow(Map.of(dateCol01, "4/1/21",
+                timeCol01, "12:32 am",
+                dateTimeCol01, "May 1, 2005 6:32 pm"), false);
+
+        expectedRowValues = Map.of(dateCol01, "01/04/21",
+                timeCol01, "0:32:0 AM -0800",
+                dateTimeCol01, "Sunday May 01 121 2005 18:32:0 -07");
+
+        table = new DataRegionTable("query", getDriver());
+
+        clickAndWait(table.getHeaderButton("Design"));
+        listDefinitionPage = new EditListDefinitionPage(getDriver());
+
+        checkField(listDefinitionPage, dateCol01, true, FieldDefinition.ColumnType.Date,
+                PROJECT_DATE_FORMAT, "Non-standard date format.");
+        checkField(listDefinitionPage, timeCol01, true, FieldDefinition.ColumnType.Time,
+                PROJECT_TIME_FORMAT, "Non-standard time format.");
+        checkField(listDefinitionPage, dateTimeCol01, true, FieldDefinition.ColumnType.DateAndTime,
+                PROJECT_DATETIME_FORMAT, "Non-standard date-time format.");
+
+        listDefinitionPage.clickCancel();
+        table = new DataRegionTable("query", getDriver());
+        actualRowValues = table.getRowDataAsMap(0);
+
+        checker().verifyEquals("Data in grid is not formatted as expected.",
+                expectedRowValues, actualRowValues);
+    }
+
+    private void createListByAPI(String listName, List<FieldDefinition> fields) throws IOException, CommandException
+    {
+        Connection connection = createDefaultConnection();
+        ListDefinition listDef = new IntListDefinition(listName, "Key");
+        for(FieldDefinition field : fields)
+        {
+            listDef.addField(field);
+        }
+
+        listDef.create(connection, getProjectName());
+    }
+
+    private void checkField(EditListDefinitionPage listDefinitionPage, String fieldName,
+                            boolean isInherited, FieldDefinition.ColumnType columnType,
+                            String expectedFormat, String expectedToolTipText)
+    {
+        DomainFormPanel domainEditor = listDefinitionPage.getFieldsPanel();
+        DomainFieldRow fieldRow = domainEditor.getField(fieldName);
+        fieldRow.expand();
+
+        String actualFormat;
+
+        if (FieldDefinition.ColumnType.Date.equals(columnType))
+        {
+            if(isInherited)
+            {
+                checker().verifyTrue(String.format("Field '%s' should show as inherited, it does not.", fieldName),
+                        fieldRow.isDateInherited());
+
+                checker().verifyFalse(String.format("Field '%s' should not be enabled.", fieldName),
+                        fieldRow.isDateFormatEnabled());
+            }
+
+            actualFormat = fieldRow.getDateFormat();
+            checker().verifyEquals(String.format("Date format for field '%s' not as expected.", fieldName),
+                    expectedFormat, actualFormat);
+        }
+        else if (FieldDefinition.ColumnType.Time.equals(columnType))
+        {
+
+            if(isInherited)
+            {
+                checker().verifyTrue(String.format("Field '%s' should show as inherited, it does not.", fieldName),
+                        fieldRow.isTimeInherited());
+
+                checker().verifyFalse(String.format("Field '%s' should not be enabled.", fieldName),
+                        fieldRow.isTimeFormatEnabled());
+            }
+
+            actualFormat = fieldRow.getTimeFormat();
+            checker().verifyEquals(String.format("Time format for field '%s' not as expected.", fieldName),
+                    expectedFormat, actualFormat);
+        }
+        else
+        {
+
+            if(isInherited)
+            {
+                checker().verifyTrue(String.format("Field '%s' should show as inherited, it does not.", fieldName),
+                        fieldRow.isDateTimeInherited());
+
+                checker().verifyFalse(String.format("Date part of DateTime field '%s' should not be enabled.", fieldName),
+                        fieldRow.isDateTimeFormatDateEnabled());
+
+                checker().verifyFalse(String.format("Time part of DateTime field '%s' should not be enabled.", fieldName),
+                        fieldRow.isDateTimeFormatTimeEnabled());
+            }
+
+            actualFormat = fieldRow.getDateTimeFormatDate();
+            checker().verifyEquals(String.format("DateTime Date format for field '%s' not as expected.", fieldName),
+                    expectedFormat, actualFormat);
+
+            actualFormat = fieldRow.getDateTimeFormatTime();
+            checker().verifyEquals(String.format("DateTime Time format for field '%s' not as expected.", fieldName),
+                    TIME_FORMAT.none.toString(), actualFormat);
+        }
+
+        if(checker().verifyTrue("No warning icon present for field with non-standard date-time format.",
+                fieldRow.hasDomainWarningIcon()))
+        {
+            WebElement icon = fieldRow.getDomainWarningIcon();
+            mouseOver(icon);
+            WebElement toolTip = Locator.tagWithClass("div", "tooltip-inner")
+                    .withText(expectedToolTipText)
+                    .findWhenNeeded(getDriver());
+
+            checker().verifyTrue("Tooltip not present or text not as expected.",
+                    waitFor(toolTip::isDisplayed, 1_000));
+        }
+
+        checker().screenShotIfNewError(String.format("Non_Standard_Field_%s_Error", fieldName));
+
+    }
+
+}

--- a/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
+++ b/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
@@ -14,7 +14,9 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.domain.DomainFieldRow;
 import org.labkey.test.components.domain.DomainFormPanel;
+import org.labkey.test.components.react.FilteringReactSelect;
 import org.labkey.test.pages.admin.FolderFormatsPage;
+import org.labkey.test.pages.admin.FolderManagementPage;
 import org.labkey.test.pages.core.admin.BaseSettingsPage;
 import org.labkey.test.pages.core.admin.BaseSettingsPage.TIME_FORMAT;
 import org.labkey.test.pages.core.admin.BaseSettingsPage.DATE_FORMAT;
@@ -204,7 +206,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
         log(String.format("Create a list named '%s' with various Date, Time and DateTime columns.", listFormat));
 
-        String nsDateFormat01 = "MMMM dd, yyyy";
+        String nsDateFormat01 = "MMMM dd, yyyy"; // Similar to a standard format, except this has a comma after the dd.
         String nsDateFormat02 = "yyyy-w G";
         String nsTimeFormat01 = "hh:mm:ss.ss a";
         String nsTimeFormat02 = "K:mm a z";
@@ -620,8 +622,8 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         String subFolder = "SubFolder_01";
         String subFolderPath = folderProject + "/" + subFolder;
 
-        String dcInParent = "DC In Parent Folder";
-        String dcInChild = "DC In Child Folder";
+        String dcInProj = "DC In Project Folder";
+        String dcInSub = "DC In Sub-Folder";
         String dateCol = "Date";
         String timeCol = "Time";
         String dateTimeCol = "DateTime";
@@ -631,10 +633,10 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         _containerHelper.deleteProject(folderProject, false);
         _containerHelper.createProject(folderProject, null);
 
-        log(String.format("Create a child folder '%s'.", folderProject));
+        log(String.format("Create a sub-folder '%s'.", folderProject));
         _containerHelper.createSubfolder(folderProject, subFolder);
 
-        log(String.format("In the parent folder create a DataClass named '%s' with various Date, Time and DateTime columns.", dcInParent));
+        log(String.format("In the parent folder create a DataClass named '%s' with various Date, Time and DateTime columns.", dcInProj));
 
         goToProjectHome(folderProject);
         _portalHelper.addWebPart("Data Classes");
@@ -645,15 +647,15 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                 new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime)
         );
 
-        createDataClass(folderProject, dcInParent, fields);
+        createDataClass(folderProject, dcInProj, fields);
 
         log("Add data to use for format validation.");
         String bulkData = String.format("%s\t%s\t%s\t%s\n", "Name", dateTimeCol, dateCol, timeCol)
                 + "P1\t12/23/24 14:45\t12/23/24\t14:45\n";
 
-        populateDataClass(folderProject, dcInParent, bulkData);
+        populateDataClass(folderProject, dcInProj, bulkData);
 
-        log(String.format("In the child folder '%s' create a DataClass named '%s' with Date & Time columns.", subFolder, dcInChild));
+        log(String.format("In the sub-folder '%s' create a DataClass named '%s' with Date & Time columns.", subFolder, dcInSub));
 
         navigateToFolder(folderProject, subFolder);
         _portalHelper.addWebPart("Data Classes");
@@ -664,18 +666,18 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                 new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime)
         );
 
-        createDataClass(subFolderPath, dcInChild, fields);
+        createDataClass(subFolderPath, dcInSub, fields);
 
         log("Add data to DataClass created in the subfolder as validation.");
 
         bulkData = String.format("%s\t%s\t%s\t%s\n", "Name", dateTimeCol, dateCol, timeCol)
                 + "C1\t11/28/24 11:11\t11/28/24\t11:11\n";
 
-        populateDataClass(subFolderPath, dcInChild, bulkData);
+        populateDataClass(subFolderPath, dcInSub, bulkData);
 
         log("In the subfolder add data to DataClass from the parent folder as validation.");
 
-        populateDataClass(subFolderPath, dcInParent, bulkData);
+        populateDataClass(subFolderPath, dcInProj, bulkData);
 
         log("Change the site setting to be non-standard.");
 
@@ -742,15 +744,15 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                 timeCol, "14:45 PST",
                 "Flag", "");
 
-        validateDataIsFormatted(folderProject, dcInParent, expectedFormatData);
+        validateDataIsFormatted(folderProject, dcInProj, expectedFormatData);
 
         expectedFormatData = Map.of("Name", "C1",
                 dateTimeCol, "November 28, 2024 11:11 PST",
                 dateCol, "November 28, 2024",
                 timeCol, "11:11 PST",
                 "Flag", "");
-        validateDataIsFormatted(subFolderPath, dcInChild, expectedFormatData);
-        validateDataIsFormatted(subFolderPath, dcInParent, expectedFormatData);
+        validateDataIsFormatted(subFolderPath, dcInSub, expectedFormatData);
+        validateDataIsFormatted(subFolderPath, dcInProj, expectedFormatData);
 
         log("Change the formats in the subFolder.");
         String nsSubDateFormat = "EEEE MMMM dd, yyyy";
@@ -773,8 +775,8 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                 dateCol, "Thursday November 28, 2024",
                 timeCol, "11:11 (PST)",
                 "Flag", "");
-        validateDataIsFormatted(subFolderPath, dcInChild, expectedFormatData);
-        validateDataIsFormatted(subFolderPath, dcInParent, expectedFormatData);
+        validateDataIsFormatted(subFolderPath, dcInSub, expectedFormatData);
+        validateDataIsFormatted(subFolderPath, dcInProj, expectedFormatData);
 
         log("Check that the 'Site Validation' report now includes the subfolder.");
         List<String> folderWarnings = List.of(String.format("Folder default display format for Dates: %s", nsSubDateFormat),
@@ -808,6 +810,173 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         log("Validate the subfolder still appears in the Site Validation report.");
         scope = String.format("Folder: %s", subFolderPath);
         validateSiteValidationReport(scope, folderWarnings, true);
+
+    }
+
+    /**
+     * <p>
+     *     Use the text values 'Date', 'Time' and 'DateTime' as the format values in a domain designer. This will use a
+     *     DataClass because its design will be visible in the sub-folder.
+     * </p>
+     * <p>
+     *     This test will:
+     *     <ul>
+     *         <li>Create a new project and set the Date-Time formats to some standard format.</li>
+     *         <li>Create a sub-folder and set the Date-Time formats to some other standard format.</li>
+     *         <li>Create a DataClass in parent folder.</li>
+     *         <li>Set the date field format to 'Date'.</li>
+     *         <li>Set the time field format to 'Time'.</li>
+     *         <li>Set the DateTime field format to 'DateTime' and 'none'.</li>
+     *         <li>Validate data is formatted as expected in the project.</li>
+     *         <li>In the sub-folder validate the data is formatted by the sub-folder settings.</li>
+     *         <li>Validate that setting the date part of a DateTime field only allows 'none' for the time format part.</li>
+     *     </ul>
+     * </p>
+     *
+     * @throws IOException Can be thrown by helpers that create the folders, etc...
+     * @throws CommandException Can be thrown by helpers that create the folders, etc...
+     */
+    @Test
+    public void testTextFormatValueOfDate() throws IOException, CommandException
+    {
+
+        String folderProject = "Text_Format_Test";
+        String subFolder = "SubFolder_01";
+        String subFolderPath = folderProject + "/" + subFolder;
+
+        log(String.format("Create a project '%s' with standard formatting.", folderProject));
+
+        _containerHelper.deleteProject(folderProject, false);
+        _containerHelper.createProject(folderProject, null);
+
+        log(String.format("Create a sub-folder '%s'.", folderProject));
+        _containerHelper.createSubfolder(folderProject, subFolder);
+
+        goToProjectHome(folderProject);
+        _portalHelper.addWebPart("Data Classes");
+
+        goToProjectHome(subFolderPath);
+        _portalHelper.addWebPart("Data Classes");
+
+        String dcSetFormats = "DC Use Text Format";
+        String dcCheckWarnings = "DC Check Warnings";
+
+        String dateCol = "Date01";
+        String timeCol = "Time01";
+        String dateTimeCol = "DateTime01";
+
+        log(String.format("Create a DataClass named '%s' with Date, Time and DateTime columns.", dcSetFormats));
+
+        List<FieldDefinition> fields = List.of(
+                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date),
+                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time),
+                new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime)
+        );
+
+        createDataClass(folderProject, dcSetFormats, fields);
+        createDataClass(folderProject, dcCheckWarnings, fields);
+
+        log("Add data in the parent folder.");
+        String bulkData = String.format("%s\t%s\t%s\t%s\n", "Name", dateTimeCol, dateCol, timeCol)
+                + "P1\t11/11/11 23:11\t11/11/11\t23:11\n";
+
+        populateDataClass(folderProject, dcSetFormats, bulkData);
+
+        log("Add data to the DataClasses in the subfolder.");
+
+        bulkData = String.format("%s\t%s\t%s\t%s\n", "Name", dateTimeCol, dateCol, timeCol)
+                + "C1\t11/11/11 23:11\t11/11/11\t23:11\n";
+
+        populateDataClass(subFolderPath, dcSetFormats, bulkData);
+
+        log("At the project level set the formats to something other than the default values.");
+        ProjectSettingsPage projectSettingsPage = ProjectSettingsPage.beginAt(this, folderProject);
+        projectSettingsPage.setDefaultDateDisplayInherited(false);
+        projectSettingsPage.setDefaultDateDisplay(DATE_FORMAT.dd_MMM_yyyy);
+        projectSettingsPage.setDefaultTimeDisplayInherited(false);
+        projectSettingsPage.setDefaultTimeDisplay(TIME_FORMAT.hh_mm_a);
+        projectSettingsPage.setDefaultDateTimeDisplayInherited(false);
+        projectSettingsPage.setDefaultDateTimeDisplay(DATE_FORMAT.dd_MMM_yyyy, TIME_FORMAT.hh_mm_a);
+        projectSettingsPage.save();
+
+        log("At the sub-folder level set the formats to something different as well.");
+        FolderFormatsPage folderFormatsPage = FolderManagementPage.beginAt(this, subFolderPath).goToFormatsTab();
+        folderFormatsPage.setDefaultDateDisplayInherited(false);
+        folderFormatsPage.setDefaultDateDisplay(DATE_FORMAT.ddMMMyy);
+        folderFormatsPage.setDefaultTimeDisplayInherited(false);
+        folderFormatsPage.setDefaultTimeDisplay(TIME_FORMAT.HH_mm_ss_SSS);
+        folderFormatsPage.setDefaultDateTimeDisplayInherited(false);
+        folderFormatsPage.setDefaultDateTimeDisplay(DATE_FORMAT.ddMMMyy, TIME_FORMAT.HH_mm_ss_SSS);
+        folderFormatsPage.clickSave();
+
+        log("Go to the project and change the formats in the DataClass.");
+        goToProjectHome(folderProject);
+
+        log(String.format("For DataClass '%s' in the parent folder, change the formats to use 'Date', 'Time' and 'DateTime'.", dcSetFormats));
+        clickAndWait(Locator.linkWithText(dcSetFormats));
+        clickAndWait(Locator.lkButton("Edit Data Class"));
+        CreateDataClassPage editPage = new CreateDataClassPage(getDriver());
+        DomainFormPanel domainEditor = editPage.getDomainEditor();
+        DomainFieldRow fieldRow = domainEditor.getField(dateCol);
+        fieldRow.setDateInherited(false);
+        fieldRow.setDateFormat(DATE_FORMAT.DATE);
+        fieldRow = domainEditor.getField(timeCol);
+        fieldRow.setTimeInherited(false);
+        fieldRow.setTimeFormat(TIME_FORMAT.TIME);
+        fieldRow = domainEditor.getField(dateTimeCol);
+        fieldRow.setDateTimeInherited(false);
+        fieldRow.setDateTimeFormat(DATE_FORMAT.DATETIME, TIME_FORMAT.none);
+        editPage.clickSave();
+
+        log("Validate that the values are formatted with the settings in the parent folder.");
+
+        Map<String, String> expectedFormatData = Map.of("Name", "P1",
+                dateTimeCol, "11-Nov-2011 11:11 PM",
+                dateCol, "11-Nov-2011",
+                timeCol, "11:11 PM", "Flag", "");
+
+        validateDataIsFormatted(folderProject, dcSetFormats, expectedFormatData);
+
+        log(String.format("Go to sub-folder '%s' and validate the data here is formatted according to sub-folder settings.", subFolder));
+
+        expectedFormatData = Map.of("Name", "C1",
+                dateTimeCol, "11Nov11 23:11:00.000",
+                dateCol, "11Nov11",
+                timeCol, "23:11:00.000", "Flag", "");
+
+        validateDataIsFormatted(subFolderPath, dcSetFormats, expectedFormatData);
+
+        log("Go back to parent folder and validate warnings for DateTime fields.");
+
+        goToProjectHome(folderProject);
+
+        clickAndWait(Locator.linkWithText(dcCheckWarnings));
+        clickAndWait(Locator.lkButton("Edit Data Class"));
+        editPage = new CreateDataClassPage(getDriver());
+        domainEditor = editPage.getDomainEditor();
+        fieldRow = domainEditor.getField(dateTimeCol);
+        fieldRow.setDateTimeInherited(false);
+        fieldRow.setDateTimeFormat(DATE_FORMAT.DATETIME, TIME_FORMAT.hh_mm_a);
+
+        checker().verifyTrue(String.format("When setting the date part of a DateTime to '%s', '%s' to should be the only allowed value for the time part.",
+                        DATE_FORMAT.DATETIME, TIME_FORMAT.none),
+                fieldRow.hasDomainWarningIcon());
+
+        List<String> actualValues = editPage.clickSaveExpectingErrors();
+
+        List<String> expectedValues = List.of(
+                String.format("Property %s: %s %s is an illegal format for type DateTime",
+                        dateTimeCol, DATE_FORMAT.DATETIME, TIME_FORMAT.hh_mm_a),
+                String.format("Please correct errors in %s before saving.",
+                        dcCheckWarnings));
+
+        checker().verifyEquals("Error messages are not as expected.",
+                expectedValues, actualValues);
+
+        checker().screenShotIfNewError("Warning_Errors");
+
+        log("Cancel out of the editor.");
+        editPage.clickCancel();
 
     }
 

--- a/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
+++ b/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
@@ -1,5 +1,6 @@
 package org.labkey.test.tests;
 
+import org.jetbrains.annotations.Nullable;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -14,16 +15,22 @@ import org.labkey.test.components.domain.DomainFieldRow;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.core.admin.BaseSettingsPage;
 import org.labkey.test.pages.core.admin.BaseSettingsPage.TIME_FORMAT;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.DATE_FORMAT;
 import org.labkey.test.pages.core.admin.ProjectSettingsPage;
+import org.labkey.test.pages.experiment.CreateDataClassPage;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.experiment.DataClassDefinition;
 import org.labkey.test.params.list.IntListDefinition;
 import org.labkey.test.params.list.ListDefinition;
 import org.labkey.test.util.APIContainerHelper;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.PortalHelper;
+import org.labkey.test.util.URLBuilder;
 import org.openqa.selenium.WebElement;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +44,16 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
     private static final String PROJECT_DATE_FORMAT = "dd/MM/yy";
     private static final String PROJECT_TIME_FORMAT = "K:m:s a Z";
     private static final String PROJECT_DATETIME_FORMAT = "EEEE MMMM dd D yyyy k:mm:s X";
+
+    private static final List<String> PROJECT_WARNINGS = List.of(String.format("Project default display format for Dates: %s", PROJECT_DATE_FORMAT),
+            String.format("Project default display format for DateTimes: %s", PROJECT_DATETIME_FORMAT),
+            String.format("Project default display format for Times: %s", PROJECT_TIME_FORMAT));
+
+    private static final String TT_NS_DATE = "Non-standard date format.";
+    private static final String TT_NS_TIME = "Non-standard time format.";
+    private static final String TT_NS_DATETIME = "Non-standard date-time format.";
+
+    private final PortalHelper _portalHelper = new PortalHelper(this);
 
     @Override
     public List<String> getAssociatedModules()
@@ -66,6 +83,11 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         new APIContainerHelper(this)
                 .setDateAndTimeFormats(createDefaultConnection(), PROJECT_NAME,
                         PROJECT_DATE_FORMAT, PROJECT_TIME_FORMAT, PROJECT_DATETIME_FORMAT);
+
+        _portalHelper.addWebPart("Lists");
+        _portalHelper.addWebPart("Data Classes");
+        _portalHelper.addWebPart("Assay List");
+
     }
 
     @AfterClass
@@ -135,14 +157,17 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         checker().verifyFalse("Default DateTime Time field should not have a non-standard warning, it does.",
                 projectSettingsPage.defaultDateTimeTimeDisplayWarning());
 
+        log("Check that Site Validation includes warnings from the project settings.");
+        checkSiteValidation(PROJECT_WARNINGS, true);
+
     }
 
     @Test
     public void testLists() throws IOException, CommandException
     {
 
-        String listFormat = "Non-Standard Formats";
-        String listInherit = "Inherit Project Formats";
+        String listFormat = "List Non-Standard Formats";
+        String listInherit = "List Inherit Project Formats";
         String dateCol01 = "Date01";
         String dateCol02 = "Date02";
         String timeCol01 = "Time01";
@@ -195,26 +220,24 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                 dateTimeCol01, "May 01, 2005 06:32:00.00 PM",
                 dateTimeCol02, "10:00 AM PDT 2024-22 AD");
 
-        DataRegionTable table = new DataRegionTable("query", getDriver());
+        EditListDefinitionPage listDefinitionPage = _listHelper.goToEditDesign(listFormat);
+        DomainFormPanel domainEditor = listDefinitionPage.getFieldsPanel();
 
-        clickAndWait(table.getHeaderButton("Design"));
-        EditListDefinitionPage listDefinitionPage = new EditListDefinitionPage(getDriver());
-
-        checkField(listDefinitionPage, dateCol01, false, FieldDefinition.ColumnType.Date,
-                nsDateFormat01, "Non-standard date format.");
-        checkField(listDefinitionPage, dateCol02, false, FieldDefinition.ColumnType.Date,
-                nsDateFormat02, "Non-standard date format.");
-        checkField(listDefinitionPage, timeCol01, false, FieldDefinition.ColumnType.Time,
-                nsTimeFormat01, "Non-standard time format.");
-        checkField(listDefinitionPage, timeCol02, false, FieldDefinition.ColumnType.Time,
-                nsTimeFormat02, "Non-standard time format.");
-        checkField(listDefinitionPage, dateTimeCol01, false, FieldDefinition.ColumnType.DateAndTime,
-                String.format("%s %s", nsDateFormat01, nsTimeFormat01), "Non-standard date-time format.");
-        checkField(listDefinitionPage, dateTimeCol02, false, FieldDefinition.ColumnType.DateAndTime,
-                String.format("%s %s", nsTimeFormat02, nsDateFormat02), "Non-standard date-time format.");
+        checkField(domainEditor, dateCol01, false, FieldDefinition.ColumnType.Date,
+                nsDateFormat01, TT_NS_DATE);
+        checkField(domainEditor, dateCol02, false, FieldDefinition.ColumnType.Date,
+                nsDateFormat02, TT_NS_DATE);
+        checkField(domainEditor, timeCol01, false, FieldDefinition.ColumnType.Time,
+                nsTimeFormat01, TT_NS_TIME);
+        checkField(domainEditor, timeCol02, false, FieldDefinition.ColumnType.Time,
+                nsTimeFormat02, TT_NS_TIME);
+        checkField(domainEditor, dateTimeCol01, false, FieldDefinition.ColumnType.DateAndTime,
+                String.format("%s %s", nsDateFormat01, nsTimeFormat01), TT_NS_DATETIME);
+        checkField(domainEditor, dateTimeCol02, false, FieldDefinition.ColumnType.DateAndTime,
+                String.format("%s %s", nsTimeFormat02, nsDateFormat02), TT_NS_DATETIME);
 
         listDefinitionPage.clickCancel();
-        table = new DataRegionTable("query", getDriver());
+        DataRegionTable table = new DataRegionTable("query", getDriver());
         Map<String, String> actualRowValues = table.getRowDataAsMap(0);
 
         checker().verifyEquals("Data in grid is not formatted as expected.",
@@ -231,17 +254,15 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                 timeCol01, "0:32:0 AM -0800",
                 dateTimeCol01, "Sunday May 01 121 2005 18:32:0 -07");
 
-        table = new DataRegionTable("query", getDriver());
+        listDefinitionPage =  _listHelper.goToEditDesign(listInherit);
+        domainEditor = listDefinitionPage.getFieldsPanel();
 
-        clickAndWait(table.getHeaderButton("Design"));
-        listDefinitionPage = new EditListDefinitionPage(getDriver());
-
-        checkField(listDefinitionPage, dateCol01, true, FieldDefinition.ColumnType.Date,
-                PROJECT_DATE_FORMAT, "Non-standard date format.");
-        checkField(listDefinitionPage, timeCol01, true, FieldDefinition.ColumnType.Time,
-                PROJECT_TIME_FORMAT, "Non-standard time format.");
-        checkField(listDefinitionPage, dateTimeCol01, true, FieldDefinition.ColumnType.DateAndTime,
-                PROJECT_DATETIME_FORMAT, "Non-standard date-time format.");
+        checkField(domainEditor, dateCol01, true, FieldDefinition.ColumnType.Date,
+                PROJECT_DATE_FORMAT, TT_NS_DATE);
+        checkField(domainEditor, timeCol01, true, FieldDefinition.ColumnType.Time,
+                PROJECT_TIME_FORMAT, TT_NS_TIME);
+        checkField(domainEditor, dateTimeCol01, true, FieldDefinition.ColumnType.DateAndTime,
+                PROJECT_DATETIME_FORMAT, TT_NS_DATETIME);
 
         listDefinitionPage.clickCancel();
         table = new DataRegionTable("query", getDriver());
@@ -249,6 +270,142 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
         checker().verifyEquals("Data in grid is not formatted as expected.",
                 expectedRowValues, actualRowValues);
+
+        log("Validate that the Site Validation contains the expected warnings.");
+
+        List<String> expectedWarnings = List.of(String.format("Date property \"lists.%s.%s\": %s",
+                        listFormat, dateCol01, nsDateFormat01),
+                String.format("Date property \"lists.%s.%s\": %s",
+                        listFormat, dateCol02, nsDateFormat02),
+                String.format("Time property \"lists.%s.%s\": %s",
+                        listFormat, timeCol01, nsTimeFormat01),
+                String.format("Time property \"lists.%s.%s\": %s",
+                        listFormat, timeCol02, nsTimeFormat02),
+                String.format("DateTime property \"lists.%s.%s\": %s %s",
+                        listFormat, dateTimeCol01, nsDateFormat01, nsTimeFormat01),
+                String.format("DateTime property \"lists.%s.%s\": %s %s",
+                        listFormat, dateTimeCol02, nsTimeFormat02, nsDateFormat02)
+        );
+
+        checkSiteValidation(expectedWarnings, true);
+
+        log("Validate that Site Validation does not contain warnings about inherited fields.");
+
+        expectedWarnings = List.of(String.format("Date property \"lists.%s.%s\": %s",
+                        listInherit, dateCol01, nsDateFormat01),
+                String.format("Time property \"lists.%s.%s\": %s",
+                        listInherit, timeCol01, nsTimeFormat01),
+                String.format("DateTime property \"lists.%s.%s\": %s %s",
+                        listInherit, dateTimeCol01, nsDateFormat01, nsTimeFormat01)
+        );
+
+        checkSiteValidation(expectedWarnings, false);
+
+    }
+
+    @Test
+    public void testEdit() throws IOException, CommandException
+    {
+        String listEdit = "List Edit Non-Standard Formats";
+        String dateCol = "Date";
+        String timeCol = "Time";
+        String dateTimeCol = "DateTime";
+
+        log(String.format("Create a list named '%s' with various Date, Time and DateTime columns.", listEdit));
+
+        String nsDateFormat = "MMMM dd, yyyy";
+        String nsTimeFormat = "hh:mm:ss.ss a";
+
+        List<FieldDefinition> listFields = List.of(
+                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date).setFormat(nsDateFormat),
+                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time).setFormat(nsTimeFormat),
+                new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setFormat(String.format("%s %s", nsDateFormat, nsTimeFormat))
+        );
+
+        createListByAPI(listEdit, listFields);
+
+        log("Check that Site Validation tags the fields in the list.");
+
+        List<String> expectedWarnings = List.of(String.format("Date property \"lists.%s.%s\": %s",
+                        listEdit, dateCol, nsDateFormat),
+                String.format("Time property \"lists.%s.%s\": %s",
+                        listEdit, timeCol, nsTimeFormat),
+                String.format("DateTime property \"lists.%s.%s\": %s %s",
+                        listEdit, dateTimeCol, nsDateFormat, nsTimeFormat));
+
+        checkSiteValidation(expectedWarnings, true);
+
+        goToProjectHome();
+        _listHelper.goToList(listEdit);
+        EditListDefinitionPage listDefinitionPage = _listHelper.goToEditDesign(listEdit);
+
+        log("Edit the Date, Time and DateTime fields but then cancel out of the edit.");
+
+        DomainFormPanel domainEditor = listDefinitionPage.getFieldsPanel();
+        DomainFieldRow fieldRow = domainEditor.getField(dateCol);
+        fieldRow.expand();
+        fieldRow.setDateFormat(DATE_FORMAT.yyyy_MM_dd);
+        checker().verifyFalse(String.format("Changing '%s' to a standard format should remove the warning icon.", dateCol),
+                fieldRow.hasDomainWarningIcon());
+
+        fieldRow = domainEditor.getField(timeCol);
+        fieldRow.expand();
+        fieldRow.setTimeFormat(TIME_FORMAT.HH_mm_ss);
+        checker().verifyFalse(String.format("Changing '%s' to a standard format should remove the warning icon.", timeCol),
+                fieldRow.hasDomainWarningIcon());
+
+        fieldRow = domainEditor.getField(dateTimeCol);
+        fieldRow.expand();
+        fieldRow.setDateTimeFormat(DATE_FORMAT.yyyy_MM_dd, TIME_FORMAT.hh_mm_a);
+        checker().verifyFalse(String.format("Changing '%s' to a standard format should remove the warning icon.", dateTimeCol),
+                fieldRow.hasDomainWarningIcon());
+
+        log("Cancel out of the edit.");
+        listDefinitionPage.clickCancel();
+
+        log("Go back to the design page and validate that the non-standard formats are still there.");
+        listDefinitionPage = _listHelper.goToEditDesign(listEdit);
+        domainEditor = listDefinitionPage.getFieldsPanel();
+
+        checkField(domainEditor, dateCol, false, FieldDefinition.ColumnType.Date,
+                nsDateFormat, TT_NS_DATE);
+        checkField(domainEditor, timeCol, false, FieldDefinition.ColumnType.Time,
+                nsTimeFormat, TT_NS_TIME);
+        checkField(domainEditor, dateTimeCol, false, FieldDefinition.ColumnType.DateAndTime,
+                String.format("%s %s", nsDateFormat, nsTimeFormat), TT_NS_DATETIME);
+
+        listDefinitionPage.clickCancel();
+
+        log("Now edit the field to a standard format.");
+        listDefinitionPage = _listHelper.goToEditDesign(listEdit);
+
+        domainEditor = listDefinitionPage.getFieldsPanel();
+        fieldRow = domainEditor.getField(dateCol);
+        fieldRow.expand();
+        fieldRow.setDateFormat(DATE_FORMAT.yyyy_MM_dd);
+        fieldRow = domainEditor.getField(timeCol);
+        fieldRow.expand();
+        fieldRow.setTimeFormat(TIME_FORMAT.HH_mm_ss);
+        fieldRow = domainEditor.getField(dateTimeCol);
+        fieldRow.expand();
+        fieldRow.setDateTimeFormat(DATE_FORMAT.yyyy_MM_dd, TIME_FORMAT.hh_mm_a);
+
+        listDefinitionPage.clickSave();
+
+        listDefinitionPage = _listHelper.goToEditDesign(listEdit);
+        domainEditor = listDefinitionPage.getFieldsPanel();
+
+        checkField(domainEditor, dateCol, false, FieldDefinition.ColumnType.Date,
+                DATE_FORMAT.yyyy_MM_dd.toString(), null);
+        checkField(domainEditor, timeCol, false, FieldDefinition.ColumnType.Time,
+                TIME_FORMAT.HH_mm_ss.toString(), null);
+        checkField(domainEditor, dateTimeCol, false, FieldDefinition.ColumnType.DateAndTime,
+                String.format("%s %s", DATE_FORMAT.yyyy_MM_dd, TIME_FORMAT.hh_mm_a), null);
+
+        log("Check that Site Validation Does not tag the fields in the list after they have been edited.");
+
+        checkSiteValidation(expectedWarnings, false);
+
     }
 
     private void createListByAPI(String listName, List<FieldDefinition> fields) throws IOException, CommandException
@@ -263,11 +420,154 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         listDef.create(connection, getProjectName());
     }
 
-    private void checkField(EditListDefinitionPage listDefinitionPage, String fieldName,
-                            boolean isInherited, FieldDefinition.ColumnType columnType,
-                            String expectedFormat, String expectedToolTipText)
+    @Test
+    public void testDataClass() throws IOException, CommandException
     {
-        DomainFormPanel domainEditor = listDefinitionPage.getFieldsPanel();
+        String dcFormat = "DC Non-Standard Formats";
+        String dcInherit = "DC Inherit Project Formats";
+        String dateCol = "Date";
+        String timeCol = "Time";
+        String dateTimeCol = "DateTime";
+
+        String nsDateFormat = "MMMM dd, yyyy";
+        String nsTimeFormat = "hh:mm:ss.ss a";
+
+        List<FieldDefinition> fields = List.of(
+                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date).setFormat(nsDateFormat),
+                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time).setFormat(nsTimeFormat),
+                new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime).setFormat(String.format("%s %s", nsDateFormat, nsTimeFormat))
+        );
+
+        log(String.format("Create a Data Class named '%s' with non-standard format fields.", dcFormat));
+
+        DataClassDefinition dataClass = new DataClassDefinition(dcFormat);
+        for(FieldDefinition field : fields)
+        {
+            dataClass.addField(field);
+        }
+
+        dataClass.create(createDefaultConnection(), getProjectName());
+
+        fields = List.of(
+                new FieldDefinition(dateCol, FieldDefinition.ColumnType.Date),
+                new FieldDefinition(timeCol, FieldDefinition.ColumnType.Time),
+                new FieldDefinition(dateTimeCol, FieldDefinition.ColumnType.DateAndTime)
+        );
+
+        log(String.format("Create a Data Class named '%s' that inherits non-standard format fields from the project.", dcFormat));
+
+        dataClass = new DataClassDefinition(dcInherit);
+        for(FieldDefinition field : fields)
+        {
+            dataClass.addField(field);
+        }
+
+        dataClass.create(createDefaultConnection(), getProjectName());
+
+        log("Add some data to both data classes as a sanity validation of the formats.");
+
+        goToProjectHome();
+        clickAndWait(Locator.linkWithText(dcFormat));
+
+        String bulkData = String.format("%s\t%s\t%s\t%s\n", "Name", dateTimeCol, dateCol, timeCol)
+                + "A\t12/23/24 14:45\t12/23/24\t14:45\n";
+
+        Map<String, String> expectedFormatData = Map.of("Name", "A",
+                dateTimeCol, "December 23, 2024 02:45:00.00 PM",
+                dateCol, "December 23, 2024",
+                timeCol, "02:45:00.00 PM", "Flag", "");
+
+        Map<String, String> expectedInheritedData = Map.of("Name", "A",
+                dateTimeCol, "Monday December 23 358 2024 14:45:0 -08",
+                dateCol, "23/12/24",
+                timeCol, "2:45:0 PM -0800", "Flag", "");
+
+        DataRegionTable dataTable = new DataRegionTable("query", getDriver());
+        dataTable.clickImportBulkData()
+                .setText(bulkData);
+        clickButton("Submit");
+
+        goToProjectHome();
+        clickAndWait(Locator.linkWithText(dcInherit));
+
+        dataTable = new DataRegionTable("query", getDriver());
+        dataTable.clickImportBulkData()
+                .setText(bulkData);
+        clickButton("Submit");
+
+        log(String.format("Validate domain designer feedback for '%s'.", dcFormat));
+
+        goToProjectHome();
+        clickAndWait(Locator.linkWithText(dcFormat));
+        clickAndWait(Locator.lkButton("Edit Data Class"));
+        CreateDataClassPage editPage = new CreateDataClassPage(getDriver());
+        DomainFormPanel domainEditor = editPage.getDomainEditor();
+
+        checkField(domainEditor, dateCol,
+        false, FieldDefinition.ColumnType.Date,
+                nsDateFormat, TT_NS_DATE);
+
+        checkField(domainEditor, timeCol,
+                false, FieldDefinition.ColumnType.Time,
+                nsTimeFormat, TT_NS_TIME);
+
+        checkField(domainEditor, dateTimeCol,
+                false, FieldDefinition.ColumnType.DateAndTime,
+                String.format("%s %s", nsDateFormat, nsTimeFormat), TT_NS_DATETIME);
+
+        editPage.clickCancel();
+
+        log("Validate the data (make sure we still respect non-standard formats).");
+
+        dataTable = new DataRegionTable("query", getDriver());
+        Map<String, String> actualData = dataTable.getRowDataAsMap(0);
+        checker().verifyEquals("Data with formatted fields is not as expected.",
+                expectedFormatData, actualData);
+
+        log("Validate that data sets are reported in Site Validation.");
+        List<String> expectedWarnings = List.of(String.format("Date property \"exp.data.%s.%s\": %s",
+                        dcFormat, dateCol, nsDateFormat),
+                String.format("Time property \"exp.data.%s.%s\": %s",
+                        dcFormat, timeCol, nsTimeFormat),
+                String.format("DateTime property \"exp.data.%s.%s\": %s %s",
+                        dcFormat, dateTimeCol, nsDateFormat, nsTimeFormat));
+
+        checkSiteValidation(expectedWarnings, true);
+
+        log(String.format("Validate domain designer feedback for '%s'.", dcInherit));
+
+        goToProjectHome();
+        clickAndWait(Locator.linkWithText(dcInherit));
+        clickAndWait(Locator.lkButton("Edit Data Class"));
+        editPage = new CreateDataClassPage(getDriver());
+        domainEditor = editPage.getDomainEditor();
+
+        checkField(domainEditor, dateCol,
+                false, FieldDefinition.ColumnType.Date,
+                PROJECT_DATE_FORMAT, TT_NS_DATE);
+
+        checkField(domainEditor, timeCol,
+                false, FieldDefinition.ColumnType.Time,
+                PROJECT_TIME_FORMAT, TT_NS_TIME);
+
+        checkField(domainEditor, dateTimeCol,
+                false, FieldDefinition.ColumnType.DateAndTime,
+                PROJECT_DATETIME_FORMAT, TT_NS_DATETIME);
+
+        editPage.clickCancel();
+
+        log("Validate the data (make sure we still respect non-standard formats).");
+        dataTable = new DataRegionTable("query", getDriver());
+        actualData = dataTable.getRowDataAsMap(0);
+        checker().verifyEquals("Data with inherited fields is not as expected.",
+                expectedInheritedData, actualData);
+
+    }
+
+    private void checkField(DomainFormPanel domainEditor, String fieldName,
+                            boolean isInherited, FieldDefinition.ColumnType columnType,
+                            String expectedFormat, @Nullable String expectedToolTipText)
+    {
         DomainFieldRow fieldRow = domainEditor.getField(fieldName);
         fieldRow.expand();
 
@@ -319,30 +619,135 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                         fieldRow.isDateTimeFormatTimeEnabled());
             }
 
+            String expectedDateFormat;
+            String expectedTimeFormat;
+
+            // If expected tooltip text is not null treat the field as a non-standard format field.
+            if (null != expectedToolTipText)
+            {
+                expectedDateFormat = expectedFormat;
+                expectedTimeFormat = TIME_FORMAT.none.toString();
+            }
+            else
+            {
+                // None of the standard dates have a space. The first space will be between the date format and the time format.
+                int index = expectedFormat.indexOf(" ");
+
+                expectedDateFormat = expectedFormat.substring(0, index);
+                expectedTimeFormat = expectedFormat.substring(index+1);
+            }
+
             actualFormat = fieldRow.getDateTimeFormatDate();
             checker().verifyEquals(String.format("DateTime Date format for field '%s' not as expected.", fieldName),
-                    expectedFormat, actualFormat);
+                    expectedDateFormat, actualFormat);
 
             actualFormat = fieldRow.getDateTimeFormatTime();
             checker().verifyEquals(String.format("DateTime Time format for field '%s' not as expected.", fieldName),
-                    TIME_FORMAT.none.toString(), actualFormat);
+                    expectedTimeFormat, actualFormat);
         }
 
-        if(checker().verifyTrue("No warning icon present for field with non-standard date-time format.",
-                fieldRow.hasDomainWarningIcon()))
+        // If expected tooltip text is not null treat the field as a non-standard format field.
+        if (null != expectedToolTipText)
         {
-            WebElement icon = fieldRow.getDomainWarningIcon();
-            mouseOver(icon);
-            WebElement toolTip = Locator.tagWithClass("div", "tooltip-inner")
-                    .withText(expectedToolTipText)
-                    .findWhenNeeded(getDriver());
+            if (checker().verifyTrue("No warning icon present for field with non-standard date-time format.",
+                    fieldRow.hasDomainWarningIcon()))
+            {
+                WebElement icon = fieldRow.getDomainWarningIcon();
+                mouseOver(icon);
+                WebElement toolTip = Locator.tagWithClass("div", "tooltip-inner")
+                        .withText(expectedToolTipText)
+                        .findWhenNeeded(getDriver());
 
-            checker().verifyTrue("Tooltip not present or text not as expected.",
-                    waitFor(toolTip::isDisplayed, 1_000));
+                checker().verifyTrue("Tooltip not present or text not as expected.",
+                        waitFor(toolTip::isDisplayed, 1_000));
+            }
         }
-
+        else
+        {
+            checker().verifyFalse(String.format("Field '%s' should not have a warning icon present, but one is there.", fieldName),
+                    fieldRow.hasDomainWarningIcon());
+        }
         checker().screenShotIfNewError(String.format("Non_Standard_Field_%s_Error", fieldName));
 
+    }
+
+    private void checkSiteValidation(List<String> expectedWarnings, boolean shouldContain)
+    {
+        List<String> actualWarnings = getProjectValidationWarnings();
+
+        log("Found Warnings: " + actualWarnings);
+
+        if (shouldContain)
+        {
+            log("Should Contain Warnings: " + expectedWarnings);
+
+            if (!actualWarnings.isEmpty())
+            {
+                checker().verifyTrue("Did not find the expected warnings.",
+                        actualWarnings.containsAll(expectedWarnings));
+
+            }
+            else
+            {
+                log(String.format("No warnings found for project '%s'.", getProjectName()));
+            }
+        }
+        else
+        {
+            log("Should Not Contain Warnings: " + expectedWarnings);
+
+            boolean shouldBeFalse = actualWarnings.stream()
+                    .anyMatch(expectedWarnings::contains);
+
+            checker().verifyFalse("Found warning that should not be there.",
+                    shouldBeFalse);
+        }
+    }
+
+    private List<String> getProjectValidationWarnings()
+    {
+        List<String> warnings = new ArrayList<>();
+
+        URLBuilder urlBuilder = new URLBuilder("admin", "configureSiteValidation");
+        String url = urlBuilder.buildRelativeURL();
+        beginAt(url);
+
+        waitForElementToBeVisible(Locator.lkButton("Validate"));
+
+        // Disable all validators.
+        Locator.tagWithAttribute("input", "type", "checkbox")
+                .findElements(getDriver()).forEach(this::uncheckCheckbox);
+
+        // Enable Display Format validator.
+        WebElement formatValidation = Locator.checkboxByNameAndValue("providers", "Display Format Validator").findWhenNeeded(getDriver());
+        checkCheckbox(formatValidation);
+
+        // Validate projects and sub-folders.
+        checkRadioButton(Locator.radioButtonByNameAndValue("includeSubfolders", "true"));
+
+        // Don't run in the background.
+        uncheckCheckbox(Locator.id("background"));
+
+        clickAndWait(Locator.lkButton("Validate"));
+
+        waitForText("Folder Validation Results");
+
+        String xpath = String.format("//li[contains(text(),'Project: %s')]//li[contains(text(),'Warnings:')]//ul", getProjectName());
+        WebElement ul = Locator.xpath(xpath).findWhenNeeded(getDriver());
+
+        if (ul.isDisplayed())
+        {
+            List<String> actualWarnings = ul.findElements(Locator.tag("li")).stream().map(WebElement::getText).toList();
+
+            for(String warning : actualWarnings)
+            {
+                // Trim off the MORE INFO text.
+                String temp = warning.trim().substring(0, warning.length() - 10);
+                warnings.add(temp);
+            }
+        }
+
+        return warnings;
     }
 
 }

--- a/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
+++ b/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
@@ -14,9 +14,11 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.domain.DomainFieldRow;
 import org.labkey.test.components.domain.DomainFormPanel;
+import org.labkey.test.pages.admin.FolderFormatsPage;
 import org.labkey.test.pages.core.admin.BaseSettingsPage;
 import org.labkey.test.pages.core.admin.BaseSettingsPage.TIME_FORMAT;
 import org.labkey.test.pages.core.admin.BaseSettingsPage.DATE_FORMAT;
+import org.labkey.test.pages.core.admin.LookAndFeelSettingsPage;
 import org.labkey.test.pages.core.admin.ProjectSettingsPage;
 import org.labkey.test.pages.experiment.CreateDataClassPage;
 import org.labkey.test.pages.list.EditListDefinitionPage;
@@ -91,7 +93,6 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
         _portalHelper.addWebPart("Lists");
         _portalHelper.addWebPart("Data Classes");
-        _portalHelper.addWebPart("Assay List");
 
     }
 
@@ -153,48 +154,19 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
     @Test
     public void testProjectSettingsPage()
     {
+
+        log("Check that the Date, Time and DateTime format fields in the Project Settings page.");
+
         goToProjectHome();
-        ProjectSettingsPage projectSettingsPage = ProjectSettingsPage.beginAt(this);
-
-        log("Check that the Date, Time and DateTime format fields are not inherited.");
-
-        checker().verifyFalse("Date format field should not be shown as inherited.",
-                projectSettingsPage.getDefaultDateDisplayInherited());
-
-        checker().verifyFalse("Time format field should not be shown as inherited.",
-                projectSettingsPage.getDefaultTimeDisplayInherited());
-
-        checker().verifyFalse("DateTime format field should not be shown as inherited.",
-                projectSettingsPage.getDefaultDateDisplayInherited());
-
-        log("Check that the format and warnings in the designer are as expected.");
-
-        checker().verifyEquals("Format of Default Date is not as expected.",
-                PROJECT_DATE_FORMAT, projectSettingsPage.getDefaultDateDisplay());
-
-        checker().verifyTrue("Default Date field should have a non-standard warning, it does not.",
-                projectSettingsPage.defaultDateDisplayWarning());
-
-        checker().verifyEquals("Format of Default Time is not as expected.",
-                PROJECT_TIME_FORMAT, projectSettingsPage.getDefaultTimeDisplay());
-
-        checker().verifyTrue("Default Time field should have a non-standard warning, it does not.",
-                projectSettingsPage.defaultTimeDisplayWarning());
-
-        checker().verifyEquals("Format of Default DateTime (Date) is not as expected.",
-                PROJECT_DATETIME_FORMAT, projectSettingsPage.getDefaultDateTimeDateDisplay());
-
-        checker().verifyTrue("Default DateTime Date field should have a non-standard warning, it does not.",
-                projectSettingsPage.defaultDateTimeDateDisplayWarning());
-
-        checker().verifyEquals("Format of Default DateTime (Time) is not as expected.",
-                "", projectSettingsPage.getDefaultDateTimeTimeDisplay());
-
-        checker().verifyFalse("Default DateTime Time field should not have a non-standard warning, it does.",
-                projectSettingsPage.defaultDateTimeTimeDisplayWarning());
+        ProjectSettingsPage.beginAt(this);
+        validateSettingsPage(false, PROJECT_DATE_FORMAT, true,
+                false, PROJECT_TIME_FORMAT, true,
+                false, PROJECT_DATETIME_FORMAT, "",
+                true, false);
 
         log("Check that Site Validation includes warnings from the project settings.");
-        checkSiteValidation(PROJECT_WARNINGS, true);
+        String scope = String.format("Project: %s", getProjectName());
+        validateSiteValidationReport(scope, PROJECT_WARNINGS, true);
 
     }
 
@@ -278,25 +250,20 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         EditListDefinitionPage listDefinitionPage = _listHelper.goToEditDesign(listFormat);
         DomainFormPanel domainEditor = listDefinitionPage.getFieldsPanel();
 
-        checkField(domainEditor, dateCol01, false, FieldDefinition.ColumnType.Date,
+        validateFieldsInDesigner(domainEditor, dateCol01, false, FieldDefinition.ColumnType.Date,
                 nsDateFormat01, TT_NS_DATE);
-        checkField(domainEditor, dateCol02, false, FieldDefinition.ColumnType.Date,
+        validateFieldsInDesigner(domainEditor, dateCol02, false, FieldDefinition.ColumnType.Date,
                 nsDateFormat02, TT_NS_DATE);
-        checkField(domainEditor, timeCol01, false, FieldDefinition.ColumnType.Time,
+        validateFieldsInDesigner(domainEditor, timeCol01, false, FieldDefinition.ColumnType.Time,
                 nsTimeFormat01, TT_NS_TIME);
-        checkField(domainEditor, timeCol02, false, FieldDefinition.ColumnType.Time,
+        validateFieldsInDesigner(domainEditor, timeCol02, false, FieldDefinition.ColumnType.Time,
                 nsTimeFormat02, TT_NS_TIME);
-        checkField(domainEditor, dateTimeCol01, false, FieldDefinition.ColumnType.DateAndTime,
+        validateFieldsInDesigner(domainEditor, dateTimeCol01, false, FieldDefinition.ColumnType.DateAndTime,
                 String.format("%s %s", nsDateFormat01, nsTimeFormat01), TT_NS_DATETIME);
-        checkField(domainEditor, dateTimeCol02, false, FieldDefinition.ColumnType.DateAndTime,
+        validateFieldsInDesigner(domainEditor, dateTimeCol02, false, FieldDefinition.ColumnType.DateAndTime,
                 String.format("%s %s", nsTimeFormat02, nsDateFormat02), TT_NS_DATETIME);
 
-        listDefinitionPage.clickCancel();
-        DataRegionTable table = new DataRegionTable("query", getDriver());
-        Map<String, String> actualRowValues = table.getRowDataAsMap(0);
-
-        checker().verifyEquals("Data in grid is not formatted as expected.",
-                expectedRowValues, actualRowValues);
+        validateDataIsFormatted(getProjectName(), listFormat, expectedRowValues);
 
         log(String.format("Validate the design and data of list '%s' (does inherit formats).", listInherit));
         goToProjectHome();
@@ -312,19 +279,16 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         listDefinitionPage =  _listHelper.goToEditDesign(listInherit);
         domainEditor = listDefinitionPage.getFieldsPanel();
 
-        checkField(domainEditor, dateCol01, true, FieldDefinition.ColumnType.Date,
+        validateFieldsInDesigner(domainEditor, dateCol01, true, FieldDefinition.ColumnType.Date,
                 PROJECT_DATE_FORMAT, TT_NS_DATE);
-        checkField(domainEditor, timeCol01, true, FieldDefinition.ColumnType.Time,
+        validateFieldsInDesigner(domainEditor, timeCol01, true, FieldDefinition.ColumnType.Time,
                 PROJECT_TIME_FORMAT, TT_NS_TIME);
-        checkField(domainEditor, dateTimeCol01, true, FieldDefinition.ColumnType.DateAndTime,
+        validateFieldsInDesigner(domainEditor, dateTimeCol01, true, FieldDefinition.ColumnType.DateAndTime,
                 PROJECT_DATETIME_FORMAT, TT_NS_DATETIME);
 
         listDefinitionPage.clickCancel();
-        table = new DataRegionTable("query", getDriver());
-        actualRowValues = table.getRowDataAsMap(0);
 
-        checker().verifyEquals("Data in grid is not formatted as expected.",
-                expectedRowValues, actualRowValues);
+        validateDataIsFormatted(getProjectName(), listInherit, expectedRowValues);
 
         log("Validate that the Site Validation contains the expected warnings.");
 
@@ -342,7 +306,8 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                         listFormat, dateTimeCol02, nsTimeFormat02, nsDateFormat02)
         );
 
-        checkSiteValidation(expectedWarnings, true);
+        String scope = String.format("Project: %s", getProjectName());
+        validateSiteValidationReport(scope, expectedWarnings, true);
 
         log("Validate that Site Validation does not contain warnings about inherited fields.");
 
@@ -354,7 +319,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                         listInherit, dateTimeCol01, nsDateFormat01, nsTimeFormat01)
         );
 
-        checkSiteValidation(expectedWarnings, false);
+        validateSiteValidationReport(scope, expectedWarnings, false);
 
     }
 
@@ -407,7 +372,8 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                 String.format("DateTime property \"lists.%s.%s\": %s %s",
                         listEdit, dateTimeCol, nsDateFormat, nsTimeFormat));
 
-        checkSiteValidation(expectedWarnings, true);
+        String scope = String.format("Project: %s", getProjectName());
+        validateSiteValidationReport(scope, expectedWarnings, true);
 
         goToProjectHome();
         _listHelper.goToList(listEdit);
@@ -419,20 +385,23 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         DomainFieldRow fieldRow = domainEditor.getField(dateCol);
         fieldRow.expand();
         fieldRow.setDateFormat(DATE_FORMAT.yyyy_MM_dd);
-        checker().verifyFalse(String.format("Changing '%s' to a standard format should remove the warning icon.", dateCol),
-                fieldRow.hasDomainWarningIcon());
+        checker().withScreenshot()
+                .verifyFalse(String.format("Changing '%s' to a standard format should remove the warning icon.", dateCol),
+                        fieldRow.hasDomainWarningIcon());
 
         fieldRow = domainEditor.getField(timeCol);
         fieldRow.expand();
         fieldRow.setTimeFormat(TIME_FORMAT.HH_mm_ss);
-        checker().verifyFalse(String.format("Changing '%s' to a standard format should remove the warning icon.", timeCol),
-                fieldRow.hasDomainWarningIcon());
+        checker().withScreenshot()
+                .verifyFalse(String.format("Changing '%s' to a standard format should remove the warning icon.", timeCol),
+                        fieldRow.hasDomainWarningIcon());
 
         fieldRow = domainEditor.getField(dateTimeCol);
         fieldRow.expand();
         fieldRow.setDateTimeFormat(DATE_FORMAT.yyyy_MM_dd, TIME_FORMAT.hh_mm_a);
-        checker().verifyFalse(String.format("Changing '%s' to a standard format should remove the warning icon.", dateTimeCol),
-                fieldRow.hasDomainWarningIcon());
+        checker().withScreenshot()
+                .verifyFalse(String.format("Changing '%s' to a standard format should remove the warning icon.", dateTimeCol),
+                        fieldRow.hasDomainWarningIcon());
 
         log("Cancel out of the edit.");
         listDefinitionPage.clickCancel();
@@ -441,11 +410,11 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         listDefinitionPage = _listHelper.goToEditDesign(listEdit);
         domainEditor = listDefinitionPage.getFieldsPanel();
 
-        checkField(domainEditor, dateCol, false, FieldDefinition.ColumnType.Date,
+        validateFieldsInDesigner(domainEditor, dateCol, false, FieldDefinition.ColumnType.Date,
                 nsDateFormat, TT_NS_DATE);
-        checkField(domainEditor, timeCol, false, FieldDefinition.ColumnType.Time,
+        validateFieldsInDesigner(domainEditor, timeCol, false, FieldDefinition.ColumnType.Time,
                 nsTimeFormat, TT_NS_TIME);
-        checkField(domainEditor, dateTimeCol, false, FieldDefinition.ColumnType.DateAndTime,
+        validateFieldsInDesigner(domainEditor, dateTimeCol, false, FieldDefinition.ColumnType.DateAndTime,
                 String.format("%s %s", nsDateFormat, nsTimeFormat), TT_NS_DATETIME);
 
         listDefinitionPage.clickCancel();
@@ -469,16 +438,16 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         listDefinitionPage = _listHelper.goToEditDesign(listEdit);
         domainEditor = listDefinitionPage.getFieldsPanel();
 
-        checkField(domainEditor, dateCol, false, FieldDefinition.ColumnType.Date,
+        validateFieldsInDesigner(domainEditor, dateCol, false, FieldDefinition.ColumnType.Date,
                 DATE_FORMAT.yyyy_MM_dd.toString(), null);
-        checkField(domainEditor, timeCol, false, FieldDefinition.ColumnType.Time,
+        validateFieldsInDesigner(domainEditor, timeCol, false, FieldDefinition.ColumnType.Time,
                 TIME_FORMAT.HH_mm_ss.toString(), null);
-        checkField(domainEditor, dateTimeCol, false, FieldDefinition.ColumnType.DateAndTime,
+        validateFieldsInDesigner(domainEditor, dateTimeCol, false, FieldDefinition.ColumnType.DateAndTime,
                 String.format("%s %s", DATE_FORMAT.yyyy_MM_dd, TIME_FORMAT.hh_mm_a), null);
 
         log("Check that Site Validation Does not tag the fields in the list after they have been edited.");
 
-        checkSiteValidation(expectedWarnings, false);
+        validateSiteValidationReport(scope, expectedWarnings, false);
 
     }
 
@@ -557,26 +526,22 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         CreateDataClassPage editPage = new CreateDataClassPage(getDriver());
         DomainFormPanel domainEditor = editPage.getDomainEditor();
 
-        checkField(domainEditor, dateCol,
+        validateFieldsInDesigner(domainEditor, dateCol,
         false, FieldDefinition.ColumnType.Date,
                 nsDateFormat, TT_NS_DATE);
 
-        checkField(domainEditor, timeCol,
+        validateFieldsInDesigner(domainEditor, timeCol,
                 false, FieldDefinition.ColumnType.Time,
                 nsTimeFormat, TT_NS_TIME);
 
-        checkField(domainEditor, dateTimeCol,
+        validateFieldsInDesigner(domainEditor, dateTimeCol,
                 false, FieldDefinition.ColumnType.DateAndTime,
                 String.format("%s %s", nsDateFormat, nsTimeFormat), TT_NS_DATETIME);
 
         editPage.clickCancel();
 
         log("Validate the data (make sure we still respect non-standard formats).");
-
-        DataRegionTable dataTable = new DataRegionTable("query", getDriver());
-        Map<String, String> actualData = dataTable.getRowDataAsMap(0);
-        checker().verifyEquals("Data with formatted fields is not as expected.",
-                expectedFormatData, actualData);
+        validateDataIsFormatted(getProjectName(), dcFormat, expectedFormatData);
 
         log("Validate that data sets are reported in Site Validation.");
         List<String> expectedWarnings = List.of(String.format("Date property \"exp.data.%s.%s\": %s",
@@ -586,7 +551,8 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                 String.format("DateTime property \"exp.data.%s.%s\": %s %s",
                         dcFormat, dateTimeCol, nsDateFormat, nsTimeFormat));
 
-        checkSiteValidation(expectedWarnings, true);
+        String scope = String.format("Project: %s", getProjectName());
+        validateSiteValidationReport(scope, expectedWarnings, true);
 
         log(String.format("Validate domain designer feedback for '%s'.", dcInherit));
 
@@ -596,30 +562,58 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         editPage = new CreateDataClassPage(getDriver());
         domainEditor = editPage.getDomainEditor();
 
-        checkField(domainEditor, dateCol,
+        validateFieldsInDesigner(domainEditor, dateCol,
                 false, FieldDefinition.ColumnType.Date,
                 PROJECT_DATE_FORMAT, TT_NS_DATE);
 
-        checkField(domainEditor, timeCol,
+        validateFieldsInDesigner(domainEditor, timeCol,
                 false, FieldDefinition.ColumnType.Time,
                 PROJECT_TIME_FORMAT, TT_NS_TIME);
 
-        checkField(domainEditor, dateTimeCol,
+        validateFieldsInDesigner(domainEditor, dateTimeCol,
                 false, FieldDefinition.ColumnType.DateAndTime,
                 PROJECT_DATETIME_FORMAT, TT_NS_DATETIME);
 
         editPage.clickCancel();
 
         log("Validate the data (make sure we still respect non-standard formats).");
-        dataTable = new DataRegionTable("query", getDriver());
-        actualData = dataTable.getRowDataAsMap(0);
-        checker().verifyEquals("Data with inherited fields is not as expected.",
-                expectedInheritedData, actualData);
+        validateDataIsFormatted(getProjectName(), dcInherit, expectedInheritedData);
 
     }
 
+    /**
+     * <p>
+     *     This test will check the scoping of non-standard formats when set at the site and subfolder levels. This test
+     *     creates a separate project to avoid the project settings from changed for the default test project from
+     *     interfering. This test also uses data classes for validation because a data class is visible in subfolders.
+     * </p>
+     * <p>
+     *     This test will:
+     *     <ul>
+     *         <li>Create a separate project with a subfolder.</li>
+     *         <li>Create and populate a data class in the project.</li>
+     *         <li>Create and populate a data class in the subfolder.</li>
+     *         <li>From the subfolder add a record to the data class in the parent folder.</li>
+     *         <li>Change the Date-Time settings at the site level to be non-standard.</li>
+     *         <li>Validate the 'Look and Feel' page for the site.</li>
+     *         <li>Validate the Site Validation report calls out the site settings.</li>
+     *         <li>Change the Date-Time format at the subfolder.</li>
+     *         <li>Validate the 'Formats' page for the subfolder.</li>
+     *         <li>Validate the Site Validation report.</li>
+     *         <li>Validate the data in both data classes is formatted as expected in the subfolder.</li>
+     *         <li>Reset the site settings.</li>
+     *         <li>Validate the Site Validation does not call out the site settings but still calls out the subfolder.</li>
+     *         <li>Validate the 'Look and Feel' page is updated with the default formats.</li>
+     *         <li>Validate the subfolder formats are unchanged.</li>
+     *     </ul>
+     *     Note: there are periodic checks that the data is formatted as expected at the various levels.
+     * </p>
+     *
+     * @throws IOException Can be thrown by the test APIs.
+     * @throws CommandException Can be thrown by the test APIs.
+     */
     @Test
-    public void testChildFolder() throws IOException, CommandException
+    public void testScopeFromSiteToSubFolder() throws IOException, CommandException
     {
 
         String folderProject = "Non-Standard Sub-Folder Test";
@@ -637,20 +631,10 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         _containerHelper.deleteProject(folderProject, false);
         _containerHelper.createProject(folderProject, null);
 
-        // Use the API to set the formats for the project.
-//        new APIContainerHelper(this)
-//                .setDateAndTimeFormats(createDefaultConnection(), folderProject,
-//                        DATE_FORMAT.Default.toString(), TIME_FORMAT.Default.toString(), String.format("%s %s", DATE_FORMAT.Default, TIME_FORMAT.DTDefault));
-
         log(String.format("Create a child folder '%s'.", folderProject));
         _containerHelper.createSubfolder(folderProject, subFolder);
 
-        // Use the API to set the formats for the project.
-//        new APIContainerHelper(this)
-//                .setDateAndTimeFormats(createDefaultConnection(), subFolderPath,
-//                        DATE_FORMAT.Default.toString(), TIME_FORMAT.Default.toString(), String.format("%s %s", DATE_FORMAT.Default, TIME_FORMAT.DTDefault));
-
-        log(String.format("In the parent folder create a DataClass named '%s' with various Date, Time and DateTime columns some with non-standard formatting.", dcInParent));
+        log(String.format("In the parent folder create a DataClass named '%s' with various Date, Time and DateTime columns.", dcInParent));
 
         goToProjectHome(folderProject);
         _portalHelper.addWebPart("Data Classes");
@@ -689,18 +673,154 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
         populateDataClass(subFolderPath, dcInChild, bulkData);
 
-        log("In the subfolder add data to DataClass in the parent folder as validation.");
+        log("In the subfolder add data to DataClass from the parent folder as validation.");
 
         populateDataClass(subFolderPath, dcInParent, bulkData);
 
-        String nsDateFormat = "MMMM dd, yyyy";
-        String nsTimeFormat = "hh:mm a";
+        String nsSiteDateFormat = "MMMM dd, yyyy";
+        String nsSiteTimeFormat = "kk:mm z";
 
-        // Change the site setting to be non-standard and validate inheritance.
-        goToProjectSettings();
+        log("Change the site setting to be non-standard.");
+        changeSiteDateAndTimeFormats(nsSiteDateFormat, nsSiteTimeFormat);
+
+        goToProjectHome(folderProject);
+
+        log("Validate the site 'Look and Feel' page has the correct values, feedback, etc...");
+        LookAndFeelSettingsPage lookAndFeelSettingsPage = goToAdminConsole().clickLookAndFeelSettings();
+        validateSettingsPage(null, nsSiteDateFormat, true,
+                null, nsSiteTimeFormat, true,
+                null, String.format("%s %s", nsSiteDateFormat, nsSiteTimeFormat), "",
+                true, false);
+
+        if (checker().withScreenshot()
+                .verifyTrue("The warning banner at the top of the Site Setting page does not contain the expected comment.",
+                        lookAndFeelSettingsPage.getFormatWarningMessage()
+                                .startsWith("Warning: One or more date, time, or date-time display formats are using non-standard patterns.")))
+        {
+            WebElement link = Locator.linkWithText("Click here").findWhenNeeded(getDriver());
+            if (checker().withScreenshot()
+                    .verifyTrue("'Click here' link is not visible.", link.isDisplayed()))
+            {
+                link.click();
+                switchToWindow(1);
+                WebElement banner = Locator.tagWithText("h3", "Date & Number Display Formats").refindWhenNeeded(getDriver());
+                checker().withScreenshot()
+                        .verifyTrue("'Click here' link did not navigate as expected.",
+                                waitFor(banner::isDisplayed, 1_000));
+                closeExtraWindows();
+            }
+        }
+
+        log("Check that the Site Validation report calls out the site settings.");
+
+        List<String> siteWarnings = List.of(String.format("Site default display format for Dates: %s", nsSiteDateFormat),
+                String.format("Site default display format for Times: %s", nsSiteTimeFormat),
+                String.format("Site default display format for DateTimes: %s %s", nsSiteDateFormat, nsSiteTimeFormat));
+
+        String scope = "Root: /";
+        validateSiteValidationReport(scope, siteWarnings, true);
+
+        log(String.format("Validate project settings for '%s' inherit the site settings.", folderProject));
+        ProjectSettingsPage.beginAt(this, folderProject);
+        validateSettingsPage(true, nsSiteDateFormat, false,
+                true, nsSiteTimeFormat, false,
+                true, String.format("%s %s", nsSiteDateFormat, nsSiteTimeFormat), "",
+                false, false);
+
+        log("Validate fields in the designer at the project level.");
+        goToProjectHome(folderProject);
+        clickAndWait(Locator.linkWithText(dcInParent));
+        clickAndWait(Locator.lkButton("Edit Data Class"));
+        CreateDataClassPage editPage = new CreateDataClassPage(getDriver());
+        DomainFormPanel domainEditor = editPage.getDomainEditor();
+
+        validateFieldsInDesigner(domainEditor, dateCol,
+                true, FieldDefinition.ColumnType.Date,
+                nsSiteDateFormat, TT_NS_DATE);
+        validateFieldsInDesigner(domainEditor, timeCol,
+                true, FieldDefinition.ColumnType.Time,
+                nsSiteTimeFormat, TT_NS_TIME);
+        validateFieldsInDesigner(domainEditor, dateTimeCol,
+                true, FieldDefinition.ColumnType.DateAndTime,
+                String.format("%s %s", nsSiteDateFormat, nsSiteTimeFormat), TT_NS_DATETIME);
+
+        log(String.format("Validate subfolder settings for '%s' inherit the site settings.", subFolderPath));
+        FolderFormatsPage.beginAt(this, subFolderPath);
+        validateSettingsPage(true, nsSiteDateFormat, false,
+                true, nsSiteTimeFormat, false,
+                true, String.format("%s %s", nsSiteDateFormat, nsSiteTimeFormat), "",
+                false, false);
+
+        log("Sanity check that the DataClass data is formatted in the project and subfolder.");
+        Map<String, String> expectedFormatData = Map.of("Name", "P1",
+                dateTimeCol, "December 23, 2024 14:45 PST",
+                dateCol, "December 23, 2024",
+                timeCol, "14:45 PST", "Flag", "");
+
+        validateDataIsFormatted(folderProject, dcInParent, expectedFormatData);
+
+        expectedFormatData = Map.of("Name", "C1",
+                dateTimeCol, "November 28, 2024 11:11 PST",
+                dateCol, "November 28, 2024",
+                timeCol, "11:11 PST", "Flag", "");
+        validateDataIsFormatted(subFolderPath, dcInChild, expectedFormatData);
+        validateDataIsFormatted(subFolderPath, dcInParent, expectedFormatData);
+
+        log("Change the format in the subFolder.");
+        String nsSubDateFormat = "EEEE MMMM dd, yyyy";
+        String nsSubTimeFormat = "kk:mm (z)";
+
         new APIContainerHelper(this)
-                .setDateAndTimeFormats(createDefaultConnection(), "/",
-                        nsDateFormat, nsTimeFormat, String.format("%s %s", nsDateFormat, nsTimeFormat));
+                .setDateAndTimeFormats(createDefaultConnection(), subFolderPath,
+                        nsSubDateFormat, nsSubTimeFormat, String.format("%s %s", nsSubDateFormat, nsSubTimeFormat));
+
+        log(String.format("Validate folder settings for '%s' no longer inherit the site settings.", subFolderPath));
+        FolderFormatsPage.beginAt(this, subFolderPath);
+        validateSettingsPage(false, nsSubDateFormat, true,
+                false, nsSubTimeFormat, true,
+                false, String.format("%s %s", nsSubDateFormat, nsSubTimeFormat), "",
+                true, false);
+
+        log("Check the format in the DataClasses");
+        expectedFormatData = Map.of("Name", "C1",
+                dateTimeCol, "Thursday November 28, 2024 11:11 (PST)",
+                dateCol, "Thursday November 28, 2024",
+                timeCol, "11:11 (PST)", "Flag", "");
+        validateDataIsFormatted(subFolderPath, dcInChild, expectedFormatData);
+        validateDataIsFormatted(subFolderPath, dcInParent, expectedFormatData);
+
+        log("Check that the 'Site Validation' report includes the subfolder.");
+        List<String> folderWarnings = List.of(String.format("Folder default display format for Dates: %s", nsSubDateFormat),
+                String.format("Folder default display format for Times: %s", nsSubTimeFormat),
+                String.format("Folder default display format for DateTimes: %s %s", nsSubDateFormat, nsSubTimeFormat));
+
+        scope = String.format("Folder: %s", subFolderPath);
+        validateSiteValidationReport(scope, folderWarnings, true);
+
+        log("Reset the site settings.");
+        resetSiteSettings();
+
+        log("Validate 'Look and Feel' page after reset.");
+        goToAdminConsole().clickLookAndFeelSettings();
+        validateSettingsPage(null, DATE_FORMAT.Default.toString(), false,
+                null, TIME_FORMAT.Default.toString(), false,
+                null, DATE_FORMAT.DTDefault.toString(), TIME_FORMAT.DTDefault.toString(),
+                false, false);
+
+        log("Validate site is no longer listed in Site Validation report.");
+        scope = "Root: /";
+        validateSiteValidationReport(scope, siteWarnings, false);
+
+        log(String.format("Validate subfolder settings for '%s' still do not inherit the site settings.", subFolderPath));
+        FolderFormatsPage.beginAt(this, subFolderPath);
+        validateSettingsPage(false, nsSubDateFormat, true,
+                false, nsSubTimeFormat, true,
+                false, String.format("%s %s", nsSubDateFormat, nsSubTimeFormat), "",
+                true, false);
+
+        log("Validate the subfolder still appears in the Site Validation report.");
+        scope = String.format("Folder: %s", subFolderPath);
+        validateSiteValidationReport(scope, folderWarnings, true);
 
     }
 
@@ -744,13 +864,59 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
     }
 
+    // Private helper to validate the data in the list or data class is formatted as expected.
+    private void validateDataIsFormatted(String projectPath, String domainName, Map<String, String> expectedFormatData)
+    {
+        goToProjectHome(projectPath);
+        clickAndWait(Locator.linkWithText(domainName));
+        DataRegionTable dataTable = new DataRegionTable("query", getDriver());
+        Map<String, String> actualData = dataTable.getRowDataAsMap(0);
+        checker().withScreenshot()
+                .verifyEquals(String.format("Data in '%s' is not formatted as expected.", domainName),
+                        expectedFormatData, actualData);
+
+    }
+
+    // Private helper to change the Date-Time formats at the site level to non-standard formats.
+    // This modifies the html of the page to make an option in each field to be of a non-standard format.
+    private void changeSiteDateAndTimeFormats(String dateFormat, String timeFormat)
+    {
+        LookAndFeelSettingsPage lookAndFeelSettingsPage = goToAdminConsole().clickLookAndFeelSettings();
+
+        log(String.format("Chang date format '%s' to have a value of '%s'.", DATE_FORMAT.ddMMMyy, dateFormat));
+        WebElement defaultDate = Locator.id("defaultDateFormat").findElement(getDriver());
+        WebElement optionEl = Locator.tagWithAttribute("option", "value", DATE_FORMAT.ddMMMyy.toString()).findElement(defaultDate);
+        executeScript("arguments[0].value = arguments[1]", optionEl, dateFormat);
+        selectOptionByValue(defaultDate, dateFormat);
+
+        log(String.format("Chang time format '%s' to have a value of '%s'.", TIME_FORMAT.hh_mm_a, timeFormat));
+        WebElement defaultTime = Locator.id("defaultTimeFormat").findElement(getDriver());
+        optionEl = Locator.tagWithAttribute("option", "value", TIME_FORMAT.hh_mm_a.toString()).findElement(defaultTime);
+        executeScript("arguments[0].value = arguments[1]", optionEl, timeFormat);
+        selectOptionByValue(defaultTime, timeFormat);
+
+        log(String.format("Chang DateTime date format '%s' to have a value of '%s'.", DATE_FORMAT.ddMMMyy, dateFormat));
+        WebElement defaultDTDate = Locator.id("dateSelect").findElement(getDriver());
+        optionEl = Locator.tagWithAttribute("option", "value", DATE_FORMAT.ddMMMyy.toString()).findElement(defaultDTDate);
+        executeScript("arguments[0].value = arguments[1]", optionEl, dateFormat);
+        selectOptionByValue(defaultDTDate, dateFormat);
+
+        log(String.format("Chang DateTime time format '%s' to have a value of '%s'.", TIME_FORMAT.hh_mm_a, timeFormat));
+        WebElement defaultDTTime = Locator.id("timeSelect").findElement(getDriver());
+        optionEl = Locator.tagWithAttribute("option", "value", TIME_FORMAT.hh_mm_a.toString()).findElement(defaultDTTime);
+        executeScript("arguments[0].value = arguments[1]", optionEl, timeFormat);
+        selectOptionByValue(defaultDTTime, timeFormat);
+
+        lookAndFeelSettingsPage.save();
+    }
+
     // Private helper that validates Date, Time and DateTime fields in a domain designer.
     // isInherited: Used to check the enabled / editable state of the field.
     // columnType: Used to identify the expected field options and messages.
     // expectedToolTipText: Used as a check for the warning icon. If null no warning icon is expected.
-    private void checkField(DomainFormPanel domainEditor, String fieldName,
-                            boolean isInherited, FieldDefinition.ColumnType columnType,
-                            String expectedFormat, @Nullable String expectedToolTipText)
+    private void validateFieldsInDesigner(DomainFormPanel domainEditor, String fieldName,
+                                          boolean isInherited, FieldDefinition.ColumnType columnType,
+                                          String expectedFormat, @Nullable String expectedToolTipText)
     {
         DomainFieldRow fieldRow = domainEditor.getField(fieldName);
         fieldRow.expand();
@@ -851,15 +1017,95 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
             checker().verifyFalse(String.format("Field '%s' should not have a warning icon present, but one is there.", fieldName),
                     fieldRow.hasDomainWarningIcon());
         }
+
         checker().screenShotIfNewError(String.format("Non_Standard_Field_%s_Error", fieldName));
 
     }
 
+    // These controls are shared across multiple pages. It is easier to find them here in the test than to use
+    // the page objects.
+    private String getFormatFromControl(String fieldId)
+    {
+        return getSelectedOptionValue(Locator.id(fieldId).findElement(getDriver()));
+    }
+
+    private boolean getFieldInherited(String fieldName)
+    {
+        return Locator.checkboxByName(fieldName).findElement(getDriver()).isSelected();
+    }
+
+    private boolean getNonStandardWarning(String fieldId)
+    {
+        String xpath = String.format("//select[@id='%s']/following-sibling::span[@class='has-warning']", fieldId);
+        return Locator.xpath(xpath).findWhenNeeded(getDriver()).isDisplayed();
+    }
+
+    // Private helper to check the format settings at the site, project or folder.
+    // Site settings do not inherit, if the inherited parameter is null that check is skipped.
+    private void validateSettingsPage(@Nullable Boolean dateInherited, String dateFormat, boolean dateWarning,
+                                      @Nullable Boolean timeInherited, String timeFormat, boolean timeWarning,
+                                      @Nullable Boolean dateTimeInherited, String dtDateFormat, String dtTimeFormat,
+                                      boolean dtDateWarning, boolean dtTimeWarning)
+    {
+
+        log("Check Date field settings.");
+
+        checker().verifyEquals("Format of Default Date is not as expected.",
+                dateFormat, getFormatFromControl("defaultDateFormat"));
+
+        if (null != dateInherited)
+        {
+            checker().verifyEquals("Inherited value for Date format not as expected.",
+                    dateInherited, getFieldInherited("defaultDateFormatInherited"));
+        }
+
+        checker().verifyEquals("Non-standard warning for Date field not as expected.",
+                dateWarning, getNonStandardWarning("defaultDateFormat"));
+
+
+        log("Check Time field settings.");
+
+        checker().verifyEquals("Format of Default Time is not as expected.",
+                timeFormat, getFormatFromControl("defaultTimeFormat"));
+
+        if (null != timeInherited)
+        {
+            checker().verifyEquals("Inherited value for Time format not as expected.",
+                    timeInherited, getFieldInherited("defaultTimeFormatInherited"));
+        }
+
+        checker().verifyEquals("Non-standard warning for Time field not as expected.",
+                timeWarning, getNonStandardWarning("defaultTimeFormat"));
+
+
+        log("Check DateTime field settings.");
+
+        checker().verifyEquals("Format of Default DateTime (Date) is not as expected.",
+                dtDateFormat, getFormatFromControl("dateSelect"));
+
+        checker().verifyEquals("Format of Default DateTime (Time) is not as expected.",
+                dtTimeFormat, getFormatFromControl("timeSelect"));
+
+        if (null != dateTimeInherited)
+        {
+            checker().verifyEquals("Inherited value for DateTime format not as expected.",
+                    dateTimeInherited, getFieldInherited("defaultDateTimeFormatInherited"));
+        }
+
+        checker().verifyEquals("Non-standard warning for DateTime (Date) not as expected.",
+                dtDateWarning, getNonStandardWarning("dateSelect"));
+
+        checker().verifyEquals("Non-standard warning for DateTime (Time) not as expected.",
+                dtTimeWarning, getNonStandardWarning("timeSelect"));
+
+        checker().screenShotIfNewError("Settings_Page_Error");
+    }
+
     // Private helper to check the Site Validation report. Checks to see if the report should, or should not, contain
     // the list of warnings.
-    private void checkSiteValidation(List<String> expectedWarnings, boolean shouldContain)
+    private void validateSiteValidationReport(String scope, List<String> expectedWarnings, boolean shouldContain)
     {
-        List<String> actualWarnings = getProjectValidationWarnings();
+        List<String> actualWarnings = getProjectValidationWarnings(scope);
 
         log("Found Warnings: " + actualWarnings);
 
@@ -867,15 +1113,13 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         {
             log("Should Contain Warnings: " + expectedWarnings);
 
-            if (!actualWarnings.isEmpty())
+            if (checker().withScreenshot()
+                    .verifyFalse(String.format("Found no Site Validation warnings under '%s'.", scope),
+                            actualWarnings.isEmpty()))
             {
-                checker().verifyTrue("Did not find the expected warnings.",
+                checker().verifyTrue("Did not find the expected warnings in the 'Site Validation' report.",
                         actualWarnings.containsAll(expectedWarnings));
 
-            }
-            else
-            {
-                log(String.format("No warnings found for project '%s'.", getProjectName()));
             }
         }
         else
@@ -885,12 +1129,15 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
             boolean shouldBeFalse = actualWarnings.stream()
                     .anyMatch(expectedWarnings::contains);
 
-            checker().verifyFalse("Found warning that should not be there.",
-                    shouldBeFalse);
+            checker().withScreenshot()
+                    .verifyFalse("Found Site Validation warning(s) that should not be there.",
+                            shouldBeFalse);
         }
+
+        checker().screenShotIfNewError("Site_Validation_Error");
     }
 
-    private List<String> getProjectValidationWarnings()
+    private List<String> getProjectValidationWarnings(String scope)
     {
         List<String> warnings = new ArrayList<>();
 
@@ -918,7 +1165,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
         waitForText("Folder Validation Results");
 
-        String xpath = String.format("//li[contains(text(),'Project: %s')]//li[contains(text(),'Warnings:')]//ul", getProjectName());
+        String xpath = String.format("//li[contains(text(),'%s')]//li[contains(text(),'Warnings:')]//ul", scope);
         WebElement ul = Locator.xpath(xpath).findWhenNeeded(getDriver());
 
         int linkTextLength = " more info".length();

--- a/src/org/labkey/test/tests/ProjectSettingsTest.java
+++ b/src/org/labkey/test/tests/ProjectSettingsTest.java
@@ -346,7 +346,7 @@ public class ProjectSettingsTest extends BaseWebDriverTest
         String dateFormatInjection = DATE_FORMAT.yyyy_MM_dd.toString() + "'" + INJECT_CHARS + "'";
         String timeFormatInjection = TIME_FORMAT.HH_mm.toString() + "'" + INJECT_CHARS + "'";
 
-        new APIContainerHelper(this).setNonStandardDateAndTimeFormat(createDefaultConnection(), PROJ_CHANGE,
+        new APIContainerHelper(this).setDateAndTimeFormats(createDefaultConnection(), PROJ_CHANGE,
                 dateFormatInjection, timeFormatInjection, String.format("%s %s", dateFormatInjection, timeFormatInjection));
 
         var projectSettingPage = ProjectSettingsPage.beginAt(this, PROJ_CHANGE);

--- a/src/org/labkey/test/tests/ProjectSettingsTest.java
+++ b/src/org/labkey/test/tests/ProjectSettingsTest.java
@@ -343,8 +343,8 @@ public class ProjectSettingsTest extends BaseWebDriverTest
         resetSiteSettings();
         resetProjectSettings();
 
-        String dateFormatInjection = DATE_FORMAT.yyyy_MM_dd.toString() + "'" + INJECT_CHARS + "'";
-        String timeFormatInjection = TIME_FORMAT.HH_mm.toString() + "'" + INJECT_CHARS + "'";
+        String dateFormatInjection = DATE_FORMAT.yyyy_MM_dd + "'" + INJECT_CHARS + "'";
+        String timeFormatInjection = TIME_FORMAT.HH_mm + "'" + INJECT_CHARS + "'";
 
         new APIContainerHelper(this).setDateAndTimeFormats(createDefaultConnection(), PROJ_CHANGE,
                 dateFormatInjection, timeFormatInjection, String.format("%s %s", dateFormatInjection, timeFormatInjection));

--- a/src/org/labkey/test/tests/ReportAndDatasetNotificationTest.java
+++ b/src/org/labkey/test/tests/ReportAndDatasetNotificationTest.java
@@ -31,6 +31,7 @@ import org.labkey.test.components.SaveChartDialog;
 import org.labkey.test.components.dumbster.EmailRecordTable;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.pages.TimeChartWizard;
+import org.labkey.test.util.APIContainerHelper;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PortalHelper;
@@ -171,15 +172,9 @@ public class ReportAndDatasetNotificationTest extends StudyBaseTest
 
         // This test depends on a non-standard date format, one that contains a timestamp, to validate the reports are
         // shown as updated. The non-standard format can only be set by an API call to UpdateContainerSettings.
-        Connection cn = createDefaultConnection();
-        SimplePostCommand command = new SimplePostCommand("admin", "UpdateContainerSettings");
-        JSONObject json = new JSONObject();
-        json.put("defaultDateFormat", NON_STANDARD_DATEFORMAT);
-        json.put("defaultDateFormatInherited", false);
-        json.put("defaultDateTimeFormatInherited", true);
-        json.put("defaultTimeFormatInherited", true);
-        command.setJsonObject(json);
-        command.execute(cn, getCurrentContainerPath());
+        APIContainerHelper apiContainerHelper = new APIContainerHelper(this);
+        apiContainerHelper.setNonStandardDateAndTimeFormat(createDefaultConnection(), getCurrentContainerPath(),
+                NON_STANDARD_DATEFORMAT, null, null);
 
         clickTab("Clinical and Assay Data");
         waitForElement(Locator.linkWithText("GenericAssay"));

--- a/src/org/labkey/test/tests/ReportAndDatasetNotificationTest.java
+++ b/src/org/labkey/test/tests/ReportAndDatasetNotificationTest.java
@@ -15,11 +15,8 @@
  */
 package org.labkey.test.tests;
 
-import org.json.JSONObject;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
-import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
@@ -173,7 +170,7 @@ public class ReportAndDatasetNotificationTest extends StudyBaseTest
         // This test depends on a non-standard date format, one that contains a timestamp, to validate the reports are
         // shown as updated. The non-standard format can only be set by an API call to UpdateContainerSettings.
         APIContainerHelper apiContainerHelper = new APIContainerHelper(this);
-        apiContainerHelper.setNonStandardDateAndTimeFormat(createDefaultConnection(), getCurrentContainerPath(),
+        apiContainerHelper.setDateAndTimeFormats(createDefaultConnection(), getCurrentContainerPath(),
                 NON_STANDARD_DATEFORMAT, null, null);
 
         clickTab("Clinical and Assay Data");

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -233,7 +233,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
 
         ProjectSettingsPage projectSettingsPage = goToProjectSettings();
         projectSettingsPage.setDefaultDateTimeDisplayInherited(false);
-        projectSettingsPage.setDefaultDateTimeDisplay(BaseSettingsPage.DATE_FORMAT.yyyy_MM_dd, BaseSettingsPage.TIME_FORMAT.Default);
+        projectSettingsPage.setDefaultDateTimeDisplay(BaseSettingsPage.DATE_FORMAT.MMMM_dd_yyyy, BaseSettingsPage.TIME_FORMAT.Default);
         projectSettingsPage.save();
 
         // images for thumbnails

--- a/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
+++ b/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
@@ -22,6 +22,8 @@ import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.core.admin.BaseSettingsPage;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.DATE_FORMAT;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.TIME_FORMAT;
 import org.labkey.test.pages.core.admin.LookAndFeelSettingsPage;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.params.FieldDefinition;
@@ -1116,10 +1118,10 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
     @Test
     public void testDateAndTimeFormat() throws IOException, CommandException
     {
-        BaseSettingsPage.DATE_FORMAT dateFormat01 = BaseSettingsPage.DATE_FORMAT.Default;
-        BaseSettingsPage.TIME_FORMAT timeFormat01 = BaseSettingsPage.TIME_FORMAT.hh_mm_a;
+        DATE_FORMAT dateFormat01 = DATE_FORMAT.Default;
+        TIME_FORMAT timeFormat01 = TIME_FORMAT.hh_mm_a;
         String dateTimeFormat01 = String.format("%s %s",
-                BaseSettingsPage.DATE_FORMAT.Default, BaseSettingsPage.TIME_FORMAT.hh_mm_a);
+                DATE_FORMAT.Default, TIME_FORMAT.hh_mm_a);
 
         SimpleDateFormat formatterDate = new SimpleDateFormat(dateFormat01.toString());
         SimpleDateFormat formatterTime = new SimpleDateFormat(timeFormat01.toString());
@@ -1201,13 +1203,14 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
         validateListDataInUI(table, expectedData);
         checker().screenShotIfNewError("Format01_Error");
 
-        String dateFormat02 = "ddMMMyy";
-        String timeFormat02 = "HH:mm:ss";
-        String dateTimeFormat02 = "dd-MMM-yyyy HH:mm:ss";
+        DATE_FORMAT dateFormat02 = DATE_FORMAT.ddMMMyy;
+        TIME_FORMAT timeFormat02 = TIME_FORMAT.HH_mm_ss;
+        DATE_FORMAT dateTimeDateFormat02 = DATE_FORMAT.dd_MMM_yyyy;
+        TIME_FORMAT dateTimeTimeFormat02 = TIME_FORMAT.HH_mm_ss;
 
-        formatterDate = new SimpleDateFormat(dateFormat02);
-        formatterTime = new SimpleDateFormat(timeFormat02);
-        formatterDateTime = new SimpleDateFormat(dateTimeFormat02);
+        formatterDate = new SimpleDateFormat(dateFormat02.toString());
+        formatterTime = new SimpleDateFormat(timeFormat02.toString());
+        formatterDateTime = new SimpleDateFormat(String.format("%s %s", dateTimeDateFormat02, dateTimeTimeFormat02));
 
         clickAndWait(table.getHeaderButton("Design"));
         EditListDefinitionPage listDefinitionPage = new EditListDefinitionPage(getDriver());
@@ -1215,7 +1218,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
         DomainFormPanel domainEditor = listDefinitionPage.getFieldsPanel();
         domainEditor.getField(timeCol).setTimeFormat(timeFormat02);
         domainEditor.getField(dateCol).setDateFormat(dateFormat02);
-        domainEditor.getField(dateTimeCol).setDateTimeFormat(dateTimeFormat02);
+        domainEditor.getField(dateTimeCol).setDateTimeFormat(dateTimeDateFormat02, dateTimeTimeFormat02);
 
         listDefinitionPage.clickSave();
 
@@ -1254,9 +1257,9 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
         log(String.format("Create a list named '%s' with two DateTime fields that will be converted to date-only and time-only fields.", listName));
 
         String dtFormatDate = String.format("%s %s",
-                BaseSettingsPage.DATE_FORMAT.yyyy_MMM_dd, BaseSettingsPage.TIME_FORMAT.HH_mm);
+                DATE_FORMAT.yyyy_MMM_dd, TIME_FORMAT.HH_mm);
         String dtFormatTime = String.format("%s %s",
-                BaseSettingsPage.DATE_FORMAT.yyyy_MMM_dd, BaseSettingsPage.TIME_FORMAT.HH_mm_ss);
+                DATE_FORMAT.yyyy_MMM_dd, TIME_FORMAT.HH_mm_ss);
 
         SimpleDateFormat formatterFormatTime = new SimpleDateFormat(dtFormatTime);
 
@@ -1347,8 +1350,8 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
         listDefinitionPage.clickSave();
 
         // Update default format after changing the types.
-        BaseSettingsPage.DATE_FORMAT dateFormat = BaseSettingsPage.DATE_FORMAT.Default;
-        BaseSettingsPage.TIME_FORMAT timeFormat = BaseSettingsPage.TIME_FORMAT.Default;
+        DATE_FORMAT dateFormat = DATE_FORMAT.Default;
+        TIME_FORMAT timeFormat = TIME_FORMAT.Default;
 
         SimpleDateFormat formatterDate = new SimpleDateFormat(dateFormat.toString());
         SimpleDateFormat formatterTime = new SimpleDateFormat(timeFormat.toString());

--- a/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
+++ b/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
@@ -81,6 +81,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
         _defaultTimeFormat = new SimpleDateFormat(settingsPage.getDefaultTimeDisplay());
         _defaultDateTimeFormat = new SimpleDateFormat(String.format("%s %s",
                 settingsPage.getDefaultDateTimeDateDisplay(), settingsPage.getDefaultDateTimeTimeDisplay()));
+
     }
 
     @AfterClass

--- a/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
+++ b/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
@@ -1257,8 +1257,9 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         log(String.format("Create a list named '%s' with two DateTime fields that will be converted to date-only and time-only fields.", listName));
 
+        // For dtFormatDate use a date format that has spaces.
         String dtFormatDate = String.format("%s %s",
-                DATE_FORMAT.yyyy_MMM_dd, TIME_FORMAT.HH_mm);
+                DATE_FORMAT.MMMM_dd_yyyy, TIME_FORMAT.HH_mm);
         String dtFormatTime = String.format("%s %s",
                 DATE_FORMAT.yyyy_MMM_dd, TIME_FORMAT.HH_mm_ss);
 

--- a/src/org/labkey/test/tests/query/QueryMetadataTest.java
+++ b/src/org/labkey/test/tests/query/QueryMetadataTest.java
@@ -7,7 +7,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.domain.DomainFieldRow;
-import org.labkey.test.pages.core.admin.BaseSettingsPage;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.DATE_FORMAT;
 import org.labkey.test.pages.query.QueryMetadataEditorPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
@@ -217,7 +217,7 @@ public class QueryMetadataTest extends BaseWebDriverTest
         var editPage = QueryMetadataEditorPage.beginAt(this, getProjectName(), "lists", TEST_LIST);
         DomainFieldRow fieldRow = editPage.fieldsPanel().getField("Created");
         fieldRow.setDateTimeInherited(false);
-        fieldRow.setDateTimeFormatDate(BaseSettingsPage.DATE_FORMAT.ddMMMyy.toString());
+        fieldRow.setDateTimeFormat(DATE_FORMAT.ddMMMyy);
         editPage.clickSave();
 
         var queryXmlPage = editPage.clickEditSource();
@@ -244,7 +244,7 @@ public class QueryMetadataTest extends BaseWebDriverTest
         var editPage = QueryMetadataEditorPage.beginAt(this, getProjectName(), "assay.General." + TEST_ASSAY, "Data");
         DomainFieldRow fieldRow = editPage.fieldsPanel().getField("Created");
         fieldRow.setDateTimeInherited(false);
-        fieldRow.setDateTimeFormatDate(BaseSettingsPage.DATE_FORMAT.ddMMMyy.toString());
+        fieldRow.setDateTimeFormat(DATE_FORMAT.ddMMMyy);
         editPage.aliasField("Row Id");
         editPage.clickSave();
 

--- a/src/org/labkey/test/util/APIContainerHelper.java
+++ b/src/org/labkey/test/util/APIContainerHelper.java
@@ -19,6 +19,7 @@ import org.apache.hc.core5.http.HttpStatus;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.security.CreateContainerCommand;
@@ -279,4 +280,57 @@ public class APIContainerHelper extends AbstractContainerHelper
             throw new RuntimeException("Unable to get container ID for: " + containerPath, e);
         }
     }
+
+    public CommandResponse setNonStandardDateAndTimeFormat(Connection connection, String containerPath,
+                                                           @Nullable String dateFormat,
+                                                           @Nullable String timeFormat,
+                                                           @Nullable String dateTimeFormat) throws IOException, CommandException
+    {
+
+        JSONObject json = new JSONObject();
+
+        if(null != dateFormat)
+        {
+            json.put("defaultDateFormat", dateFormat);
+            json.put("defaultDateFormatInherited", false);
+        }
+        else
+        {
+            json.put("defaultDateFormatInherited", true);
+        }
+
+        if(null != timeFormat)
+        {
+            json.put("defaultTimeFormat", timeFormat);
+            json.put("defaultTimeFormatInherited", false);
+        }
+        else
+        {
+            json.put("defaultTimeFormatInherited", true);
+        }
+
+        if(null != dateTimeFormat)
+        {
+            json.put("defaultDateTimeFormat", dateTimeFormat);
+            json.put("defaultDateTimeFormatInherited", false);
+        }
+        else
+        {
+            json.put("defaultDateTimeFormatInherited", true);
+        }
+
+        return setNonStandardDateAndTimeFormat(connection, containerPath, json);
+
+    }
+
+    public CommandResponse setNonStandardDateAndTimeFormat(Connection connection, String containerPath, JSONObject json) throws IOException, CommandException
+    {
+
+        SimplePostCommand command = new SimplePostCommand("admin", "UpdateContainerSettings");
+        command.setJsonObject(json);
+
+        return command.execute(connection, containerPath);
+
+    }
+
 }

--- a/src/org/labkey/test/util/APIContainerHelper.java
+++ b/src/org/labkey/test/util/APIContainerHelper.java
@@ -287,12 +287,62 @@ public class APIContainerHelper extends AbstractContainerHelper
                                                  @Nullable String dateTimeFormat) throws IOException, CommandException
     {
 
+        boolean isRootPath = containerPath.equals("/");
+
         JSONObject json = new JSONObject();
+
+        if (isRootPath)
+        {
+            json.put("dateParsingMode", "US");
+//            json.put("customWelcome", "null");
+            json.put("shouldInherit", false);
+//            json.put("systemDescription", null);
+            json.put("systemDescriptionInherited", false);
+            json.put("systemShortName", "LabKey Server");
+            json.put("systemShortNameInherited", false);
+            json.put("themeName", "Seattle");
+            json.put("themeNameInherited", false);
+            json.put("folderDisplayMode", "ALWAYS");
+            json.put("folderDisplayModeInherited", false);
+            json.put("applicationMenuDisplayMode", "ALWAYS");
+            json.put("applicationMenuDisplayModeInherited", false);
+            json.put("helpMenuEnabled", true);
+            json.put("helpMenuEnabledInherited", false);
+            json.put("discussionEnabled", true);
+            json.put("discussionEnabledInherited", false);
+            json.put("logoHref", "${contextPath}/home/project-start.view");
+            json.put("logoHrefInherited", false);
+            json.put("companyName", "Demo Installation");
+            json.put("companyNameInherited", false);
+            json.put("systemEmailAddress", "danield@labkey.com");
+            json.put("systemEmailAddressInherited", false);
+            json.put("reportAProblemPath", "${contextPath}/home/support/project-begin.view");
+            json.put("reportAProblemPathInherited", false);
+//            json.put("supportEmail", null);
+            json.put("supportEmailInherited", false);
+//            json.put("customLogin", null);
+            json.put("customLoginInherited", false);
+            json.put("defaultDateFormatInherited", false);
+            json.put("defaultDateTimeFormatInherited", false);
+            json.put("defaultTimeFormatInherited", false);
+//            json.put("defaultNumberFormat", null);
+            json.put("defaultNumberFormatInherited", false);
+//            json.put("extraDateParsingPattern", null);
+            json.put("extraDateParsingPatternInherited", false);
+//            json.put("extraDateTimeParsingPattern", null);
+            json.put("extraDateTimeParsingPatternInherited", false);
+//            json.put("extraTimeParsingPattern", null);
+            json.put("extraTimeParsingPatternInherited", false);
+            json.put("restrictedColumnsEnabled", false);
+            json.put("restrictedColumnsEnabledInherited", false);
+        }
 
         if(null != dateFormat)
         {
             json.put("defaultDateFormat", dateFormat);
-            json.put("defaultDateFormatInherited", false);
+
+            if(!isRootPath)
+                json.put("defaultDateFormatInherited", false);
         }
         else
         {
@@ -302,7 +352,9 @@ public class APIContainerHelper extends AbstractContainerHelper
         if(null != timeFormat)
         {
             json.put("defaultTimeFormat", timeFormat);
-            json.put("defaultTimeFormatInherited", false);
+
+            if(!isRootPath)
+                json.put("defaultTimeFormatInherited", false);
         }
         else
         {
@@ -312,7 +364,9 @@ public class APIContainerHelper extends AbstractContainerHelper
         if(null != dateTimeFormat)
         {
             json.put("defaultDateTimeFormat", dateTimeFormat);
-            json.put("defaultDateTimeFormatInherited", false);
+
+            if(!isRootPath)
+                json.put("defaultDateTimeFormatInherited", false);
         }
         else
         {
@@ -326,7 +380,16 @@ public class APIContainerHelper extends AbstractContainerHelper
     public CommandResponse setDateAndTimeFormats(Connection connection, String containerPath, JSONObject json) throws IOException, CommandException
     {
 
-        SimplePostCommand command = new SimplePostCommand("admin", "UpdateContainerSettings");
+        String actionName;
+        if (containerPath.equals("/"))
+        {
+            actionName = "ProjectSettings";
+        }
+        else
+        {
+            actionName = "UpdateContainerSettings";
+        }
+        SimplePostCommand command = new SimplePostCommand("admin", actionName);
         command.setJsonObject(json);
 
         return command.execute(connection, containerPath);

--- a/src/org/labkey/test/util/APIContainerHelper.java
+++ b/src/org/labkey/test/util/APIContainerHelper.java
@@ -287,62 +287,12 @@ public class APIContainerHelper extends AbstractContainerHelper
                                                  @Nullable String dateTimeFormat) throws IOException, CommandException
     {
 
-        boolean isRootPath = containerPath.equals("/");
-
         JSONObject json = new JSONObject();
-
-        if (isRootPath)
-        {
-            json.put("dateParsingMode", "US");
-//            json.put("customWelcome", "null");
-            json.put("shouldInherit", false);
-//            json.put("systemDescription", null);
-            json.put("systemDescriptionInherited", false);
-            json.put("systemShortName", "LabKey Server");
-            json.put("systemShortNameInherited", false);
-            json.put("themeName", "Seattle");
-            json.put("themeNameInherited", false);
-            json.put("folderDisplayMode", "ALWAYS");
-            json.put("folderDisplayModeInherited", false);
-            json.put("applicationMenuDisplayMode", "ALWAYS");
-            json.put("applicationMenuDisplayModeInherited", false);
-            json.put("helpMenuEnabled", true);
-            json.put("helpMenuEnabledInherited", false);
-            json.put("discussionEnabled", true);
-            json.put("discussionEnabledInherited", false);
-            json.put("logoHref", "${contextPath}/home/project-start.view");
-            json.put("logoHrefInherited", false);
-            json.put("companyName", "Demo Installation");
-            json.put("companyNameInherited", false);
-            json.put("systemEmailAddress", "danield@labkey.com");
-            json.put("systemEmailAddressInherited", false);
-            json.put("reportAProblemPath", "${contextPath}/home/support/project-begin.view");
-            json.put("reportAProblemPathInherited", false);
-//            json.put("supportEmail", null);
-            json.put("supportEmailInherited", false);
-//            json.put("customLogin", null);
-            json.put("customLoginInherited", false);
-            json.put("defaultDateFormatInherited", false);
-            json.put("defaultDateTimeFormatInherited", false);
-            json.put("defaultTimeFormatInherited", false);
-//            json.put("defaultNumberFormat", null);
-            json.put("defaultNumberFormatInherited", false);
-//            json.put("extraDateParsingPattern", null);
-            json.put("extraDateParsingPatternInherited", false);
-//            json.put("extraDateTimeParsingPattern", null);
-            json.put("extraDateTimeParsingPatternInherited", false);
-//            json.put("extraTimeParsingPattern", null);
-            json.put("extraTimeParsingPatternInherited", false);
-            json.put("restrictedColumnsEnabled", false);
-            json.put("restrictedColumnsEnabledInherited", false);
-        }
 
         if(null != dateFormat)
         {
             json.put("defaultDateFormat", dateFormat);
-
-            if(!isRootPath)
-                json.put("defaultDateFormatInherited", false);
+            json.put("defaultDateFormatInherited", false);
         }
         else
         {
@@ -352,9 +302,7 @@ public class APIContainerHelper extends AbstractContainerHelper
         if(null != timeFormat)
         {
             json.put("defaultTimeFormat", timeFormat);
-
-            if(!isRootPath)
-                json.put("defaultTimeFormatInherited", false);
+            json.put("defaultTimeFormatInherited", false);
         }
         else
         {
@@ -364,9 +312,7 @@ public class APIContainerHelper extends AbstractContainerHelper
         if(null != dateTimeFormat)
         {
             json.put("defaultDateTimeFormat", dateTimeFormat);
-
-            if(!isRootPath)
-                json.put("defaultDateTimeFormatInherited", false);
+            json.put("defaultDateTimeFormatInherited", false);
         }
         else
         {
@@ -380,16 +326,7 @@ public class APIContainerHelper extends AbstractContainerHelper
     public CommandResponse setDateAndTimeFormats(Connection connection, String containerPath, JSONObject json) throws IOException, CommandException
     {
 
-        String actionName;
-        if (containerPath.equals("/"))
-        {
-            actionName = "ProjectSettings";
-        }
-        else
-        {
-            actionName = "UpdateContainerSettings";
-        }
-        SimplePostCommand command = new SimplePostCommand("admin", actionName);
+        SimplePostCommand command = new SimplePostCommand("admin", "UpdateContainerSettings");
         command.setJsonObject(json);
 
         return command.execute(connection, containerPath);

--- a/src/org/labkey/test/util/APIContainerHelper.java
+++ b/src/org/labkey/test/util/APIContainerHelper.java
@@ -281,10 +281,10 @@ public class APIContainerHelper extends AbstractContainerHelper
         }
     }
 
-    public CommandResponse setNonStandardDateAndTimeFormat(Connection connection, String containerPath,
-                                                           @Nullable String dateFormat,
-                                                           @Nullable String timeFormat,
-                                                           @Nullable String dateTimeFormat) throws IOException, CommandException
+    public CommandResponse setDateAndTimeFormats(Connection connection, String containerPath,
+                                                 @Nullable String dateFormat,
+                                                 @Nullable String timeFormat,
+                                                 @Nullable String dateTimeFormat) throws IOException, CommandException
     {
 
         JSONObject json = new JSONObject();
@@ -319,11 +319,11 @@ public class APIContainerHelper extends AbstractContainerHelper
             json.put("defaultDateTimeFormatInherited", true);
         }
 
-        return setNonStandardDateAndTimeFormat(connection, containerPath, json);
+        return setDateAndTimeFormats(connection, containerPath, json);
 
     }
 
-    public CommandResponse setNonStandardDateAndTimeFormat(Connection connection, String containerPath, JSONObject json) throws IOException, CommandException
+    public CommandResponse setDateAndTimeFormats(Connection connection, String containerPath, JSONObject json) throws IOException, CommandException
     {
 
         SimplePostCommand command = new SimplePostCommand("admin", "UpdateContainerSettings");


### PR DESCRIPTION
#### Rationale
Test automation for non-standard date and time formats. The tests are in NonStandardDateAndTimeFormatTest.java.
Consolidated various test helpers that set date and time fields. Change various helpers, UI components, other tests, etc... to use the enums defined in the base setting page for the format not a string (not a string).

Added a page to set formats at the page level (FolderFormatsPage).

Added APIContainerHelper.setDateAndTimeFormats. This allows setting of non-standard formats to projects and folders.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/888

#### Changes
- Consolidate and clean up helpers.
- Add back tests that had been commented out.
- Added NonStandardDateAndTimeFormatTest.java
- Updated tests and other code to use helpers from LKS tests.
- Added check for format warnings to domain designer and settings pages.
- APIContainerHelper.setDateAndTimeFormats
