### PR TITLE
Update tests for removal of substitution support

### DIFF
--- a/src/org/labkey/test/tests/MessagesLongTest.java
+++ b/src/org/labkey/test/tests/MessagesLongTest.java
@@ -76,9 +76,9 @@ public class MessagesLongTest extends BaseWebDriverTest
     private static final String RESPONDER = "responder@messages.test";
     private static final String WEBPART_SUBSTITUTION = "${labkey.webPart(partName='Lists')}";
     private static final String HTML_BODY = "1 <b>x</b>\n" +
-            "<b>" +
+            "<p>" +
             WEBPART_SUBSTITUTION +
-            "</b>\n";
+            "</p>\n";
     private static final String HTML_BODY_WEBPART_TEST = "manage lists";
     private static final String MEMBER_LIST = "memberListInput";
     private static final String TEMPLATE_TEXT = "***Please do not reply to this email notification. Replies to this email are routed to an unmonitored mailbox. Instead, please use the link below.***";
@@ -250,11 +250,7 @@ public class MessagesLongTest extends BaseWebDriverTest
         assertElementPresent(Locator.tagWithText("li", "internet trolls"));
         assertElementPresent(Locator.tagWithText("p", "<b>escaped</b>"));
 
-        // Issue 52214: Remove markdown support for HTML substitution patterns
-        assertElementPresent(PortalHelper.Locators.webPart("Lists"));
-        assertElementPresent(Locator.linkWithText("manage lists"));
-        // TODO: Update assertion
-        // assertElementPresent(Locator.tagWithText("p", MACRO_WEBPART));
+        assertElementPresent(Locator.tagWithText("p", WEBPART_SUBSTITUTION));
 
         clickButton("Submit");
         assertElementPresent(Locator.tagWithText("h1", "Holy Header, Batman!"));
@@ -277,7 +273,9 @@ public class MessagesLongTest extends BaseWebDriverTest
                 .setBody(HTML_BODY)
                 .submit();
         assertElementPresent(Locator.tag("div").withClass("message-text").withPredicate("starts-with(normalize-space(), '1 x')"));
-        assertElementPresent(Locator.linkWithText(HTML_BODY_WEBPART_TEST));
+        // 52214: Remove messages and markdown support for HTML substitution patterns
+        assertElementPresent(Locator.tagWithText("p", WEBPART_SUBSTITUTION));
+        assertElementNotPresent(Locator.linkWithText(HTML_BODY_WEBPART_TEST));
 
         log("Check that edit works");
         clickAndWait(Locator.linkWithText("view message or respond"));
@@ -438,7 +436,9 @@ public class MessagesLongTest extends BaseWebDriverTest
         assertTextPresent("RE: " + MSG1_TITLE, 0); // Do not expect original title in "RE:" email subjects
         assertTextPresent("RE: " + RESP1_TITLE, 6); // "RE:" email subjects should include the title of the response
         click(Locator.linkWithText(MSG1_TITLE));
-        assertElementPresent(Locator.linkWithText("manage lists"));
+        // 52214: Remove messages and markdown support for HTML substitution patterns
+        assertElementPresent(Locator.tagWithText("p", WEBPART_SUBSTITUTION));
+        assertElementNotPresent(Locator.linkWithText(HTML_BODY_WEBPART_TEST));
         click(Locator.linkWithText(MSG1_TITLE).index(1));
         assertTextPresent("first message testing");
         assertElementNotPresent(Locator.linkWithText(MSG3_TITLE));
@@ -457,9 +457,6 @@ public class MessagesLongTest extends BaseWebDriverTest
         waitForTextWithRefresh(WAIT_FOR_JAVASCRIPT, "New posts");
         click(Locator.linkWithText("New posts to /" + PROJECT_NAME));
         assertTextPresent("The following new posts were made yesterday");
-
-        // Will be resolved by Issue 52214: Remove markdown support for HTML substitution patterns
-        checkExpectedErrors(1);
     }
 
     @Test

--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -234,11 +234,7 @@ public class WikiLongTest extends BaseWebDriverTest
         assertElementPresent(Locator.tagWithText("h1", "Title MD"));
         assertElementPresent(Locator.tagWithText("p", "<b>escaped</b>"));
 
-        // Issue 52214: Remove markdown support for HTML substitution patterns
-        assertElementPresent(PortalHelper.Locators.webPart("Lists"));
-        assertElementPresent(Locator.linkWithText("manage lists"));
-        // TODO: Update assertion
-        // assertElementPresent(Locator.tagWithText("p", MACRO_WEBPART));
+        assertElementPresent(Locator.tagWithText("p", WIKI_PAGE7_WEBPART_SUBSTITUTION));
 
         assertTextNotPresent("# Title MD");
         clickAndWait(Locator.linkWithText("Edit"));


### PR DESCRIPTION
#### Rationale
[Issue 52214: Remove messages and markdown support for HTML substitution patterns](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52214)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6313

#### Changes
- Update tests for removal of substitution support
