### PR TITLE
Mark modules that support both databases

### DIFF
--- a/modules/ETLtest/module.properties
+++ b/modules/ETLtest/module.properties
@@ -1,2 +1,3 @@
 Name: ETLtest
 SchemaVersion: 24.002
+SupportedDatabases: mssql, pgsql

--- a/modules/chartingapi/module.properties
+++ b/modules/chartingapi/module.properties
@@ -1,1 +1,2 @@
 ModuleClass: org.labkey.api.module.SimpleModule
+SupportedDatabases: mssql, pgsql

--- a/modules/crawlerTest/module.properties
+++ b/modules/crawlerTest/module.properties
@@ -4,3 +4,4 @@ Description: Module with actions vulnerable to script injection. For validating 
 URL: http://labkey.org
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/modules/dumbster/module.properties
+++ b/modules/dumbster/module.properties
@@ -4,3 +4,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/modules/editableModule/module.properties
+++ b/modules/editableModule/module.properties
@@ -4,3 +4,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/modules/footerTest/module.properties
+++ b/modules/footerTest/module.properties
@@ -3,3 +3,4 @@ Description: Enable testing of custom footer functionality
 URL: https://www.labkey.org
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/modules/linkedschematest/module.properties
+++ b/modules/linkedschematest/module.properties
@@ -1,1 +1,2 @@
 ModuleClass: org.labkey.api.module.SimpleModule
+SupportedDatabases: mssql, pgsql

--- a/modules/miniassay/module.properties
+++ b/modules/miniassay/module.properties
@@ -1,1 +1,2 @@
 ModuleClass: org.labkey.api.module.SimpleModule
+SupportedDatabases: mssql, pgsql

--- a/modules/pipelinetest/module.properties
+++ b/modules/pipelinetest/module.properties
@@ -1,1 +1,2 @@
 ModuleClass: org.labkey.api.module.SimpleModule
+SupportedDatabases: mssql, pgsql

--- a/modules/pipelinetest2/module.properties
+++ b/modules/pipelinetest2/module.properties
@@ -1,1 +1,2 @@
 ModuleClass: org.labkey.api.module.SimpleModule
+SupportedDatabases: mssql, pgsql

--- a/modules/restrictedModule/module.properties
+++ b/modules/restrictedModule/module.properties
@@ -1,1 +1,2 @@
 ModuleClass: org.labkey.api.module.SimpleModule
+SupportedDatabases: mssql, pgsql

--- a/modules/scriptpad/module.properties
+++ b/modules/scriptpad/module.properties
@@ -1,1 +1,2 @@
 ModuleClass: org.labkey.api.module.SimpleModule
+SupportedDatabases: mssql, pgsql

--- a/modules/simpletest/module.properties
+++ b/modules/simpletest/module.properties
@@ -1,2 +1,3 @@
 Name: simpletest
 SchemaVersion: 24.000
+SupportedDatabases: mssql, pgsql

--- a/modules/triggerTestModule/module.properties
+++ b/modules/triggerTestModule/module.properties
@@ -1,1 +1,2 @@
 ModuleClass: org.labkey.api.module.SimpleModule
+SupportedDatabases: mssql, pgsql


### PR DESCRIPTION
#### Rationale
Need to explicitly declare support for SQL Server since we're about to change the default to PostgreSQL-only