### PR TITLE
ChartingAPITest.genericChartHelperTest test fix for recent change to getChartType() helper

### DIFF
--- a/modules/chartingapi/resources/views/exportGenericChartTest.html
+++ b/modules/chartingapi/resources/views/exportGenericChartTest.html
@@ -55,7 +55,7 @@
         // chartConfig is the saved information about the chart (labels, scales, etc.)
         var gch = LABKEY.vis.GenericChartHelper;
         var DEFAULT_WIDTH = 800, DEFAULT_HEIGHT = 600;
-        var chartType = gch.getChartType(chartConfig.renderType, chartConfig.measures.x.normalizedType);
+        var chartType = gch.getChartType(chartConfig);
         var layerConfig = {
             data: responseData.rows,
             geom: gch.generateGeom(chartType, chartConfig.geomOptions)


### PR DESCRIPTION
#### Rationale
There was a change to the getChartType() helper in the related PR. This PR fixes the test case usage of that helper.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6100

#### Changes
- pass chartConfig to getChartType() instead of individual params
