### PR TITLE
Update expected invalid email message

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -49,6 +49,7 @@ import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.labkey.remoteapi.query.ContainerFilter;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.SelectRowsResponse;
+import org.labkey.remoteapi.security.CreateUserResponse;
 import org.labkey.serverapi.reader.TabLoader;
 import org.labkey.serverapi.writer.PrintWriters;
 import org.labkey.test.components.CustomizeView;
@@ -1946,15 +1947,17 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     /**
      * Create a user with the specified permissions for the specified project
      */
-    public void createUserWithPermissions(String userName, String projectName, String permissions)
+    public CreateUserResponse createUserWithPermissions(String userName, String projectName, String permissions)
     {
         if (projectName == null)
         {
             projectName = getProjectName();
         }
-        _userHelper.createUser(userName, true);
+        CreateUserResponse ret = _userHelper.createUser(userName, true);
         new ApiPermissionsHelper(this)
                 .addMemberToRole(userName, permissions, PermissionsHelper.MemberType.user, projectName);
+
+        return ret;
     }
 
     public ApiPermissionsHelper createSiteDeveloper(String userEmail)

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -412,12 +412,18 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         assertTrue(String.format("Wrong errors.\nExpected: ['%s']\nActual: '%s'", String.join("',\n'", expectedMessages), errorText), missingErrors.isEmpty());
     }
 
-    protected String setInitialPassword(String user)
+    @Deprecated // TODO: Call the variant that takes a userId instead
+    protected String setInitialPassword(String email)
+    {
+        return setInitialPassword(_userHelper.getUserId(email));
+    }
+
+    protected String setInitialPassword(int userId)
     {
         String password = PasswordUtil.getPassword();
-        SetPasswordForm.goToInitialPasswordForUser(this, user)
-                .setNewPassword(password)
-                .clickSubmit();
+        SetPasswordForm.goToInitialPasswordForUser(this, userId)
+            .setNewPassword(password)
+            .clickSubmit();
 
         return password;
     }

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -428,9 +428,9 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         return password;
     }
 
-    protected String getPasswordResetUrl(String username)
+    protected String getPasswordResetUrl(int userId)
     {
-        beginAt(buildURL("security", "showResetEmail", Map.of("email", username)));
+        beginAt(buildURL("security", "showResetEmail", Map.of("userId", userId)));
 
         WebElement resetLink = Locator.xpath("//a[contains(@href, 'setPassword.view')]").findElement(getDriver());
         shortWait().until(ExpectedConditions.elementToBeClickable(resetLink));

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -608,8 +608,10 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
             refresh(); // Clear form
 
             log("Testing bad email addresses");
-            verifyInitialUserError(null, null, null, "Invalid email address");
-            verifyInitialUserError("bogus@bogus@bogus", null, null, "Invalid email address: bogus@bogus@bogus");
+            verifyInitialUserError(null, null, null, "email: '' is not a valid email address. Please enter an email address in this form: user@domain.tld");
+            verifyInitialUserError("bogus@bogus@bogus", null, null, "email: 'bogus@bogus@bogus' is not a valid email address. Please enter an email address in this form: user@domain.tld");
+            // In the past, email address was getting double encoded
+            verifyInitialUserError("<>\"&%", null, null, "email: '<>\"&%' is not a valid email address. Please enter an email address in this form: user@domain.tld");
 
             log("Testing bad passwords");
             verifyInitialUserError(email, null, null, "You must enter a password.");

--- a/src/org/labkey/test/components/core/login/SetPasswordForm.java
+++ b/src/org/labkey/test/components/core/login/SetPasswordForm.java
@@ -55,9 +55,9 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
     }
 
     // Don't use this unless you're actually testing authentication functionality
-    public static SetPasswordForm goToInitialPasswordForUser(WebDriverWrapper wrapper, String email)
+    public static SetPasswordForm goToInitialPasswordForUser(WebDriverWrapper wrapper, int userId)
     {
-        wrapper.beginAt(WebTestHelper.buildURL("security", "showRegistrationEmail", Map.of("email", email)));
+        wrapper.beginAt(WebTestHelper.buildURL("security", "showRegistrationEmail", Map.of("userId", userId)));
         // Get setPassword URL from notification email.
         WebElement resetLink = Locator.linkWithHref("setPassword.view").findElement(wrapper.getDriver());
 

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -32,7 +32,6 @@ import org.labkey.test.pages.core.login.LoginConfigurePage;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PermissionsHelper;
-import org.openqa.selenium.WebElement;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -331,8 +330,8 @@ public class AdminConsoleTest extends BaseWebDriverTest
 
     private void createTestUser()
     {
-        _userHelper.createUser(APP_ADMIN_USER, true, false);
-        setInitialPassword(APP_ADMIN_USER);
+        int userId = _userHelper.createUser(APP_ADMIN_USER, true, false).getUserId();
+        setInitialPassword(userId);
 
         ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
         apiPermissionsHelper.addMemberToRole(APP_ADMIN_USER, "Application Admin", PermissionsHelper.MemberType.user, "/");

--- a/src/org/labkey/test/tests/SecurityApiTest.java
+++ b/src/org/labkey/test/tests/SecurityApiTest.java
@@ -81,8 +81,8 @@ public class SecurityApiTest extends BaseWebDriverTest
         apiPermissionsHelper.setPermissions(GROUP_2, "Reader");
 
         // Create the admin user that will be used to call the APIs.
-        _userHelper.createUserAndNotify(ADMIN_USER);
-        setInitialPassword(ADMIN_USER);
+        int userId = _userHelper.createUserAndNotify(ADMIN_USER).getUserId();
+        setInitialPassword(userId);
         apiPermissionsHelper.addUserToSiteGroup(ADMIN_USER, "Site Administrators");
 
     }

--- a/src/org/labkey/test/tests/UserDetailsPermissionTest.java
+++ b/src/org/labkey/test/tests/UserDetailsPermissionTest.java
@@ -94,13 +94,13 @@ public class UserDetailsPermissionTest extends BaseWebDriverTest
             domainFormPanel.addField(CUSTOM_USER_COLUMN).setType(FieldDefinition.ColumnType.String);
         domainDesignerPage.clickFinish();
 
-        _userHelper.createUser(ADMIN_USER, true, true);
-        _userHelper.createUser(USER_INFO_VIEWER, true, true);
-        _userHelper.createUser(IMPERSONATED_USER, true, true);
+        int adminId = _userHelper.createUser(ADMIN_USER, true, true).getUserId();
+        int userInfoId = _userHelper.createUser(USER_INFO_VIEWER, true, true).getUserId();
+        int impersonatedId = _userHelper.createUser(IMPERSONATED_USER, true, true).getUserId();
         _userHelper.createUser(CHECKED_USER, true, true);
-        setInitialPassword(ADMIN_USER);
-        setInitialPassword(USER_INFO_VIEWER);
-        setInitialPassword(IMPERSONATED_USER);
+        setInitialPassword(adminId);
+        setInitialPassword(userInfoId);
+        setInitialPassword(impersonatedId);
 
         _containerHelper.createProject(getProjectName(), null);
 

--- a/src/org/labkey/test/tests/UserPermissionsTest.java
+++ b/src/org/labkey/test/tests/UserPermissionsTest.java
@@ -23,7 +23,6 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.util.LogMethod;
-import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.PortalHelper;
 import org.openqa.selenium.WebElement;
 
@@ -227,7 +226,7 @@ public class UserPermissionsTest extends BaseWebDriverTest
         impersonate(GAMMA_READER_USER);
         WebElement projectTree = projectMenu().expandProjectFully(PERM_PROJECT_NAME);
         assertNotNull("No link to subfolder: /" + PERM_PROJECT_NAME + "/" + GAMMA_SUB_FOLDER_NAME, Locator.linkWithText(GAMMA_SUB_FOLDER_NAME).findElementOrNull(projectTree));
-        assertNotNull("Link found to inaccessable subfolder: /" + PERM_PROJECT_NAME + "/" + GAMMA_SUB_FOLDER_NAME, Locator.linkWithText(GAMMA_SUB_FOLDER_NAME).findElementOrNull(projectTree)); // it will appear as a span, no link
+        assertNotNull("Link found to inaccessible subfolder: /" + PERM_PROJECT_NAME + "/" + GAMMA_SUB_FOLDER_NAME, Locator.linkWithText(GAMMA_SUB_FOLDER_NAME).findElementOrNull(projectTree)); // it will appear as a span, no link
         // Ensure only one project visible during project impersonation. Regression test 13346
         assertEquals("Only one project should be visible while impersonating", Arrays.asList(PERM_PROJECT_NAME), getTexts(projectMenu().projectMenuLinks()));
 

--- a/src/org/labkey/test/tests/UserTest.java
+++ b/src/org/labkey/test/tests/UserTest.java
@@ -79,6 +79,7 @@ public class UserTest extends BaseWebDriverTest
     private static final String SELF_SERVICE_EMAIL_USER_CHANGED = "newaddress@user.test";
 
     protected final UIUserHelper _userHelper = new UIUserHelper(this);
+    private int _normalUserId;
 
     @Nullable
     @Override
@@ -103,7 +104,7 @@ public class UserTest extends BaseWebDriverTest
     private void doSetup()
     {
         _containerHelper.createProject(getProjectName(), null);
-        createUserWithPermissions(NORMAL_USER, getProjectName(), "Editor");
+        _normalUserId = createUserWithPermissions(NORMAL_USER, getProjectName(), "Editor").getUserId();
     }
 
     @Override
@@ -164,8 +165,8 @@ public class UserTest extends BaseWebDriverTest
     @Test
     public void testChangeUserEmail()
     {
-        new UIUserHelper(this).cloneUser(CHANGE_EMAIL_USER, NORMAL_USER);
-        setInitialPassword(CHANGE_EMAIL_USER);
+        int userId = new UIUserHelper(this).cloneUser(CHANGE_EMAIL_USER, NORMAL_USER).getUserId();
+        setInitialPassword(userId);
 
         //change their email address
         changeUserEmail(CHANGE_EMAIL_USER, CHANGE_EMAIL_USER_ALTERNATE);
@@ -198,8 +199,8 @@ public class UserTest extends BaseWebDriverTest
         assertEquals("Failed to set authentication param to enable self service email via http get", 200, getResponse);
 
         log("Create a new user.");
-        _userHelper.createUser(SELF_SERVICE_EMAIL_USER, true, true);
-        setInitialPassword(SELF_SERVICE_EMAIL_USER);
+        int selfServiceId = _userHelper.createUser(SELF_SERVICE_EMAIL_USER, true, true).getUserId();
+        setInitialPassword(selfServiceId);
 
         goToHome();
 
@@ -263,7 +264,7 @@ public class UserTest extends BaseWebDriverTest
     public void testCustomFieldLogin()
     {
         String customFieldValue = "loginCredentials";
-        setInitialPassword(NORMAL_USER);
+        setInitialPassword(_normalUserId);
 
         goToSiteUsers();
         DataRegionTable table = new DataRegionTable("Users", getDriver());
@@ -341,7 +342,7 @@ public class UserTest extends BaseWebDriverTest
             }
         }
 
-        assertTrue("Could not find a url in the email to follow.", urlString.length() > 0);
+        assertTrue("Could not find a url in the email to follow.", !urlString.isEmpty());
         try
         {
             resetUrl = new URL(urlString);
@@ -413,8 +414,8 @@ public class UserTest extends BaseWebDriverTest
         {
             ensureRequiredFieldsSet();
 
-            _userHelper.createUserAndNotify(BLANK_USER);
-            setInitialPassword(BLANK_USER);
+            int userId = _userHelper.createUserAndNotify(BLANK_USER).getUserId();
+            setInitialPassword(userId);
 
             DomainDesignerPage domainDesignerPage = goToSiteUsers().clickChangeUserProperties();
             DomainFormPanel domainFormPanel = domainDesignerPage.fieldsPanel();

--- a/src/org/labkey/test/tests/core/login/PasswordTest.java
+++ b/src/org/labkey/test/tests/core/login/PasswordTest.java
@@ -300,7 +300,7 @@ public class PasswordTest extends BaseWebDriverTest
         clickButtonContainingText("Reset", 0);
 
         signIn();
-        return getPasswordResetUrl(username);
+        return getPasswordResetUrl(_userId);
     }
 
     String[] wrongPasswordEntered =
@@ -324,11 +324,12 @@ public class PasswordTest extends BaseWebDriverTest
                 .getUsersTable()
                 .setFilter("Email", "Equals", username);
         clickAndWait(Locator.linkContainingText(_userHelper.getDisplayNameForEmail(username)));
+        int userId = Integer.valueOf(getUrlParam("userId"));
         clickButton("Reset Password");
         assertTextPresent("You are about to clear the user's current password");
         clickAndWait(Locator.lkButton("OK"));
 
-        String url = getPasswordResetUrl(username);
+        String url = getPasswordResetUrl(userId);
 
         //make sure user can't log in with current password
         signOut();

--- a/src/org/labkey/test/tests/core/login/PasswordTest.java
+++ b/src/org/labkey/test/tests/core/login/PasswordTest.java
@@ -172,7 +172,7 @@ public class PasswordTest extends BaseWebDriverTest
 
         String currentPassword = VERY_STRONG_PASSWORD + 0;
 
-        setInitialPassword(USER, currentPassword);
+        setInitialPassword(_userId, currentPassword);
         impersonate(USER);
 
         int i = 1;
@@ -223,7 +223,7 @@ public class PasswordTest extends BaseWebDriverTest
     @Test
     public void testPasswordParameter()
     {
-        setInitialPassword(USER, WEAK_PASSWORD);
+        setInitialPassword(_userId, WEAK_PASSWORD);
 
         // 31000: fail login actions if parameters present on URL
         SimplePostCommand command = new SimplePostCommand("login", "loginAPI");
@@ -345,9 +345,9 @@ public class PasswordTest extends BaseWebDriverTest
         return newPassword;
     }
 
-    protected String setInitialPassword(String user, String password)
+    protected String setInitialPassword(int userId, String password)
     {
-        SetPasswordForm.goToInitialPasswordForUser(this, _userId)
+        SetPasswordForm.goToInitialPasswordForUser(this, userId)
                 .setNewPassword(password)
                 .clickSubmit();
 
@@ -372,5 +372,4 @@ public class PasswordTest extends BaseWebDriverTest
         clickButton("Change Password");
         return new SetPasswordForm(getDriver());
     }
-
 }

--- a/src/org/labkey/test/tests/core/login/PasswordTest.java
+++ b/src/org/labkey/test/tests/core/login/PasswordTest.java
@@ -58,6 +58,8 @@ public class PasswordTest extends BaseWebDriverTest
 {
     private static final String USER = "user_passwordtest@password.test";
 
+    private int _userId;
+
     @Override
     public List<String> getAssociatedModules()
     {
@@ -83,7 +85,7 @@ public class PasswordTest extends BaseWebDriverTest
     public void resetUser()
     {
         _userHelper.deleteUsers(false, USER);
-        _userHelper.createUser(USER);
+        _userId = _userHelper.createUser(USER).getUserId();
     }
 
     @Test
@@ -121,7 +123,7 @@ public class PasswordTest extends BaseWebDriverTest
                 PasswordStrength.Strong,
                 PasswordExpiration.Never);
 
-        SetPasswordForm setPasswordForm = SetPasswordForm.goToInitialPasswordForUser(this, USER);
+        SetPasswordForm setPasswordForm = SetPasswordForm.goToInitialPasswordForUser(this, _userId);
         log("Verify strength gauge for 'SetPasswordAction'");
         setPasswordForm.verifyPasswordStrengthGauge(USER);
 
@@ -344,7 +346,7 @@ public class PasswordTest extends BaseWebDriverTest
 
     protected String setInitialPassword(String user, String password)
     {
-        SetPasswordForm.goToInitialPasswordForUser(this, user)
+        SetPasswordForm.goToInitialPasswordForUser(this, _userId)
                 .setNewPassword(password)
                 .clickSubmit();
 

--- a/src/org/labkey/test/tests/core/security/AppAdminRoleTest.java
+++ b/src/org/labkey/test/tests/core/security/AppAdminRoleTest.java
@@ -71,8 +71,8 @@ public class AppAdminRoleTest extends BaseWebDriverTest
     private void doSetup()
     {
         _userHelper.createUser(USER);
-        _userHelper.createUserAndNotify(APP_ADMIN, true);
-        setInitialPassword(APP_ADMIN);
+        int userId = _userHelper.createUserAndNotify(APP_ADMIN, true).getUserId();
+        setInitialPassword(userId);
 
         ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
         apiPermissionsHelper.addUserAsAppAdmin(APP_ADMIN);

--- a/src/org/labkey/test/tests/core/security/ImpersonatingTroubleshooterRoleTest.java
+++ b/src/org/labkey/test/tests/core/security/ImpersonatingTroubleshooterRoleTest.java
@@ -37,7 +37,7 @@ public class ImpersonatingTroubleshooterRoleTest extends TroubleshooterRoleTest
     protected void doSetup()
     {
         super.doSetup();
-        setInitialPassword(TROUBLESHOOTER);
+        setInitialPassword(_troubleShooterId);
     }
 
     @Override

--- a/src/org/labkey/test/tests/core/security/TroubleshooterRoleTest.java
+++ b/src/org/labkey/test/tests/core/security/TroubleshooterRoleTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertTrue;
 public class TroubleshooterRoleTest extends BaseWebDriverTest
 {
     protected static final String TROUBLESHOOTER = "troubleshooter@troubleshooter.test";
+    protected int _troubleShooterId;
 
     @BeforeClass
     public static void setupProject()
@@ -44,7 +45,7 @@ public class TroubleshooterRoleTest extends BaseWebDriverTest
 
     protected void doSetup()
     {
-        _userHelper.createUser(TROUBLESHOOTER);
+        _troubleShooterId = _userHelper.createUser(TROUBLESHOOTER).getUserId();
         ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
         apiPermissionsHelper.addMemberToRole(TROUBLESHOOTER, getRole(), PermissionsHelper.MemberType.user,"/");
         _containerHelper.createProject(getProjectName());

--- a/src/org/labkey/test/util/APIUserHelper.java
+++ b/src/org/labkey/test/util/APIUserHelper.java
@@ -250,15 +250,16 @@ public class APIUserHelper extends AbstractUserHelper
     }
 
     private static final Pattern regEmailVerification = Pattern.compile("verification=([A-Za-z0-9]+)");
+
     @Override
-    public String setInitialPassword(String email)
+    public String setInitialPassword(int userId)
     {
         String verification;
 
         try
         {
             SimpleGetCommand getRegEmailCommand = new SimpleGetCommand("security", "showRegistrationEmail");
-            getRegEmailCommand.setParameters(Map.of("email", email));
+            getRegEmailCommand.setParameters(Map.of("userId", userId));
 
             String responseText = getRegEmailCommand.execute(connectionSupplier.get(), null).getText();
             Matcher matcher = regEmailVerification.matcher(responseText);
@@ -280,7 +281,7 @@ public class APIUserHelper extends AbstractUserHelper
         try
         {
             String password = PasswordUtil.getPassword();
-            new SetPasswordCommand(email, password, verification).execute(connectionSupplier.get(), null);
+            new SetPasswordCommand(password, verification).execute(connectionSupplier.get(), null);
             return password;
         }
         catch (IOException | CommandException e)
@@ -292,14 +293,12 @@ public class APIUserHelper extends AbstractUserHelper
 
 class SetPasswordCommand extends PostCommand<CommandResponse>
 {
-    private final String _email;
     private final String _password;
     private final String _verification;
 
-    public SetPasswordCommand(String email, String password, String verification)
+    public SetPasswordCommand(String password, String verification)
     {
         super("login", "setPassword");
-        _email = email;
         _password = password;
         _verification = verification;
     }
@@ -307,7 +306,6 @@ class SetPasswordCommand extends PostCommand<CommandResponse>
     protected List<BasicNameValuePair> getPostData()
     {
         List<BasicNameValuePair> postData = new ArrayList<>();
-        postData.add(new BasicNameValuePair("email", _email));
         postData.add(new BasicNameValuePair("password", _password));
         postData.add(new BasicNameValuePair("password2", _password));
         postData.add(new BasicNameValuePair("verification", _verification));

--- a/src/org/labkey/test/util/AbstractUserHelper.java
+++ b/src/org/labkey/test/util/AbstractUserHelper.java
@@ -145,7 +145,7 @@ public abstract class AbstractUserHelper
 
     public abstract void ensureUsersExist(List<String> userEmails);
     public abstract CreateUserResponse createUser(String userName, boolean sendEmail, boolean verifySuccess);
-    public abstract String setInitialPassword(String email);
+    public abstract String setInitialPassword(int userId);
     protected abstract void _deleteUser(String userEmail);
     protected abstract void _deleteUsers(boolean failIfNotFound, String... userEmails);
 }

--- a/src/org/labkey/test/util/TestUser.java
+++ b/src/org/labkey/test/util/TestUser.java
@@ -68,7 +68,7 @@ public class TestUser
     {
         if (_password == null)  // if null, this is the initial password - we can use the UI to set it now
         {
-            _password = _apiUserHelper.setInitialPassword(_email);
+            _password = _apiUserHelper.setInitialPassword(_createUserResponse.getUserId());
         }
         else
         {

--- a/src/org/labkey/test/util/UIUserHelper.java
+++ b/src/org/labkey/test/util/UIUserHelper.java
@@ -59,7 +59,7 @@ public class UIUserHelper extends AbstractUserHelper
         String email;
         Integer userId;
         List<WebElement> userInfo = Locator.css("meta").findElements(resultEl);
-        if (userInfo.size() > 0)
+        if (!userInfo.isEmpty())
         {
             email = userInfo.get(0).getAttribute("email");
             String userIdStr = userInfo.get(0).getAttribute("userId");
@@ -200,10 +200,10 @@ public class UIUserHelper extends AbstractUserHelper
     }
 
     @Override
-    public String setInitialPassword(String user)
+    public String setInitialPassword(int userId)
     {
         String password = PasswordUtil.getPassword();
-        SetPasswordForm.goToInitialPasswordForUser(getWrapper(), user)
+        SetPasswordForm.goToInitialPasswordForUser(getWrapper(), userId)
                 .setNewPassword(password)
                 .clickSubmit();
 


### PR DESCRIPTION
#### Rationale
Validation in the "set password" actions has changed, causing a different invalid email address message to appear. Teach the test.

Also, the test passes email addresses to set password actions. These now require a user id.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6021