### PR TITLE
Add ManageVersion property to all module.properties files

### DIFF
--- a/buildTestModules/communityArtifacts/module.properties
+++ b/buildTestModules/communityArtifacts/module.properties
@@ -4,3 +4,4 @@ Description: Module used for testing the use of published community artifacts fo
 URL: http://labkey.org
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+ManageVersion: true

--- a/buildTestModules/starterArtifacts/module.properties
+++ b/buildTestModules/starterArtifacts/module.properties
@@ -5,3 +5,4 @@ Description: Includes all Starter Edition modules as Gradle Module dependencies.
 URL: http://labkey.org
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+ManageVersion: true

--- a/modules/ETLtest/module.properties
+++ b/modules/ETLtest/module.properties
@@ -1,3 +1,4 @@
 Name: ETLtest
 SchemaVersion: 25.000
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/modules/chartingapi/module.properties
+++ b/modules/chartingapi/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.api.module.SimpleModule
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/modules/crawlerTest/module.properties
+++ b/modules/crawlerTest/module.properties
@@ -5,3 +5,4 @@ URL: http://labkey.org
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/modules/dumbster/module.properties
+++ b/modules/dumbster/module.properties
@@ -5,3 +5,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/modules/editableModule/module.properties
+++ b/modules/editableModule/module.properties
@@ -5,3 +5,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/modules/footerTest/module.properties
+++ b/modules/footerTest/module.properties
@@ -4,3 +4,4 @@ URL: https://www.labkey.org
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/modules/linkedschematest/module.properties
+++ b/modules/linkedschematest/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.api.module.SimpleModule
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/modules/miniassay/module.properties
+++ b/modules/miniassay/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.api.module.SimpleModule
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/modules/pipelinetest/module.properties
+++ b/modules/pipelinetest/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.api.module.SimpleModule
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/modules/pipelinetest2/module.properties
+++ b/modules/pipelinetest2/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.api.module.SimpleModule
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/modules/restrictedModule/module.properties
+++ b/modules/restrictedModule/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.api.module.SimpleModule
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/modules/scriptpad/module.properties
+++ b/modules/scriptpad/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.api.module.SimpleModule
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/modules/simpletest/module.properties
+++ b/modules/simpletest/module.properties
@@ -1,3 +1,4 @@
 Name: simpletest
 SchemaVersion: 25.000
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/modules/triggerTestModule/module.properties
+++ b/modules/triggerTestModule/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.api.module.SimpleModule
 SupportedDatabases: mssql, pgsql
+ManageVersion: true


### PR DESCRIPTION
#### Rationale
We want every LabKey-managed module to specify the `ManageVersion` property. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47369
