### PR TITLE
Restore old behavior of DomainFormPanel

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -518,16 +518,16 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
      */
     public String getPanelAlertText()
     {
-        WebElement alertEl = getPanelAlertWebElement();
-        if (alertEl != null)
-            return alertEl.getText();
-
-        return "";
+        return getPanelAlertText(0);
     }
 
     public String getPanelAlertText(int index)
     {
-        return getPanelAlertWebElement(index).getText();
+        WebElement panelAlertWebElement = getPanelAlertWebElement(index);
+        if (panelAlertWebElement != null)
+            return panelAlertWebElement.getText();
+        else
+            return "";
     }
 
     public List<String> getPanelAlertTexts()
@@ -546,17 +546,16 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
 
     public WebElement getPanelAlertWebElement(int index)
     {
-        return getPanelAlertElements().get(index);
+        List<WebElement> panelAlertElements = getPanelAlertElements();
+        if (panelAlertElements.size() > index)
+            return panelAlertElements.get(index);
+        else
+            return null;
     }
 
     public List<WebElement> getPanelAlertElements()
     {
-        if (!WebDriverWrapper.waitFor(() -> BootstrapLocators.infoBanner.existsIn(this), 1000))
-        {
-            return null;
-        }
-
-        return BootstrapLocators.infoBanner.findElements(this);
+        return BootstrapLocators.infoBanner.waitForElements(this, 1000);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
This restores the old behavior of some DomainFormPanel methods.
When there is no alert `getPanelAlertText` should return an empty string and `getPanelAlertWebElement` should return `null`

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2120

#### Changes
- Restore old behavior of DomainFormPanel