### PR TITLE
Configure pipeline tools directory with `additional.pipeline.tools`

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -83,6 +83,7 @@ import org.labkey.test.util.Log4jUtils;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.PermissionsHelper;
+import org.labkey.test.util.PipelineToolsHelper;
 import org.labkey.test.util.ReadOnlyTest;
 import org.labkey.test.util.SecurityHelper;
 import org.labkey.test.util.SimpleHttpResponse;
@@ -691,6 +692,8 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         }
 
         cleanup(false);
+
+        new PipelineToolsHelper(this).resetPipelineToolsDirectory();
     }
 
     private void enableTroubleshootingStacktraces()

--- a/src/org/labkey/test/util/PipelineToolsHelper.java
+++ b/src/org/labkey/test/util/PipelineToolsHelper.java
@@ -32,10 +32,10 @@ import static java.io.File.pathSeparator;
 public class PipelineToolsHelper
 {
     private final LabKeySiteWrapper _test;
-    private static Set<String> _originalToolsDirs = null;
-    private static Set<String> _currentToolsDirs = null;
     private static final String _defaultToolsDirectory = new File(TestFileUtils.getModulesDir().getParentFile(), "bin").getAbsoluteFile().toString();
     private static final String _extraPipelineTools = TestProperties.getAdditionalPipelineTools();
+    private static Set<String> _originalToolsDirs = null;
+    private static Set<String> _currentToolsDirs = Set.of(_defaultToolsDirectory); // Presume current tools dir is just the default dir
 
     public PipelineToolsHelper(LabKeySiteWrapper test)
     {
@@ -90,7 +90,7 @@ public class PipelineToolsHelper
         Set<String> directoriesToAppend = new LinkedHashSet<>(Arrays.asList(directories));
         directoriesToAppend.remove("");
         directoriesToAppend.remove(null);
-        if (directoriesToAppend.isEmpty() || _currentToolsDirs != null && _currentToolsDirs.containsAll(directoriesToAppend))
+        if (directoriesToAppend.isEmpty() || _currentToolsDirs.containsAll(directoriesToAppend))
         {
             TestLogger.log("No changes needed");
             return;

--- a/src/org/labkey/test/util/PipelineToolsHelper.java
+++ b/src/org/labkey/test/util/PipelineToolsHelper.java
@@ -31,7 +31,7 @@ import static java.io.File.pathSeparator;
 
 public class PipelineToolsHelper
 {
-    private LabKeySiteWrapper _test;
+    private final LabKeySiteWrapper _test;
     private static Set<String> _originalToolsDirs = null;
     private static Set<String> _currentToolsDirs = null;
     private static final String _defaultToolsDirectory = new File(TestFileUtils.getModulesDir().getParentFile(), "bin").getAbsoluteFile().toString();
@@ -125,14 +125,10 @@ public class PipelineToolsHelper
     @LogMethod
     public void resetPipelineToolsDirectory()
     {
-        if (_originalToolsDirs != null)
-        {
-            if (TestProperties.isTestRunningOnTeamCity())
-                setToolsDirToTestDefault();
-            else
-                setPipelineToolsDirectory(pathFromDirs(_originalToolsDirs));
-            _originalToolsDirs = null;
-        }
+        if (TestProperties.isTestRunningOnTeamCity())
+            setToolsDirToTestDefault();
+        else if (_originalToolsDirs != null)
+            setPipelineToolsDirectory(pathFromDirs(_originalToolsDirs));
     }
 
     /**
@@ -143,7 +139,7 @@ public class PipelineToolsHelper
     {
         setPipelineToolsDirectory(getDefaultToolsPath());
         if (TestProperties.isTestRunningOnTeamCity())
-            _originalToolsDirs = null;
+            _originalToolsDirs = _currentToolsDirs; // Don't remove 'additional.pipeline.tools' between tests
     }
 
     private void goToSiteSettings()


### PR DESCRIPTION
#### Rationale
If `additional.pipeline.tools` is configured, the base test should configure the pipeline tools directory.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Configure pipeline tools directory with `additional.pipeline.tools`