### PR TITLE
Wait for readyState when switching test windows

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.awaitility.Awaitility;
 import org.eclipse.jetty.util.URIUtil;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.Contract;
@@ -1006,9 +1007,8 @@ public abstract class WebDriverWrapper implements WrapsDriver
         try
         {
             getDriver().switchTo().window(windows.get(index));
-            new WebDriverWait(getDriver(), Duration.ofSeconds(WAIT_FOR_PAGE))
-                .withMessage("waiting for document to be ready")
-                .until(wd -> Objects.equals(executeScript("return document.readyState;"), "complete"));
+            Awaitility.await("waiting for document to be ready").atMost(Duration.ofMillis(WAIT_FOR_PAGE)).untilAsserted(() ->
+                assertEquals("document.readyState", "complete", executeScript("return document.readyState;")));
         }
         catch (StackOverflowError soe)
         {

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.eclipse.jetty.util.URIUtil;
 import org.intellij.lang.annotations.Language;
@@ -1008,7 +1009,8 @@ public abstract class WebDriverWrapper implements WrapsDriver
         {
             getDriver().switchTo().window(windows.get(index));
             Awaitility.await("waiting for document to be ready").atMost(Duration.ofMillis(WAIT_FOR_PAGE)).untilAsserted(() ->
-                assertEquals("document.readyState", "complete", executeScript("return document.readyState;")));
+                Assertions.assertThat(executeScript("return document.readyState;"))
+                    .as("document.readyState").isIn("complete", "uninitialized")); // "uninitialized" for blank firefox tab
         }
         catch (StackOverflowError soe)
         {


### PR DESCRIPTION
#### Rationale
A change to how we switch windows was accidentally included in a previous PR. It attempts to prevent errors with `assertTextPresent` throwing an NPE after switching windows by waiting for `document.readyState` to be `"complete"`. This mostly works, except one place in WNPRC that opens a window in a unique method. In Firefox, the `readyState` of that page is the nonstandard "uninitialized".
```
org.junit.runners.model.TestTimedOutException: test timed out after 30 minutes
  at java.base@17.0.7/java.lang.Thread.sleep(Native Method)
  at app//org.openqa.selenium.support.ui.Sleeper.lambda$static$0(Sleeper.java:25)
  at app//org.openqa.selenium.support.ui.Sleeper$$Lambda$675/0x00000008016d5478.sleep(Unknown Source)
  at app//org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:232)
  at app//org.labkey.test.WebDriverWrapper.switchToWindow(WebDriverWrapper.java:1011)
  at app//org.labkey.test.tests.wnprc_ehr.WNPRC_EHRTest.testClinpathVirologyBulkUploadPreviewAndDate(WNPRC_EHRTest.java:3294)
```
_Note: the test timeout was caused by using seconds instead of milliseconds for the readyState timeout. That has also been fixed._

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2182

#### Changes
- Handle "uninitialized" readyState when switching windows
- Use `Duration.ofMillis` instead of `Duration.ofSeconds` for timeout
