### PR TITLE
Update to Selenium 4.13.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ hamcrestCoreVersion=1.3
 
 lookfirstSardineVersion=5.7
 jettyRepackagedVersion=9.4.12.v20180830
-seleniumVersion=4.11.0
+seleniumVersion=4.13.0
 mockserverNettyVersion=5.15.0
 
 labkeySchemasTestVersion=23.7-SNAPSHOT


### PR DESCRIPTION
#### Rationale
Our new Windows agent AMI doesn't have geckodriver preinstalled. Selenium should be able to [download it automatically](https://www.selenium.dev/documentation/webdriver/troubleshooting/errors/driver_location/) as of v4.6. It didn't download successfully.
```
Caused by: org.openqa.selenium.remote.NoSuchDriverException: geckodriver located at C:\Windows\system32\config\systemprofile\.cache\selenium\geckodriver\win64\0.35.0\geckodriver.exe, but invalid
For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors/driver_location/
Build info: version: '4.11.0', revision: '040bc5406b'
System info: os.name: 'Windows Server 2022', os.arch: 'amd64', os.version: '10.0', java.version: '17.0.7'
Driver info: driver.version: BaseWebDriverTest$SingletonWebDriver
  at app//org.openqa.selenium.remote.service.DriverFinder.getPath(DriverFinder.java:45)
  at app//org.openqa.selenium.remote.service.DriverFinder.getPath(DriverFinder.java:13)
  at app//org.openqa.selenium.firefox.FirefoxDriver.generateExecutor(FirefoxDriver.java:141)
  at app//org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:132)
  at app//org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:127)
  at app//org.labkey.test.WebDriverWrapper.createNewWebDriver(WebDriverWrapper.java:380)
  ... 9 more
```
Updating to Selenium 4.13 seems to fix it without introducing any problems with existing tests (4.14+ required more significant refactors when we [made that update in 24.4](https://github.com/LabKey/testAutomation/pull/1815)).

#### Related Pull Requests
- N/A

#### Changes
- Update to Selenium 4.13.0
