### PR TITLE
Don't encode parameters passed to WebTestHelper.buildUrl

### DIFF
--- a/src/org/labkey/test/util/APIContainerHelper.java
+++ b/src/org/labkey/test/util/APIContainerHelper.java
@@ -31,8 +31,6 @@ import org.labkey.test.WebTestHelper;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -197,10 +195,10 @@ public class APIContainerHelper extends AbstractContainerHelper
     @LogMethod
     public void renameFolder(@LoggedParam String containerPath, @LoggedParam String newName, final boolean createAlias)
     {
-        Map<String, String> params = new HashMap<>();
-        params.put("name", URLEncoder.encode(newName, StandardCharsets.UTF_8));
-        params.put("addAlias", String.valueOf(createAlias));
-        params.put("titleSameAsName", String.valueOf(true));
+        Map<String, Object> params = new HashMap<>();
+        params.put("name", newName);
+        params.put("addAlias", createAlias);
+        params.put("titleSameAsName", true);
         SimpleHttpRequest simpleHttpRequest = new SimpleHttpRequest(WebTestHelper.buildURL("admin", containerPath, "renameFolder", params), "POST");
         simpleHttpRequest.copySession(_test.getDriver());
 

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -1430,9 +1430,12 @@ public class Crawler
         {
             if (!sb.isEmpty())
                 sb.append('&');
-            sb.append(URLEncoder.encode(e.getKey(), StandardCharsets.UTF_8));
-            sb.append('=');
-            sb.append(null==e.getValue()?"":URLEncoder.encode(e.getValue(), StandardCharsets.UTF_8));
+            sb.append(EscapeUtil.encode(e.getKey()));
+            if (e.getValue() != null)
+            {
+                sb.append('=');
+                sb.append(EscapeUtil.encode(e.getValue()));
+            }
         }
         );
         return sb.toString();

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -1431,11 +1431,8 @@ public class Crawler
             if (!sb.isEmpty())
                 sb.append('&');
             sb.append(EscapeUtil.encode(e.getKey()));
-            if (e.getValue() != null)
-            {
-                sb.append('=');
-                sb.append(EscapeUtil.encode(e.getValue()));
-            }
+            sb.append('=');
+            sb.append(EscapeUtil.encode(e.getValue()));
         }
         );
         return sb.toString();

--- a/src/org/labkey/test/util/EscapeUtil.java
+++ b/src/org/labkey/test/util/EscapeUtil.java
@@ -78,7 +78,9 @@ public class EscapeUtil
      */
     public static String encode(String s)
     {
-        return s == null ? "" : URLEncoder.encode(s, StandardCharsets.UTF_8);
+        return s == null ? "" : URLEncoder.encode(s, StandardCharsets.UTF_8)
+            // Product often doesn't decode '+' into ' '. "%20" is a more reliable encoding
+            .replace("+", "%20");
     }
 
     /**


### PR DESCRIPTION
#### Rationale
`WebTestHelper.buildUrl` and `buildRelativeUrl` now automatically encode parameters. No need for callers to do so.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2169

#### Changes
- Don't encode parameters passed to `WebTestHelper.buildUrl`