### PR TITLE
Don't leave deprecatedObjectLevelDiscussions enabled between tests

### DIFF
--- a/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
+++ b/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
@@ -23,6 +23,7 @@ import org.labkey.test.pages.ConfigureReportsAndScriptsPage;
 import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.pages.compliance.ComplianceSettingsAccountsPage;
 import org.labkey.test.pages.core.login.LoginConfigurePage;
+import org.labkey.test.util.OptionalFeatureHelper;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -133,8 +134,8 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
 
     public void clickDeprecatedFeatures()
     {
-        goToSettingsSection();
-        clickAndWait(elementCache().deprecatedFeaturesLink);
+        throw new UnsupportedOperationException("Use %s to manage experimental/optional/deprecated features"
+            .formatted(OptionalFeatureHelper.class.getSimpleName()));
     }
 
     public void clickEmailCustomization()
@@ -267,7 +268,6 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
         protected WebElement configurePageElements = Locator.linkWithText("configure page elements").findWhenNeeded(this);
         protected WebElement complianceSettings = Locator.linkWithText("Compliance Settings").findWhenNeeded(this);
         protected WebElement changeUserPropertiesLink = Locator.linkWithText("change user properties").findWhenNeeded(this);
-        protected WebElement deprecatedFeaturesLink = Locator.linkWithText("deprecated features").findWhenNeeded(this);
         protected WebElement emailCustomizationLink = Locator.linkWithText("email customization").findWhenNeeded(this);
         protected WebElement notificationServiceAdminLink = Locator.linkWithText("notification service admin").findWhenNeeded(this);
         protected WebElement filesLink = Locator.linkWithText("files").findWhenNeeded(this);

--- a/src/org/labkey/test/tests/NonStudyReportsTest.java
+++ b/src/org/labkey/test/tests/NonStudyReportsTest.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.tests;
 
+import org.junit.After;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
@@ -26,6 +27,7 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Reports;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.RReportHelper;
 import org.labkey.test.util.ext4cmp.Ext4FileFieldRef;
@@ -35,6 +37,7 @@ import java.io.File;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.tests.announcements.DiscussionLinkTest.OBJECT_DISCUSSION_FEATURE;
 
 @Category({Daily.class, Reports.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
@@ -80,6 +83,16 @@ public class NonStudyReportsTest extends ReportTest
         rReportHelper.ensureRConfig();
     }
 
+    /**
+     * Don't leave feature enabled. Warning banner might interfere with other tests
+     */
+    @After
+    public void disableDiscussions()
+    {
+        // Issue 51620: Remove the UI for Object-level discussions
+        OptionalFeatureHelper.disableOptionalFeature(createDefaultConnection(), OBJECT_DISCUSSION_FEATURE);
+    }
+
     @Override
     @LogMethod
     protected void doVerifySteps()
@@ -93,6 +106,9 @@ public class NonStudyReportsTest extends ReportTest
     @LogMethod
     private void doAttachmentReportTest()
     {
+        // Issue 51620: Remove the UI for Object-level discussions
+        OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), OBJECT_DISCUSSION_FEATURE);
+
         clickProject(getProjectName());
         goToManageViews();
         BootstrapMenu.find(getDriver(), "Add Report").clickSubMenu(true, "Attachment Report");

--- a/src/org/labkey/test/tests/announcements/DiscussionLinkTest.java
+++ b/src/org/labkey/test/tests/announcements/DiscussionLinkTest.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.tests.announcements;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -36,12 +37,14 @@ import static org.junit.Assert.assertEquals;
 @BaseWebDriverTest.ClassTimeout(minutes = 4)
 public class DiscussionLinkTest extends BaseWebDriverTest
 {
+    public static final String OBJECT_DISCUSSION_FEATURE = "deprecatedObjectLevelDiscussions";
+
     public static final String WIKI_NAME = "Link test";
 
     @BeforeClass
     public static void setupProject()
     {
-        DiscussionLinkTest init = (DiscussionLinkTest) getCurrentTest();
+        DiscussionLinkTest init = getCurrentTest();
 
         init.doSetup();
     }
@@ -51,13 +54,22 @@ public class DiscussionLinkTest extends BaseWebDriverTest
         _containerHelper.createProject(getProjectName());
 
         // Issue 51620: Remove the UI for Object-level discussions
-        OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "deprecatedObjectLevelDiscussions");
+        OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), OBJECT_DISCUSSION_FEATURE);
     }
 
     @Before
     public void preTest()
     {
         goToProjectHome();
+    }
+
+    /**
+     * Don't leave feature enabled. Warning banner might interfere with other tests
+     */
+    @After public void disableDiscussions()
+    {
+        // Issue 51620: Remove the UI for Object-level discussions
+        OptionalFeatureHelper.disableOptionalFeature(createDefaultConnection(), OBJECT_DISCUSSION_FEATURE);
     }
 
     @Test

--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -16,6 +16,7 @@
 
 package org.labkey.test.tests.wiki;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
@@ -37,6 +38,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.tests.announcements.DiscussionLinkTest.OBJECT_DISCUSSION_FEATURE;
 
 @Category({Daily.class, Wiki.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 11)
@@ -153,6 +155,15 @@ public class WikiLongTest extends BaseWebDriverTest
     protected String getProjectName()
     {
         return PROJECT_NAME;
+    }
+
+    /**
+     * Don't leave feature enabled. Warning banner might interfere with other tests
+     */
+    @After public void disableDiscussions()
+    {
+        // Issue 51620: Remove the UI for Object-level discussions
+        OptionalFeatureHelper.disableOptionalFeature(createDefaultConnection(), OBJECT_DISCUSSION_FEATURE);
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
The warning banner for deprecated features can interfere with other tests. We should disable the feature when it isn't needed.

![image](https://github.com/user-attachments/assets/2d03d6db-fc6a-4ff2-9f9d-95aa4983275e)


#### Related Pull Requests
- #2260 

#### Changes
- Disable deprecatedObjectLevelDiscussions when they aren't needed
