### PR TITLE
Include hidden pipeline directories in test artifacts

### DIFF
--- a/src/org/labkey/test/util/ArtifactCollector.java
+++ b/src/org/labkey/test/util/ArtifactCollector.java
@@ -330,7 +330,7 @@ public class ArtifactCollector
     {
         FileFilter directoryOrArtifactFilter = pathname ->
                 pathname.isDirectory()
-                        ? !pathname.isHidden() && !pathname.getName().equals("@labkey_full_text_index")
+                        ? !pathname.getName().equals("@labkey_full_text_index")
                         : pathname.lastModified() > _testStart && filter.accept(pathname);
 
         File[] files = path.listFiles(directoryOrArtifactFilter);


### PR DESCRIPTION
#### Rationale
There isn't any particular reason to exclude "hidden" pipeline directories from our TeamCity artifacts. Doing so is causing us to miss some files necessary to investigate a particular error.

#### Related Pull Requests
- N/A

#### Changes
- Include hidden pipeline directories in test artifacts