### PR TITLE
Fix error when splitting DateTime format string

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -1320,6 +1320,8 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
     public void clickProject(String project, boolean assertDestination)
     {
         projectMenu().navigateToProject(project);
+        // After clicking menu item mouse could be left in a position that would be over an element that could have a pop-up.
+        mouseOut();
         if (assertDestination)
         {
             acceptTermsOfUse(null, true);

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -139,21 +139,28 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
             else if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.DateAndTime))
             {
 
-                // Identify the part of the format that is the date and the part that is the time. Take into account
-                // a data format may include spaces (time does not).
-                String format = fieldDefinition.getFormat().trim();
-                int index = format.lastIndexOf(" ");
+                // Identify the part of the format that is the date and the part that is the time.
+                String formatStr = fieldDefinition.getFormat().trim();
+                int index = formatStr.indexOf(":");
 
-                if (format.substring(index + 1).contains(":"))
+                if (index == -1)
                 {
-                    fieldRow.setDateTimeFormat(
-                            DATE_FORMAT.get(format.substring(0, index)),
-                            TIME_FORMAT.get(format.substring(index + 1)));
+                    // If there is no ':' then it is a date only format.
+                    fieldRow.setDateTimeFormat(DATE_FORMAT.get(formatStr));
                 }
                 else
                 {
-                    fieldRow.setDateTimeFormat(DATE_FORMAT.get(format));
+                    // Split the format into the date part and the time part. Take into account that the date part may
+                    // have several spaces and the time part may have a space if there is an am/pm indicator.
+                    // Find the last index of the ' ' before the ':'.
+                    String tmpStr = formatStr.substring(0, index);
+                    index = tmpStr.lastIndexOf(" ");
+
+                    fieldRow.setDateTimeFormat(
+                            DATE_FORMAT.get(formatStr.substring(0, index)),
+                            TIME_FORMAT.get(formatStr.substring(index + 1)));
                 }
+
             }
             else
             {

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -936,6 +936,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
 
         // check the row level audit details
         popLocation();
+        waitForElement(Locator.linkWithText("vehicle.Models"));
         selectSchema(VEHICLE_SCHEMA);
         selectQuery(VEHICLE_SCHEMA, "Models");
         assertElementPresent(Locator.linkWithText("view data"));
@@ -1214,7 +1215,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
     {
         log("Verify module report \"created\" date");
         click(Locator.tag("span").withClass("fa-list-ul").notHidden());
-        waitForText("2015-08-01");
+        waitForText("August 01 2015");
     }
 
     @LogMethod

--- a/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
+++ b/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
@@ -1113,11 +1113,9 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
      * <p>
      *     Test setting the format property on a date-only, time-only and DateTime field.
      * </p>
-     * @throws IOException Can be thrown by helper that checks if the list already exists.
-     * @throws CommandException Can be thrown by helper that checks if the list already exists.
      */
     @Test
-    public void testDateAndTimeFormat() throws IOException, CommandException
+    public void testDateAndTimeFormat()
     {
         DATE_FORMAT dateFormat01 = DATE_FORMAT.Default;
         TIME_FORMAT timeFormat01 = TIME_FORMAT.hh_mm_a;


### PR DESCRIPTION
#### Rationale
Fixing a bad string split.

#### Related Pull Requests
- none

#### Changes
- Be smarter about splitting a DateTime format string into a date part and a time part.
- Remove unused 'throw' annotation.
