### PR TITLE
KnitrReportTest: use checkExpectedErrors()

### DIFF
--- a/src/org/labkey/test/tests/KnitrReportTest.java
+++ b/src/org/labkey/test/tests/KnitrReportTest.java
@@ -199,10 +199,11 @@ public class KnitrReportTest extends AbstractKnitrReportTest
 
         createKnitrReport(rmdDependenciesReport, RReportHelper.ReportOption.knitrMarkdown);
 
+        int errorCountBefore = getServerErrorCount();
         _rReportHelper.clickReportTab();
         waitForElement(Locator.id("mtcars_table"));
         assertElementNotPresent(Locator.id("mtcars_table_wrapper")); // Created by jQuery
-        checkExpectedErrors(1); // JavaScript error: "$(...).dataTable is not a function"
+        checkExpectedErrors(errorCountBefore + 1); // JavaScript error: "$(...).dataTable is not a function"
 
         // now set the dependencies
         _rReportHelper.clickSourceTab();

--- a/src/org/labkey/test/tests/KnitrReportTest.java
+++ b/src/org/labkey/test/tests/KnitrReportTest.java
@@ -16,6 +16,7 @@
 package org.labkey.test.tests;
 
 import org.apache.hc.core5.http.HttpStatus;
+import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assume;
 import org.junit.Test;

--- a/src/org/labkey/test/tests/KnitrReportTest.java
+++ b/src/org/labkey/test/tests/KnitrReportTest.java
@@ -199,13 +199,10 @@ public class KnitrReportTest extends AbstractKnitrReportTest
 
         createKnitrReport(rmdDependenciesReport, RReportHelper.ReportOption.knitrMarkdown);
 
-        pauseJsErrorChecker(); // Don't fail due to "$ is not a function"
-        {
-            _rReportHelper.clickReportTab();
-            waitForElement(Locator.id("mtcars_table"));
-            assertElementNotPresent(Locator.id("mtcars_table_wrapper")); // Created by jQuery
-        }
-        resumeJsErrorChecker();
+        _rReportHelper.clickReportTab();
+        waitForElement(Locator.id("mtcars_table"));
+        assertElementNotPresent(Locator.id("mtcars_table_wrapper")); // Created by jQuery
+        checkExpectedErrors(1); // JavaScript error: "$(...).dataTable is not a function"
 
         // now set the dependencies
         _rReportHelper.clickSourceTab();

--- a/src/org/labkey/test/tests/KnitrReportTest.java
+++ b/src/org/labkey/test/tests/KnitrReportTest.java
@@ -199,11 +199,11 @@ public class KnitrReportTest extends AbstractKnitrReportTest
 
         createKnitrReport(rmdDependenciesReport, RReportHelper.ReportOption.knitrMarkdown);
 
-        int errorCountBefore = getServerErrorCount();
         _rReportHelper.clickReportTab();
         waitForElement(Locator.id("mtcars_table"));
         assertElementNotPresent(Locator.id("mtcars_table_wrapper")); // Created by jQuery
-        checkExpectedErrors(errorCountBefore + 1); // JavaScript error: "$(...).dataTable is not a function"
+        Assertions.assertThat(getServerErrors()).as("Server errors").contains("$(...).dataTable is not a function");
+        checkExpectedErrors(1); // JavaScript error: "$(...).dataTable is not a function"
 
         // now set the dependencies
         _rReportHelper.clickSourceTab();


### PR DESCRIPTION
#### Rationale
Switch `KnitrReportTest` to use `checkExpectedErrors()` to handle expected client-side errors when test is running.

#### Changes
- Utilize `checkExpectedErrors(1)` to handle expected client-side error.
