### PR TITLE
component updates for auto-hit-selection

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -1212,6 +1212,25 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         return new ConditionalFormatDialog(this);
     }
 
+    public boolean hasHitSelectionCriteriaBtn()
+    {
+        return elementCache().hitSelectionCriteriaBtnLoc.existsIn(this);
+    }
+
+    public HitSelectionDialog clickHitSelectionCriteriaButton()
+    {
+        expand();
+        getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().hitSelectionCriteriaButton()));
+        elementCache().hitSelectionCriteriaButton().click();
+        return new HitSelectionDialog(getDriver());
+    }
+
+    public List<String> getHitSelectionCriteria()
+    {
+        expand();
+        return elementCache().hitSelectionCriteria();
+    }
+
     @Override
     protected ElementCache newElementCache()
     {
@@ -1766,6 +1785,18 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         {
             return Locator.waitForAnyElement(new FluentWait<SearchContext>(this).withTimeout(Duration.ofMillis(WAIT_FOR_JAVASCRIPT)),
                     Locator.button("Add Format"), Locator.button("Edit Formats"));
+        }
+
+        public Locator hitSelectionCriteriaBtnLoc = Locator.button("Edit Criteria");
+        public WebElement hitSelectionCriteriaButton()
+        {
+            return hitSelectionCriteriaBtnLoc.waitForElement(this, WAIT_FOR_JAVASCRIPT);
+        }
+
+        public List<String> hitSelectionCriteria()
+        {
+            return getWrapper().getTexts(Locator.tagWithClass("li", "hit-criteria-renderer__field-value")
+                    .findElements(this));
         }
 
         public RadioButton aliquotOption(ExpSchema.DerivationDataScopeType option)

--- a/src/org/labkey/test/components/domain/HitSelectionDialog.java
+++ b/src/org/labkey/test/components/domain/HitSelectionDialog.java
@@ -1,0 +1,93 @@
+package org.labkey.test.components.domain;
+
+import org.labkey.test.Locator;
+import org.labkey.test.components.Component;
+import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.bootstrap.ModalDialog;
+import org.labkey.test.components.html.Input;
+import org.labkey.test.components.ui.search.FilterExpressionPanel;
+import org.labkey.test.pages.LabKeyPage;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static org.labkey.test.components.html.Input.Input;
+
+
+public class HitSelectionDialog extends ModalDialog
+{
+
+    public HitSelectionDialog(WebDriver driver)
+    {
+        super(new ModalDialogFinder(driver));
+    }
+
+    public List<String> getAvailableFields()
+    {
+        return getWrapper().getTexts(elementCache().findFieldOptions());
+    }
+
+    public FilterExpressionPanel selectField(String fieldName)
+    {
+        var fieldItem = elementCache().findFieldOption(fieldName);
+        fieldItem.click();
+        return elementCache().filterExpressionPanel();
+    }
+
+    public void cancel()
+    {
+        dismiss("Cancel");
+    }
+
+    public void clickApply()
+    {
+        if (!elementCache().submitButton.isEnabled())
+        {
+            throw new IllegalStateException("Apply button is not enabled.");
+        }
+        elementCache().submitButton.click();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+
+    protected class ElementCache extends ModalDialog.ElementCache
+    {
+        public final Locator listItemLoc = Locator.byClass("list-group-item");
+
+        // fields panel
+        WebElement fieldsPanel = Locator.tagWithClass("div", "field-modal__col")
+                .withChild(Locator.tagWithClass("div", "field-modal__col-title").withText("Fields"))
+                .child(Locator.tagWithClass("div", "field-modal__col-content")).findWhenNeeded(this).withTimeout(5000);
+        protected WebElement findFieldOption(String queryName)
+        {
+            return listItemLoc.withText(queryName).findElement(fieldsPanel);
+        }
+        protected List<WebElement> findFieldOptions()
+        {
+            return listItemLoc.findElements(fieldsPanel);
+        }
+
+        // filter panel
+        WebElement filterCriteriaPanel = Locator.tagWithClass("div", "field-modal__col")
+                .withChild(Locator.tagWithClass("div", "field-modal__col-title").withText("Filter Criteria"))
+                .child(Locator.tagWithClass("div", "field-modal__col-content")).findWhenNeeded(this).withTimeout(5000);
+        protected final FilterExpressionPanel filterExpressionPanel()
+        {
+            return new FilterExpressionPanel.FilterExpressionPanelFinder(getDriver()).findWhenNeeded(filterCriteriaPanel);
+        }
+
+        protected final WebElement submitButton = Locator.css(".modal-footer .btn-success").findWhenNeeded(this);
+    }
+}

--- a/src/org/labkey/test/components/domain/HitSelectionDialog.java
+++ b/src/org/labkey/test/components/domain/HitSelectionDialog.java
@@ -47,6 +47,7 @@ public class HitSelectionDialog extends ModalDialog
             throw new IllegalStateException("Apply button is not enabled.");
         }
         elementCache().submitButton.click();
+        waitForClose();
     }
 
     @Override

--- a/src/org/labkey/test/pages/ReactAssayDesignerPage.java
+++ b/src/org/labkey/test/pages/ReactAssayDesignerPage.java
@@ -22,6 +22,7 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.DomainDesignerPage;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.domain.DomainPanel;
+import org.labkey.test.components.domain.HitSelectionDialog;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.html.OptionSelect;
@@ -33,6 +34,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.Select;
 
 import java.io.File;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
@@ -205,6 +207,19 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
         return this;
     }
 
+    public HitSelectionDialog clickEditCriteria()
+    {
+        expandPropertiesPanel();
+        elementCache().hitSelectionCriteriaBtn.click();
+        return new HitSelectionDialog(getDriver());
+    }
+
+    public List<String> getHitCriteria()
+    {
+        expandPropertiesPanel();
+        return getWrapper().getTexts(elementCache().hitSelectionCriteriaLoc.findElements(elementCache().propertiesPanel));
+    }
+
     public ReactAssayDesignerPage setStatus(boolean checked)
     {
         expandPropertiesPanel();
@@ -351,5 +366,9 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
         final Checkbox qcEnabledCheckbox = Checkbox(Locator.checkboxById("assay-design-qcEnabled")).findWhenNeeded(propertiesPanel);
         final Checkbox plateTemplateCheckbox = Checkbox(Locator.checkboxById("assay-design-plateMetadata")).findWhenNeeded(propertiesPanel);
         final Checkbox activeStatusCheckBox = Checkbox(Locator.checkboxById("assay-design-status")).findWhenNeeded(propertiesPanel);
+
+        final WebElement hitSelectionCriteriaBtn = Locator.tagWithClass("div", "filter-criteria-input__button")
+                .child(Locator.button("Edit Criteria")).findWhenNeeded(propertiesPanel);
+        final Locator hitSelectionCriteriaLoc = Locator.tagWithClass("li", "hit-criteria-renderer__field-value");
     }
 }


### PR DESCRIPTION
#### Rationale
This adds component support needed for automatic hit-selection test coverage in Biologics.

#### Related Pull Requests
https://github.com/LabKey/limsModules/pull/1043

#### Changes
Add hit selection summary and button controls to `DomainFieldRow`
Add hit selection summary and button control to `ReactAssayDesignerPage`
new Dialog, `HitSelectionDialog`
