### PR TITLE
EntityBulkUpdateDialog.getSelectionFieldValues to enableAndWait

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -219,6 +219,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
     // See QueryKey.ILLEGAL  TODO make that array public so it can be used here
     public static final String[] ILLEGAL_QUERY_KEY_CHARACTERS = {"$", "/", "&", "}", "~", ",", "."};
+    public static final String ALL_ILLEGAL_QUERY_KEY_CHARACTERS = StringUtils.join(ILLEGAL_QUERY_KEY_CHARACTERS, "");
     // See TSVWriter.shouldQuote. Generally we are not able to use the tab and new line characters when creating field names in the UI, but including here for completeness
     public static final String[] TRICKY_IMPORT_FIELD_CHARACTERS = {"\\", "\"", "\\t", ",", "\\n", "\\r"};
 

--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -77,7 +77,7 @@ public class EntityBulkUpdateDialog extends ModalDialog
 
     public List<String> getSelectionFieldValues(String fieldKey)
     {
-        return elementCache().getSelect(fieldKey).getSelections();
+        return enableAndWait(fieldKey, elementCache().getSelect(fieldKey)).getSelections();
     }
 
     public EntityBulkUpdateDialog setTextArea(String fieldKey, String text)


### PR DESCRIPTION
#### Rationale
See related PR for rationale. This PR is an update to a test component for the EntityBulkUpdateDialog as it needs to enable the field before trying to get the selected value from the form.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1715

#### Changes
- EntityBulkUpdateDialog.getSelectionFieldValues to enableAndWait
