### PR TITLE
Handle missing info banner correctly

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -10,6 +10,7 @@ import org.labkey.test.components.react.ToggleButton;
 import org.labkey.test.components.ui.grids.ResponsiveGrid;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.selenium.WebElementWrapper;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -17,6 +18,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -555,7 +557,14 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
 
     public List<WebElement> getPanelAlertElements()
     {
-        return BootstrapLocators.infoBanner.waitForElements(this, 1000);
+        try
+        {
+            return BootstrapLocators.infoBanner.waitForElements(this, 1000);
+        }
+        catch (NoSuchElementException nothing)
+        {
+            return Collections.emptyList();
+        }
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Previous fix introduced a different error.
```
org.openqa.selenium.NoSuchElementException: Expected condition failed: waiting for css=div.alert-info
within: DomainFormPanel [[FirefoxDriver: firefox on linux (45a95b94-47d3-49d8-b209-f5365ee0fc8d)] -> xpath: (//div[contains(concat(' ',normalize-space(@class),' '), " domain-form-panel ")][.//*[contains(concat(' ',normalize-space(@class),' '), " domain-panel-title ")]])[2]] (tried for 1 second(s) with 100 milliseconds interval)
  at app//org.labkey.test.Locator.waitForElement(Locator.java:545)
  at app//org.labkey.test.Locator.waitForElement(Locator.java:521)
  at app//org.labkey.test.Locator.waitForElement(Locator.java:514)
  at app//org.labkey.test.Locator.waitForElements(Locator.java:482)
  at app//org.labkey.test.components.domain.DomainFormPanel.getPanelAlertElements(DomainFormPanel.java:558)
  at app//org.labkey.test.components.domain.DomainFormPanel.getPanelAlertWebElement(DomainFormPanel.java:549)
  at app//org.labkey.test.components.domain.DomainFormPanel.getPanelAlertText(DomainFormPanel.java:526)
  at app//org.labkey.test.components.domain.DomainFormPanel.getPanelAlertText(DomainFormPanel.java:521)
  at app//org.labkey.test.tests.premium.SampleTypeUniqueIdTest.testSampleTypeCreateUniqueIdMessaging(SampleTypeUniqueIdTest.java:86)
```

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2131

#### Changes
- Handle missing info banner correctly
