### PR TITLE
Issue 52099: Don't allow sample statuses that differ only by case

### DIFF
--- a/src/org/labkey/test/components/ManageSampleStatusesPanel.java
+++ b/src/org/labkey/test/components/ManageSampleStatusesPanel.java
@@ -161,6 +161,7 @@ public class ManageSampleStatusesPanel extends WebDriverComponent<ManageSampleSt
     public ManageSampleStatusesPanel clickAddStatus()
     {
         elementCache().addStatusButton.click();
+        waitForEditReady();
         return this;
     }
 
@@ -224,8 +225,6 @@ public class ManageSampleStatusesPanel extends WebDriverComponent<ManageSampleSt
     public ManageSampleStatusesPanel addStatus(String label, String description, SampleTypeHelper.StatusType statusType, String hexColor)
     {
         clickAddStatus();
-
-        waitForEditReady();
 
         setLabel(label)
                 .setColor(hexColor)


### PR DESCRIPTION
#### Rationale
Everyone needs to wait for ready.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1174

#### Changes
- Move `waitForReady`