### PR TITLE
Encode URL query parameters when building a URL

### DIFF
--- a/src/org/labkey/test/util/URLBuilder.java
+++ b/src/org/labkey/test/util/URLBuilder.java
@@ -212,11 +212,11 @@ public class URLBuilder
                 if (null != param.getKey())
                 {
                     url.append(firstParam ? "?" : "&");
-                    url.append(param.getKey());
+                    url.append(EscapeUtil.encode(param.getKey()));
                     if (null != param.getValue())
                     {
                         url.append("=");
-                        url.append(param.getValue());
+                        url.append(EscapeUtil.encode(String.valueOf(param.getValue())));
                     }
                     firstParam = false;
                 }

--- a/src/org/labkey/test/util/URLBuilder.java
+++ b/src/org/labkey/test/util/URLBuilder.java
@@ -107,7 +107,7 @@ public class URLBuilder
     public URLBuilder setAppResourcePath(Object... pathParts)
     {
         List<String> encodedParts = Arrays.stream(pathParts).map(Objects::requireNonNull).map(String::valueOf)
-                .map(URIUtil::encodePath).collect(Collectors.toList());
+                .map(s -> EscapeUtil.encode(s).replace("+", " ")).collect(Collectors.toList());
         setFragment("/" + String.join("/", encodedParts));
         return this;
     }


### PR DESCRIPTION
#### Rationale
I updated a test to use `WebTestHelper.buildURL` to create a URL and it started failing because the URL query isn't properly encoded. The page just says "Invalid characters in request." and the test fails with:
```
java.lang.AssertionError: Incorrect response code expected:<404> but was:<200>
  at org.junit.Assert.fail(Assert.java:89)
  at org.junit.Assert.failNotEquals(Assert.java:835)
  at org.junit.Assert.assertEquals(Assert.java:647)
  at org.labkey.test.tests.list.ListTest.testCustomViews(ListTest.java:691)
```

#### Related Pull Requests
- #2154 

#### Changes
- Encode URL query parameters when building a URL
