### PR TITLE
Issue 51749: Site validator fails on some wikis

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -198,7 +198,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     private static boolean _dumpedHeap = false;
     private final ArtifactCollector _artifactCollector;
     private final DeferredErrorCollector _errorCollector;
-    private final CspCheckPageLoadListener _cspCheckPageLoadListener; // Need a strong reference to this
+    protected final CspCheckPageLoadListener _cspCheckPageLoadListener; // Need a strong reference to this
 
     public AbstractContainerHelper _containerHelper = new APIContainerHelper(this);
     public final CustomizeView _customizeViewsHelper;
@@ -2817,10 +2817,12 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         }
     }
 
-    private static class CspCheckPageLoadListener implements PageLoadListener
+    public static class CspCheckPageLoadListener implements PageLoadListener
     {
         private final ArtifactCollector _artifactCollector;
         private final DeferredErrorCollector _checker;
+
+        private boolean _enabled = true;
 
         public CspCheckPageLoadListener(BaseWebDriverTest baseWebDriverTest)
         {
@@ -2828,16 +2830,25 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             _checker = baseWebDriverTest.checker();
         }
 
+        /** Allows test code to suppress expected CSP violations */
+        public void setEnabled(boolean enabled)
+        {
+            _enabled = enabled;
+        }
+
         @Override
         public void beforePageLoad()
         {
-            try
+            if (_enabled)
             {
-                CspLogUtil.checkNewCspWarnings(_artifactCollector);
-            }
-            catch (CspLogUtil.CspWarningDetectedException ex)
-            {
-                _checker.withScreenshot("csp_violation").recordError(ex);
+                try
+                {
+                    CspLogUtil.checkNewCspWarnings(_artifactCollector);
+                }
+                catch (CspLogUtil.CspWarningDetectedException ex)
+                {
+                    _checker.withScreenshot("csp_violation").recordError(ex);
+                }
             }
         }
 

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -2878,7 +2878,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         @Override
         public String toString()
         {
-            return getClass().getSimpleName() + "-" + _artifactCollector.getDumpDirName();
+            return getClass().getSimpleName() + "-" + _artifactCollector.getDumpDirName() + "@" + System.identityHashCode(this);
         }
     }
 }

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -198,7 +198,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     private static boolean _dumpedHeap = false;
     private final ArtifactCollector _artifactCollector;
     private final DeferredErrorCollector _errorCollector;
-    protected final CspCheckPageLoadListener _cspCheckPageLoadListener; // Need a strong reference to this
+    private final CspCheckPageLoadListener _cspCheckPageLoadListener; // Need a strong reference to this
 
     public AbstractContainerHelper _containerHelper = new APIContainerHelper(this);
     public final CustomizeView _customizeViewsHelper;
@@ -2817,12 +2817,10 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         }
     }
 
-    public class CspCheckPageLoadListener implements PageLoadListener
+    private static class CspCheckPageLoadListener implements PageLoadListener
     {
         private final ArtifactCollector _artifactCollector;
         private final DeferredErrorCollector _checker;
-
-        private boolean _enabled = true;
 
         public CspCheckPageLoadListener(BaseWebDriverTest baseWebDriverTest)
         {
@@ -2830,33 +2828,16 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             _checker = baseWebDriverTest.checker();
         }
 
-        /** Allows test code to suppress expected CSP violations */
-        public void setEnabled(boolean enabled)
-        {
-            log("Setting CSP to " + enabled + " on " + this);
-            if (enabled && !_enabled)
-            {
-                // Turning back on, so ignore anything that was logged in the interim
-                CspLogUtil.resetCspLogMark();
-            }
-
-            _enabled = enabled;
-        }
-
         @Override
         public void beforePageLoad()
         {
-            if (_enabled)
+            try
             {
-                try
-                {
-                    CspLogUtil.checkNewCspWarnings(_artifactCollector);
-                }
-                catch (CspLogUtil.CspWarningDetectedException ex)
-                {
-                    log("CSP problem detected on " + this);
-                    _checker.withScreenshot("csp_violation").recordError(ex);
-                }
+                CspLogUtil.checkNewCspWarnings(_artifactCollector);
+            }
+            catch (CspLogUtil.CspWarningDetectedException ex)
+            {
+                _checker.withScreenshot("csp_violation").recordError(ex);
             }
         }
 

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -277,9 +277,9 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         return urlsSeen;
     }
 
-    public static BaseWebDriverTest getCurrentTest()
+    public static <T extends BaseWebDriverTest> T getCurrentTest()
     {
-        return currentTest;
+        return (T)currentTest;
     }
 
     private static Class<? extends BaseWebDriverTest> getCurrentTestClass()

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -2817,7 +2817,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         }
     }
 
-    public static class CspCheckPageLoadListener implements PageLoadListener
+    public class CspCheckPageLoadListener implements PageLoadListener
     {
         private final ArtifactCollector _artifactCollector;
         private final DeferredErrorCollector _checker;
@@ -2833,6 +2833,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         /** Allows test code to suppress expected CSP violations */
         public void setEnabled(boolean enabled)
         {
+            log("Setting CSP to " + enabled + " on " + this);
             if (enabled && !_enabled)
             {
                 // Turning back on, so ignore anything that was logged in the interim
@@ -2853,6 +2854,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                 }
                 catch (CspLogUtil.CspWarningDetectedException ex)
                 {
+                    log("CSP problem detected on " + this);
                     _checker.withScreenshot("csp_violation").recordError(ex);
                 }
             }

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -246,7 +246,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         _cspCheckPageLoadListener = new CspCheckPageLoadListener(this);
 
         String seleniumBrowser = System.getProperty("selenium.browser");
-        if (seleniumBrowser == null || seleniumBrowser.length() == 0)
+        if (seleniumBrowser == null || seleniumBrowser.isEmpty())
         {
             if (isTestRunningOnTeamCity())
                 BROWSER_TYPE = BrowserType.FIREFOX;
@@ -2833,6 +2833,12 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         /** Allows test code to suppress expected CSP violations */
         public void setEnabled(boolean enabled)
         {
+            if (enabled && !_enabled)
+            {
+                // Turning back on, so ignore anything that was logged in the interim
+                CspLogUtil.resetCspLogMark();
+            }
+
             _enabled = enabled;
         }
 

--- a/src/org/labkey/test/pages/core/admin/BaseSettingsPage.java
+++ b/src/org/labkey/test/pages/core/admin/BaseSettingsPage.java
@@ -327,9 +327,9 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
         WebElement defaultDateTimeTimeFormat = Locator.id("timeSelect").findWhenNeeded(this);
 
         WebElement defaultNumberFormat = Locator.inputByNameContaining("defaultNumberFormat").findWhenNeeded(this);
-        WebElement additionalParsingPatternDates = Locator.inputByNameContaining("extraDateParsingPattern").findElement(this);
-        WebElement additionalParsingPatternTimes = Locator.inputByNameContaining("extraTimeParsingPattern").findElement(this);
-        WebElement additionalParsingPatternDateAndTime = Locator.inputByNameContaining("extraDateTimeParsingPattern").findElement(this);
+        WebElement additionalParsingPatternDates = Locator.inputByNameContaining("extraDateParsingPattern").findWhenNeeded(this);
+        WebElement additionalParsingPatternTimes = Locator.inputByNameContaining("extraTimeParsingPattern").findWhenNeeded(this);
+        WebElement additionalParsingPatternDateAndTime = Locator.inputByNameContaining("extraDateTimeParsingPattern").findWhenNeeded(this);
         WebElement restrictChartingColsChk = Locator.checkboxByName("restrictedColumnsEnabled").findWhenNeeded(this);
         WebElement altLoginPageTxt = Locator.inputById("customLogin").findWhenNeeded(this);
         WebElement saveBtn = Locator.lkButton("Save").findWhenNeeded(this);

--- a/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
+++ b/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
@@ -163,6 +163,13 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
         return new FolderTypePages(getDriver());
     }
 
+    public SiteValidationPage clickSiteValidation()
+    {
+        goToSettingsSection();
+        clickAndWait(elementCache().siteValidationLink);
+        return new SiteValidationPage(getDriver());
+    }
+
     public LookAndFeelSettingsPage clickLookAndFeelSettings()
     {
         goToSettingsSection();
@@ -259,6 +266,7 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
         protected WebElement filesLink = Locator.linkWithText("files").findWhenNeeded(this);
         protected WebElement fullTextSearchLink = Locator.linkWithText("full-text search").findWhenNeeded(this);
         protected WebElement folderTypeLink = Locator.linkWithText("folder types").findWhenNeeded(this);
+        protected WebElement siteValidationLink = Locator.linkWithText("site validation").findWhenNeeded(this);
         protected WebElement lookAndFeelSettingsLink = Locator.linkWithText("look and feel settings").findWhenNeeded(this);
         protected WebElement masterPatientIndex = Locator.linkWithText("Master Patient Index").findWhenNeeded(this);
         protected WebElement profilerLink = Locator.linkWithText("profiler").findWhenNeeded(this);

--- a/src/org/labkey/test/pages/core/admin/SiteValidationPage.java
+++ b/src/org/labkey/test/pages/core/admin/SiteValidationPage.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2017-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.test.pages.core.admin;
+
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.components.html.Checkbox;
+import org.labkey.test.components.html.RadioButton;
+import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class SiteValidationPage extends BaseSettingsPage
+{
+    public SiteValidationPage(WebDriver driver)
+    {
+        super(driver);
+        waitForPage();
+    }
+
+    @Override
+    protected void waitForPage()
+    {
+        Locator.waitForAnyElement(shortWait(), Locator.lkButton("Validate"));
+    }
+
+    public static SiteValidationPage beginAt(WebDriverWrapper wrapper)
+    {
+        wrapper.beginAt(WebTestHelper.buildURL("admin", "configureSiteValidation"));
+        return new SiteValidationPage(wrapper.getDriver());
+    }
+
+
+    public void setWholeSite(boolean wholeSite)
+    {
+        RadioButton button;
+
+        if (wholeSite)
+            button = new RadioButton(elementCache().wholeSiteRadio);
+        else
+            button = new RadioButton(elementCache().projectsOnlyRadio);
+
+        button.check();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    public void setAllValidators(boolean enabled)
+    {
+        WebElement formEl = Locator.id("form").findElement(getDriver());
+        // Enable all validators
+        Locator.tagWithAttribute("input", "name", "provider")
+                .findElements(formEl).forEach(x -> setCheckbox(x, enabled));
+    }
+
+    public void setBackground(boolean background)
+    {
+        // Run in background
+        checkCheckbox(Locator.id("background"));
+        new Checkbox(elementCache().backgroundCheckbox).set(background);
+    }
+
+    public PipelineStatusDetailsPage clickValidateInBackground()
+    {
+        setBackground(true);
+        clickAndWait(elementCache().validateButton);
+        return new PipelineStatusDetailsPage(getDriver());
+    }
+
+    public void setWikiValidator(boolean checked)
+    {
+        new Checkbox(elementCache().wikiCheckbox).set(checked);
+    }
+
+    protected class ElementCache extends BaseSettingsPage.ElementCache
+    {
+        WebElement displayFormatCheckbox = Locator.xpath("//input[@name='providers' and @value='Display Format Validator']").findWhenNeeded(this);
+        WebElement permissionsCheckbox = Locator.xpath("//input[@name='providers' and @value='Permissions Validator']").findWhenNeeded(this);
+        WebElement pipelineCheckbox = Locator.xpath("//input[@name='providers' and @value='Pipeline Validator']").findWhenNeeded(this);
+        WebElement fileRootSizeCheckbox = Locator.xpath("//input[@name='providers' and @value='File Root Size']").findWhenNeeded(this);
+        WebElement wikiCheckbox = Locator.xpath("//input[@name='providers' and @value='Wiki Validator']").findWhenNeeded(this);
+
+        WebElement wholeSiteRadio = Locator.xpath("//input[@name='includeSubfolders' and @value='true']").findWhenNeeded(this);
+        WebElement projectsOnlyRadio = Locator.xpath("//input[@name='includeSubfolders' and @value='false']").findWhenNeeded(this);
+
+        WebElement backgroundCheckbox = Locator.xpath("//input[@name='background']").findWhenNeeded(this);
+
+        WebElement validateButton = Locator.lkButton("Validate").findWhenNeeded(this);
+    }
+
+}

--- a/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
+++ b/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
@@ -16,6 +16,7 @@
 package org.labkey.test.tests;
 
 import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
@@ -34,7 +35,9 @@ import org.labkey.test.util.Maps;
 import org.labkey.test.util.Order;
 import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.PipelineStatusTable;
+import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.TextSearcher;
+import org.labkey.test.util.WikiHelper;
 import org.openqa.selenium.WebElement;
 
 import java.io.File;
@@ -50,10 +53,15 @@ import static org.junit.Assert.assertTrue;
 @BaseWebDriverTest.ClassTimeout(minutes = 20)
 public class DatabaseDiagnosticsTest extends BaseWebDriverTest
 {
+    private static final String PROJECT_NAME = TRICKY_CHARACTERS_FOR_PROJECT_NAMES + "DatabaseDiagnosticsTest";
+    private static final String WIKI_PAGE_TITLE = "TOC_with_inline";
+    private static final String WIKI_PAGE_BODY = "${labkey.webPart(partName='Wiki TOC', showFrame='false')}\n" +
+            "<div onclick=\"alert('bad page')\">Click me</div>";
+
     @Override
     protected String getProjectName()
     {
-        return null;
+        return PROJECT_NAME;
     }
 
     @Test
@@ -71,9 +79,36 @@ public class DatabaseDiagnosticsTest extends BaseWebDriverTest
                 .assertLogTextContains("Check complete, 0 errors found");
     }
 
+    @BeforeClass
+    public static void setupProject()
+    {
+        DatabaseDiagnosticsTest init = getCurrentTest();
+        init.doSetup();
+    }
+
+    private void doSetup()
+    {
+        _containerHelper.createProject(PROJECT_NAME, null);
+        _containerHelper.enableModules(Arrays.asList("Wiki"));
+
+        goToProjectHome();
+        PortalHelper portalHelper = new PortalHelper(this);
+        portalHelper.addBodyWebPart("Wiki");
+    }
+
     @Test
     public void testSiteValidator()
     {
+        goToProjectHome(PROJECT_NAME);
+
+        // Issue 51749 - Create a CSP problem and a Wiki table of contents that caused a problem when checked in the background
+        WikiHelper wikiHelper = new WikiHelper(this);
+        wikiHelper.createNewWikiPage("HTML");
+        wikiHelper.setWikiName(WIKI_PAGE_TITLE);
+        wikiHelper.setWikiTitle(WIKI_PAGE_TITLE);
+        wikiHelper.setWikiBody(WIKI_PAGE_BODY);
+        wikiHelper.saveWikiPage();
+
         goToAdminConsole().goToSettingsSection();
 
         clickAndWait(Locator.linkWithText("site validation"));
@@ -103,7 +138,10 @@ public class DatabaseDiagnosticsTest extends BaseWebDriverTest
         assertTextPresent(textSearcher,
                 "Site Level Validation Results", "Folder Validation Results",
                 "Module: Core", "Permissions Validator", "Display Format Validator",
-                "Module: Pipeline", "Pipeline Validator");
+                "Module: Pipeline", "Pipeline Validator", "Wiki Validator");
+
+        // Issue 51749 - check for expected CSP problem
+        assertTextPresent(textSearcher, "CSP (CSP): onclick");
         assertTextNotPresent(textSearcher, "Error");
     }
 

--- a/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
+++ b/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
@@ -31,6 +31,7 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Git;
 import org.labkey.test.io.Grep;
 import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
+import org.labkey.test.util.CspLogUtil;
 import org.labkey.test.util.Maps;
 import org.labkey.test.util.Order;
 import org.labkey.test.util.PasswordUtil;

--- a/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
+++ b/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
@@ -101,15 +101,24 @@ public class DatabaseDiagnosticsTest extends BaseWebDriverTest
     {
         goToProjectHome(PROJECT_NAME);
 
-        // Issue 51749 - Create a CSP problem and a Wiki table of contents that caused a problem when checked in the background
-        WikiHelper wikiHelper = new WikiHelper(this);
-        wikiHelper.createNewWikiPage("HTML");
-        wikiHelper.setWikiName(WIKI_PAGE_TITLE);
-        wikiHelper.setWikiTitle(WIKI_PAGE_TITLE);
-        wikiHelper.setWikiBody(WIKI_PAGE_BODY);
-        wikiHelper.saveWikiPage();
+        try
+        {
+            _cspCheckPageLoadListener.setEnabled(false);
 
-        goToAdminConsole().goToSettingsSection();
+            // Issue 51749 - Create a CSP problem and a Wiki table of contents that caused a problem when checked in the background
+            WikiHelper wikiHelper = new WikiHelper(this);
+            wikiHelper.createNewWikiPage("HTML");
+            wikiHelper.setWikiName(WIKI_PAGE_TITLE);
+            wikiHelper.setWikiTitle(WIKI_PAGE_TITLE);
+            wikiHelper.setWikiBody(WIKI_PAGE_BODY);
+            wikiHelper.saveWikiPage();
+
+            goToAdminConsole().goToSettingsSection();
+        }
+        finally
+        {
+            _cspCheckPageLoadListener.setEnabled(true);
+        }
 
         clickAndWait(Locator.linkWithText("site validation"));
 
@@ -141,7 +150,7 @@ public class DatabaseDiagnosticsTest extends BaseWebDriverTest
                 "Module: Pipeline", "Pipeline Validator", "Wiki Validator");
 
         // Issue 51749 - check for expected CSP problem
-        assertTextPresent(textSearcher, "CSP (CSP): onclick");
+        assertTextPresent(textSearcher, WIKI_PAGE_TITLE + " (" + WIKI_PAGE_TITLE + "): onclick");
         assertTextNotPresent(textSearcher, "Error");
     }
 

--- a/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
+++ b/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
@@ -30,6 +30,7 @@ import org.labkey.test.categories.CustomModules;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Git;
 import org.labkey.test.io.Grep;
+import org.labkey.test.pages.core.admin.SiteValidationPage;
 import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.labkey.test.util.CspLogUtil;
 import org.labkey.test.util.Maps;
@@ -49,20 +50,16 @@ import java.util.TreeMap;
 
 import static org.junit.Assert.assertTrue;
 
+/** Intended to be run at the end of suites to do some extra validation, without adding much extra overhead. */
 @Category({BVT.class, Daily.class, Git.class, CustomModules.class})
 @Order(1)
 @BaseWebDriverTest.ClassTimeout(minutes = 20)
 public class DatabaseDiagnosticsTest extends BaseWebDriverTest
 {
-    private static final String PROJECT_NAME = TRICKY_CHARACTERS_FOR_PROJECT_NAMES + "DatabaseDiagnosticsTest";
-    private static final String WIKI_PAGE_TITLE = "TOC_with_inline";
-    private static final String WIKI_PAGE_BODY = "${labkey.webPart(partName='Wiki TOC', showFrame='false')}\n" +
-            "<div onclick=\"alert('bad page')\">Click me</div>";
-
     @Override
     protected String getProjectName()
     {
-        return PROJECT_NAME;
+        return null;
     }
 
     @Test
@@ -80,78 +77,29 @@ public class DatabaseDiagnosticsTest extends BaseWebDriverTest
                 .assertLogTextContains("Check complete, 0 errors found");
     }
 
-    @BeforeClass
-    public static void setupProject()
-    {
-        DatabaseDiagnosticsTest init = getCurrentTest();
-        init.doSetup();
-    }
-
-    private void doSetup()
-    {
-        _containerHelper.createProject(PROJECT_NAME, null);
-        _containerHelper.enableModules(Arrays.asList("Wiki"));
-
-        goToProjectHome();
-        PortalHelper portalHelper = new PortalHelper(this);
-        portalHelper.addBodyWebPart("Wiki");
-    }
-
     @Test
     public void testSiteValidator()
     {
-        goToProjectHome(PROJECT_NAME);
+        SiteValidationPage validationPage = goToAdminConsole().clickSiteValidation();
 
-        try
-        {
-            _cspCheckPageLoadListener.setEnabled(false);
-
-            // Issue 51749 - Create a CSP problem and a Wiki table of contents that caused a problem when checked in the background
-            WikiHelper wikiHelper = new WikiHelper(this);
-            wikiHelper.createNewWikiPage("HTML");
-            wikiHelper.setWikiName(WIKI_PAGE_TITLE);
-            wikiHelper.setWikiTitle(WIKI_PAGE_TITLE);
-            wikiHelper.setWikiBody(WIKI_PAGE_BODY);
-            wikiHelper.saveWikiPage();
-
-            goToAdminConsole().goToSettingsSection();
-        }
-        finally
-        {
-            _cspCheckPageLoadListener.setEnabled(true);
-        }
-
-        clickAndWait(Locator.linkWithText("site validation"));
-
-        WebElement formEl = Locator.id("form").findElement(getDriver());
-
-        // Enable all validators
-        Locator.tagWithAttribute("input", "type", "checkbox")
-                .findElements(formEl).forEach(this::checkCheckbox);
+        validationPage.setAllValidators(true);
 
         // Validate projects and subfolders
-        checkRadioButton(Locator.radioButtonByNameAndValue("includeSubfolders", "true"));
+        validationPage.setWholeSite(true);
 
-        // Run in background
-        checkCheckbox(Locator.id("background"));
+        PipelineStatusDetailsPage jobPage = validationPage.clickValidateInBackground();
 
-        clickAndWait(Locator.lkButton("Validate"));
-
-        new PipelineStatusDetailsPage(getDriver())
-                .waitForComplete(300_000)
+        jobPage.waitForComplete(300_000)
                 .assertLogTextContains("Site validation complete");
-
-        clickAndWait(Locator.lkButton("Data"));
+        jobPage.clickDataLink();
 
         assertNoLabKeyErrors();
         TextSearcher textSearcher = new TextSearcher(getText(Locators.bodyPanel()));
         assertTextPresent(textSearcher,
                 "Site Level Validation Results", "Folder Validation Results",
                 "Module: Core", "Permissions Validator", "Display Format Validator",
-                "Module: Pipeline", "Pipeline Validator", "Wiki Validator");
+                "Module: Pipeline", "Pipeline Validator");
 
-        // Issue 51749 - check for expected CSP problem
-        assertTextPresent(textSearcher, WIKI_PAGE_TITLE + " (" + WIKI_PAGE_TITLE + "): onclick");
         assertTextNotPresent(textSearcher, "Error");
     }
 

--- a/src/org/labkey/test/tests/wiki/EmbeddedWebPartTest.java
+++ b/src/org/labkey/test/tests/wiki/EmbeddedWebPartTest.java
@@ -71,7 +71,7 @@ public class EmbeddedWebPartTest extends BaseWebDriverTest
         //embed query part in wiki page
         portalHelper.addWebPart("Wiki");
         wikiHelper.createNewWikiPage();
-        setFormElement(Locator.name("name"), TRICKY_CHARACTERS + "wiki page");
+        wikiHelper.setWikiName(TRICKY_CHARACTERS + "wiki page");
 
         wikiHelper.setWikiBody(TestFileUtils.getFileContents(TestFileUtils.getSampleData("api/EmbeddedQueryWebPart.html")));
 

--- a/src/org/labkey/test/tests/wiki/WikiAliasesTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiAliasesTest.java
@@ -33,7 +33,7 @@ public class WikiAliasesTest extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject()
     {
-        WikiAliasesTest init = (WikiAliasesTest) getCurrentTest();
+        WikiAliasesTest init = getCurrentTest();
         init.doSetup();
     }
 

--- a/src/org/labkey/test/tests/wiki/WikiCspTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiCspTest.java
@@ -1,0 +1,98 @@
+package org.labkey.test.tests.wiki;
+
+import org.jetbrains.annotations.Nullable;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locators;
+import org.labkey.test.categories.Daily;
+import org.labkey.test.categories.Wiki;
+import org.labkey.test.pages.core.admin.SiteValidationPage;
+import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
+import org.labkey.test.util.TextSearcher;
+import org.labkey.test.util.WikiHelper;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Category({Daily.class, Wiki.class})
+@BaseWebDriverTest.ClassTimeout(minutes = 2)
+public class WikiCspTest extends BaseWebDriverTest
+{
+    private static final String PROJECT_NAME = TRICKY_CHARACTERS_FOR_PROJECT_NAMES + "WikiCspTest";
+    private static final String WIKI_PAGE_TITLE = "TOC_with_inline";
+    private static final String WIKI_PAGE_BODY = "${labkey.webPart(partName='Wiki TOC', showFrame='false')}\n" +
+            "<div onclick=\"alert('bad page')\">Click me</div>";
+
+    @BeforeClass
+    public static void setupProject()
+    {
+        WikiCspTest init = getCurrentTest();
+        init.doSetup();
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return List.of("Wiki");
+    }
+
+    @Override
+    protected @Nullable String getProjectName()
+    {
+        return PROJECT_NAME;
+    }
+
+    private void doSetup()
+    {
+        _containerHelper.createProject(PROJECT_NAME, null);
+        _containerHelper.enableModules(Arrays.asList("Wiki"));
+        goToProjectHome();
+    }
+
+    @Test
+    public void testCspChecks()
+    {
+        goToProjectHome(PROJECT_NAME);
+
+        try
+        {
+            _cspCheckPageLoadListener.setEnabled(false);
+
+            // Issue 51749 - Create a CSP problem and a Wiki table of contents that caused a problem when checked in the background
+            WikiHelper wikiHelper = new WikiHelper(this);
+            wikiHelper.createNewWikiPage("HTML");
+            wikiHelper.setWikiName(WIKI_PAGE_TITLE);
+            wikiHelper.setWikiTitle(WIKI_PAGE_TITLE);
+            wikiHelper.setWikiBody(WIKI_PAGE_BODY);
+            wikiHelper.saveWikiPage();
+
+            goToAdminConsole().goToSettingsSection();
+        }
+        finally
+        {
+            _cspCheckPageLoadListener.setEnabled(true);
+        }
+
+        SiteValidationPage validationPage = goToAdminConsole().clickSiteValidation();
+        validationPage.setAllValidators(false);
+        validationPage.setWikiValidator(true);
+
+        PipelineStatusDetailsPage jobPage = validationPage.clickValidateInBackground();
+
+        jobPage.waitForComplete(60_000)
+                .assertLogTextContains("Site validation complete");
+        jobPage.clickDataLink();
+
+        assertNoLabKeyErrors();
+        TextSearcher textSearcher = new TextSearcher(getText(Locators.bodyPanel()));
+        assertTextPresent(textSearcher,
+                "Wiki Validator");
+
+        assertTextNotPresent(textSearcher, "Error");
+
+        // Issue 51749 - check for expected CSP problem
+        assertTextPresent(textSearcher, WIKI_PAGE_TITLE + " (" + WIKI_PAGE_TITLE + "): onclick");
+    }
+}

--- a/src/org/labkey/test/tests/wiki/WikiCspTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiCspTest.java
@@ -1,6 +1,7 @@
 package org.labkey.test.tests.wiki;
 
 import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -10,6 +11,7 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Wiki;
 import org.labkey.test.pages.core.admin.SiteValidationPage;
 import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
+import org.labkey.test.util.CspLogUtil;
 import org.labkey.test.util.TextSearcher;
 import org.labkey.test.util.WikiHelper;
 
@@ -51,29 +53,34 @@ public class WikiCspTest extends BaseWebDriverTest
         goToProjectHome();
     }
 
+    @Override
+    protected void checkLeaks()
+    {
+        // No-op to avoid triggering the CSP violation during the crawl
+    }
+
     @Test
     public void testCspChecks()
     {
         goToProjectHome(PROJECT_NAME);
 
+        // Issue 51749 - Create a CSP problem and a Wiki table of contents that caused a problem when checked in the background
+        WikiHelper wikiHelper = new WikiHelper(this);
+        wikiHelper.createNewWikiPage("HTML");
+        wikiHelper.setWikiName(WIKI_PAGE_TITLE);
+        wikiHelper.setWikiTitle(WIKI_PAGE_TITLE);
+        wikiHelper.setWikiBody(WIKI_PAGE_BODY);
+        wikiHelper.saveWikiPage();
+
+        waitForText("Click me");
+
         try
         {
-            _cspCheckPageLoadListener.setEnabled(false);
-
-            // Issue 51749 - Create a CSP problem and a Wiki table of contents that caused a problem when checked in the background
-            WikiHelper wikiHelper = new WikiHelper(this);
-            wikiHelper.createNewWikiPage("HTML");
-            wikiHelper.setWikiName(WIKI_PAGE_TITLE);
-            wikiHelper.setWikiTitle(WIKI_PAGE_TITLE);
-            wikiHelper.setWikiBody(WIKI_PAGE_BODY);
-            wikiHelper.saveWikiPage();
-
-            goToAdminConsole().goToSettingsSection();
+            CspLogUtil.checkNewCspWarnings(getArtifactCollector());
         }
-        finally
-        {
-            _cspCheckPageLoadListener.setEnabled(true);
-        }
+        catch (CspLogUtil.CspWarningDetectedException ignore) {}
+
+        goToAdminConsole().goToSettingsSection();
 
         SiteValidationPage validationPage = goToAdminConsole().clickSiteValidation();
         validationPage.setAllValidators(false);

--- a/src/org/labkey/test/tests/wiki/WikiHistoryTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiHistoryTest.java
@@ -83,8 +83,8 @@ public class WikiHistoryTest extends BaseWebDriverTest
         log("test create new html page with a webpart");
         wikiHelper.createNewWikiPage("HTML");
 
-        setFormElement(Locator.name("name"), WIKI_PAGE_TITLE);
-        setFormElement(Locator.name("title"), WIKI_PAGE_TITLE);
+        wikiHelper.setWikiName(WIKI_PAGE_TITLE);
+        wikiHelper.setWikiTitle(WIKI_PAGE_TITLE);
         wikiHelper.setWikiBody(WIKI_PAGE_CONTENT);
         wikiHelper.saveWikiPage();
 

--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -191,9 +191,9 @@ public class WikiLongTest extends BaseWebDriverTest
         log("Test new wiki page");
         _wikiHelper.createNewWikiPage("RADEOX");
 
-        setFormElement(Locator.name("name"), WIKI_PAGE1_NAME);
-        setFormElement(Locator.name("title"), WIKI_PAGE1_TITLE);
-        setFormElement(Locator.name("body"), WIKI_PAGE1_CONTENT);
+        _wikiHelper.setWikiName(WIKI_PAGE1_NAME);
+        _wikiHelper.setWikiTitle(WIKI_PAGE1_TITLE);
+        _wikiHelper.setWikiBody(WIKI_PAGE1_CONTENT);
         _wikiHelper.saveWikiPage();
 
         searchFor(PROJECT_NAME, "normal normal normal", 1, WIKI_PAGE1_TITLE);
@@ -206,8 +206,8 @@ public class WikiLongTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText("add content"));
         _wikiHelper.convertWikiFormat("RADEOX");
 
-        setFormElement(Locator.name("title"), WIKI_PAGE2_TITLE);
-        setFormElement(Locator.name("body"), WIKI_PAGE2_CONTENT);
+        _wikiHelper.setWikiTitle(WIKI_PAGE2_TITLE);
+        _wikiHelper.setWikiBody(WIKI_PAGE2_CONTENT);
         _wikiHelper.saveWikiPage();
 
         clickAndWait(Locator.linkWithText("Welcome to the WikiLongTest"));
@@ -217,9 +217,9 @@ public class WikiLongTest extends BaseWebDriverTest
 
         log("Test new wiki page using markdown");
         _wikiHelper.createNewWikiPage("MARKDOWN");
-        setFormElement(Locator.name("name"), WIKI_PAGE7_NAME);
-        setFormElement(Locator.name("title"), WIKI_PAGE7_TITLE);
-        setFormElement(Locator.name("body"), WIKI_PAGE7_CONTENT);
+        _wikiHelper.setWikiName(WIKI_PAGE7_NAME);
+        _wikiHelper.setWikiTitle(WIKI_PAGE7_TITLE);
+        _wikiHelper.setWikiBody(WIKI_PAGE7_CONTENT);
         _wikiHelper.saveWikiPage();
         // verify that after saving the markdown that it is rendered as html that does not include the markdown symbols
         assertTextPresent("Title MD");
@@ -234,8 +234,8 @@ public class WikiLongTest extends BaseWebDriverTest
 
         log("test html wiki containing malformed javascript entities... we should allow this, see #12268");
         _wikiHelper.createNewWikiPage();
-        setFormElement(Locator.name("name"), WIKI_PAGE5_NAME);
-        setFormElement(Locator.name("title"), WIKI_PAGE5_TITLE);
+        _wikiHelper.setWikiName(WIKI_PAGE5_NAME);
+        _wikiHelper.setWikiTitle(WIKI_PAGE5_TITLE);
         _wikiHelper.setWikiBody(WIKI_PAGE5_CONTENT);
         _wikiHelper.saveWikiPage();
         assertTextNotPresent("New Page");  // Should not be an error, so should have left the editor
@@ -243,8 +243,8 @@ public class WikiLongTest extends BaseWebDriverTest
         log("test create new html page with a webpart");
         _wikiHelper.createNewWikiPage("HTML");
 
-        setFormElement(Locator.name("name"), WIKI_PAGE3_NAME_TITLE);
-        setFormElement(Locator.name("title"), WIKI_PAGE3_NAME_TITLE);
+        _wikiHelper.setWikiName(WIKI_PAGE3_NAME_TITLE);
+        _wikiHelper.setWikiTitle(WIKI_PAGE3_NAME_TITLE);
         selectOptionByText(Locator.name("parent"), WIKI_PAGE2_TITLE + " (" + WIKI_PAGE2_NAME + ")");
         _wikiHelper.setWikiBody(WIKI_PAGE3_CONTENT);
         log("test attachments in wiki");
@@ -261,7 +261,7 @@ public class WikiLongTest extends BaseWebDriverTest
 
         log("test edit");
         clickAndWait(Locator.linkWithText("Edit"));
-        setFormElement(Locator.name("title"), WIKI_PAGE3_ALTTITLE);
+        _wikiHelper.setWikiTitle(WIKI_PAGE3_ALTTITLE);
         String wikiPage3ContentEdited =
                 "<b>Some HTML content</b><br>\n" +
                 "<b>More HTML content</b><br>\n" +
@@ -272,7 +272,7 @@ public class WikiLongTest extends BaseWebDriverTest
         assertTextPresent("More HTML content");
         clickAndWait(Locator.linkWithText("Edit"));
         _wikiHelper.setWikiBody(WIKI_PAGE3_CONTENT_NO_QUERY);
-        setFormElement(Locator.name("title"), WIKI_PAGE3_NAME_TITLE);
+        _wikiHelper.setWikiTitle(WIKI_PAGE3_NAME_TITLE);
         _wikiHelper.saveWikiPage();
 
         log("test change renderer type");
@@ -329,7 +329,7 @@ public class WikiLongTest extends BaseWebDriverTest
         click(Locator.linkWithText("discussions"));
         waitForElement(Locator.linkWithText("Start new discussion"), defaultWaitForPage);
         clickAndWait(Locator.linkWithText("Start new discussion"));
-        setFormElement(Locator.name("title"), DISC1_TITLE);
+        _wikiHelper.setWikiTitle(DISC1_TITLE);
         setFormElement(Locator.id("body"), DISC1_BODY);
         submit();
         _ext4Helper.waitForOnReady();
@@ -341,7 +341,7 @@ public class WikiLongTest extends BaseWebDriverTest
 
         log("Check response on discussion board works");
         clickButton("Respond");
-        setFormElement(Locator.name("title"), RESP1_TITLE);
+        _wikiHelper.setWikiTitle(RESP1_TITLE);
         setFormElement(Locator.id("body"), RESP1_BODY);
         submit();
         assertTextPresent(RESP1_TITLE,
@@ -352,8 +352,8 @@ public class WikiLongTest extends BaseWebDriverTest
 
         log("test navTree and header");
         _wikiHelper.createNewWikiPage("RADEOX");
-        setFormElement(Locator.name("name"), "_navTree");
-        setFormElement(Locator.name("title"), WIKI_NAVTREE_TITLE);
+        _wikiHelper.setWikiName("_navTree");
+        _wikiHelper.setWikiTitle(WIKI_NAVTREE_TITLE);
         _wikiHelper.setWikiBody(NAVBAR1_CONTENT);
         _wikiHelper.saveWikiPage();
 
@@ -373,8 +373,8 @@ public class WikiLongTest extends BaseWebDriverTest
         assertElementNotPresent(Locator.linkWithText(WIKI_NAVTREE_TITLE));
 
         _wikiHelper.createNewWikiPage("HTML");
-        setFormElement(Locator.name("name"), "_header");
-        setFormElement(Locator.name("title"), "Header");
+        _wikiHelper.setWikiName("_header");
+        _wikiHelper.setWikiTitle("Header");
         _wikiHelper.setWikiBody(HEADER_CONTENT);
         _wikiHelper.saveWikiPage();
 
@@ -510,7 +510,7 @@ public class WikiLongTest extends BaseWebDriverTest
 
         log("test fixup for unsafe _blank targets, see #33356");
         _wikiHelper.createNewWikiPage();
-        setFormElement(Locator.name("name"), WIKI_PAGE9_NAME);
+        _wikiHelper.setWikiName(WIKI_PAGE9_NAME);
         _wikiHelper.setWikiBody(WIKI_PAGE9_CONTENT);
         _wikiHelper.saveWikiPage();
         assertTextNotPresent("New Page");  // Should not be an error, so should have left the editor
@@ -522,7 +522,7 @@ public class WikiLongTest extends BaseWebDriverTest
 
         log("Ensure non-developer can't save script");
         _wikiHelper.createNewWikiPage();
-        setFormElement(Locator.name("name"), "Unsaveable");
+        _wikiHelper.setWikiName("Unsaveable");
         _wikiHelper.setWikiBody(WIKI_PAGE5_CONTENT);
         _wikiHelper.saveWikiPage(false);
         waitForText("There was a problem while saving: Illegal element <script>. For permissions to use this element, contact your system administrator.");
@@ -540,7 +540,7 @@ public class WikiLongTest extends BaseWebDriverTest
         log("test wiki TOC customize link");
         _portalHelper.addWebPart("Wiki Table of Contents");
         portalHelper.clickWebpartMenuItem("Pages", true, "Customize");
-        setFormElement(Locator.name("title"), "Test Customize TOC");
+        _wikiHelper.setWikiTitle("Test Customize TOC");
         log("check that container is set to current project");
         assertOptionEquals(Locator.name("webPartContainer"), "/" + PROJECT2_NAME);
         selectOptionByText(Locator.name("webPartContainer"), "/" + PROJECT_NAME);
@@ -561,7 +561,7 @@ public class WikiLongTest extends BaseWebDriverTest
         portalHelper.clickWebpartMenuItem("Test Customize TOC", true, "New");
         _wikiHelper.convertWikiFormat("HTML");
 
-        setFormElement(Locator.name("name"), WIKI_PAGE4_TITLE);
+        _wikiHelper.setWikiName(WIKI_PAGE4_TITLE);
         _wikiHelper.setWikiBody(WIKI_PAGE4_CONTENT);
         _wikiHelper.saveWikiPage();
         clickProject(PROJECT_NAME);
@@ -583,8 +583,8 @@ public class WikiLongTest extends BaseWebDriverTest
         log("test delete subtree");
         // create child first
         _wikiHelper.createNewWikiPage();
-        setFormElement(Locator.name("name"), WIKI_PAGE8_NAME);
-        setFormElement(Locator.name("title"), WIKI_PAGE8_TITLE);
+        _wikiHelper.setWikiName(WIKI_PAGE8_NAME);
+        _wikiHelper.setWikiTitle(WIKI_PAGE8_TITLE);
         selectOptionByText(Locator.name("parent"), "  " + WIKI_PAGE3_ALTTITLE + " (" + WIKI_PAGE3_NAME_TITLE + ")");
         _wikiHelper.saveWikiPage();
 
@@ -603,8 +603,8 @@ public class WikiLongTest extends BaseWebDriverTest
 //        {
 //            //test create new html page
 //            clickAndWait(Locator.linkWithText("new page"));
-//            setFormElement(Locator.name("name"), "Page" + Integer.toString(i));
-//            setFormElement(Locator.name("title"), "Page" + Integer.toString(i));
+//            _wikiHelper.setWikiName("Page" + Integer.toString(i));
+//            _wikiHelper.setWikiTitle("Page" + Integer.toString(i));
 //
 //            if (i > 99)
 //            {
@@ -712,8 +712,8 @@ public class WikiLongTest extends BaseWebDriverTest
         //
         assertChecked(Locator.id(WIKI_INDEX_EDIT_CHECKBOX));
 
-        setFormElement(Locator.name("name"), WIKI_PAGE6_NAME);
-        setFormElement(Locator.name("title"), WIKI_PAGE6_TITLE);
+        _wikiHelper.setWikiName(WIKI_PAGE6_NAME);
+        _wikiHelper.setWikiTitle(WIKI_PAGE6_TITLE);
         _wikiHelper.setWikiBody(WIKI_PAGE6_CONTENT);
 
         if (!shouldIndex)

--- a/src/org/labkey/test/tests/wiki/WikiTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiTest.java
@@ -100,7 +100,6 @@ public class WikiTest extends BaseWebDriverTest
 
         wikiHelper.setWikiName(WIKI_PAGE_TITLE);
         wikiHelper.setWikiTitle(WIKI_PAGE_TITLE);
-        setFormElement(Locator.name("title"), WIKI_PAGE_TITLE);
         wikiHelper.setWikiBody(WIKI_PAGE_CONTENT);
 
         log("test attachments in wiki");

--- a/src/org/labkey/test/tests/wiki/WikiTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiTest.java
@@ -54,7 +54,7 @@ public class WikiTest extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject()
     {
-        WikiTest init = (WikiTest) getCurrentTest();
+        WikiTest init = getCurrentTest();
         init.doSetup();
     }
 
@@ -98,7 +98,8 @@ public class WikiTest extends BaseWebDriverTest
         wikiHelper.createNewWikiPage("HTML");
         numberOfWikiCreated++;
 
-        setFormElement(Locator.name("name"), WIKI_PAGE_TITLE);
+        wikiHelper.setWikiName(WIKI_PAGE_TITLE);
+        wikiHelper.setWikiTitle(WIKI_PAGE_TITLE);
         setFormElement(Locator.name("title"), WIKI_PAGE_TITLE);
         wikiHelper.setWikiBody(WIKI_PAGE_CONTENT);
 
@@ -168,8 +169,8 @@ public class WikiTest extends BaseWebDriverTest
         WikiHelper wikiHelper = new WikiHelper(this);
         wikiHelper.createNewWikiPage("RADEOX");
         numberOfWikiCreated++;
-        setFormElement(Locator.name("name"), wikiName);
-        setFormElement(Locator.name("title"), wikiTitle);
+        wikiHelper.setWikiName(wikiName);
+        wikiHelper.setWikiTitle(wikiTitle);
         wikiHelper.setWikiBody(wikiContent);
         wikiHelper.saveWikiPage();
 
@@ -185,8 +186,8 @@ public class WikiTest extends BaseWebDriverTest
         WikiHelper wikiHelper = new WikiHelper(this);
         wikiHelper.createNewWikiPage("HTML");
         numberOfWikiCreated++;
-        setFormElement(Locator.name("name"), WIKI_PAGE_NAME);
-        setFormElement(Locator.name("title"), WIKI_PAGE_TITLE);
+        wikiHelper.setWikiName(WIKI_PAGE_NAME);
+        wikiHelper.setWikiTitle(WIKI_PAGE_TITLE);
         wikiHelper.setWikiBody(WIKI_CHECK_CONTENT);
         wikiHelper.saveWikiPage();
 
@@ -213,8 +214,8 @@ public class WikiTest extends BaseWebDriverTest
         log("Creating the wiki " + wikiTitle);
         WikiHelper wikiHelper = new WikiHelper(this);
         wikiHelper.createNewWikiPage("HTML");
-        setFormElement(Locator.name("name"), wikiName);
-        setFormElement(Locator.name("title"), wikiTitle);
+        wikiHelper.setWikiName(wikiName);
+        wikiHelper.setWikiTitle(wikiTitle);
         wikiHelper.setWikiBody("<p>" + wikiContent + "</p>");
         wikiHelper.saveWikiPage();
         numberOfWikiCreated++;

--- a/src/org/labkey/test/util/CspLogUtil.java
+++ b/src/org/labkey/test/util/CspLogUtil.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 public class CspLogUtil
 {
-    private static final List<String> ignoredVioloations = List.of(
+    private static final List<String> ignoredViolations = List.of(
             "/_rstudio/",
             "/_rstudioReport/",
             "/reports-createScriptReport.view?",
@@ -41,7 +41,7 @@ public class CspLogUtil
         if (TestProperties.isServerRemote() || missingLog)
             return;
 
-        BasicFileAttributes logFileAttributes = null;
+        BasicFileAttributes logFileAttributes;
         try
         {
             logFileAttributes = Files.readAttributes(logFile.toPath(), BasicFileAttributes.class);
@@ -94,7 +94,7 @@ public class CspLogUtil
                     {
                         foundVioloation = true;
                         String url = split[1];
-                        if (ignoredVioloations.stream().anyMatch(url::contains))
+                        if (ignoredViolations.stream().anyMatch(url::contains))
                         {
                             TestLogger.warn("Ignoring CSP warning on page: " + url);
                         }

--- a/src/org/labkey/test/util/WikiHelper.java
+++ b/src/org/labkey/test/util/WikiHelper.java
@@ -305,6 +305,16 @@ public class WikiHelper
         _test.clickButton("Copy Pages");
     }
 
+    public void setWikiName(String name)
+    {
+        _test.setFormElement(Locator.name("name"), name);
+    }
+
+    public void setWikiTitle(String title)
+    {
+        _test.setFormElement(Locator.name("title"), title);
+    }
+
     public enum WikiRendererType
     {
         RADEOX ("Wiki Page"),


### PR DESCRIPTION
#### Rationale
Add some test coverage for site validation of wikis.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6096

#### Changes
- Create a wiki with CSP problems (inline script)
- Improve WikiHelper
- Eliminate need for casting when calling `getCurrentTest()`
