### PR TITLE
Prepare test for markdown substitution removal

### DIFF
--- a/src/org/labkey/test/tests/MessagesLongTest.java
+++ b/src/org/labkey/test/tests/MessagesLongTest.java
@@ -74,10 +74,10 @@ public class MessagesLongTest extends BaseWebDriverTest
     private static final String USER3 = "messageslong_user3@messages.test";
     private static final String NOT_A_USER = "Squirrel";
     private static final String RESPONDER = "responder@messages.test";
-    private static final String MACRO_WEBPART = "${labkey.webPart(partName='Lists')}";
+    private static final String WEBPART_SUBSTITUTION = "${labkey.webPart(partName='Lists')}";
     private static final String HTML_BODY = "1 <b>x</b>\n" +
             "<b>" +
-            MACRO_WEBPART +
+            WEBPART_SUBSTITUTION +
             "</b>\n";
     private static final String HTML_BODY_WEBPART_TEST = "manage lists";
     private static final String MEMBER_LIST = "memberListInput";
@@ -238,8 +238,9 @@ public class MessagesLongTest extends BaseWebDriverTest
                         + stinky feet
                         + internet trolls
 
-                        <b>escaped</b>""" +
-                        "\n" + MACRO_WEBPART);
+                        <b>escaped</b>
+                        
+                        """ + WEBPART_SUBSTITUTION);
 
         // now look at the preview pane
         markdownPage.selectPreviewTab();
@@ -248,8 +249,13 @@ public class MessagesLongTest extends BaseWebDriverTest
         assertElementPresent(Locator.tagWithText("li", "stinky feet"));
         assertElementPresent(Locator.tagWithText("li", "internet trolls"));
         assertElementPresent(Locator.tagWithText("p", "<b>escaped</b>"));
+
+        // Issue 52214: Remove markdown support for HTML substitution patterns
         assertElementPresent(PortalHelper.Locators.webPart("Lists"));
         assertElementPresent(Locator.linkWithText("manage lists"));
+        // TODO: Update assertion
+        // assertElementPresent(Locator.tagWithText("p", MACRO_WEBPART));
+
         clickButton("Submit");
         assertElementPresent(Locator.tagWithText("h1", "Holy Header, Batman!"));
         assertElementPresent(Locator.tagWithText("strong", "bold as bold can possibly be"));
@@ -451,6 +457,9 @@ public class MessagesLongTest extends BaseWebDriverTest
         waitForTextWithRefresh(WAIT_FOR_JAVASCRIPT, "New posts");
         click(Locator.linkWithText("New posts to /" + PROJECT_NAME));
         assertTextPresent("The following new posts were made yesterday");
+
+        // Will be resolved by Issue 52214: Remove markdown support for HTML substitution patterns
+        checkExpectedErrors(1);
     }
 
     @Test

--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -25,7 +25,6 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Wiki;
-import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.WikiHelper;
 import org.openqa.selenium.WebElement;
@@ -117,6 +116,7 @@ public class WikiLongTest extends BaseWebDriverTest
             "The " + WIKI_SEARCH_TERM +
             " was called the African unicorn by Europeans and wasn't widely known to exist until 1901.\n";
 
+    private static final String WIKI_PAGE7_WEBPART_SUBSTITUTION = "${labkey.webPart(partName='Lists')}";
     private static final String WIKI_PAGE7_CONTENT =
             """
                     # Title MD
@@ -124,9 +124,8 @@ public class WikiLongTest extends BaseWebDriverTest
                     *italic text MD*
 
                     <b>escaped</b>
-                    
-                    ${labkey.webPart(partName='Query', title='WebPart Macro', schemaName='core', queryName='containers', allowChooseQuery='true', allowChooseView='true')}
-                    """;
+
+                    """ + WIKI_PAGE7_WEBPART_SUBSTITUTION;
 
     private static final String SAFE_LINK_HTML = "<a href=\"http://labkey.com\">Safe link</a>";
     private static final String FIXUP_LINK_HTML = "<a href=\"http://labkey.com\" target=\"_blank\">Fixup</a>";
@@ -229,8 +228,13 @@ public class WikiLongTest extends BaseWebDriverTest
         // verify that after saving the markdown that it is rendered as html that does not include the markdown symbols
         assertElementPresent(Locator.tagWithText("h1", "Title MD"));
         assertElementPresent(Locator.tagWithText("p", "<b>escaped</b>"));
-        assertElementPresent(PortalHelper.Locators.webPart("WebPart Macro"));
-        assertElementPresent(DataRegionTable.Locators.dataRegionTable().descendant(Locator.linkWithText(getProjectName())));
+
+        // Issue 52214: Remove markdown support for HTML substitution patterns
+        assertElementPresent(PortalHelper.Locators.webPart("Lists"));
+        assertElementPresent(Locator.linkWithText("manage lists"));
+        // TODO: Update assertion
+        // assertElementPresent(Locator.tagWithText("p", MACRO_WEBPART));
+
         assertTextNotPresent("# Title MD");
         clickAndWait(Locator.linkWithText("Edit"));
         _wikiHelper.convertWikiFormat("HTML");

--- a/src/org/labkey/test/util/Ext4Helper.java
+++ b/src/org/labkey/test/util/Ext4Helper.java
@@ -669,7 +669,7 @@ public class Ext4Helper
 
     public void clickTabContainingText(String tabText)
     {
-        _test.click(Locators.tab().containing(tabText));
+        _test.waitAndClick(Locators.tab().containing(tabText));
     }
 
     public void waitForMaskToDisappear()


### PR DESCRIPTION
#### Rationale
[Issue 52214: Remove markdown support for HTML substitution patterns](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52214)

We will be removing support for substitution patterns in markdown. This prepares affected tests for this change and handles a currently expected error.

#### Related Pull Requests
- #2256 

#### Changes
- Add disabled checks for expected future markdown functionality
- Mark assertions that should be removed once 
- Ignore error generated by messages daily digest
- Timing fix for a problem I was hitting locally clicking ext tabs
