### PR TITLE
Stress test framework improvements

### DIFF
--- a/src/org/labkey/test/WebTestHelper.java
+++ b/src/org/labkey/test/WebTestHelper.java
@@ -42,12 +42,14 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
+import org.junit.Assert;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.query.DeleteRowsCommand;
 import org.labkey.remoteapi.query.Filter;
+import org.labkey.remoteapi.query.SaveRowsResponse;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.serverapi.reader.Readers;
 import org.labkey.test.util.InstallCert;
@@ -82,10 +84,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -113,6 +117,7 @@ public class WebTestHelper
     private static final Map<String, Map<String, Cookie>> savedCookies = new HashMap<>();
     private static final Map<String, String> savedSessionKeys = new HashMap<>();
     private static final Map<String, String> savedApiKeys = new HashMap<>();
+    private static final Set<String> deletedApiKeys = new HashSet<>();
 
     static { TestProperties.load(); }
 
@@ -195,8 +200,10 @@ public class WebTestHelper
                 {
                     DeleteRowsCommand deleteRowsCommand = new DeleteRowsCommand("core", "apiKeys");
                     deleteRowsCommand.setRows(rows);
-                    deleteRowsCommand.execute(connection, null);
+                    SaveRowsResponse response = deleteRowsCommand.execute(connection, null);
                     savedApiKeys.remove(apiKey);
+                    deletedApiKeys.add(apiKey);
+                    Assert.assertEquals("Wrong number of rows affected by apiKey deletion", 1, response.getRowsAffected());
                 }
                 else
                 {
@@ -210,7 +217,14 @@ public class WebTestHelper
         }
         else
         {
-            TestLogger.warn("Refusing to delete an API key not created by this test");
+            if (deletedApiKeys.contains(apiKey))
+            {
+                TestLogger.warn("API key already deleted");
+            }
+            else
+            {
+                TestLogger.warn("Refusing to delete an API key not created by 'WebTestHelper.createApiKey'");
+            }
         }
     }
 

--- a/src/org/labkey/test/components/ui/grids/GridFilterModal.java
+++ b/src/org/labkey/test/components/ui/grids/GridFilterModal.java
@@ -89,6 +89,12 @@ public class GridFilterModal extends ModalDialog
         return elementCache().filterExpressionPanel();
     }
 
+    public GridFilterModal setFilter(FilterExpressionPanel.Expression expression)
+    {
+        selectExpressionTab().setFilter(expression);
+        return this;
+    }
+
     /**
      * Select the facet tab for the current field. Will throw <code>NoSuchElementException</code> if tab isn't present.
      * @return panel for configuring faceted filter

--- a/src/org/labkey/test/components/ui/search/SampleFinder.java
+++ b/src/org/labkey/test/components/ui/search/SampleFinder.java
@@ -27,6 +27,8 @@ import java.util.stream.Collectors;
  */
 public class SampleFinder extends WebDriverComponent<SampleFinder.ElementCache>
 {
+    public static final String ALL_SAMPLE_TYPES = "All Sample Types";
+
     private final WebElement _el;
     private final WebDriver _driver;
 

--- a/src/org/labkey/test/stress/ActivityRecorder.java
+++ b/src/org/labkey/test/stress/ActivityRecorder.java
@@ -1,0 +1,49 @@
+package org.labkey.test.stress;
+
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.miniprofiler.RequestInfo;
+import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.LoggedParam;
+import org.labkey.test.util.TestLogger;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class ActivityRecorder
+{
+    private final RecentRequestsCollector recentRequestsCollector;
+
+    public ActivityRecorder(Connection connection) throws IOException, CommandException
+    {
+        recentRequestsCollector = new RecentRequestsCollector(connection);
+    }
+
+    @LogMethod
+    public <R> R recordActivity(@LoggedParam String description, Supplier<R> activity) throws IOException, CommandException
+    {
+        R result = activity.get();
+
+        List<RequestInfo> recentRequests = recentRequestsCollector.getRecentRequests();
+        TestLogger.log("%s triggered %s requests".formatted(description, recentRequests.size()));
+
+        return result;
+    }
+
+    public void recordActivity(String description, Runnable activity) throws IOException, CommandException
+    {
+        recordActivity(description, () -> {
+            activity.run();
+            return null;
+        });
+    }
+
+    public List<RequestInfo> skipRecentRequests() throws IOException, CommandException
+    {
+        List<RequestInfo> recentRequests = recentRequestsCollector.getRecentRequests();
+        TestLogger.log("Skipping %s requests".formatted(recentRequests.size()));
+
+        return recentRequests;
+    }
+}

--- a/src/org/labkey/test/stress/HarConverter.java
+++ b/src/org/labkey/test/stress/HarConverter.java
@@ -73,7 +73,7 @@ import java.util.regex.Pattern;
 public class HarConverter
 {
     private static final Logger LOG = LogManager.getLogger(HarConverter.class);
-    private static final Set<ControllerActionId> excludedActions = Set.of(new ControllerActionId("login", "whoami"));
+    public static final Set<ControllerActionId> EXCLUDED_ACTIONS = Set.of(new ControllerActionId("login", "whoami"));
 
     private final String inputParam;
 
@@ -213,7 +213,7 @@ public class HarConverter
         try
         {
             ControllerActionId actionId = new ControllerActionId(url);
-            if (excludedActions.contains(actionId) || StringUtils.isBlank(actionId.getAction()) || "app".equals(actionId.getAction()))
+            if (EXCLUDED_ACTIONS.contains(actionId) || StringUtils.isBlank(actionId.getAction()) || "app".equals(actionId.getAction()))
             {
                 LOG.info("Skipping request: " + url);
                 return false;

--- a/src/org/labkey/test/stress/RecentRequestsCollector.java
+++ b/src/org/labkey/test/stress/RecentRequestsCollector.java
@@ -1,0 +1,29 @@
+package org.labkey.test.stress;
+
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.miniprofiler.RecentRequestsCommand;
+import org.labkey.remoteapi.miniprofiler.RequestInfo;
+import org.labkey.test.util.Crawler;
+
+import java.io.IOException;
+import java.util.List;
+
+public class RecentRequestsCollector
+{
+    private final Connection _connection;
+    private long lastRequestId = 0L;
+
+    public RecentRequestsCollector(Connection connection) throws IOException, CommandException
+    {
+        _connection = connection;
+        getRecentRequests(); // Prime 'lastRequestId'
+    }
+
+    public List<RequestInfo> getRecentRequests() throws IOException, CommandException
+    {
+        List<RequestInfo> requestInfos = new RecentRequestsCommand(lastRequestId).execute(_connection, null).getRequestInfos();
+        lastRequestId = requestInfos.get(requestInfos.size() - 1).getId();
+        return requestInfos.stream().filter(requestInfo -> HarConverter.EXCLUDED_ACTIONS.contains(new Crawler.ControllerActionId(requestInfo.getUrl()))).toList();
+    }
+}

--- a/src/org/labkey/test/stress/Simulation.java
+++ b/src/org/labkey/test/stress/Simulation.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -35,7 +36,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Simulation: A series of activities that represents some user workflow (e.g. loading the dashboard, navigating to the sample finder, and performing a search). For simplicity, API simulations in the initial proof of concept will consist of a single activity.
@@ -230,7 +230,10 @@ public class Simulation<T>
      *         {@link #_connectionFactory} - used to generate an API connection for the simulation to use
      *     </li>
      *     <li>
-     *         {@link #activityDefinitions} - {@link Activity} list that defines the simulation. These are deserialized from {@link ApiTestsDocument} XML files.
+     *         {@link #activityFiles} - {@link ApiTestsDocument} XML files that define the simulation. Used to generate {@link Activity} definitions.
+     *     </li>
+     *     <li>
+     *         {@link #replacements} - String replacements to inject into activity definitions. e.g. 'CONTAINER' or 'USERID'
      *     </li>
      *     <li>
      *         {@link #maxActivityThreads} - the size of thread pool to use for requests
@@ -248,7 +251,8 @@ public class Simulation<T>
     {
         private final Supplier<Connection> _connectionFactory;
 
-        private List<Activity> activityDefinitions = Collections.emptyList();
+        private List<File> activityFiles = new ArrayList<>();
+        private Map<String, String> replacements = Collections.emptyMap();
         private int maxActivityThreads = 6; // This seems to be the number of parallel requests browsers handle
         private int delayBetweenActivities = 5_000;
         private boolean runOnce = false;
@@ -287,15 +291,13 @@ public class Simulation<T>
 
         public Definition setActivityFiles(File... activityFiles)
         {
-            return setActivityFilesWithReplacements(
-                    Arrays.stream(activityFiles).collect(Collectors.toMap(f -> f, f -> Collections.emptyMap())));
+            this.activityFiles = Arrays.asList(activityFiles);
+            return this;
         }
 
-        public Definition setActivityFilesWithReplacements(Map<File, Map<String, String>> activityFilesWithReplacements)
+        public Definition setReplacements(Map<String, String> replacements)
         {
-            activityDefinitions = activityFilesWithReplacements.entrySet().stream()
-                    .map(entry -> new Activity(entry.getKey().getName(), Definition.parseTests(entry.getKey(), entry.getValue())))
-                    .toList();
+            this.replacements = new HashMap<>(replacements);
             return this;
         }
 
@@ -303,6 +305,17 @@ public class Simulation<T>
         {
             this.runOnce = runOnce;
             return this;
+        }
+
+        private List<Activity> buildActivityDefinitions()
+        {
+            if (activityFiles.isEmpty())
+            {
+                throw new IllegalArgumentException("No activity files specified");
+            }
+            return activityFiles.stream()
+                .map(file -> new Activity(file.getName(), Definition.parseTests(file, replacements)))
+                .toList();
         }
 
         /**
@@ -316,7 +329,7 @@ public class Simulation<T>
             Connection connection = _connectionFactory.get();
             // Prime connection before starting simulation to ensure credentials are good
             new WhoAmICommand().execute(connection, null);
-            return new Simulation<>(connection, activityDefinitions, delayBetweenActivities, maxActivityThreads, resultCollectorFactory.apply(connection), runOnce);
+            return new Simulation<>(connection, buildActivityDefinitions(), delayBetweenActivities, maxActivityThreads, resultCollectorFactory.apply(connection), runOnce);
         }
 
         public Simulation<RequestResult> startSimulation() throws IOException, CommandException

--- a/src/org/labkey/test/util/APIAssayHelper.java
+++ b/src/org/labkey/test/util/APIAssayHelper.java
@@ -251,6 +251,34 @@ public class APIAssayHelper extends AbstractAssayHelper
         return resultData;
     }
 
+    /**
+     * For a given container get rowIds for all assay protocols.
+     *
+     * @param containerPath Container path.
+     * @param connection remoteApi connection
+     * @return Map of assay rowIds by protocol name and assay type
+     * @throws IOException Can be thrown by the SelectRowsCommand.
+     * @throws CommandException Can be thrown by the SelectRowsCommand.
+     */
+    public static Map<String, Integer> getProtocolIds(String containerPath, Connection connection) throws IOException, CommandException
+    {
+        SelectRowsCommand cmd = new SelectRowsCommand("assay", "AssayList");
+        cmd.setColumns(Arrays.asList("Name", "Type", "RowId"));
+
+        Map<String, Integer> resultData = new HashMap<>();
+
+        SelectRowsResponse response = cmd.execute(connection, containerPath);
+        for(Row row : response.getRowset())
+        {
+            String type = (String) row.getValue("Type");
+            String name = (String) row.getValue("Name");
+            Integer rowId = (Integer) row.getValue("RowId");
+            resultData.put(type + "." + name, rowId);
+        }
+
+        return resultData;
+    }
+
     public void saveBatch(String assayName, String runName, Map<String, Object> runProperties, List<Map<String, Object>> resultRows, String projectName) throws IOException, CommandException
     {
         int assayId = getIdFromAssayName(assayName, projectName);

--- a/src/org/labkey/test/util/perf/JsonPerfScenarioHelper.java
+++ b/src/org/labkey/test/util/perf/JsonPerfScenarioHelper.java
@@ -1,7 +1,13 @@
 package org.labkey.test.util.perf;
 
+import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.PostCommand;
+import org.labkey.remoteapi.ResponseObject;
+import org.labkey.remoteapi.assay.ImportRunCommand;
+import org.labkey.remoteapi.assay.ImportRunResponse;
 import org.labkey.remoteapi.miniprofiler.RequestInfo;
 import org.labkey.remoteapi.query.ImportDataCommand;
 import org.labkey.remoteapi.query.ImportDataResponse;
@@ -9,6 +15,7 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.params.perf.PerfScenario;
 import org.labkey.test.stress.AbstractScenario;
 import org.labkey.test.stress.RequestInfoTsvWriter;
+import org.labkey.test.util.APIAssayHelper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.TestDateUtils;
 import org.labkey.test.util.TestLogger;
@@ -35,14 +42,16 @@ public class JsonPerfScenarioHelper
     private final String containerPath;
     private final Connection connection;
     private final Function<String, File> perfDataFileSupplier;
+    private final Map<String, Integer> assayIds;
     private Function<Result, Result> resultHandler = Function.identity();
     private int importThreads = 3;
 
-    public JsonPerfScenarioHelper(String containerPath, Connection connection, File perfDataDir)
+    public JsonPerfScenarioHelper(String containerPath, Connection connection, File perfDataDir) throws IOException, CommandException
     {
         this.containerPath = containerPath;
         this.connection = connection;
         this.perfDataFileSupplier = perfDataDir == null ? TestFileUtils::getSampleData : name -> new File(perfDataDir, name);
+        this.assayIds = APIAssayHelper.getProtocolIds(containerPath, connection);
     }
 
     public JsonPerfScenarioHelper setResultHandler(Function<Result, Result> resultHandler)
@@ -72,7 +81,10 @@ public class JsonPerfScenarioHelper
                 expectedDuration += perfScenario.getAverage();
             }
             importExecutor.shutdown();
-            importExecutor.awaitTermination(expectedDuration, TimeUnit.MILLISECONDS);
+            if (!importExecutor.awaitTermination(expectedDuration, TimeUnit.MILLISECONDS))
+            {
+                TestLogger.warn("Import timed out");
+            }
             Map<String, Result> results = new LinkedHashMap<>();
             for (Map.Entry<String, Future<Result>> entry : futures.entrySet())
             {
@@ -92,18 +104,39 @@ public class JsonPerfScenarioHelper
         String schemaName = SCHEMA_NAMES.get(perfScenario.getType());
         if (schemaName == null)
         {
-            return null; // unsupported type
+            throw new IllegalArgumentException("Unsupported scenario type '%s' in '%s'".formatted(perfScenario.getType(), perfScenario.getName()));
         }
-        ImportDataCommand command = new ImportDataCommand(schemaName, perfScenario.getTypeName());
-        command.setFile(perfDataFileSupplier.apply(perfScenario.getFileName()));
+
+        PostCommand<?> command;
+        if (schemaName.startsWith("assay."))
+        {
+            String key = schemaName.split("\\.", 2)[1] + "." + perfScenario.getTypeName();
+            Integer assayId = assayIds.get(key);
+            if (assayId == null)
+            {
+                throw new IllegalArgumentException("'%s' not defined in '%s'. Found %s".formatted(key, containerPath, assayIds.keySet()));
+            }
+            command = new ImportRunCommand(assayId, perfDataFileSupplier.apply(perfScenario.getFileName()));
+        }
+        else
+        {
+            ImportDataCommand importDataCommand = new ImportDataCommand(schemaName, perfScenario.getTypeName());
+            importDataCommand.setFile(perfDataFileSupplier.apply(perfScenario.getFileName()));
+            importDataCommand.setInsertOption(ImportDataCommand.InsertOption.MERGE);
+
+            command = importDataCommand;
+        }
+
         command.setTimeout(Math.max(connection.getTimeout(), perfScenario.getAverage() * importThreads) * 2);
-        command.setInsertOption(ImportDataCommand.InsertOption.MERGE);
         Timer timer = new Timer();
         String msgSuffix = "";
         try
         {
-            ImportDataResponse response = command.execute(connection, containerPath);
-            msgSuffix = "Imported %d rows".formatted(response.getRowCount());
+            CommandResponse response = command.execute(connection, containerPath);
+            if (response instanceof ImportDataResponse idr)
+            {
+                msgSuffix = "Imported %d rows".formatted(idr.getRowCount());
+            }
             return new Result(perfScenario, response.getStatusCode(), timer);
         }
         catch (IOException e)


### PR DESCRIPTION
#### Rationale
Adding functionality to stress test framework in support of Sample Finder stress test.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1088

#### Changes
- Add assay import suport to `JsonPerfScenarioHelper`
- `RecentRequestsCollector`: collects incremental batches of recent requests
- `ActivityRecorder`: collects request summary of selenium activities
