### PR TITLE
Remove coverage for now-deleted object-level discussions

### DIFF
--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -62,10 +62,6 @@ public class WikiLongTest extends BaseWebDriverTest
     private static final String WIKI_PAGE8_NAME= "Page 8 Name For Delete Subtree Test " + BaseWebDriverTest.INJECT_CHARS_1;
     private static final String WIKI_PAGE9_NAME= "Page 9 _blank " + BaseWebDriverTest.INJECT_CHARS_1;
 
-    private static final String DISC1_TITLE = "Let's Talk";
-    private static final String DISC1_BODY = "I don't know how normal this wiki is";
-    private static final String RESP1_TITLE = "Let's Keep Talking";
-    private static final String RESP1_BODY = "I disagree";
     private static final String USER1 = "wikilong_user1@wikilong.test";
     private static final String USER2 = "wikilong_user2@wikilong.test";
     private static final String USERS_GROUP = "Users";
@@ -322,33 +318,6 @@ public class WikiLongTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(WIKI_PAGE1_TITLE));
         clickAndWait(Locator.linkWithText("next"));
         assertTextPresent("Some HTML content");
-
-        log("Check that discussion board works");
-        clickAndWait(Locator.linkWithText(WIKI_PAGE1_TITLE));
-        _ext4Helper.waitForOnReady();
-        click(Locator.linkWithText("discussions"));
-        waitForElement(Locator.linkWithText("Start new discussion"), defaultWaitForPage);
-        clickAndWait(Locator.linkWithText("Start new discussion"));
-        _wikiHelper.setWikiTitle(DISC1_TITLE);
-        setFormElement(Locator.id("body"), DISC1_BODY);
-        submit();
-        _ext4Helper.waitForOnReady();
-        clickMenuButton(true, Locator.linkWithText("discussions")
-                .findElement(getDriver()), false, DISC1_TITLE);
-
-        assertTextPresent(DISC1_TITLE,
-                DISC1_BODY);
-
-        log("Check response on discussion board works");
-        clickButton("Respond");
-        _wikiHelper.setWikiTitle(RESP1_TITLE);
-        setFormElement(Locator.id("body"), RESP1_BODY);
-        submit();
-        assertTextPresent(RESP1_TITLE,
-                RESP1_BODY);
-        clickButton("Delete Message");
-        clickButton("Delete");
-        assertTextNotPresent(DISC1_TITLE, DISC1_BODY);
 
         log("test navTree and header");
         _wikiHelper.createNewWikiPage("RADEOX");


### PR DESCRIPTION
#### Rationale
[Issue 51620: Remove the UI for Object-level discussions](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=51620)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6275

#### Changes
- Stop testing wiki-scoped discussions