### PR TITLE
Remove dependency on API classes for `getConversionErrorMessage`

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -36,9 +36,7 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.junit.Assume;
-import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.dialect.DatabaseNotSupportedException;
-import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
@@ -1680,15 +1678,23 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         clickButton("Confirm Delete");
     }
 
+    public String getConversionErrorMessage(Object value, String fieldName, Class<?> targetClass)
+    {
+        return getConversionErrorMessage(value, fieldName, targetClass, true);
+    }
+
     // Note: Keep in sync with ConvertHelper.getStandardConversionErrorMessage()
     // Example: "Could not convert value '2.34' (Double) for Boolean field 'Medical History.Dep Diagnosed in Last 18 Months'"
-    public String getConversionErrorMessage(Object value, String fieldName, Class<?> targetClass)
+    public String getConversionErrorMessage(Object value, String fieldName, Class<?> targetClass, boolean useUSDateParsing)
     {
         String fieldType = targetClass.getSimpleName();
 
         // Issue 50768: Need a better error message if date value is not in the expected format.
         if (fieldType.equalsIgnoreCase("date") || fieldType.equalsIgnoreCase("datetime") || fieldType.equalsIgnoreCase("timestamp"))
-            return "'" + value + "’ is not a valid " + fieldType + " for " + fieldName + " using " + LookAndFeelProperties.getInstance(ContainerManager.getRoot()).getDateParsingMode().getDisplayString();
+        {
+            String parsingMode = useUSDateParsing ? "U.S. date parsing (MDY)" : "Non-U.S. date parsing (DMY)";
+            return "'" + value + "’ is not a valid " + fieldType + " for " + fieldName + " using " + parsingMode;
+        }
 
         return "Could not convert value '" + value + "' (" + value.getClass().getSimpleName() + ") for " + fieldType + " field '" + fieldName + "'" ;
     }


### PR DESCRIPTION
#### Rationale
Previous PR added in run-time dependencies on API module methods, which need some transitive dependencies, which we don't have. This updates the `getConversionErrorMessage` to not require those.

#### Related Pull Requests
- #2316 

#### Changes
- update `getConversionErrorMessage` with new parameter to allow the test to indicate with parsing mode is expected.
