### PR TITLE
Add test property to set the browser time zone

### DIFF
--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -172,7 +172,7 @@ public abstract class TestProperties
         String tz = StringUtils.trimToNull(System.getProperty("webtest.browser.tz"));
         if (tz != null)
         {
-            String[] split = tz.split("[, ]+");
+            String[] split = tz.split("[,\\s]+");
             tz = split[DAY_OF_MONTH % split.length];
             // Verify that time zone is valid
             ZoneId zoneId = ZoneId.of(tz);

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -162,6 +162,11 @@ public abstract class TestProperties
         return getBooleanProperty("webtest.dump.browser.console", false);
     }
 
+    public static String getBrowserTimeZone()
+    {
+        return System.getProperty("webtest.browser.tz");
+    }
+
     public static double getTimeoutMultiplier()
     {
         return Math.max(0, getDoubleProperty("webtest.timeout.multiplier", 1.0));

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -74,6 +74,7 @@ public abstract class TestProperties
 
     // Initialize once so that value doesn't change if suite runs through midnight
     private static final int DAY_OF_MONTH = LocalDateTime.now().getDayOfMonth();
+    private static ZoneId browserTimeZone = null;
 
     public static void load()
     {
@@ -167,18 +168,24 @@ public abstract class TestProperties
         return getBooleanProperty("webtest.dump.browser.console", false);
     }
 
-    public static String getBrowserTimeZone()
+    public static ZoneId getBrowserTimeZone()
     {
-        String tz = StringUtils.trimToNull(System.getProperty("webtest.browser.tz"));
-        if (tz != null)
+        if (browserTimeZone == null)
         {
-            String[] split = tz.split("[,\\s]+");
-            tz = split[DAY_OF_MONTH % split.length];
-            // Verify that time zone is valid
-            ZoneId zoneId = ZoneId.of(tz);
-            TestLogger.warn("Starting browser with TZ = %s (%s)".formatted(tz, zoneId));
+            String tz = StringUtils.trimToNull(System.getProperty("webtest.browser.tz"));
+            if (tz != null)
+            {
+                String[] split = tz.split("[,\\s]+");
+                tz = split[DAY_OF_MONTH % split.length];
+                // Verify that time zone is valid
+                browserTimeZone = ZoneId.of(tz);
+            }
+            else
+            {
+                browserTimeZone = ZoneId.systemDefault();
+            }
         }
-        return tz;
+        return browserTimeZone;
     }
 
     public static double getTimeoutMultiplier()

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -164,7 +164,7 @@ public abstract class TestProperties
 
     public static String getBrowserTimeZone()
     {
-        return System.getProperty("webtest.browser.tz");
+        return StringUtils.trimToNull(System.getProperty("webtest.browser.tz"));
     }
 
     public static double getTimeoutMultiplier()

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -72,8 +72,6 @@ public abstract class TestProperties
         }
     }
 
-    // Initialize once so that value doesn't change if suite runs through midnight
-    private static final int DAY_OF_MONTH = LocalDateTime.now().getDayOfMonth();
     private static ZoneId browserTimeZone = null;
 
     public static void load()
@@ -176,7 +174,7 @@ public abstract class TestProperties
             if (tz != null)
             {
                 String[] split = tz.split("[,\\s]+");
-                tz = split[DAY_OF_MONTH % split.length];
+                tz = split[LocalDateTime.now().getDayOfMonth() % split.length];
                 // Verify that time zone is valid
                 browserTimeZone = ZoneId.of(tz);
             }

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -26,6 +26,8 @@ import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -69,6 +71,9 @@ public abstract class TestProperties
             ioe.printStackTrace(System.err);
         }
     }
+
+    // Initialize once so that value doesn't change if suite runs through midnight
+    private static final int DAY_OF_MONTH = LocalDateTime.now().getDayOfMonth();
 
     public static void load()
     {
@@ -164,7 +169,16 @@ public abstract class TestProperties
 
     public static String getBrowserTimeZone()
     {
-        return StringUtils.trimToNull(System.getProperty("webtest.browser.tz"));
+        String tz = StringUtils.trimToNull(System.getProperty("webtest.browser.tz"));
+        if (tz != null)
+        {
+            String[] split = tz.split("[, ]+");
+            tz = split[DAY_OF_MONTH % split.length];
+            // Verify that time zone is valid
+            ZoneId zoneId = ZoneId.of(tz);
+            TestLogger.warn("Starting browser with TZ = %s (%s)".formatted(tz, zoneId));
+        }
+        return tz;
     }
 
     public static double getTimeoutMultiplier()

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -120,6 +120,7 @@ import java.nio.file.StandardCopyOption;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -212,9 +213,15 @@ public abstract class WebDriverWrapper implements WrapsDriver
         DriverService oldDriverService = oldDriverAndService.getRight();
         DriverService newDriverService = null;
         Map<String, String> browserEnv = new HashMap<>();
-        if (TestProperties.getBrowserTimeZone() != null)
+        ZoneId browserTimeZone = TestProperties.getBrowserTimeZone();
+        if (browserTimeZone != ZoneId.systemDefault())
         {
-            browserEnv.put("TZ", TestProperties.getBrowserTimeZone());
+            TestLogger.info("Starting browser with TZ = " + browserTimeZone);
+            browserEnv.put("TZ", browserTimeZone.toString());
+        }
+        else
+        {
+            TestLogger.info("Starting browser with TZ = " + browserTimeZone + " (system default)");
         }
 
         switch (browserType)

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -96,6 +96,7 @@ import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.firefox.GeckoDriverService;
 import org.openqa.selenium.ie.InternetExplorerDriver;
+import org.openqa.selenium.ie.InternetExplorerDriverService;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.service.DriverService;
@@ -210,6 +211,11 @@ public abstract class WebDriverWrapper implements WrapsDriver
         WebDriver newWebDriver = null;
         DriverService oldDriverService = oldDriverAndService.getRight();
         DriverService newDriverService = null;
+        Map<String, String> browserEnv = new HashMap<>();
+        if (TestProperties.getBrowserTimeZone() != null)
+        {
+            browserEnv.put("TZ", TestProperties.getBrowserTimeZone());
+        }
 
         switch (browserType)
         {
@@ -236,7 +242,8 @@ public abstract class WebDriverWrapper implements WrapsDriver
                 }
                 if (oldWebDriver == null)
                 {
-                    newWebDriver = new InternetExplorerDriver();
+                    newDriverService = new InternetExplorerDriverService.Builder().withEnvironment(browserEnv).build();
+                    newWebDriver = new InternetExplorerDriver((InternetExplorerDriverService) newDriverService);
                 }
                 break;
             }
@@ -276,7 +283,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
                         options.addArguments("headless");
                     }
 
-                    newDriverService = ChromeDriverService.createDefaultService();
+                    newDriverService = new ChromeDriverService.Builder().withEnvironment(browserEnv).build();
                     newWebDriver = new ChromeDriver((ChromeDriverService) newDriverService, options);
                 }
                 break;
@@ -373,7 +380,10 @@ public abstract class WebDriverWrapper implements WrapsDriver
                     capabilities.setUnhandledPromptBehaviour(UnexpectedAlertBehaviour.IGNORE);
                     FirefoxOptions firefoxOptions = new FirefoxOptions(capabilities);
 
-                    newDriverService = GeckoDriverService.createDefaultService();
+                    GeckoDriverService.Builder driverServiceBuilder = new GeckoDriverService.Builder()
+                        .withEnvironment(browserEnv);
+
+                    newDriverService = driverServiceBuilder.build();
                     try
                     {
                         newWebDriver = new FirefoxDriver((FirefoxDriverService) newDriverService, firefoxOptions);
@@ -384,7 +394,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
                         {
                             retry.printStackTrace(System.err);
                             newDriverService.stop();
-                            newDriverService = GeckoDriverService.createDefaultService();
+                            newDriverService = driverServiceBuilder.build();
                             sleep(10000);
                             newWebDriver = new FirefoxDriver((FirefoxDriverService) newDriverService, firefoxOptions);
                         }

--- a/test.properties.template
+++ b/test.properties.template
@@ -88,6 +88,8 @@ selenium.reuseWebDriver=true
 #webtest.webdriver.headless=false
 ## Customize browser window size
 #webtest.window.size=1280x1024
+## Set browser time zone
+#webtest.browser.tz=America/New_York
 
 
 #==============================================================================


### PR DESCRIPTION
#### Rationale
We need to be able to run selenium tests as if the client is in a different time zone from the server.

#### Related Pull Requests
- N/A

#### Changes
- Add test property to set the browser time zone: `webtest.browser.tz`
