### PR TITLE
Add tests for escaped characters in markdown

### DIFF
--- a/src/org/labkey/test/tests/MessagesLongTest.java
+++ b/src/org/labkey/test/tests/MessagesLongTest.java
@@ -74,8 +74,11 @@ public class MessagesLongTest extends BaseWebDriverTest
     private static final String USER3 = "messageslong_user3@messages.test";
     private static final String NOT_A_USER = "Squirrel";
     private static final String RESPONDER = "responder@messages.test";
+    private static final String MACRO_WEBPART = "${labkey.webPart(partName='Lists')}";
     private static final String HTML_BODY = "1 <b>x</b>\n" +
-            "<b>${labkey.webPart(partName='Lists')}</b>\n";
+            "<b>" +
+            MACRO_WEBPART +
+            "</b>\n";
     private static final String HTML_BODY_WEBPART_TEST = "manage lists";
     private static final String MEMBER_LIST = "memberListInput";
     private static final String TEMPLATE_TEXT = "***Please do not reply to this email notification. Replies to this email are routed to an unmonitored mailbox. Instead, please use the link below.***";
@@ -224,15 +227,19 @@ public class MessagesLongTest extends BaseWebDriverTest
         InsertPage markdownPage = new InsertPage(getDriver());
         assertEquals("default selection should be 'Markdown'",markdownPage.getRenderAs(), WikiHelper.WikiRendererType.MARKDOWN);
         markdownPage.setTitle("Markdown is a thing now")
-                .setBody("# Holy Header, Batman!\n" +
-                        "**bold as bold can possibly be**\n" +
-                        "\n" +
-                        "```var foo = bar.fooValue;```\n" +
-                        "\n" +
-                        "## List of things I don't like \n" +
-                        "+ hair clogs\n" +
-                        "+ stinky feet\n" +
-                        "+ internet trolls");
+                .setBody("""
+                        # Holy Header, Batman!
+                        **bold as bold can possibly be**
+
+                        ```var foo = bar.fooValue;```
+
+                        ## List of things I don't like\s
+                        + hair clogs
+                        + stinky feet
+                        + internet trolls
+
+                        <b>escaped</b>""" +
+                        "\n" + MACRO_WEBPART);
 
         // now look at the preview pane
         markdownPage.selectPreviewTab();
@@ -240,6 +247,9 @@ public class MessagesLongTest extends BaseWebDriverTest
         assertElementPresent(Locator.tagWithText("li", "hair clogs"));
         assertElementPresent(Locator.tagWithText("li", "stinky feet"));
         assertElementPresent(Locator.tagWithText("li", "internet trolls"));
+        assertElementPresent(Locator.tagWithText("p", "<b>escaped</b>"));
+        assertElementPresent(PortalHelper.Locators.webPart("Lists"));
+        assertElementPresent(Locator.linkWithText("manage lists"));
         clickButton("Submit");
         assertElementPresent(Locator.tagWithText("h1", "Holy Header, Batman!"));
         assertElementPresent(Locator.tagWithText("strong", "bold as bold can possibly be"));

--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -25,6 +25,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Wiki;
+import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.WikiHelper;
 import org.openqa.selenium.WebElement;
@@ -121,6 +122,10 @@ public class WikiLongTest extends BaseWebDriverTest
                     # Title MD
                     ## Subtitle MD
                     *italic text MD*
+
+                    <b>escaped</b>
+                    
+                    ${labkey.webPart(partName='Query', title='WebPart Macro', schemaName='core', queryName='containers', allowChooseQuery='true', allowChooseView='true')}
                     """;
 
     private static final String SAFE_LINK_HTML = "<a href=\"http://labkey.com\">Safe link</a>";
@@ -222,13 +227,18 @@ public class WikiLongTest extends BaseWebDriverTest
         _wikiHelper.setWikiBody(WIKI_PAGE7_CONTENT);
         _wikiHelper.saveWikiPage();
         // verify that after saving the markdown that it is rendered as html that does not include the markdown symbols
-        assertTextPresent("Title MD");
+        assertElementPresent(Locator.tagWithText("h1", "Title MD"));
+        assertElementPresent(Locator.tagWithText("p", "<b>escaped</b>"));
+        assertElementPresent(PortalHelper.Locators.webPart("WebPart Macro"));
+        assertElementPresent(DataRegionTable.Locators.dataRegionTable().descendant(Locator.linkWithText(getProjectName())));
         assertTextNotPresent("# Title MD");
         clickAndWait(Locator.linkWithText("Edit"));
         _wikiHelper.convertWikiFormat("HTML");
         // verify that after converting the markdown to html that it is rendered as html that does not include the markdown symbols
         _wikiHelper.saveWikiPage();
-        assertTextPresent("Title MD");
+        assertElementPresent(Locator.tagWithText("h1", "Title MD"));
+        assertElementPresent(Locator.tagWithText("p", "<b>escaped</b>"));
+        // Webpart macro
         assertTextNotPresent("# Title MD");
         searchFor(PROJECT_NAME, "italic text MD", 1, WIKI_PAGE7_TITLE);
 


### PR DESCRIPTION
#### Rationale
Add coverage for the new markdown renderer.
The behavior should match 24.11 so I'm introducing the tests here.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6245

#### Changes
- Add tests for escaped characters in markdown
