### PR TITLE
Issue 52190: Expose Postgres connections and locks to admins

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1997,7 +1997,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
     /**
      * Used by CohortTest and StudyCohortExportTest
-     * Returns the data region for the the cohort table to enable setting
+     * Returns the data region for the cohort table to enable setting
      * or verifying the enrolled status of the cohort
      */
     public DataRegionTable getCohortDataRegionTable()

--- a/src/org/labkey/test/pages/LabkeyErrorPage.java
+++ b/src/org/labkey/test/pages/LabkeyErrorPage.java
@@ -1,11 +1,17 @@
 package org.labkey.test.pages;
 
+import org.hamcrest.CoreMatchers;
 import org.labkey.test.Locator;
+import org.labkey.test.util.DeferredErrorCollector;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 public class LabkeyErrorPage extends LabKeyPage<LabkeyErrorPage.ElementCache>
 {
+    public static final String UNAUTHORIZED_FULL_PAGE_MESSAGE = "User does not have permission to perform this operation.";
+    public static final String IMAGE_TITLE = "permission_error.svg";
+
+
     public LabkeyErrorPage(WebDriver driver)
     {
         super(driver);
@@ -49,6 +55,15 @@ public class LabkeyErrorPage extends LabKeyPage<LabkeyErrorPage.ElementCache>
     protected ElementCache newElementCache()
     {
         return new ElementCache();
+    }
+
+    public void assertUnauthorized(DeferredErrorCollector checker)
+    {
+        checker.verifyEquals("Incorrect error heading message", "Oops! An error has occurred.",
+                getErrorHeading());
+        checker.verifyEquals("Incorrect error sub-heading message", UNAUTHORIZED_FULL_PAGE_MESSAGE,
+                getSubErrorHeading());
+        checker.verifyThat("Incorrect error image", getErrorImage(), CoreMatchers.containsString(IMAGE_TITLE));
     }
 
     protected class ElementCache extends LabKeyPage.ElementCache

--- a/src/org/labkey/test/pages/LabkeyErrorPage.java
+++ b/src/org/labkey/test/pages/LabkeyErrorPage.java
@@ -64,6 +64,7 @@ public class LabkeyErrorPage extends LabKeyPage<LabkeyErrorPage.ElementCache>
         checker.verifyEquals("Incorrect error sub-heading message", UNAUTHORIZED_FULL_PAGE_MESSAGE,
                 getSubErrorHeading());
         checker.verifyThat("Incorrect error image", getErrorImage(), CoreMatchers.containsString(IMAGE_TITLE));
+        checker.verifyEquals("Incorrect response code", 403, getResponseCode());
     }
 
     protected class ElementCache extends LabKeyPage.ElementCache

--- a/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
+++ b/src/org/labkey/test/pages/core/admin/ShowAdminPage.java
@@ -240,6 +240,18 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
         clickAndWait(elementCache().creditsLink);
     }
 
+    public void clickPostgresActivity()
+    {
+        goToSettingsSection();
+        clickAndWait(elementCache().postgresActivityLink);
+    }
+
+    public void clickPostgresLocks()
+    {
+        goToSettingsSection();
+        clickAndWait(elementCache().postgresLocksLink);
+    }
+
     public List<WebElement> getAllAdminConsoleLinks()
     {
         goToSettingsSection();
@@ -284,6 +296,9 @@ public class ShowAdminPage extends LabKeyPage<ShowAdminPage.ElementCache>
         protected WebElement systemPropertiesLink = Locator.linkContainingText("system properties").findWhenNeeded(this);
         protected WebElement viewsAndScriptingLink = Locator.linkWithText("views and scripting").findWhenNeeded(this);
         protected WebElement creditsLink = Locator.linkWithText("credits").findWhenNeeded(this);
+
+        protected WebElement postgresActivityLink = Locator.linkWithText("postgres activity").findWhenNeeded(this);
+        protected WebElement postgresLocksLink = Locator.linkWithText("postgres locks").findWhenNeeded(this);
 
         protected List<WebElement> findActiveUsers()
         {

--- a/src/org/labkey/test/tests/AbstractAdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AbstractAdminConsoleTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2013-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.test.tests;
+
+import org.junit.BeforeClass;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.TestTimeoutException;
+import org.labkey.test.util.ApiPermissionsHelper;
+import org.labkey.test.util.PermissionsHelper;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public abstract class AbstractAdminConsoleTest extends BaseWebDriverTest
+{
+    protected static final String APP_ADMIN_USER = "app_admin_test_user@adminconsole.test";
+    protected static final String TROUBLESHOOTER_USER = "troubleshooter@adminconsole.test";
+
+    @Override
+    public String getProjectName()
+    {
+        return null;
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Arrays.asList("admin");
+    }
+
+    @Override
+    public void checkQueries()
+    {
+
+    }
+
+    @Override
+    public void checkViews()
+    {
+
+    }
+
+    @BeforeClass
+    public static void doSetup() throws Exception
+    {
+        AbstractAdminConsoleTest initTest = getCurrentTest();
+        initTest.createTestUsers();
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest) throws TestTimeoutException
+    {
+        _userHelper.deleteUsers(false, APP_ADMIN_USER);
+        _userHelper.deleteUsers(false, TROUBLESHOOTER_USER);
+    }
+
+    protected void createTestUsers()
+    {
+        ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
+
+        int appAdminId = _userHelper.createUser(APP_ADMIN_USER, true, false).getUserId();
+        setInitialPassword(appAdminId);
+        apiPermissionsHelper.addMemberToRole(APP_ADMIN_USER, "Application Admin", PermissionsHelper.MemberType.user, "/");
+
+        int troubleshooterId = _userHelper.createUser(TROUBLESHOOTER_USER, true, false).getUserId();
+        setInitialPassword(troubleshooterId);
+        apiPermissionsHelper.addMemberToRole(TROUBLESHOOTER_USER, "Troubleshooter", PermissionsHelper.MemberType.user, "/");
+    }
+
+    @Override
+    protected BrowserType bestBrowser()
+    {
+        return BrowserType.CHROME;
+    }
+}

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -23,15 +23,12 @@ import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.SimpleGetCommand;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
-import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.core.admin.CustomizeSitePage;
 import org.labkey.test.pages.core.login.LoginConfigRow;
 import org.labkey.test.pages.core.login.LoginConfigurePage;
-import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.LogMethod;
-import org.labkey.test.util.PermissionsHelper;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,16 +42,8 @@ import static org.junit.Assert.assertTrue;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
-public class AdminConsoleTest extends BaseWebDriverTest
+public class AdminConsoleTest extends AbstractAdminConsoleTest
 {
-    protected static final String APP_ADMIN_USER = "app_admin_test_user@adminconsole.test";
-
-    @Override
-    public String getProjectName()
-    {
-        return null;
-    }
-
     @Test
     public void testServerHttpHeaderSetting()
     {
@@ -295,51 +284,10 @@ public class AdminConsoleTest extends BaseWebDriverTest
         assertTextPresent("JAR Files Distributed with the API Module");
     }
 
-
-
-    @Override
-    public List<String> getAssociatedModules()
-    {
-        return Arrays.asList("admin");
-    }
-
-    @Override
-    public void checkQueries()
-    {
-
-    }
-
-    @Override
-    public void checkViews()
-    {
-
-    }
-
     @BeforeClass
     public static void doSetup() throws Exception
     {
-        AdminConsoleTest initTest = (AdminConsoleTest)getCurrentTest();
-        initTest.createTestUser();
-    }
-
-    @Override
-    protected void doCleanup(boolean afterTest) throws TestTimeoutException
-    {
-        _userHelper.deleteUsers(false, APP_ADMIN_USER);
-    }
-
-    private void createTestUser()
-    {
-        int userId = _userHelper.createUser(APP_ADMIN_USER, true, false).getUserId();
-        setInitialPassword(userId);
-
-        ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
-        apiPermissionsHelper.addMemberToRole(APP_ADMIN_USER, "Application Admin", PermissionsHelper.MemberType.user, "/");
-    }
-
-    @Override
-    protected BrowserType bestBrowser()
-    {
-        return BrowserType.CHROME;
+        AdminConsoleTest initTest = getCurrentTest();
+        initTest.createTestUsers();
     }
 }

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -283,11 +283,4 @@ public class AdminConsoleTest extends AbstractAdminConsoleTest
         log("Verifying the page is properly loaded");
         assertTextPresent("JAR Files Distributed with the API Module");
     }
-
-    @BeforeClass
-    public static void doSetup() throws Exception
-    {
-        AdminConsoleTest initTest = getCurrentTest();
-        initTest.createTestUsers();
-    }
 }

--- a/src/org/labkey/test/tests/LabkeyErrorPageTest.java
+++ b/src/org/labkey/test/tests/LabkeyErrorPageTest.java
@@ -23,7 +23,7 @@ public class LabkeyErrorPageTest extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject()
     {
-        LabkeyErrorPageTest init = (LabkeyErrorPageTest) getCurrentTest();
+        LabkeyErrorPageTest init = getCurrentTest();
         init.doSetup();
     }
 
@@ -60,18 +60,12 @@ public class LabkeyErrorPageTest extends BaseWebDriverTest
     @Test
     public void testPermissionErrors()
     {
-        String imageTitle = "permission_error.svg";
-
         goToProjectHome();
         impersonate(READER_USER);
         beginAt(WebTestHelper.buildURL("test", "PermUpdate"));
-        LabkeyErrorPage errorPage = new LabkeyErrorPage(getDriver());
 
-        checker().verifyEquals("Incorrect error heading message", "Oops! An error has occurred.",
-                errorPage.getErrorHeading());
-        checker().verifyEquals("Incorrect error sub-heading message", "User does not have permission to perform this operation.",
-                errorPage.getSubErrorHeading());
-        checker().verifyThat("Incorrect error image", errorPage.getErrorImage(), CoreMatchers.containsString(imageTitle));
+        LabkeyErrorPage errorPage = new LabkeyErrorPage(getDriver());
+        errorPage.assertUnauthorized(checker());
 
         errorPage.clickViewDetails();
         scrollIntoView(Locator.button("Stop Impersonating"));

--- a/src/org/labkey/test/tests/PostgresQueriesTest.java
+++ b/src/org/labkey/test/tests/PostgresQueriesTest.java
@@ -154,8 +154,9 @@ public class PostgresQueriesTest extends AbstractAdminConsoleTest implements Pos
         DataRegionTable table = new DataRegionTable("query", this);
         List<String> cols = table.getColumnLabels();
         Assertions.assertThat(cols).as("pg_stat_activity columns").contains("Query", "Running Time Ms");
-        assertTextPresent("GREATEST(EXTRACT(MILLISECONDS FROM AGE(NOW(), query_start)), 0) END AS running_time_ms");
-        assertTextPresent("AsyncQueryRequest:");
+        assertTextPresent(
+            "GREATEST(EXTRACT(MILLISECONDS FROM AGE(NOW(), query_start)), 0) END AS running_time_ms", 
+            "AsyncQueryRequest:");
         assertEquals("Delete button should " + (expectDelete ? "" : "not ") + " be present",
                 expectDelete ? 1 : 0,
                 table.getHeaderButtons().stream().filter(a -> "Delete".equals(a.getDomAttribute("data-original-title"))).count());

--- a/src/org/labkey/test/tests/PostgresQueriesTest.java
+++ b/src/org/labkey/test/tests/PostgresQueriesTest.java
@@ -15,7 +15,7 @@
  */
 package org.labkey.test.tests;
 
-import org.junit.BeforeClass;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
@@ -35,7 +35,6 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @Category({Daily.class})
@@ -102,12 +101,14 @@ public class PostgresQueriesTest extends AbstractAdminConsoleTest implements Pos
         SelectRowsResponse activityResponse = selectRows(expectSuccess, "pg_stat_activity");
         if (expectSuccess)
         {
+            assertNotNull("Should have a response from a successful request", activityResponse);
             assertFalse("Should have at least one row", activityResponse.getRows().isEmpty());
             assertNotNull("Should have a pid", activityResponse.getRows().get(0).get("pid"));
         }
         SelectRowsResponse locksResponse = selectRows(expectSuccess, "pg_locks");
         if (expectSuccess)
         {
+            assertNotNull("Should have a response from a successful request", locksResponse);
             assertFalse("Should have at least one row", locksResponse.getRows().isEmpty());
             assertNotNull("Should have a pid", locksResponse.getRows().get(0).get("locktype"));
         }
@@ -161,13 +162,4 @@ public class PostgresQueriesTest extends AbstractAdminConsoleTest implements Pos
                 expectDelete ? 1 : 0,
                 table.getHeaderButtons().stream().filter(a -> "Delete".equals(a.getDomAttribute("data-original-title"))).count());
     }
-
-    @BeforeClass
-    public static void doSetup() throws Exception
-    {
-        AbstractAdminConsoleTest initTest = getCurrentTest();
-        initTest.createTestUsers();
-    }
-
-
 }

--- a/src/org/labkey/test/tests/PostgresQueriesTest.java
+++ b/src/org/labkey/test/tests/PostgresQueriesTest.java
@@ -153,8 +153,7 @@ public class PostgresQueriesTest extends AbstractAdminConsoleTest implements Pos
         assertTextPresent("pg_stat_activity");
         DataRegionTable table = new DataRegionTable("query", this);
         List<String> cols = table.getColumnLabels();
-        assertTrue("Didn't find a Query column: " + cols, cols.contains("Query"));
-        assertTrue("Didn't find a Running Time Ms column: " + cols, cols.contains("Running Time Ms"));
+        Assertions.assertThat(cols).as("pg_stat_activity columns").contains("Query", "Running Time Ms");
         assertTextPresent("GREATEST(EXTRACT(MILLISECONDS FROM AGE(NOW(), query_start)), 0) END AS running_time_ms");
         assertTextPresent("AsyncQueryRequest:");
         assertEquals("Delete button should " + (expectDelete ? "" : "not ") + " be present",

--- a/src/org/labkey/test/tests/PostgresQueriesTest.java
+++ b/src/org/labkey/test/tests/PostgresQueriesTest.java
@@ -145,8 +145,7 @@ public class PostgresQueriesTest extends AbstractAdminConsoleTest implements Pos
         assertTextPresent("pg_locks");
         DataRegionTable table = new DataRegionTable("query", this);
         List<String> cols = table.getColumnLabels();
-        assertTrue("Didn't find a Locktype column: " + cols, cols.contains("Locktype"));
-        assertTrue("Didn't find a Virtualtransaction column: " + cols, cols.contains("Virtualtransaction"));
+        Assertions.assertThat(cols).as("pg_locks columns").contains("Locktype", "Virtualtransaction");
     }
 
     private void verifyActivityGrid(boolean expectDelete)

--- a/src/org/labkey/test/tests/PostgresQueriesTest.java
+++ b/src/org/labkey/test/tests/PostgresQueriesTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2013-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.test.tests;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.query.SelectRowsCommand;
+import org.labkey.remoteapi.query.SelectRowsResponse;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.categories.Daily;
+import org.labkey.test.pages.LabkeyErrorPage;
+import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.PostgresOnlyTest;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@Category({Daily.class})
+@BaseWebDriverTest.ClassTimeout(minutes = 3)
+public class PostgresQueriesTest extends AbstractAdminConsoleTest implements PostgresOnlyTest
+{
+
+    @Test
+    public void testQueries() throws IOException, CommandException
+    {
+        // Verify activity grid as site admin
+        goToAdminConsole().clickPostgresActivity();
+        assertTextPresent("pg_stat_activity");
+        verifyActivityGrid(true);
+        verifyApiAccess(true);
+
+        // Verify project admin gets a 401 for activity grid
+        pushLocation();
+        goToHome();
+        impersonateRole("Project Administrator");
+        popLocation();
+        LabkeyErrorPage errorPage = new LabkeyErrorPage(getDriver());
+        errorPage.assertUnauthorized(checker());
+        verifyApiAccess(false);
+        stopImpersonating();
+
+        // Verify locks grid as site admin
+        goToAdminConsole().clickPostgresLocks();
+        verifyLocksGrid();
+
+
+        // Verify project admin gets a 401 for locks grid
+        pushLocation();
+        goToHome();
+        impersonateRole("Project Administrator");
+        popLocation();
+        errorPage = new LabkeyErrorPage(getDriver());
+        errorPage.assertUnauthorized(checker());
+        stopImpersonating();
+
+        // Log in as appAdmin
+        signOut();
+        signIn(APP_ADMIN_USER);
+        goToAdminConsole().clickPostgresActivity();
+        verifyActivityGrid(true);
+
+        goToAdminConsole().clickPostgresLocks();
+        verifyLocksGrid();
+        verifyApiAccess(true);
+
+        // log in as troubleshooter
+        signOut();
+        signIn(TROUBLESHOOTER_USER);
+        goToAdminConsole().clickPostgresActivity();
+        verifyActivityGrid(false);
+
+        goToAdminConsole().clickPostgresLocks();
+        verifyLocksGrid();
+        verifyApiAccess(true);
+    }
+
+    private void verifyApiAccess(boolean expectSuccess) throws IOException, CommandException
+    {
+        SelectRowsResponse activityResponse = selectRows(expectSuccess, "pg_stat_activity");
+        if (expectSuccess)
+        {
+            assertFalse("Should have at least one row", activityResponse.getRows().isEmpty());
+            assertNotNull("Should have a pid", activityResponse.getRows().get(0).get("pid"));
+        }
+        SelectRowsResponse locksResponse = selectRows(expectSuccess, "pg_locks");
+        if (expectSuccess)
+        {
+            assertFalse("Should have at least one row", locksResponse.getRows().isEmpty());
+            assertNotNull("Should have a pid", locksResponse.getRows().get(0).get("locktype"));
+        }
+    }
+
+    private SelectRowsResponse selectRows(boolean expectSuccess, String queryName) throws IOException, CommandException
+    {
+        Connection connection = WebTestHelper.getRemoteApiConnection();
+        SelectRowsCommand command = new SelectRowsCommand("postgres", queryName);
+        try
+        {
+            SelectRowsResponse response = command.execute(connection, "/");
+            if (!expectSuccess)
+            {
+                fail("Request should have failed");
+            }
+            return response;
+        }
+        catch (CommandException e)
+        {
+            if (expectSuccess)
+            {
+                throw e;
+            }
+            else
+            {
+                assertEquals("Wrong status code", 404, e.getStatusCode());
+            }
+        }
+        return null;
+    }
+
+    private void verifyLocksGrid()
+    {
+        assertTextPresent("pg_locks");
+        DataRegionTable table = new DataRegionTable("query", this);
+        List<String> cols = table.getColumnLabels();
+        assertTrue("Didn't find a Locktype column: " + cols, cols.contains("Locktype"));
+        assertTrue("Didn't find a Virtualtransaction column: " + cols, cols.contains("Virtualtransaction"));
+    }
+
+    private void verifyActivityGrid(boolean expectDelete)
+    {
+        assertTextPresent("pg_stat_activity");
+        DataRegionTable table = new DataRegionTable("query", this);
+        List<String> cols = table.getColumnLabels();
+        assertTrue("Didn't find a Query column: " + cols, cols.contains("Query"));
+        assertTrue("Didn't find a Running Time Ms column: " + cols, cols.contains("Running Time Ms"));
+        assertTextPresent("GREATEST(EXTRACT(MILLISECONDS FROM AGE(NOW(), query_start)), 0) END AS running_time_ms");
+        assertTextPresent("AsyncQueryRequest:");
+        assertEquals("Delete button should " + (expectDelete ? "" : "not ") + " be present",
+                expectDelete ? 1 : 0,
+                table.getHeaderButtons().stream().filter(a -> "Delete".equals(a.getDomAttribute("data-original-title"))).count());
+    }
+
+    @BeforeClass
+    public static void doSetup() throws Exception
+    {
+        AbstractAdminConsoleTest initTest = getCurrentTest();
+        initTest.createTestUsers();
+    }
+
+
+}

--- a/src/org/labkey/test/tests/SecurityTest.java
+++ b/src/org/labkey/test/tests/SecurityTest.java
@@ -29,6 +29,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.BVT;
 import org.labkey.test.components.dumbster.EmailRecordTable;
+import org.labkey.test.pages.LabkeyErrorPage;
 import org.labkey.test.pages.admin.PermissionsPage;
 import org.labkey.test.pages.user.ShowUsersPage;
 import org.labkey.test.util.ApiPermissionsHelper;
@@ -74,7 +75,6 @@ public class SecurityTest extends BaseWebDriverTest
     private static final String ADDED_USER = "fromprojectusers@security.test";
     protected static final String TO_BE_DELETED_USER = "delete_me@security.test";
     protected static final String SITE_ADMIN_USER = "siteadmin_securitytest@security.test";
-    protected static final String PERMISSION_ERROR = "User does not have permission to perform this operation.";
     protected static final String NOT_FOUND_ERROR = "notFound";
 
     protected static final String SIGN_IN_TEXT = "Sign In";
@@ -215,7 +215,7 @@ public class SecurityTest extends BaseWebDriverTest
         SimpleHttpResponse httpResponse = WebTestHelper.getHttpResponse(url);
 
         if ((HttpStatus.SC_FORBIDDEN != httpResponse.getResponseCode() ||
-                !httpResponse.getResponseBody().contains(PERMISSION_ERROR)) &&
+                !httpResponse.getResponseBody().contains(LabkeyErrorPage.UNAUTHORIZED_FULL_PAGE_MESSAGE)) &&
                 (HttpStatus.SC_NOT_FOUND != httpResponse.getResponseCode() ||
                 !httpResponse.getResponseBody().contains(NOT_FOUND_ERROR)))
         {

--- a/src/org/labkey/test/tests/announcements/AnnouncementAPITest.java
+++ b/src/org/labkey/test/tests/announcements/AnnouncementAPITest.java
@@ -16,6 +16,7 @@ import org.labkey.remoteapi.announcements.MessageThreadResponse;
 import org.labkey.remoteapi.announcements.UpdateMessageThreadCommand;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.pages.LabkeyErrorPage;
 import org.labkey.test.util.WikiHelper;
 
 import java.util.Arrays;
@@ -324,7 +325,7 @@ public class AnnouncementAPITest extends BaseWebDriverTest
         }
         catch (CommandException success)
         {
-             assertThat(success.getMessage(), is("User does not have permission to perform this operation."));
+             assertThat(success.getMessage(), is(LabkeyErrorPage.UNAUTHORIZED_FULL_PAGE_MESSAGE));
         }
 
         // respond to a thread
@@ -335,7 +336,7 @@ public class AnnouncementAPITest extends BaseWebDriverTest
         }
         catch (CommandException success)
         {
-            assertThat(success.getMessage(), is("User does not have permission to perform this operation."));
+            assertThat(success.getMessage(), is(LabkeyErrorPage.UNAUTHORIZED_FULL_PAGE_MESSAGE));
         }
 
         // delete a thread
@@ -347,7 +348,7 @@ public class AnnouncementAPITest extends BaseWebDriverTest
         }
         catch (CommandException success)
         {
-            assertThat(success.getMessage(), is("User does not have permission to perform this operation."));
+            assertThat(success.getMessage(), is(LabkeyErrorPage.UNAUTHORIZED_FULL_PAGE_MESSAGE));
         }
 
         // update a thread
@@ -359,7 +360,7 @@ public class AnnouncementAPITest extends BaseWebDriverTest
         }
         catch (CommandException success)
         {
-            assertThat(success.getMessage(), is("User does not have permission to perform this operation."));
+            assertThat(success.getMessage(), is(LabkeyErrorPage.UNAUTHORIZED_FULL_PAGE_MESSAGE));
         }
 
         stopImpersonatingHTTP();

--- a/src/org/labkey/test/tests/core/security/ImpersonatingTroubleshooterRoleTest.java
+++ b/src/org/labkey/test/tests/core/security/ImpersonatingTroubleshooterRoleTest.java
@@ -8,6 +8,7 @@ import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.user.ImpersonateRolesCommand;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Git;
+import org.labkey.test.pages.LabkeyErrorPage;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.PermissionsHelper;
@@ -57,7 +58,7 @@ public class ImpersonatingTroubleshooterRoleTest extends TroubleshooterRoleTest
         Assertions.assertThatThrownBy(() -> apiAsTroubleshooter().addMemberToRole(USER, "Site Admin", PermissionsHelper.MemberType.user, "/"))
                 .as("Impersonating Troubleshooter assigning Site Admin over API").cause()
                 .isInstanceOf(CommandException.class)
-                .hasMessage("User does not have permission to perform this operation.");
+                .hasMessage(LabkeyErrorPage.UNAUTHORIZED_FULL_PAGE_MESSAGE);
 
         apiAsImpersonatingSiteAdmin().addMemberToRole(USER, "Site Admin", PermissionsHelper.MemberType.user, "/");
         Assertions.assertThat(_apiPermissionsHelper.getUserRoles("/", USER)).contains(PermissionsHelper.toRole("Site Administrator"));

--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -25,6 +25,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Wiki;
+import org.labkey.test.pages.LabkeyErrorPage;
 import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PortalHelper;
@@ -469,7 +470,7 @@ public class WikiLongTest extends BaseWebDriverTest
         impersonate(USER1);
         assertElementNotPresent(Locator.linkWithText(PROJECT2_NAME));     // Project should not be visible
         popLocation();
-        assertTextPresent("User does not have permission to perform this operation.");  // Not authorized
+        new LabkeyErrorPage(getDriver()).assertUnauthorized(checker());
         goToHome();
         stopImpersonating();
 


### PR DESCRIPTION
#### Rationale
To troubleshoot deadlocks and performance issues it's often useful to get the status of the database connections, what they might be blocked on, and what locks are involved. By making this available through the app instead of strictly though Postgres tools we can make this faster and easier for admins.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6304

#### Changes
- Automated test coverage for Admin Console links, direct API access to schema, and export diagnostics
- Stronger validation for 401 pages
- Centralize string constant
