### PR TITLE
Issue 51822: Assay import API to support result field mapping via field Name, Label, and Import Aliases

### DIFF
--- a/data/api/rlabkey-api-experiment.xml
+++ b/data/api/rlabkey-api-experiment.xml
@@ -185,6 +185,26 @@
             ]]>
         </response>
     </test>
+    <test name="labkey.saveBatch for assay with field import alias (Issue 51822)" type="post">
+        <url>
+            <![CDATA[
+                library(Rlabkey)
+                print(labkey.saveBatch(baseUrl=labkey.url.base, folderPath="%projectName%", "Rlabkey GPAT Test", data.frame(guspec=c(4,5))))
+            ]]>
+        </url>
+        <response>
+            <![CDATA[
+                $batch$runs[[1]]$dataRows[[1]]$SpecimenID
+                [1] "4"
+
+                $batch$runs[[1]]$dataRows[[2]]$SpecimenID
+                [1] "5"
+
+                $batch$runs[[1]]$schemaName
+                [1] "assay.General.Rlabkey GPAT Test"
+            ]]>
+        </response>
+    </test>
     <test name="create sample type and load data" type="post">
         <url>
             <![CDATA[


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51822

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6135
- https://github.com/LabKey/testAutomation/pull/2180

#### Changes
- add API test via Rlabkey to test assay import using result field import alias
