### PR TITLE
Enable timezone shifting in DataViewsTest

### DIFF
--- a/src/org/labkey/test/tests/DataViewsTest.java
+++ b/src/org/labkey/test/tests/DataViewsTest.java
@@ -58,15 +58,6 @@ public class DataViewsTest extends ParticipantListTest
 
     private final PortalHelper _portalHelper = new PortalHelper(this);
 
-    /**
-     * 52268: Data Views Webpart behaves badly when the server is in a different time zone
-     */
-    @Override
-    protected boolean allowTimeZoneShifting()
-    {
-        return false;
-    }
-
     @Override @LogMethod
     protected void doCreateSteps()
     {


### PR DESCRIPTION
#### Rationale
[Issue 52268: Data Views Webpart behaves badly when the server is in a different time zone](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52268)

We can enable timezone shifting now that this grid has been fixed.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6389

#### Changes
- Enable timezone shifting in DataViewsTest
