### PR TITLE
Add new element and method for getting danger warnings

### DIFF
--- a/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
@@ -107,6 +107,11 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
         return (null == disabledValue) || (!disabledValue.equalsIgnoreCase("true"));
     }
 
+    public String getErrorText()
+    {
+        return elementCache().dangerText.getText();
+    }
+
     public String getNameExpression()
     {
         expandPropertiesPanel();
@@ -378,6 +383,7 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
             WebDriverWrapper.sleep(500);
         }
 
+        protected final WebElement dangerText = Locator.tagWithClass("span", "text-danger").findWhenNeeded(this);
         protected final ValidatingInput nameInput = new ValidatingInput(Locator.id("entity-name").findWhenNeeded(propertiesPanel), getDriver());
         protected final Input nameExpressionInput = new ValidatingInput(Locator.id("entity-nameExpression").findWhenNeeded(propertiesPanel), getDriver());
         protected final Input descriptionInput = new ValidatingInput(Locator.id("entity-description").findWhenNeeded(propertiesPanel), getDriver());

--- a/src/org/labkey/test/pages/list/EditListDefinitionPage.java
+++ b/src/org/labkey/test/pages/list/EditListDefinitionPage.java
@@ -76,6 +76,12 @@ public class EditListDefinitionPage extends DomainDesigner<EditListDefinitionPag
 
     // List Properties
 
+    public String getName()
+    {
+        expandPropertiesPanel();
+        return elementCache().nameInput.getValue();
+    }
+
     public EditListDefinitionPage setName(String listName)
     {
         expandPropertiesPanel();

--- a/src/org/labkey/test/tests/GpatAssayTest.java
+++ b/src/org/labkey/test/tests/GpatAssayTest.java
@@ -343,7 +343,7 @@ public class GpatAssayTest extends BaseWebDriverTest
         ReactAssayDesignerPage assayDesignerPage = startCreateGpatAssay(trialData, invalidAssayName);
         List<String> errors = assayDesignerPage.clickSaveExpectingErrors();
         assayDesignerPage.clickCancel();
-        Assert.assertTrue("Error msg not as expected during assay creation", errors.contains("Invalid Assay Design name \"" + invalidAssayName + "\". Assay Design name must start with a letter or a number."));
+        Assert.assertTrue("Error msg not as expected during assay creation", errors.contains("Invalid Assay Design name '" + invalidAssayName + "'. Assay Design name must start with a letter or a number."));
 
         BaseSettingsPage.resetSettings(createDefaultConnection(), "/");
         BaseSettingsPage.resetSettings(createDefaultConnection(), getProjectName());

--- a/src/org/labkey/test/tests/GpatAssayTest.java
+++ b/src/org/labkey/test/tests/GpatAssayTest.java
@@ -408,7 +408,7 @@ public class GpatAssayTest extends BaseWebDriverTest
 
         assayDesignerPage.setName(invalidAssayName);
         errors = assayDesignerPage.clickSaveExpectingErrors();
-        Assert.assertTrue("Error msg not as expected during assay update", errors.contains("Invalid Assay Design name \"" + invalidAssayName + "\". Assay Design name must start with a letter or a number."));
+        Assert.assertTrue("Error msg not as expected during assay update", errors.contains("Invalid Assay Design name '" + invalidAssayName + "'. Assay Design name must start with a letter or a number."));
 
         assayDesignerPage.setName(newAssayName);
 

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -47,6 +47,7 @@ import org.labkey.test.components.ext4.Checkbox;
 import org.labkey.test.components.list.AdvancedListSettingsDialog;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.list.EditListDefinitionPage;
+import org.labkey.test.pages.list.GridPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.LookupInfo;
 import org.labkey.test.params.FieldDefinition.StringLookup;
@@ -473,6 +474,29 @@ public class ListTest extends BaseWebDriverTest
         table.clickInsertNewRow();
         assertTextNotPresent(HIDDEN_TEXT); // Hidden from insert view.
         clickButton("Cancel");
+    }
+
+    @Test
+    public void testNameTrimming()
+    {
+        goToProjectHome();
+        String trimmedName = "Trimmings";
+        log("Add list with leading spaces");
+        _listHelper.createList(getProjectName(), " Trimmings", new FieldDefinition(LIST_KEY_NAME2, LIST_KEY_TYPE), _listColFake);
+        log("Assure we can go to the page with the trimmed name");
+        GridPage grid = GridPage.beginAt(this, getProjectName(), trimmedName);
+        grid.click(Locator.linkWithText("Design"));
+        EditListDefinitionPage editList = new EditListDefinitionPage(this.getDriver());
+        checker().withScreenshot().verifyEquals("Name not trimmed as expected", trimmedName, editList.getName());
+
+        trimmedName = "Extra Trimmings";
+        log("Add list with leading and trailing spaces");
+        _listHelper.createList(getProjectName(), " Extra Trimmings   ", new FieldDefinition(LIST_KEY_NAME2, LIST_KEY_TYPE), _listColFake);
+        log("Assure we can go to the page with the trimmed name");
+        grid = GridPage.beginAt(this, getProjectName(), trimmedName);
+        grid.click(Locator.linkWithText("Design"));
+        editList = new EditListDefinitionPage(this.getDriver());
+        checker().withScreenshot().verifyEquals("Name not trimmed as expected", trimmedName, editList.getName());
     }
 
     @Test
@@ -1155,7 +1179,7 @@ public class ListTest extends BaseWebDriverTest
         EditListDefinitionPage listDefinitionPage = _listHelper.beginCreateList(PROJECT_VERIFY, invalidListName);
         listDefinitionPage.manuallyDefineFieldsWithAutoIncrementingKey("key");
         List<String> errors = listDefinitionPage.clickSaveExpectingErrors();
-        Assert.assertTrue("Error msg not as expected during list creation", errors.contains("Invalid IntList name \"" + invalidListName + "\". IntList name must start with a letter or a number."));
+        Assert.assertTrue("Error msg not as expected during list creation", errors.contains("Invalid IntList name '" + invalidListName + "'. IntList name must start with a letter or a number."));
 
         _listHelper.createList(PROJECT_VERIFY, listName, "key",
                 new FieldDefinition(origFieldName, ColumnType.String).setLabel(origFieldName).setDescription("first column"));
@@ -1163,7 +1187,7 @@ public class ListTest extends BaseWebDriverTest
         listDefinitionPage = _listHelper.goToEditDesign(listName);
         listDefinitionPage.setName(invalidListName);
         errors = listDefinitionPage.clickSaveExpectingErrors();
-        Assert.assertTrue("Error msg not as expected during list renaming", errors.contains("Invalid IntList name \"" + invalidListName + "\". IntList name must start with a letter or a number."));
+        Assert.assertTrue("Error msg not as expected during list renaming", errors.contains("Invalid IntList name '" + invalidListName + "'. IntList name must start with a letter or a number."));
         listDefinitionPage.setName(listName);
         listDefinitionPage.getFieldsPanel()
                 .getField(origFieldName)


### PR DESCRIPTION
#### Rationale
We are adding warning messages when users supply names of things with multiple spaces between words and have added tests to assure the warnings appear. We need to find these on the page.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1165

#### Changes
- Add `getErrorText()` method in `EntityTypeDesigner`
