### PR TITLE
Some test fixes.

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -262,7 +262,7 @@ public class EntityBulkUpdateDialog extends ModalDialog
 
         public FilteringReactSelect getSelect(String fieldKey)
         {
-            return FilteringReactSelect.finder(getDriver()).withNamedInput(fieldKey).findWhenNeeded(this);
+            return FilteringReactSelect.finder(getDriver()).withNamedInput(fieldKey).refindWhenNeeded(this);
         }
 
         public Input textInput(String fieldKey)


### PR DESCRIPTION
#### Rationale
Make finder for field on bulk update dialog more robust.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1002

#### Changes
- In EntityBulkUpdateDialog use refind to help protect against a stale element.
