### PR TITLE
Chart builder support for Trendline option in line chart

### DIFF
--- a/src/org/labkey/test/components/ChartTypeDialog.java
+++ b/src/org/labkey/test/components/ChartTypeDialog.java
@@ -124,6 +124,22 @@ public class ChartTypeDialog extends ChartWizardDialog<ChartTypeDialog.ElementCa
         return this;
     }
 
+    public boolean hasTrendlineOption()
+    {
+        return getWrapper().isElementVisible(Ext4Helper.Locators.formItemWithInputNamed("trendlineType"));
+    }
+
+    public List<String> getTrendlineOptions()
+    {
+        return getWrapper()._ext4Helper.getComboBoxOptions(Ext4Helper.Locators.formItemWithInputNamed("trendlineType"));
+    }
+
+    public ChartTypeDialog selectTrendlineType(String type)
+    {
+        getWrapper()._ext4Helper.selectComboBoxItem(Ext4Helper.Locators.formItemWithInputNamed("trendlineType"), type);
+        return this;
+    }
+
     public ChartTypeDialog setXCategory(String columnName)
     {
         setXCategory(columnName, false);

--- a/src/org/labkey/test/components/ChartTypeDialog.java
+++ b/src/org/labkey/test/components/ChartTypeDialog.java
@@ -126,7 +126,10 @@ public class ChartTypeDialog extends ChartWizardDialog<ChartTypeDialog.ElementCa
 
     public boolean hasTrendlineOption()
     {
-        return getWrapper().isElementVisible(Ext4Helper.Locators.formItemWithInputNamed("trendlineType"));
+        Locator loc = Ext4Helper.Locators.formItemWithInputNamed("trendlineType");
+        if (getWrapper().isElementPresent(loc))
+            return getWrapper().isElementVisible(loc);
+        return false;
     }
 
     public List<String> getTrendlineOptions()

--- a/src/org/labkey/test/components/react/QueryChartDialog.java
+++ b/src/org/labkey/test/components/react/QueryChartDialog.java
@@ -184,6 +184,14 @@ public class QueryChartDialog extends ModalDialog
     /*
         trendline is an option for line
      */
+    public boolean hasTrendlineOption()
+    {
+        return elementCache().reactSelectByLabel("Trendline", true) != null;
+    }
+
+    /*
+        trendline is an option for line
+     */
     public List<String> getTrendlineOptions()
     {
         return elementCache().reactSelectByLabel("Trendline").getOptions();
@@ -355,9 +363,16 @@ public class QueryChartDialog extends ModalDialog
 
         public ReactSelect reactSelectByLabel(String label)
         {
-            WebElement container = Locator.tag("div").withChild(Locator.tagContainingText("label", label))
-                    .waitForElement(this, 1500);
-            return ReactSelect.finder(getDriver()).find(container);
+            return reactSelectByLabel(label, false);
+        }
+
+        public ReactSelect reactSelectByLabel(String label, boolean allowNull)
+        {
+            Locator loc = Locator.tag("div").withChild(Locator.tagContainingText("label", label));
+            if (allowNull && loc.findElementOrNull(this) == null)
+                return null;
+            else
+                return ReactSelect.finder(getDriver()).find(loc.waitForElement(this, 1500));
         }
 
         private Locator.XPathLocator previewContainerLoc = Locator.tag("div").withChild(Locator.tagWithText("label", "Preview"));

--- a/src/org/labkey/test/components/react/QueryChartDialog.java
+++ b/src/org/labkey/test/components/react/QueryChartDialog.java
@@ -181,6 +181,23 @@ public class QueryChartDialog extends ModalDialog
         return this;
     }
 
+    /*
+        trendline is an option for line
+     */
+    public List<String> getTrendlineOptions()
+    {
+        return elementCache().reactSelectByLabel("Trendline").getOptions();
+    }
+
+    /*
+        trendline is an option for line
+     */
+    public QueryChartDialog selectTrendline(String field)
+    {
+        elementCache().reactSelectByLabel("Trendline").select(field);
+        return this;
+    }
+
     public String getSelectedSeries()
     {
         return elementCache().reactSelectByLabel("Series").getValue();

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -12,6 +12,7 @@ import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.UpdatingComponent;
 import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.html.RadioButton;
 import org.labkey.test.components.react.ReactCheckBox;
 import org.labkey.test.components.ui.search.FilterExpressionPanel;
 import org.openqa.selenium.Keys;
@@ -176,6 +177,18 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
             filterModal.confirm();
         });
 
+        return _this;
+    }
+
+    public T filterBooleanColumn(String columnLabel, boolean value)
+    {
+        T _this = getThis();
+        doAndWaitForUpdate(() -> {
+            clickColumnMenuItem(columnLabel, "Filter...", false);
+            GridFilterModal filterModal = new GridFilterModal(getDriver(), this);
+            new RadioButton.RadioButtonFinder().withNameAndValue("field-value-bool-0", value?"true":"false").find(filterModal).set(true);
+            filterModal.confirm();
+        });
         return _this;
     }
 


### PR DESCRIPTION
#### Rationale
See related PR for rationale. This PR adds test helpers for the chart wizard Trendline option UI components / panel.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1650

#### Changes
- app chart helper for selecting new line chart Trendline option
- add app grid helper for filtering a boolean column for true/false value
- app chart helper for checking if Trendline option is available
- LKS Chart wizard helper for trendline options in ChartTypeDialog
