### PR TITLE
Wait for groups grid to load on permissions page

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -494,19 +494,53 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
     @Deprecated
     public void ensureAdminMode()
     {
+        boolean didSomething = false;
         if (!onLabKeyPage())
+        {
             goToHome();
+            didSomething = true;
+        }
         if (!isSignedIn())
+        {
             simpleSignIn();
+            didSomething = true;
+        }
         else if (!isUserSystemAdmin() && isImpersonating())
+        {
             stopImpersonating(false);
+            didSomething = true;
+        }
         Locator projectMenu = ProjectMenu.Locators.menuProjectNav;
         if (!isElementPresent(projectMenu))
         {
             goToHome();
             waitForElement(projectMenu, WAIT_FOR_PAGE);
+            didSomething = true;
         }
         assertTrue("Test user '" + getCurrentUser() + "' is not an admin", isUserAdmin());
+
+        StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+        StringBuilder relevantCalls = new StringBuilder();
+        for (int i = 1; i < stackTrace.length; i++)
+        {
+            if (stackTrace[i].getClassName().contains("labkey"))
+            {
+                relevantCalls.append("\n");
+                relevantCalls.append(stackTrace[i].toString());
+            }
+            else
+            {
+                break;
+            }
+        }
+        if (didSomething)
+        {
+            TestLogger.warn("Necessary call to 'ensureAdminMode'. Consider refactoring to make it unnecessary." + relevantCalls);
+        }
+        else
+        {
+            TestLogger.warn("Unnecessary call to 'ensureAdminMode'. Consider removing it." + relevantCalls);
+        }
     }
 
     public ShowAdminPage goToAdminConsole()

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -936,6 +936,8 @@ public abstract class WebDriverWrapper implements WrapsDriver
     {
         if (!isElementPresent(tag("a").withClass("x4-tab-active").withText("Site Groups")))
             clickAdminMenuItem("Site", "Site Groups");
+        // Wait for groups grid
+        shortWait().until(ExpectedConditions.visibilityOfElementLocated(Locator.tagWithClass("div", "pSite").withText("Guests")));
     }
 
     public void goToSitePermissions()

--- a/src/org/labkey/test/tests/GroupTest.java
+++ b/src/org/labkey/test/tests/GroupTest.java
@@ -307,7 +307,6 @@ public class GroupTest extends BaseWebDriverTest
     {
         String projectName = getProject2Name();
 
-        ensureAdminMode();
         navBar()
                 .goToCreateProjectPage()
                 .setProjectName(projectName)

--- a/src/org/labkey/test/util/UIPermissionsHelper.java
+++ b/src/org/labkey/test/util/UIPermissionsHelper.java
@@ -99,8 +99,7 @@ public class UIPermissionsHelper extends PermissionsHelper
     public Integer createPermissionsGroup(String groupName)
     {
         _driver.log("Creating permissions group " + groupName);
-        enterPermissionsUI();
-        _driver._ext4Helper.clickTabContainingText("Project Groups");
+        goToProjectGroups();
         _driver.setFormElement(Locator.xpath("//input[contains(@name, 'projectgroupsname')]"), groupName);
         _driver.clickButton("Create New Group", 0);
         _driver._extHelper.waitForExtDialog(groupName + " Information");
@@ -108,6 +107,13 @@ public class UIPermissionsHelper extends PermissionsHelper
         _driver.click(Ext4Helper.Locators.ext4Button("Done"));
         WebElement addedGroup = _driver.waitForElement(Locator.css(".groupPicker .x4-grid-cell-inner div").withText(groupName), BaseWebDriverTest.WAIT_FOR_JAVASCRIPT);
         return Integer.parseInt(addedGroup.getAttribute("groupId"));
+    }
+
+    private void goToProjectGroups()
+    {
+        enterPermissionsUI();
+        _driver._ext4Helper.clickTabContainingText("Project Groups");
+        _driver.shortWait().until(ExpectedConditions.visibilityOfElementLocated(Locator.tagWithClass("div", "pGroup").withText("Guests")));
     }
 
     @Override
@@ -349,8 +355,7 @@ public class UIPermissionsHelper extends PermissionsHelper
     {
         _driver.ensureAdminMode();
         _driver.clickProject(projectName);
-        enterPermissionsUI();
-        _driver._ext4Helper.clickTabContainingText("Project Groups");
+        goToProjectGroups();
         _driver.waitForText("Member Groups");
         List<Ext4CmpRef> refs = _driver._ext4Helper.componentQuery("grid", Ext4CmpRef.class);
         Ext4CmpRef ref = refs.get(0);
@@ -364,8 +369,7 @@ public class UIPermissionsHelper extends PermissionsHelper
     {
         _driver.ensureAdminMode();
         _driver.clickProject(projectName);
-        enterPermissionsUI();
-        _driver._ext4Helper.clickTabContainingText("Project Groups");
+        goToProjectGroups();
         _driver.waitForElement(Locator.css(".groupPicker"), BaseWebDriverTest.WAIT_FOR_JAVASCRIPT);
         _driver.waitAndClick(Locator.xpath("//div[text()='" + groupName + "']"));
         _driver._extHelper.waitForExtDialog(groupName + " Information");
@@ -400,7 +404,7 @@ public class UIPermissionsHelper extends PermissionsHelper
 
     public void openGroupPermissionsDisplay(String groupName)
     {
-        _driver._ext4Helper.clickTabContainingText("Project Groups");
+        goToProjectGroups();
         // warning Administrators can appear multiple times
         List<Ext4CmpRef> refs = _driver._ext4Helper.componentQuery("grid", Ext4CmpRef.class);
         Ext4CmpRef ref = refs.get(0);

--- a/src/org/labkey/test/util/UIPermissionsHelper.java
+++ b/src/org/labkey/test/util/UIPermissionsHelper.java
@@ -113,7 +113,7 @@ public class UIPermissionsHelper extends PermissionsHelper
     {
         enterPermissionsUI();
         _driver._ext4Helper.clickTabContainingText("Project Groups");
-        _driver.shortWait().until(ExpectedConditions.visibilityOfElementLocated(Locator.tagWithClass("div", "pGroup").withText("Guests")));
+        _driver.shortWait().until(ExpectedConditions.visibilityOfElementLocated(Locator.tagWithClass("div", "pGroup").withText("Users")));
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
If a test doesn't wait for the groups grid to load, it can cause a JavaScript error by creating a group too quickly.
```
TypeError: this.user is null
  initComponent (http://localhost:8111/Security/window/UserInfoPopup.js:20:43)
  [...]
  showPopup (http://localhost:8111/Security/panel/PermissionEditor.js:230:26)
  success (http://localhost:8111/Security/util/SecurityCache.js:349:30)
  responseTransformer.call (webpack://@labkey/api/src/labkey/Utils.ts:484:15)
  callback (webpack://@labkey/api/src/labkey/Ajax.ts:130:11)
  onreadystatechange (webpack://@labkey/api/src/labkey/Ajax.ts:322:12)
```

#### Related Pull Requests
- N/A

#### Changes
- Wait for grid to load on "Site Groups" page
- Wait for grid to load on "Project Groups" page
- Add some logging to help track down usages of deprecated `enterAdminMode`
