### PR TITLE
Issue 51620: Remove the UI for Object-level discussions Test Updates

### DIFF
--- a/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
+++ b/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
@@ -23,6 +23,7 @@ import org.labkey.test.pages.ConfigureReportsAndScriptsPage;
 import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.pages.compliance.ComplianceSettingsAccountsPage;
 import org.labkey.test.pages.core.login.LoginConfigurePage;
+import org.labkey.test.util.OptionalFeatureHelper;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -133,8 +134,8 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
 
     public void clickDeprecatedFeatures()
     {
-        goToSettingsSection();
-        clickAndWait(elementCache().deprecatedFeaturesLink);
+        throw new UnsupportedOperationException("Use %s to manage experimental/optional/deprecated features"
+                .formatted(OptionalFeatureHelper.class.getSimpleName()));
     }
 
     public void clickEmailCustomization()
@@ -267,7 +268,6 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
         protected WebElement configurePageElements = Locator.linkWithText("configure page elements").findWhenNeeded(this);
         protected WebElement complianceSettings = Locator.linkWithText("Compliance Settings").findWhenNeeded(this);
         protected WebElement changeUserPropertiesLink = Locator.linkWithText("change user properties").findWhenNeeded(this);
-        protected WebElement deprecatedFeaturesLink = Locator.linkWithText("deprecated features").findWhenNeeded(this);
         protected WebElement emailCustomizationLink = Locator.linkWithText("email customization").findWhenNeeded(this);
         protected WebElement notificationServiceAdminLink = Locator.linkWithText("notification service admin").findWhenNeeded(this);
         protected WebElement filesLink = Locator.linkWithText("files").findWhenNeeded(this);

--- a/src/org/labkey/test/tests/NonStudyReportsTest.java
+++ b/src/org/labkey/test/tests/NonStudyReportsTest.java
@@ -26,6 +26,7 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Reports;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.RReportHelper;
 import org.labkey.test.util.ext4cmp.Ext4FileFieldRef;
@@ -65,6 +66,7 @@ public class NonStudyReportsTest extends ReportTest
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
         _userHelper.deleteUsers(false, ATTACHMENT_USER);
+        OptionalFeatureHelper.disableOptionalFeature(createDefaultConnection(), "deprecatedObjectLevelDiscussions");
         super.doCleanup(afterTest);
     }
 
@@ -258,6 +260,9 @@ public class NonStudyReportsTest extends ReportTest
     @LogMethod
     private void doReportDiscussionTest()
     {
+        // Issue 51620: Remove the UI for Object-level discussions
+        OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "deprecatedObjectLevelDiscussions");
+
         clickProject(getProjectName());
 
         goToManageViews();

--- a/src/org/labkey/test/tests/announcements/DiscussionLinkTest.java
+++ b/src/org/labkey/test/tests/announcements/DiscussionLinkTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.core.admin.ProjectSettingsPage;
 import org.labkey.test.util.OptionalFeatureHelper;
@@ -52,6 +53,13 @@ public class DiscussionLinkTest extends BaseWebDriverTest
 
         // Issue 51620: Remove the UI for Object-level discussions
         OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "deprecatedObjectLevelDiscussions");
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest) throws TestTimeoutException
+    {
+        OptionalFeatureHelper.disableOptionalFeature(createDefaultConnection(), "deprecatedObjectLevelDiscussions");
+        super.doCleanup(afterTest);
     }
 
     @Before

--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -781,6 +781,7 @@ public class WikiLongTest extends BaseWebDriverTest
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
+        OptionalFeatureHelper.disableOptionalFeature(createDefaultConnection(), "deprecatedObjectLevelDiscussions");
         deleteUsersIfPresent(USER1);
         _containerHelper.deleteProject(PROJECT2_NAME, afterTest);
         _containerHelper.deleteProject(PROJECT_NAME, afterTest);


### PR DESCRIPTION
#### Rationale
See issue [here](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=51620).
This PR does cleanup and addresses additional outages.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2260
- https://github.com/LabKey/testAutomation/pull/2262

#### Changes
- Add disabling deprecated feature in cleanups
- Address additional spot in NonStudyReportsTest.testSteps
