### PR TITLE
Fix Test Timing Issues

### DIFF
--- a/src/org/labkey/test/pages/query/QueryMetadataEditorPage.java
+++ b/src/org/labkey/test/pages/query/QueryMetadataEditorPage.java
@@ -14,6 +14,7 @@ import org.openqa.selenium.WebElement;
 import java.util.Map;
 
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+import static org.labkey.test.WebDriverWrapper.waitFor;
 
 /**
  * Automates the platform component defined in: query/src/client/QueryMetadataEditor/QueryMetadataEditor.tsx
@@ -34,6 +35,11 @@ public class QueryMetadataEditorPage extends WebDriverComponent<QueryMetadataEdi
     {
         webDriverWrapper.beginAt(WebTestHelper.buildURL("query", containerPath, "metadataQuery",
                 Map.of("schemaName", schemaName, "query.queryName", queryName)));
+
+        // Wait for domain editor rows to show up.
+        waitFor(()->!Locator.tagWithClass("div", "domain-field-row domain-row-border-default").findElements(webDriverWrapper.getDriver()).isEmpty(),
+                "Query Metadata Editor Page did not load in time.", 2_500);
+
         return new QueryMetadataEditorPage(webDriverWrapper.getDriver());
     }
 

--- a/src/org/labkey/test/pages/query/QueryMetadataEditorPage.java
+++ b/src/org/labkey/test/pages/query/QueryMetadataEditorPage.java
@@ -38,7 +38,7 @@ public class QueryMetadataEditorPage extends WebDriverComponent<QueryMetadataEdi
 
         // Wait for domain editor rows to show up.
         waitFor(()->!Locator.tagWithClass("div", "domain-field-row domain-row-border-default").findElements(webDriverWrapper.getDriver()).isEmpty(),
-                "Query Metadata Editor Page did not load in time.", 2_500);
+                "Query Metadata Editor Page did not load in time.", 5_000);
 
         return new QueryMetadataEditorPage(webDriverWrapper.getDriver());
     }

--- a/src/org/labkey/test/tests/viability/ViabilityTest.java
+++ b/src/org/labkey/test/tests/viability/ViabilityTest.java
@@ -93,6 +93,7 @@ public class ViabilityTest extends AbstractViabilityTest
         assertNotChecked(Locator.checkboxByName("_pool_1604505335_0_Unreliable"));
         assertEquals("", getFormElement(Locator.name("_pool_1604505335_0_IntValue")));
 
+        sleep(500);
         clickButton(SAVE_AND_FINISH, 0);
         String alertText = cancelAlert();
         assertTrue(alertText.contains("Save anyway"));


### PR DESCRIPTION
#### Rationale
A couple of test failures because of timing issues.

#### Related Pull Requests
- None

#### Changes
- ViabilityTest: Slow the test down to allow for processing. ([TeamCity run](https://teamcity.labkey.org/buildConfiguration/LabKey_2411_Community_DailySuites_DailyEPostgres/3266039?buildTab=tests))
- QueryMetadataEditorPage: Wait for page load. ([TeamCity run](https://teamcity.labkey.org/buildConfiguration/LabKey_2411_Premium_CommunitySqlserver_DailyDSqlserver/3266101?buildTab=tests))
