### PR TITLE
override setMeasure on FieldDefinition

### DIFF
--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -150,6 +150,13 @@ public class FieldDefinition extends PropertyDescriptor
     }
 
     @Override
+    public FieldDefinition setMeasure(Boolean measure)
+    {
+        super.setMeasure(measure);
+        return this;
+    }
+
+    @Override
     public FieldDefinition setHidden(Boolean hidden)
     {
         super.setHidden(hidden);


### PR DESCRIPTION
#### Rationale
This adds an override method for FieldDefinition.setMeasure to allow inline initialization of class members as final

#### Related Pull Requests
https://github.com/LabKey/limsModules/pull/881

#### Changes
override setMeasure
