### PR TITLE
App add ability to create multiple types from creation modal and EntityInsertPanel tabs

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
+++ b/src/org/labkey/test/components/ui/entities/EntityInsertPanel.java
@@ -53,7 +53,7 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     public String getTargetEntityType()
     {
-        return elementCache().targetType.getText();
+        return elementCache().targetTab.getText();
     }
 
     public boolean isAddParentMenuPresent()
@@ -402,7 +402,9 @@ public class EntityInsertPanel extends WebDriverComponent<EntityInsertPanel.Elem
 
     protected class ElementCache extends Component<?>.ElementCache
     {
-        WebElement targetType = Locator.tagWithId("div", "target-entity-type").findWhenNeeded(this);
+        Locator navTab = Locator.tagWithClass("ul", "nav-tabs")
+                .child(Locator.tag("li").withChild(Locator.tag("a")));
+        WebElement targetTab = navTab.findWhenNeeded(this);
 
         MultiMenu addParent = new MultiMenu.MultiMenuFinder(getDriver()).containsText("Add Parent")
                 .timeout(WAIT_FOR_JAVASCRIPT).refindWhenNeeded();


### PR DESCRIPTION
#### Rationale
This set of PRs are the final step in the move towards allowing multiple sample types to be created at once when adding / deriving samples and sources. This PR updates the EntityCreationModal to allow up to 5 types to be selected when adding/deriving (in certain cases) and updates the EntityInsertPanel grid component to handle rendering multiple tabs and using saveRows instead of insertRows on finish/save.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1673

#### Changes
- EntityInsertPanel target type locator update
