### PR TITLE
New helpers encodeUriPath() and decodeUriPath()

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -24,7 +24,6 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
-import org.eclipse.jetty.util.URIUtil;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -51,6 +50,7 @@ import org.labkey.test.pages.user.ShowUsersPage;
 import org.labkey.test.selenium.EphemeralWebElement;
 import org.labkey.test.util.CodeMirrorHelper;
 import org.labkey.test.util.Crawler;
+import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.ExtHelper;
 import org.labkey.test.util.LabKeyExpectedConditions;
@@ -1217,8 +1217,8 @@ public abstract class WebDriverWrapper implements WrapsDriver
         {
             String currentUrl = getDriver().getCurrentUrl();
             String destinationAction = new Crawler.ControllerActionId(destinationUrl).getAction();
-            String currentSansHash = URIUtil.decodePath(currentUrl.split("#", 2)[0]);
-            String destinationSansHash = URIUtil.decodePath(destinationUrl.split("#", 2)[0]);
+            String currentSansHash = EscapeUtil.decodeUriPath(currentUrl.split("#", 2)[0]);
+            String destinationSansHash = EscapeUtil.decodeUriPath(destinationUrl.split("#", 2)[0]);
 
             return !destinationAction.equals(appAction) ||
                     !destinationUrl.contains("#") || // Will always navigate if there is no hash

--- a/src/org/labkey/test/pages/files/WebFilesHtmlViewPage.java
+++ b/src/org/labkey/test/pages/files/WebFilesHtmlViewPage.java
@@ -15,11 +15,11 @@
  */
 package org.labkey.test.pages.files;
 
-import org.eclipse.jetty.util.URIUtil;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.pages.LabKeyPage;
+import org.labkey.test.util.EscapeUtil;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -37,7 +37,7 @@ public class WebFilesHtmlViewPage extends LabKeyPage<WebFilesHtmlViewPage.Elemen
 
     public static WebFilesHtmlViewPage beginAt(WebDriverWrapper driver, String containerPath)
     {
-        driver.beginAt(WebTestHelper.getBaseURL() + "/_webfiles/" + URIUtil.encodePath(containerPath) + "/?listing=html");
+        driver.beginAt(WebTestHelper.getBaseURL() + "/_webfiles/" + EscapeUtil.encodeUriPath(containerPath) + "/?listing=html");
         return new WebFilesHtmlViewPage(driver.getDriver());
     }
 

--- a/src/org/labkey/test/tests/filecontent/FileContentDownloadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentDownloadTest.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.test.tests.filecontent;
 
-import org.eclipse.jetty.util.URIUtil;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -26,6 +25,7 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.FileBrowser;
+import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.FileBrowserHelper;
 import org.labkey.test.util.PortalHelper;
 
@@ -45,7 +45,7 @@ public class FileContentDownloadTest extends BaseWebDriverTest
     @BeforeClass
     public static void doSetup() throws Exception
     {
-        FileContentDownloadTest initTest = (FileContentDownloadTest)getCurrentTest();
+        FileContentDownloadTest initTest = getCurrentTest();
 
         initTest.doSetupSteps();
     }
@@ -186,7 +186,7 @@ public class FileContentDownloadTest extends BaseWebDriverTest
         signOut();
         // Test that renderAs can be observed through a login
         log("Test renderAs through login and ensure that page is rendered inside of server UI");
-        beginAt("files/" + URIUtil.encodePath(getProjectName() + "/@files/" + folderName + "/" + textFile.getName()) + "?renderAs=INLINE");
+        beginAt("files/" + EscapeUtil.encodeUriPath(getProjectName() + "/@files/" + folderName + "/" + textFile.getName()) + "?renderAs=INLINE");
         assertTitleContains("Sign In");
 
         // If this succeeds, then page has been rendered in frame

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -30,7 +30,6 @@ import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.assertj.core.api.Assertions;
-import org.eclipse.jetty.util.URIUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
@@ -607,8 +606,8 @@ public class Crawler
 
             String strippedRelativeURL = stripQueryParams(getRelativeURL());
 
-            // never go to the exactly same URL (minus query params) twice:
-            if (_urlsChecked.contains(URIUtil.decodePath(strippedRelativeURL)))
+            // never go to the exact same URL (minus query params) twice:
+            if (_urlsChecked.contains(EscapeUtil.decodeUriPath(strippedRelativeURL)))
                 return false;
 
             if (getRelativeURL().contains("export=")) //Study report export uses same URL for export. But don't mark visited yet
@@ -969,7 +968,7 @@ public class Crawler
         // Keep track of where crawler has been
         _actionsVisited.add(actionId);
         _urlsChecked.add(stripQueryParams(relativeURL));
-        _urlsChecked.add(URIUtil.decodePath(stripQueryParams(relativeURL)));
+        _urlsChecked.add(EscapeUtil.decodeUriPath(stripQueryParams(relativeURL)));
         URL origin = urlToCheck.getOrigin();
         int depth = urlToCheck.getDepth();
         String originMessage = (origin != null ? "\nOriginating page: " + origin : "") +

--- a/src/org/labkey/test/util/EscapeUtil.java
+++ b/src/org/labkey/test/util/EscapeUtil.java
@@ -74,7 +74,7 @@ public class EscapeUtil
      * Encode a string to be used as a URL query key or value
      * @param s to be encoded
      * @return encoded value or empty string if provided string was `null`
-     * @apiNote Use {@link URIUtil#encodePath(String)} for URL paths
+     * @apiNote Use {@link #encodeUriPath(String)} for URL paths
      */
     public static String encode(String s)
     {
@@ -84,14 +84,36 @@ public class EscapeUtil
     }
 
     /**
+     * Encode a string to be used as a URL path
+     * For now, simply designates to URIUtil. Will replace with an impl that doesn't require Jetty utils.
+     * @param path Path to be encoded
+     * @return encoded value or empty string if provided string was `null`
+     */
+    public static String encodeUriPath(String path)
+    {
+        return URIUtil.encodePath(path);
+    }
+
+    /**
      * Decode a string extracted from a URL query
      * @param s to be decoded
      * @return decoded value or empty string if provided string was `null`
-     * @apiNote Use {@link URIUtil#decodePath(String)} for URL paths
+     * @apiNote Use {@link #decodeUriPath(String)} for URL paths
      */
     public static String decode(String s)
     {
         return null == s ? "" : URLDecoder.decode(s, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Decode a string representing a URL path
+     * For now, simply designates to URIUtil. Will replace with an impl that doesn't require Jetty utils.
+     * @param path path to be decoded
+     * @return decoded value or empty string if the provided string was `null`
+     */
+    public static String decodeUriPath(String path)
+    {
+        return URIUtil.decodePath(path);
     }
 
     public static String fieldKeyEncodePart(String str)

--- a/src/org/labkey/test/util/URLBuilder.java
+++ b/src/org/labkey/test/util/URLBuilder.java
@@ -1,7 +1,6 @@
 package org.labkey.test.util;
 
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.jetty.util.URIUtil;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.test.WebTestHelper;
 
@@ -167,7 +166,7 @@ public class URLBuilder
         if (_containerPath != null) // null is root container; nothing to append.
         {
             url.append("/");
-            url.append(URIUtil.encodePath(_containerPath)
+            url.append(EscapeUtil.encodeUriPath(_containerPath)
                     .replace("+", "%2B")
                     .replace("[", "%5B")
                     .replace("]", "%5D"));

--- a/src/org/labkey/test/util/core/webdav/WebDavUrlFactory.java
+++ b/src/org/labkey/test/util/core/webdav/WebDavUrlFactory.java
@@ -17,7 +17,7 @@ package org.labkey.test.util.core.webdav;
 
 
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.jetty.util.URIUtil;
+import org.labkey.test.util.EscapeUtil;
 
 import static org.labkey.test.util.core.webdav.WebDavUtils.buildBaseWebDavUrl;
 import static org.labkey.test.util.core.webdav.WebDavUtils.buildBaseWebfilesUrl;
@@ -33,12 +33,12 @@ public class WebDavUrlFactory
 
     public String getPath(String relativePath)
     {
-        return baseUrl + URIUtil.encodePath(StringUtils.strip(relativePath, "/"));
+        return baseUrl + EscapeUtil.encodeUriPath(StringUtils.strip(relativePath, "/"));
     }
 
     public String getPath(String relativeParent, String fileName)
     {
-        return getPath(relativeParent) + "/" + URIUtil.encodePath(fileName);
+        return getPath(relativeParent) + "/" + EscapeUtil.encodeUriPath(fileName);
     }
 
     public static WebDavUrlFactory pipelineUrlFactory(String containerPath)

--- a/src/org/labkey/test/util/core/webdav/WebDavUtils.java
+++ b/src/org/labkey/test/util/core/webdav/WebDavUtils.java
@@ -19,9 +19,9 @@ import com.github.sardine.Sardine;
 import com.github.sardine.SardineFactory;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.jetty.util.URIUtil;
 import org.labkey.test.TestProperties;
 import org.labkey.test.WebTestHelper;
+import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.PasswordUtil;
@@ -66,7 +66,7 @@ public class WebDavUtils
     public static String buildBaseWebDavUrl(String containerPath, String webDavDir)
     {
         return WebTestHelper.getBaseURL() + "/_webdav/"
-                + URIUtil.encodePath(StringUtils.strip(containerPath, "/")) + "/"
+                + EscapeUtil.encodeUriPath(StringUtils.strip(containerPath, "/")) + "/"
                 + StringUtils.strip(webDavDir, "/") + "/";
     }
 
@@ -78,7 +78,7 @@ public class WebDavUtils
     public static String buildBaseWebfilesUrl(String containerPath)
     {
         return WebTestHelper.getBaseURL() + "/_webfiles/"
-                + URIUtil.encodePath(StringUtils.strip(containerPath, "/")) + "/";
+                + EscapeUtil.encodeUriPath(StringUtils.strip(containerPath, "/")) + "/";
     }
 
     @LogMethod


### PR DESCRIPTION
#### Rationale
The Jetty utils dependency is used only for encoding and decoding URL paths. We can likely use other existing libraries for these purposes and eliminate this dependency.

Introduce helper methods and route all callers to them. These methods can be updated to test and migrate to new implementations.