### PR TITLE
Decode reportId to avoid double-encoding later

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -22,7 +22,6 @@ import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hc.client5.http.utils.URIUtils;
 import org.eclipse.jetty.util.URIUtil;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.Contract;
@@ -3923,6 +3922,13 @@ public abstract class WebDriverWrapper implements WrapsDriver
         return paramValue;
     }
 
+    /**
+     * Parses the URL query of the current page
+     * @deprecated Duplicated in {@link WebTestHelper#parseUrlQueryString(String)}. Warning: valueless parameters are
+     * handled differently ({@code null} instead of {@code ""})
+     * @return Map of encoded URL parameters
+     */
+    @Deprecated (since = "25.1")
     public Map<String, String> getUrlParameters()
     {
         Map<String, String> params = new HashMap<>();

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1006,6 +1006,9 @@ public abstract class WebDriverWrapper implements WrapsDriver
         try
         {
             getDriver().switchTo().window(windows.get(index));
+            new WebDriverWait(getDriver(), Duration.ofSeconds(WAIT_FOR_PAGE))
+                .withMessage("waiting for document to be ready")
+                .until(wd -> Objects.equals(executeScript("return document.readyState;"), "complete"));
         }
         catch (StackOverflowError soe)
         {

--- a/src/org/labkey/test/pages/reports/ScriptReportPage.java
+++ b/src/org/labkey/test/pages/reports/ScriptReportPage.java
@@ -86,7 +86,7 @@ public class ScriptReportPage extends LabKeyPage<ScriptReportPage.ElementCache>
         {
             saveReportWithName(name, isSaveAs);
         }
-        return getUrlParam("reportId");
+        return getUrlParam("reportId", true);
     }
 
     /**


### PR DESCRIPTION
#### Rationale
`ScriptReportPage.saveReport` should decode the `reportId` parameter so that it is compatible with the encoding behavior of `ScriptReportPage.beginAtReport`.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2169

#### Changes
- Decode reportId to avoid double-encoding by `beginAtReport`
