### PR TITLE
give large excel assay test more time on windows/sql

### DIFF
--- a/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
+++ b/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
@@ -112,7 +112,7 @@ public class UploadLargeExcelAssayTest extends BaseWebDriverTest
         clickButton("Save and Finish");
 
         // wait for import complete
-        waitForPipelineJobsToComplete(1, "200k", false);
+        waitForPipelineJobsToComplete(1, "200k", false, 12 * 60000);
 
         // export assay1 data to excel
         log("exporting samples fields to excel");
@@ -133,7 +133,7 @@ public class UploadLargeExcelAssayTest extends BaseWebDriverTest
         setFormElement(Locator.input("__primaryFile__"), largeExportExcelFile);
         clickButton("Save and Finish");
 
-        waitForPipelineJobsToComplete(2, "200k take 2", false);
+        waitForPipelineJobsToComplete(2, "200k take 2", false, 12 * 60000);
 
         var qPage = SourceQueryPage.beginAt(this, getProjectName(), "assay.General.large_assay_2", "Data");
         var dataregion  = qPage.viewData(Duration.ofSeconds(60));


### PR DESCRIPTION
#### Rationale
Recently [UploadLargeExcelAssayTest.testUpload200kRows](https://teamcity.labkey.org/viewLog.html?buildId=3276330&tab=buildResultsDiv&buildTypeId=LabKey_2411_Premium_CommunitySqlserver_DailyCSqlserver#testNameId3537965916196401765) has failed because after 10 minutes of waiting for the large upload task, it is still running.

This change gives it 12 minutes.

#### Related Pull Requests

#### Changes
12 minutes
