### PR TITLE
Prevent crawler injection on button test wiki

### DIFF
--- a/data/api/buttonCustomizationEcho.html
+++ b/data/api/buttonCustomizationEcho.html
@@ -3,10 +3,11 @@
 <script type="text/javascript">
     var html = "";
     var parameters = LABKEY.ActionURL.getParameters();
+    let paramsEl = document.getElementById("params");
     for (var p in parameters) {
         if (parameters.hasOwnProperty(p)) {
-            html += document.createTextNode(p + ": " + parameters[p]).textContent + "<br>";
+            paramsEl.append(document.createTextNode(p + ": " + parameters[p]));
+            paramsEl.append(document.createElement("br"));
         }
     }
-    document.getElementById("params").innerHTML = html;
 </script>

--- a/data/api/buttonCustomizationEcho.html
+++ b/data/api/buttonCustomizationEcho.html
@@ -5,7 +5,7 @@
     var parameters = LABKEY.ActionURL.getParameters();
     for (var p in parameters) {
         if (parameters.hasOwnProperty(p)) {
-            html += p + ": " + parameters[p] + "<br>";
+            html += document.createTextNode(p + ": " + parameters[p]).textContent + "<br>";
         }
     }
     document.getElementById("params").innerHTML = html;

--- a/src/org/labkey/test/tests/ButtonCustomizationTest.java
+++ b/src/org/labkey/test/tests/ButtonCustomizationTest.java
@@ -194,7 +194,7 @@ public class ButtonCustomizationTest extends BaseWebDriverTest
 
         // Verify that link buttons don't send parameters at all:
         clickButton(METADATA_LINK_BUTTON);
-        assertElementNotPresent(Locator.id("params").containing(".select"));
+        assertElementNotPresent(Locator.id("params").withText());
 
         // wait for the button to enable:
         waitForElement(Locator.lkButton(METADATA_GET_BUTTON), 10000);


### PR DESCRIPTION
#### Rationale
This test wiki writes all of the URL parameters to the page. This can allow the crawler to trigger an injection error if it hits this page. The page should properly encode the text before writing it to the page.

#### Related Pull Requests
- N/A

#### Changes
- Prevent crawler injection on button test wiki
