### PR TITLE
Use findElementOrNull for look and feel settings that are now deprecated

### DIFF
--- a/src/org/labkey/test/pages/core/admin/BaseSettingsPage.java
+++ b/src/org/labkey/test/pages/core/admin/BaseSettingsPage.java
@@ -327,9 +327,9 @@ public class BaseSettingsPage extends LabKeyPage<BaseSettingsPage.ElementCache>
         WebElement defaultDateTimeTimeFormat = Locator.id("timeSelect").findWhenNeeded(this);
 
         WebElement defaultNumberFormat = Locator.inputByNameContaining("defaultNumberFormat").findWhenNeeded(this);
-        WebElement additionalParsingPatternDates = Locator.inputByNameContaining("extraDateParsingPattern").findElement(this);
-        WebElement additionalParsingPatternTimes = Locator.inputByNameContaining("extraTimeParsingPattern").findElement(this);
-        WebElement additionalParsingPatternDateAndTime = Locator.inputByNameContaining("extraDateTimeParsingPattern").findElement(this);
+        WebElement additionalParsingPatternDates = Locator.inputByNameContaining("extraDateParsingPattern").findElementOrNull(this);
+        WebElement additionalParsingPatternTimes = Locator.inputByNameContaining("extraTimeParsingPattern").findElementOrNull(this);
+        WebElement additionalParsingPatternDateAndTime = Locator.inputByNameContaining("extraDateTimeParsingPattern").findElementOrNull(this);
         WebElement restrictChartingColsChk = Locator.checkboxByName("restrictedColumnsEnabled").findWhenNeeded(this);
         WebElement altLoginPageTxt = Locator.inputById("customLogin").findWhenNeeded(this);
         WebElement saveBtn = Locator.lkButton("Save").findWhenNeeded(this);


### PR DESCRIPTION
#### Rationale
See related PR for rationale. This PR just fixes the misc test failures that are now erroring out because the deprecated look and feel setting is no longer present on the page.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6097

#### Changes
- Use findElementOrNull for look and feel settings that are now deprecated
