### PR TITLE
FilterSelectionDialog: handle non-removable fields

### DIFF
--- a/src/org/labkey/test/components/ui/grids/FieldSelectionDialog.java
+++ b/src/org/labkey/test/components/ui/grids/FieldSelectionDialog.java
@@ -386,20 +386,25 @@ public class FieldSelectionDialog extends ModalDialog
     public FieldSelectionDialog removeAllSelectedFields()
     {
         List<WebElement> allItems = elementCache().getListItemElements(elementCache().selectedFieldsPanel);
+        boolean removedAll = true;
 
-        for(WebElement listItem : allItems)
+        for (WebElement listItem : allItems)
         {
             WebElement removeIcon = Locator.tagWithClass("span", "view-field__action").findWhenNeeded(listItem);
 
-            // For the tooltip not all fields can be removed.
-            if(removeIcon.isDisplayed())
+            // In some usages there may be fields that are not removable.
+            if (!removeIcon.isDisplayed())
             {
-                removeIcon.click();
+                removedAll = false;
+                continue;
             }
+
+            removeIcon.click();
         }
 
-        WebDriverWrapper.waitFor(()-> getSelectedFields().isEmpty(),
-                "Did not remove all of the selected fields.", 500);
+        // If a non-removable field is encountered, then skip check to see if all fields are removed.
+        if (removedAll)
+            WebDriverWrapper.waitFor(()-> getSelectedFields().isEmpty(), "Did not remove all of the selected fields.", 500);
 
         return this;
     }


### PR DESCRIPTION
#### Rationale
Update `FieldSelectionDialog` test component to handle removing all selected fields edge case where some fields are not actually removable.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/971

#### Changes
- Skip all fields removed check if not all fields can be removed.
