### PR TITLE
Automation test for Editor without Delete users are able to delete files

### DIFF
--- a/src/org/labkey/test/tests/UserEditorWithoutDeleteTest.java
+++ b/src/org/labkey/test/tests/UserEditorWithoutDeleteTest.java
@@ -1,0 +1,86 @@
+package org.labkey.test.tests;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.TestFileUtils;
+import org.labkey.test.categories.Daily;
+import org.labkey.test.components.FilesWebPart;
+import org.labkey.test.util.FileBrowserHelper;
+import org.labkey.test.util.PortalHelper;
+import org.labkey.test.util.TestUser;
+import org.labkey.test.util.core.webdav.WebDavUploadHelper;
+import org.labkey.test.util.core.webdav.WebDavUrlFactory;
+import org.labkey.test.util.core.webdav.WebDavUtils;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+@Category({Daily.class})
+public class UserEditorWithoutDeleteTest extends BaseWebDriverTest
+{
+    private static final TestUser EDITOR_WITHOUT_DELETE = new TestUser("editorwithoutdelete@user.test");
+    private static final File TEST_FILE = TestFileUtils.getSampleData("studies/Read_Me.txt");
+
+    @BeforeClass
+    public static void setupProject()
+    {
+        UserEditorWithoutDeleteTest init = (UserEditorWithoutDeleteTest) getCurrentTest();
+        init.doSetup();
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest)
+    {
+        _containerHelper.deleteProject(getProjectName(), afterTest);
+        _userHelper.deleteUsers(afterTest, EDITOR_WITHOUT_DELETE);
+    }
+
+    private void doSetup()
+    {
+        _containerHelper.createProject(getProjectName(), null);
+        EDITOR_WITHOUT_DELETE.create(this)
+                .setInitialPassword()
+                .addPermission("EditorWithoutDelete", getProjectName());
+
+        goToProjectHome();
+        new PortalHelper(this).addWebPart("Files");
+    }
+
+    /*
+        Regression coverage for Secure Issue 51500: Editor without Delete users are able to delete files
+     */
+    @Test
+    public void testFileDeleteWithEditorWithoutDeleteUser()
+    {
+        goToProjectHome();
+        impersonate(EDITOR_WITHOUT_DELETE.getEmail());
+        FilesWebPart filesWebPart = FilesWebPart.getWebPart(getDriver());
+        filesWebPart.fileBrowser().uploadFile(TEST_FILE);
+        Assert.assertFalse("Delete action should not be present for " + EDITOR_WITHOUT_DELETE.getEmail(),
+                filesWebPart.fileBrowser().isActionPresent(FileBrowserHelper.BrowserAction.DELETE));
+
+        WebDavUploadHelper uploadHelper = new WebDavUploadHelper(WebDavUrlFactory.webDavUrlFactory(getProjectName()),
+                WebDavUtils.beginSardine(getCurrentUser()));
+        uploadHelper.uploadFile(TEST_FILE);
+        uploadHelper.deleteFile(WebDavUtils.buildBaseWebDavUrl(getProjectName()) + TEST_FILE.getName(), true);
+        Assert.assertTrue("File should not be deleted by " + EDITOR_WITHOUT_DELETE.getEmail(),
+                uploadHelper.fileExists(WebDavUtils.buildBaseWebDavUrl(getProjectName()) + TEST_FILE.getName()));
+        stopImpersonating();
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return "UserEditorWithoutDeleteTest Project";
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Arrays.asList();
+    }
+}

--- a/src/org/labkey/test/tests/UserEditorWithoutDeleteTest.java
+++ b/src/org/labkey/test/tests/UserEditorWithoutDeleteTest.java
@@ -27,7 +27,7 @@ public class UserEditorWithoutDeleteTest extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject()
     {
-        UserEditorWithoutDeleteTest init = (UserEditorWithoutDeleteTest) getCurrentTest();
+        UserEditorWithoutDeleteTest init = getCurrentTest();
         init.doSetup();
     }
 
@@ -62,10 +62,10 @@ public class UserEditorWithoutDeleteTest extends BaseWebDriverTest
         WebDavUploadHelper uploadHelper = new WebDavUploadHelper(WebDavUrlFactory.webDavUrlFactory(getProjectName()),
                 WebDavUtils.beginSardine(getCurrentUser()));
         uploadHelper.uploadFile(TEST_FILE);
-        SardineException sardineException = uploadHelper.deleteExpectingError(WebDavUtils.buildBaseWebDavUrl(getProjectName()) + TEST_FILE.getName());
-        Assert.assertEquals("Incorrect response for deletion", 404, sardineException.getStatusCode());
+        SardineException sardineException = uploadHelper.deleteExpectingError(TEST_FILE.getName());
+        Assert.assertEquals("Incorrect response for deletion", 403, sardineException.getStatusCode());
         Assert.assertTrue("File should not be deleted by " + EDITOR_WITHOUT_DELETE.getEmail(),
-                uploadHelper.fileExists(WebDavUtils.buildBaseWebDavUrl(getProjectName()) + TEST_FILE.getName()));
+                uploadHelper.fileExists(TEST_FILE.getName()));
 
         stopImpersonating();
 

--- a/src/org/labkey/test/tests/UserEditorWithoutDeleteTest.java
+++ b/src/org/labkey/test/tests/UserEditorWithoutDeleteTest.java
@@ -1,5 +1,6 @@
 package org.labkey.test.tests;
 
+import com.github.sardine.impl.SardineException;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -7,9 +8,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.components.FilesWebPart;
 import org.labkey.test.util.FileBrowserHelper;
-import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.TestUser;
 import org.labkey.test.util.core.webdav.WebDavUploadHelper;
 import org.labkey.test.util.core.webdav.WebDavUrlFactory;
@@ -45,9 +44,6 @@ public class UserEditorWithoutDeleteTest extends BaseWebDriverTest
         EDITOR_WITHOUT_DELETE.create(this)
                 .setInitialPassword()
                 .addPermission("EditorWithoutDelete", getProjectName());
-
-        goToProjectHome();
-        new PortalHelper(this).addWebPart("Files");
     }
 
     /*
@@ -57,19 +53,27 @@ public class UserEditorWithoutDeleteTest extends BaseWebDriverTest
     public void testFileDeleteWithEditorWithoutDeleteUser()
     {
         goToProjectHome();
+        goToModule("FileContent");
         impersonate(EDITOR_WITHOUT_DELETE.getEmail());
-        FilesWebPart filesWebPart = FilesWebPart.getWebPart(getDriver());
-        filesWebPart.fileBrowser().uploadFile(TEST_FILE);
+        _fileBrowserHelper.uploadFile(TEST_FILE);
         Assert.assertFalse("Delete action should not be present for " + EDITOR_WITHOUT_DELETE.getEmail(),
-                filesWebPart.fileBrowser().isActionPresent(FileBrowserHelper.BrowserAction.DELETE));
+                _fileBrowserHelper.isActionPresent(FileBrowserHelper.BrowserAction.DELETE));
 
         WebDavUploadHelper uploadHelper = new WebDavUploadHelper(WebDavUrlFactory.webDavUrlFactory(getProjectName()),
                 WebDavUtils.beginSardine(getCurrentUser()));
         uploadHelper.uploadFile(TEST_FILE);
-        uploadHelper.deleteFile(WebDavUtils.buildBaseWebDavUrl(getProjectName()) + TEST_FILE.getName(), true);
+        SardineException sardineException = uploadHelper.deleteExpectingError(WebDavUtils.buildBaseWebDavUrl(getProjectName()) + TEST_FILE.getName());
+        Assert.assertEquals("Incorrect response for deletion", 404, sardineException.getStatusCode());
         Assert.assertTrue("File should not be deleted by " + EDITOR_WITHOUT_DELETE.getEmail(),
                 uploadHelper.fileExists(WebDavUtils.buildBaseWebDavUrl(getProjectName()) + TEST_FILE.getName()));
+
         stopImpersonating();
+
+        log("Verify delete exists for admin");
+        goToProjectHome();
+        goToModule("FileContent");
+        Assert.assertTrue("Delete action should be present for " + getCurrentUser(),
+                _fileBrowserHelper.isActionPresent(FileBrowserHelper.BrowserAction.DELETE));
     }
 
     @Override

--- a/src/org/labkey/test/tests/UserEditorWithoutDeleteTest.java
+++ b/src/org/labkey/test/tests/UserEditorWithoutDeleteTest.java
@@ -75,12 +75,12 @@ public class UserEditorWithoutDeleteTest extends BaseWebDriverTest
     @Override
     protected String getProjectName()
     {
-        return "UserEditorWithoutDeleteTest Project";
+        return getClass().getSimpleName() + TRICKY_CHARACTERS_FOR_PROJECT_NAMES + " Project";
     }
 
     @Override
     public List<String> getAssociatedModules()
     {
-        return Arrays.asList();
+        return Arrays.asList("FileContent");
     }
 }

--- a/src/org/labkey/test/util/FileBrowserHelper.java
+++ b/src/org/labkey/test/util/FileBrowserHelper.java
@@ -660,6 +660,21 @@ public class FileBrowserHelper extends WebDriverWrapper
             clickFileBrowserButtonOverflow(action);
     }
 
+    @LogMethod (quiet = true)
+    public boolean isActionPresent(@LoggedParam BrowserAction action)
+    {
+        waitForFileGridReady();
+        try
+        {
+            action.findButton(waitForToolbar());
+        }
+        catch (NoSuchElementException e)
+        {
+            return false;
+        }
+        return true;
+    }
+
     private void clickFileBrowserButtonOverflow(BrowserAction action)
     {
         Locator overflowMenuButton = Locator.css("div.fbrowser > div > a.x4-box-menu-after");

--- a/src/org/labkey/test/util/core/webdav/WebDavUploadHelper.java
+++ b/src/org/labkey/test/util/core/webdav/WebDavUploadHelper.java
@@ -133,6 +133,37 @@ public class WebDavUploadHelper
         uploadFile(file, "");
     }
 
+    public void deleteFile(@NotNull String file, boolean shouldFail)
+    {
+        try
+        {
+            if (_sardine.exists(file))
+                _sardine.delete(file);
+        }
+        catch (IOException e)
+        {
+            if (shouldFail)
+              ;
+            else
+                throw new RuntimeException(e);
+        }
+    }
+
+    public boolean fileExists(String file)
+    {
+        try
+        {
+            if (_sardine.exists(file))
+                return true;
+            else
+                return false;
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
     public void uploadFile(@NotNull File file, @NotNull String destPrefix)
     {
         if (file.isDirectory())

--- a/src/org/labkey/test/util/core/webdav/WebDavUploadHelper.java
+++ b/src/org/labkey/test/util/core/webdav/WebDavUploadHelper.java
@@ -16,6 +16,7 @@
 package org.labkey.test.util.core.webdav;
 
 import com.github.sardine.Sardine;
+import com.github.sardine.impl.SardineException;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
@@ -65,7 +66,7 @@ public class WebDavUploadHelper
 
     /**
      * Sets a custom file filter for uploading directories. Defaults to accepting all files.
-     *
+     * <p>
      * This only applies to {@link #uploadDirectory(File)} and {@link #uploadDirectoryContents(File)}. Individual file
      * uploads will ignore this filter.
      *
@@ -133,18 +134,32 @@ public class WebDavUploadHelper
         uploadFile(file, "");
     }
 
-    public void deleteFile(@NotNull String file, boolean shouldFail)
+    public void deleteFile(@NotNull String file)
     {
         try
         {
-            _sardine.delete(file);
+            _sardine.delete(_urlFactory.getPath(file));
         }
         catch (IOException e)
         {
-            if (shouldFail)
-              ;
-            else
-                throw new RuntimeException(e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public SardineException deleteExpectingError(String file)
+    {
+        try
+        {
+            _sardine.delete(_urlFactory.getPath(file));
+            throw new RuntimeException("Expected error did not occur");
+        }
+        catch (SardineException expected)
+        {
+            return expected;
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
         }
     }
 
@@ -152,10 +167,7 @@ public class WebDavUploadHelper
     {
         try
         {
-            if (_sardine.exists(file))
-                return true;
-            else
-                return false;
+            return _sardine.exists(file);
         }
         catch (IOException e)
         {

--- a/src/org/labkey/test/util/core/webdav/WebDavUploadHelper.java
+++ b/src/org/labkey/test/util/core/webdav/WebDavUploadHelper.java
@@ -137,8 +137,7 @@ public class WebDavUploadHelper
     {
         try
         {
-            if (_sardine.exists(file))
-                _sardine.delete(file);
+            _sardine.delete(file);
         }
         catch (IOException e)
         {

--- a/src/org/labkey/test/util/core/webdav/WebDavUploadHelper.java
+++ b/src/org/labkey/test/util/core/webdav/WebDavUploadHelper.java
@@ -167,7 +167,7 @@ public class WebDavUploadHelper
     {
         try
         {
-            return _sardine.exists(file);
+            return _sardine.exists(_urlFactory.getPath(file));
         }
         catch (IOException e)
         {


### PR DESCRIPTION
#### Rationale
Automation test for Editor without Delete users are able to delete files

Test case:
Create a folder.
Create a user.
Give the user Editor without Delete.
As that new user, upload a file.
As that new user, verify you can't see the Delete option in the file browser UI.
As that new user, verify that a DELETE HTTP request fails with a permission error and the file persists.

[Issue link](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=51500)

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
