### PR TITLE
Handle MultipleFailureException thrown by tests

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -37,6 +37,7 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 import org.junit.runner.Description;
+import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
 import org.junit.runners.model.TestTimedOutException;
 import org.labkey.junit.rules.TestWatcher;
@@ -928,7 +929,17 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         _testFailed = true;
         _anyTestFailed = true;
 
-        error.printStackTrace();
+        if (error instanceof MultipleFailureException mfe)
+        {
+            // Only "handle" primary test failure. Just log failures thrown during @After or @AfterClass methods.
+            error = mfe.getFailures().get(0);
+            for (int i = 1; i < mfe.getFailures().size(); i++)
+            {
+                TestLogger.error("Secondary error after test:", mfe.getFailures().get(i));
+            }
+        }
+
+        TestLogger.error("Primary test failure:", error);
 
         if (Thread.interrupted() || wasCausedBy(error, Arrays.asList(TestTimedOutException.class, InterruptedException.class)))
         {
@@ -1042,24 +1053,16 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
             try
             {
-                boolean inIFrame = Locator.css(":root").findElement(getDriver()).getSize().getHeight() > 0;
-                if (inIFrame)
+                try
                 {
-                    // TODO: Need a better way to detect when we are in an iFrame. Above method is not reliable
-                    //if (isFirefox()) // As of 2.45, Chromedriver screenshots are not restricted to currently focused iFrame
-                    //{
-                    //    getArtifactCollector().dumpPageSnapshot(testName + "-iframe", null, false); // Snapshot of iFrame
-                    //}
-                    try
-                    {
-                        // Switch to default content just in case we're in an iFrame
-                        getDriver().switchTo().defaultContent();
-                    }
-                    catch (UnhandledAlertException alert)
-                    {
-                        TestLogger.warn("Alert was triggered by iframe: " + WebDriverUtils.getUnhandledAlertText(alert, getDriver()));
-                    }
+                    // Switch to default content just in case we're in an iFrame
+                    getDriver().switchTo().defaultContent();
                 }
+                catch (UnhandledAlertException alert)
+                {
+                    TestLogger.warn("Alert was triggered by iframe: " + WebDriverUtils.getUnhandledAlertText(alert, getDriver()));
+                }
+
                 // Don't take screenshots if error was deferred and any screenshots were taken
                 if (!(error instanceof DeferredErrorCollector.DeferredAssertionError))
                 {


### PR DESCRIPTION
#### Rationale
Sometimes test use `@After` or `@AfterClass` annotations against our recommendation. If a test fails and the after method also throws an exception, JUnit combines the errors into a `MultipleFailureException`. This can mask the actual error, making `BaseWebDriverTest.handleFailure` unable to perform its duties (e.g. close alerts). We mostly care about the primary test failure so we can just pull that out of the `MultipleFailureException`.

#### Related Pull Requests
- N/A

#### Changes
- Handle `MultipleFailureException` thrown by tests
