### PR TITLE
Test fixes after fixes merged from 24.11 for special characters in field names

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
@@ -386,8 +386,11 @@ public class EntityBulkInsertDialog extends ModalDialog
             return new Input(inputEl, getDriver());
         }
 
-        public ReactDateTimePicker dateInput(String fieldName, String fieldKey)
+        public ReactDateTimePicker dateInput(String fieldName, @Nullable String fieldKey)
         {
+            if (fieldKey == null)
+                fieldKey = fieldName;
+
             return new ReactDateTimePicker.ReactDateTimeInputFinder(getDriver())
                     .withInputId(fieldKey).find(formRow(fieldName));
         }

--- a/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
@@ -1,5 +1,6 @@
 package org.labkey.test.components.ui.entities;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
@@ -221,20 +222,24 @@ public class EntityBulkInsertDialog extends ModalDialog
      * object to use the picker to set the field. If a text value is passed in it is used as a literal and jut typed
      * into the textbox.
      *
-     * @param fieldKey Field to update.
+     * @param fieldName Field to update.
      * @param dateTime A LocalDateTime, LocalDate, LocalTime or String.
      * @return A reference to this page.
      */
-    public EntityBulkInsertDialog setDateTimeField(String fieldKey, Object dateTime)
+    public EntityBulkInsertDialog setDateTimeField(String fieldName, Object dateTime)
     {
-        ReactDateTimePicker dateTimePicker = elementCache().dateInput(fieldKey);
+        return setDateTimeField(fieldName, dateTime, null);
+    }
+    public EntityBulkInsertDialog setDateTimeField(String fieldName, Object dateTime, @Nullable String fieldKey)
+    {
+        ReactDateTimePicker dateTimePicker = elementCache().dateInput(fieldName, fieldKey);
         dateTimePicker.select(dateTime);
         return this;
     }
 
-    public String getDateTimeField(String fieldKey)
+    public String getDateTimeField(String fieldName, @Nullable String fieldKey)
     {
-        return elementCache().dateInput(fieldKey).get();
+        return elementCache().dateInput(fieldName, fieldKey).get();
     }
 
     public EntityBulkInsertDialog setBooleanField(String fieldKey, boolean checked)
@@ -381,10 +386,10 @@ public class EntityBulkInsertDialog extends ModalDialog
             return new Input(inputEl, getDriver());
         }
 
-        public ReactDateTimePicker dateInput(String fieldKey)
+        public ReactDateTimePicker dateInput(String fieldName, String fieldKey)
         {
             return new ReactDateTimePicker.ReactDateTimeInputFinder(getDriver())
-                    .withInputId(fieldKey).find(formRow(fieldKey));
+                    .withInputId(fieldKey).find(formRow(fieldName));
         }
 
         public List<WebElement> fieldNames()

--- a/src/org/labkey/test/components/ui/grids/FieldSelectionDialog.java
+++ b/src/org/labkey/test/components/ui/grids/FieldSelectionDialog.java
@@ -163,9 +163,7 @@ public class FieldSelectionDialog extends ModalDialog
 
         while(iterator.hasNext())
         {
-            String field = iterator.next().trim();
-            String fieldEncoded = field.contains("$D") ? field : EscapeUtil.fieldKeyEncodePart(field);
-            fieldKey.append(fieldEncoded);
+            fieldKey.append(iterator.next().trim());
 
             // If this isn't the last item in the collection keep expanding and building the expected data-fieldkey value.
             if(iterator.hasNext())


### PR DESCRIPTION
#### Rationale
The fixes in 24.11 for handling special characters in field names included some test fixes as well. This PR makes similar adjustments to tests that we made in 24.11 but for test cases that were added in 25.1.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2251
- https://github.com/LabKey/limsModules/pull/1112

#### Changes
- EntityBulkInsertDialog.setDateTimeField to add optional param for passing encoded fieldKey
- FieldSelectionDialog.expandAvailableFields update to remove double encoding of field names
