### PR TITLE
Properly encode query parameters during injection attempts

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -55,7 +55,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.AbstractMap;
@@ -1355,9 +1354,8 @@ public class Crawler
             List<Map.Entry<String,String>> injectParams = new ArrayList<>(params);
             //noinspection SuspiciousListRemoveInLoop
             injectParams.remove(i);
-            String xss = (random.nextInt()%2)==0 ? injectScriptBlock : injectAttributeScript;
-            xss = URLEncoder.encode(xss, StandardCharsets.UTF_8);
-            String paramMalicious = key + "=" + xss;
+            String xssValue = (random.nextInt()%2)==0 ? injectScriptBlock : injectAttributeScript;
+            String paramMalicious = EscapeUtil.encode(key) + "=" + EscapeUtil.encode(xssValue);
             String queryMalicious = paramMalicious + "&" + queryStringFromEntries(injectParams);
             String urlMalicious = base + "?" + queryMalicious;
             try


### PR DESCRIPTION
#### Rationale
When adding an injection parameter to the URL query we properly encode the parameter value but we aren't encoding the key. Both need to be encoded to work correctly.

```
java.lang.AssertionError: Crawler: Bad request: http://localhost:8111/ListVerifyProject/query-updateQueryRow.view?Key%20Field%20%22`~!@#$%^&*()_-+=%7B%7D%5B%5D|\:;%3C%3E,.?/%E5%99%A8%E9%AA%A8=%22%3E%27%3E%27%22%3Cscript%3Ealert%28%278%28%27%29%3C%2Fscript%3E&schemaName=lists&query.queryName=Tricky%20Field%20Character&returnUrl=%2FListVerifyProject%2Flist-grid.view%3FlistId%3D7&rowId=258&inactive=true&TitrationExclusion.DataId%2FRun%2FRowId%7Eeq=34&graphWidth=425&newRun=true&issues-issues.priority%7Eneqornull=1
  at org.junit.Assert.fail(Assert.java:89)
  at org.labkey.test.util.Crawler.checkForError(Crawler.java:1297)
  at org.labkey.test.util.Crawler.tryInject(Crawler.java:1251)
  at org.labkey.test.util.Crawler.testInjection(Crawler.java:1365)
  at org.labkey.test.util.Crawler.crawlLink(Crawler.java:1136)
  at org.labkey.test.util.Crawler.crawl(Crawler.java:834)
  at org.labkey.test.util.Crawler.crawlAllLinks(Crawler.java:797)
```

#### Related Pull Requests
- Revealed by: #2290 

#### Changes
- Properly encode query parameters during injection attempts
