### PR TITLE
Complete migration from srcURL and returnURL to returnUrl

### DIFF
--- a/src/org/labkey/test/tests/list/CrossFolderListTest.java
+++ b/src/org/labkey/test/tests/list/CrossFolderListTest.java
@@ -106,7 +106,7 @@ public class CrossFolderListTest extends BaseWebDriverTest
                 .setName(newListName)
                 .clickSave();
 
-        // Issue 47356: Rewrite returnURL in the event of a list name change
+        // Issue 47356: Rewrite returnUrl in the event of a list name change
         new GridPage(getDriver()).getGrid();
         assertThat(getURL().getQuery()).contains("name=" + newListName);
         assertThat(getURL().getPath()).contains("/" + SUBFOLDER_A);


### PR DESCRIPTION
#### Rationale
In 2021 we made a major push to use `returnUrl` consistently instead of `srcURL` or `returnURL`. We can finish the job.

Issue 7580: inconsistent use of returnUrl parameter

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6407

#### Changes
- Change everything to `returnUrl` and get rid of code checking for old versions of the parameters