### PR TITLE
wait for job without navigating to job status page

### DIFF
--- a/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
+++ b/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
@@ -112,7 +112,7 @@ public class UploadLargeExcelAssayTest extends BaseWebDriverTest
         clickButton("Save and Finish");
 
         // wait for import complete
-        waitForPipelineJobsToFinish(1);
+        waitForPipelineJobsToComplete(1, "200k", false);
 
         // export assay1 data to excel
         log("exporting samples fields to excel");
@@ -133,7 +133,7 @@ public class UploadLargeExcelAssayTest extends BaseWebDriverTest
         setFormElement(Locator.input("__primaryFile__"), largeExportExcelFile);
         clickButton("Save and Finish");
 
-        waitForPipelineJobsToFinish(2);
+        waitForPipelineJobsToComplete(2, "200k take 2", false);
 
         var qPage = SourceQueryPage.beginAt(this, getProjectName(), "assay.General.large_assay_2", "Data");
         var dataregion  = qPage.viewData(Duration.ofSeconds(60));

--- a/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
+++ b/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
@@ -112,9 +112,7 @@ public class UploadLargeExcelAssayTest extends BaseWebDriverTest
         clickButton("Save and Finish");
 
         // wait for import complete
-        var assayJobsPage1 = new AssayUploadJobsPage(getDriver());
-        var pipelineDetailsPage1 = assayJobsPage1.clickJobStatus("200k", 3 * WebDriverWrapper.WAIT_FOR_PAGE);
-        pipelineDetailsPage1.waitForComplete(10 * WebDriverWrapper.WAIT_FOR_PAGE);
+        waitForPipelineJobsToFinish(1);
 
         // export assay1 data to excel
         log("exporting samples fields to excel");
@@ -135,9 +133,7 @@ public class UploadLargeExcelAssayTest extends BaseWebDriverTest
         setFormElement(Locator.input("__primaryFile__"), largeExportExcelFile);
         clickButton("Save and Finish");
 
-        var assayJobsPage2 = new AssayUploadJobsPage(getDriver());
-        var pipelineDetailsPage2 = assayJobsPage2.clickJobStatus("200k take 2", 3 * getDefaultWaitForPage());
-        pipelineDetailsPage2.waitForComplete(10 * WebDriverWrapper.WAIT_FOR_PAGE);
+        waitForPipelineJobsToFinish(2);
 
         var qPage = SourceQueryPage.beginAt(this, getProjectName(), "assay.General.large_assay_2", "Data");
         var dataregion  = qPage.viewData(Duration.ofSeconds(60));


### PR DESCRIPTION
#### Rationale
Recently, [UploadLargeExcelAssayTest.testUpload200kRows](https://teamcity.labkey.org/viewLog.html?tab=queuedBuildOverviewTab&buildId=3261497&buildTypeId=LabKey_2411_Premium_CommunitySqlserver_DailyCSqlserver&fromSakuraUI=true#testNameId3537965916196401765) began failing on sql because it takes > 3 minutes to navigate to the job status page.
This change awaits the job completion without attempting to navigate to the job status page.

I've opened https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51630 to track the underlying issue


#### Related Pull Requests
n/a

#### Changes
use waitForPipelineJobsToFinish() instead
