### PR TITLE
Issue 51894: Tests for cross-type and cross-folder import and fix issue

### DIFF
--- a/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/samples/SampleTypeDesigner.java
@@ -45,10 +45,10 @@ public abstract class SampleTypeDesigner<T extends SampleTypeDesigner<T>> extend
     {
         expandPropertiesPanel();
 
-        WebDriverWrapper.waitFor(elementCache().addAliasButton::isDisplayed,
+        WebDriverWrapper.waitFor(elementCache().addParentAliasButton::isDisplayed,
                 "'Add a Parent' button is not visible.", 2_500);
 
-        elementCache().addAliasButton.click();
+        elementCache().addParentAliasButton.click();
         int initialCount = findEmptyAlias();
         if (optionDisplayText == null)
         {
@@ -100,6 +100,8 @@ public abstract class SampleTypeDesigner<T extends SampleTypeDesigner<T>> extend
         protected final WebElement uniqueIdMsgCheckIcon = Locator.tagWithClass("div","uniqueid-msg")
                 .append(Locator.tagWithClassContaining("i", "domain-panel-status-icon-green")).refindWhenNeeded(this);
 
+        public final WebElement addParentAliasButton = Locator.tagWithClassContaining("span", "container--action-button")
+                .withText("Add a Parent").findWhenNeeded(propertiesPanel);
         public final WebElement addAliasButton = Locator.tagWithClass("i","container--addition-icon").findWhenNeeded(this);
     }
 }


### PR DESCRIPTION
#### Rationale
See [related PR](https://github.com/LabKey/limsModules/pull/1038). For some reason the locator for addAliasButton is not specific enough to be consistently found.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1038

#### Changes
- Add new elementCache WebElement specific to "Add a Parent"
