### PR TITLE
Issue 51620: Remove the UI for Object-level discussions

### DIFF
--- a/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
+++ b/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
@@ -131,6 +131,12 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
         return new DomainDesignerPage(getDriver());
     }
 
+    public void clickDeprecatedFeatures()
+    {
+        goToSettingsSection();
+        clickAndWait(elementCache().deprecatedFeaturesLink);
+    }
+
     public void clickEmailCustomization()
     {
         goToSettingsSection();
@@ -261,6 +267,7 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
         protected WebElement configurePageElements = Locator.linkWithText("configure page elements").findWhenNeeded(this);
         protected WebElement complianceSettings = Locator.linkWithText("Compliance Settings").findWhenNeeded(this);
         protected WebElement changeUserPropertiesLink = Locator.linkWithText("change user properties").findWhenNeeded(this);
+        protected WebElement deprecatedFeaturesLink = Locator.linkWithText("deprecated features").findWhenNeeded(this);
         protected WebElement emailCustomizationLink = Locator.linkWithText("email customization").findWhenNeeded(this);
         protected WebElement notificationServiceAdminLink = Locator.linkWithText("notification service admin").findWhenNeeded(this);
         protected WebElement filesLink = Locator.linkWithText("files").findWhenNeeded(this);

--- a/src/org/labkey/test/tests/announcements/DiscussionLinkTest.java
+++ b/src/org/labkey/test/tests/announcements/DiscussionLinkTest.java
@@ -48,6 +48,10 @@ public class DiscussionLinkTest extends BaseWebDriverTest
     private void doSetup()
     {
         _containerHelper.createProject(getProjectName());
+
+        // Issue 51620: Remove the UI for Object-level discussions
+        goToAdminConsole().clickDeprecatedFeatures();
+        click(Locator.inputById("deprecatedObjectLevelDiscussions"));
     }
 
     @Before


### PR DESCRIPTION
#### Rationale
See issue [here](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=51620).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/667
- https://github.com/LabKey/labkey-ui-components/pull/1709
- https://github.com/LabKey/limsModules/pull/1135
- https://github.com/LabKey/platform/pull/6275
- https://github.com/LabKey/testAutomation/pull/2260

#### Changes
- Temporarily ensure deprecated feature is enabled to ensure test coverage pre-feature-removal
