### PR TITLE
Fix EmailRecordTable row indexing

### DIFF
--- a/modules/dumbster/src/com/dumbster/smtp/SimpleSmtpServer.java
+++ b/modules/dumbster/src/com/dumbster/smtp/SimpleSmtpServer.java
@@ -16,26 +16,30 @@
  */
 package com.dumbster.smtp;
 
-import java.net.ServerSocket;
-import java.net.Socket;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Iterator;
+import org.apache.logging.log4j.Logger;
+import org.labkey.api.util.logging.LogHelper;
+
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
-import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Dummy SMTP server for testing purposes.
- *
- * @todo constructor allowing user to pass preinitialized ServerSocket
  */
 public class SimpleSmtpServer implements Runnable {
+  private static final Logger LOG = LogHelper.getLogger(SimpleSmtpServer.class, "Dumbster module SMTP Server");
+
   /**
    * Stores all of the email received since this instance started up.
    */
-  private List<String> receivedMail;
+  private final List<SmtpMessage> receivedMail;
 
   /**
    * Default SMTP port is 25.
@@ -91,19 +95,16 @@ public class SimpleSmtpServer implements Runnable {
       // Server: loop until stopped
       while (!isStopped()) {
         // Start server socket and listen for client connections
-        Socket socket = null;
+        Socket socket;
         try {
           socket = serverSocket.accept();
         } catch (Exception e) {
-          if (socket != null) {
-            socket.close();
-          }
           continue; // Non-blocking socket timeout occurred: try accept() again
         }
 
         // Get the input and output streams
-        BufferedReader input = new BufferedReader(new InputStreamReader(socket.getInputStream()));
-        PrintWriter out = new PrintWriter(socket.getOutputStream());
+        BufferedReader input = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+        PrintWriter out = new PrintWriter(socket.getOutputStream(), false, StandardCharsets.UTF_8);
 
         synchronized (this) {
           /*
@@ -112,20 +113,22 @@ public class SimpleSmtpServer implements Runnable {
            * For higher concurrency, we could just change handle to return void and update the list inside the method
            * to limit the duration that we hold the lock.
            */
-          List msgs = handleTransaction(out, input);
+          List<SmtpMessage> msgs = handleTransaction(out, input);
           receivedMail.addAll(msgs);
         }
         socket.close();
       }
     } catch (Exception e) {
-      /** @todo Should throw an appropriate exception here. */
-      e.printStackTrace();
+      if (!isStopped())
+      {
+        LOG.warn(e);
+      }
     } finally {
       if (serverSocket != null) {
         try {
           serverSocket.close();
         } catch (IOException e) {
-          e.printStackTrace();
+          LOG.warn("Error shutting down Dumbster SMTP server", e);
         }
       }
     }
@@ -165,7 +168,7 @@ public class SimpleSmtpServer implements Runnable {
    * @return List of SmtpMessage
    * @throws IOException
    */
-  private List handleTransaction(PrintWriter out, BufferedReader input) throws IOException {
+  private List<SmtpMessage> handleTransaction(PrintWriter out, BufferedReader input) throws IOException {
     // Initialize the state machine
     SmtpState smtpState = SmtpState.CONNECT;
     SmtpRequest smtpRequest = new SmtpRequest(SmtpActionType.CONNECT, "", smtpState);
@@ -207,6 +210,7 @@ public class SimpleSmtpServer implements Runnable {
       }
     }
 
+    LOG.debug("Dumbster received {} message{}", msgList::size, () -> msgList.size() != 1 ? "s" : "");
     return msgList;
   }
 
@@ -228,7 +232,7 @@ public class SimpleSmtpServer implements Runnable {
    * Get email received by this instance since start up.
    * @return List of String
    */
-  public synchronized Iterator getReceivedEmail() {
+  public synchronized Iterator<SmtpMessage> getReceivedEmail() {
     return receivedMail.iterator();
   }
 

--- a/modules/dumbster/src/com/dumbster/smtp/SmtpActionType.java
+++ b/modules/dumbster/src/com/dumbster/smtp/SmtpActionType.java
@@ -21,7 +21,7 @@ package com.dumbster.smtp;
  */
 public class SmtpActionType {
   /** Internal value for the action type. */
-  private byte value;
+  private final byte value;
 
   /** Internal representation of the CONNECT action. */
   private static final byte CONNECT_BYTE =  (byte) 1;

--- a/modules/dumbster/src/com/dumbster/smtp/SmtpMessage.java
+++ b/modules/dumbster/src/com/dumbster/smtp/SmtpMessage.java
@@ -16,26 +16,32 @@
  */
 package com.dumbster.smtp;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Container for a complete SMTP message - headers and message body.
  */
 public class SmtpMessage {
   /** Headers: Map of List of String hashed on header name. */
-  private Map headers;
+  private final Map<String, List<String>> headers;
   private String headerLast;
   /** Message body. */
-  private StringBuffer body;
+  private final StringBuffer body;
   private boolean inBody;
-  private Date createdTimestamp = new Date();
+  private final Date createdTimestamp = new Date();
 
 
   /**
    * Constructor. Initializes headers Map and body buffer.
    */
   public SmtpMessage() {
-    headers = new HashMap(10);
+    headers = new HashMap<>(10);
     body = new StringBuffer();
   }
 
@@ -69,8 +75,8 @@ public class SmtpMessage {
    * Get an Iterator over the header names.
    * @return an Iterator over the set of header names (String)
    */
-  public Iterator getHeaderNames() {
-    Set nameSet = headers.keySet();
+  public Iterator<String> getHeaderNames() {
+    Set<String> nameSet = headers.keySet();
     return nameSet.iterator();
   }
 
@@ -80,11 +86,11 @@ public class SmtpMessage {
    * @return value(s) associated with the header name
    */
   public String[] getHeaderValues(String name) {
-    List values = (List)headers.get(name);
+    List<String> values = headers.get(name);
     if (values == null) {
       return new String[0];
     } else {
-      return (String[])values.toArray(new String[0]);
+      return values.toArray(new String[0]);
     }
   }
 
@@ -94,12 +100,12 @@ public class SmtpMessage {
    * @return first value associated with the header name
    */
   public String getHeaderValue(String name) {
-    List values = (List)headers.get(name);
+    List<String> values = headers.get(name);
     if (values == null) {
       return null;
     } else {
-      Iterator iterator = values.iterator();
-      return (String)iterator.next();
+      Iterator<String> iterator = values.iterator();
+      return iterator.next();
     }
   }
 
@@ -117,9 +123,9 @@ public class SmtpMessage {
    * @param value header value
    */
   private void addHeader(String name, String value) {
-    List valueList = (List)headers.get(name);
+    List<String> valueList = headers.get(name);
     if (valueList == null) {
-      valueList = new ArrayList(1);
+      valueList = new ArrayList<>(1);
       headers.put(name, valueList);
     }
     valueList.add(value);
@@ -131,9 +137,9 @@ public class SmtpMessage {
    * @param value header value
    */
   private void appendHeader(String name, String value) {
-    List valueList = (List)headers.get(name);
+    List<String> valueList = headers.get(name);
     if (valueList == null) {
-      valueList = new ArrayList(1);
+      valueList = new ArrayList<>(1);
       headers.put(name, valueList);
     }
     valueList.set(0, valueList.get(0) + value);
@@ -144,12 +150,12 @@ public class SmtpMessage {
    * @return a String
    */
   public String toString() {
-    StringBuffer msg = new StringBuffer();
-    for(Iterator i = headers.keySet().iterator(); i.hasNext();) {
-      String name = (String)i.next();
-      List values = (List)headers.get(name);
-      for(Iterator j = values.iterator(); j.hasNext();) {
-        String value = (String)j.next();
+    StringBuilder msg = new StringBuilder();
+    for(Iterator<String> i = headers.keySet().iterator(); i.hasNext();) {
+      String name = i.next();
+      List<String> values = headers.get(name);
+      for(Iterator<String> j = values.iterator(); j.hasNext();) {
+        String value = j.next();
         msg.append(name);
         msg.append(": ");
         msg.append(value);

--- a/modules/dumbster/src/com/dumbster/smtp/SmtpRequest.java
+++ b/modules/dumbster/src/com/dumbster/smtp/SmtpRequest.java
@@ -43,11 +43,11 @@ package com.dumbster.smtp;
  */
 public class SmtpRequest {
   /** SMTP action received from client. */
-  private SmtpActionType action;
+  private final SmtpActionType action;
   /** Current state of the SMTP state table. */
-  private SmtpState state;
+  private final SmtpState state;
   /** Additional information passed from the client with the SMTP action. */
-  private String params;
+  private final String params;
 
   /**
    * Create a new SMTP client request.
@@ -66,7 +66,7 @@ public class SmtpRequest {
    * @return response to the request
    */
   public SmtpResponse execute() {
-    SmtpResponse response = null;
+    SmtpResponse response;
     if (action.isStateless()) {
       if (SmtpActionType.EXPN == action || SmtpActionType.VRFY == action) {
         response = new SmtpResponse(252, "Not supported", this.state);
@@ -74,8 +74,6 @@ public class SmtpRequest {
         response = new SmtpResponse(211, "No help available", this.state);
       } else if (SmtpActionType.NOOP == action) {
         response = new SmtpResponse(250, "OK", this.state);
-      } else if (SmtpActionType.VRFY == action) {
-        response = new SmtpResponse(252, "Not supported", this.state);
       } else if (SmtpActionType.RSET == action) {
         response = new SmtpResponse(250, "OK", SmtpState.GREET);
       } else {
@@ -152,13 +150,13 @@ public class SmtpRequest {
    * @return a populated SmtpRequest object
    */
   public static SmtpRequest createRequest(String s, SmtpState state) {
-    SmtpActionType action = null;
+    SmtpActionType action;
     String params = null;
 
     if (state == SmtpState.DATA_HDR) {
       if (s.equals(".")) {
         action = SmtpActionType.DATA_END;
-      } else if (s.length() < 1) {
+      } else if (s.isEmpty()) {
         action = SmtpActionType.BLANK_LINE;
       } else {
         action = SmtpActionType.UNRECOG;
@@ -201,12 +199,11 @@ public class SmtpRequest {
       }
     }
 
-    SmtpRequest req = new SmtpRequest(action, params, state);
-    return req;
+      return new SmtpRequest(action, params, state);
   }
 
   /**
-   * Get the parameters of this request (remainder of command line once the command is removed.
+   * Get the parameters of this request (remainder of command line once the command is removed).
    * @return parameters
    */
   public String getParams() {

--- a/modules/dumbster/src/com/dumbster/smtp/SmtpResponse.java
+++ b/modules/dumbster/src/com/dumbster/smtp/SmtpResponse.java
@@ -21,11 +21,11 @@ package com.dumbster.smtp;
  */
 public class SmtpResponse {
   /** Response code - see RFC-2821. */
-  private int code;
+  private final int code;
   /** Response message. */
-  private String message;
+  private final String message;
   /** New state of the SMTP server once the request has been executed. */
-  private SmtpState nextState;
+  private final SmtpState nextState;
 
   /**
    * Constructor.

--- a/modules/dumbster/src/com/dumbster/smtp/SmtpState.java
+++ b/modules/dumbster/src/com/dumbster/smtp/SmtpState.java
@@ -21,7 +21,7 @@ package com.dumbster.smtp;
  */
 public class SmtpState {
   /** Internal representation of the state. */
-  private byte value;
+  private final byte value;
 
   /** Internal representation of the CONNECT state. */
   private static final byte CONNECT_BYTE      = (byte) 1;

--- a/modules/dumbster/src/org/labkey/dumbster/view/mailWebPart.jsp
+++ b/modules/dumbster/src/org/labkey/dumbster/view/mailWebPart.jsp
@@ -16,9 +16,10 @@
  */
 %>
 <%@ page import="com.dumbster.smtp.SmtpMessage" %>
+<%@ page import="jakarta.mail.MessagingException" %>
+<%@ page import="jakarta.mail.internet.MimeMessage" %>
 <%@ page import="org.apache.commons.lang3.ArrayUtils" %>
 <%@ page import="org.labkey.api.data.Container" %>
-<%@ page import="org.labkey.api.data.DataRegion" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.util.MailHelper" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
@@ -27,8 +28,6 @@
 <%@ page import="org.labkey.dumbster.DumbsterController" %>
 <%@ page import="org.labkey.dumbster.model.DumbsterManager" %>
 <%@ page import="org.labkey.dumbster.view.MailPage" %>
-<%@ page import="jakarta.mail.MessagingException" %>
-<%@ page import="jakarta.mail.internet.MimeMessage" %>
 <%@ page import="java.util.Iterator" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="static org.labkey.api.util.DOM.Attribute.*" %>
@@ -43,17 +42,15 @@
     }
 %>
 <%
-    JspView<MailPage> me = (JspView<MailPage>) HttpView.currentView();
+    JspView<MailPage> me = HttpView.currentView();
     MailPage pageInfo = me.getModelBean();
     Container c = getContainer();
     SmtpMessage[] messages = pageInfo.getMessages();
     if ("true".equals(request.getParameter("reverse"))) ArrayUtils.reverse(messages);
     boolean recorder = pageInfo.isEnableRecorder();
 
-    DataRegion emailRegion = new DataRegion();
-    emailRegion.setName("EmailRecord");
-
-    String renderId = "emailRecordEmpty-" + getRequestScopedUID();
+    String tableId = makeId("EmailRecord");
+    String renderId = makeId("emailRecordEmpty-");
 
     %><p id="emailRecordError" class="labkey-error" style="display: none;">&nbsp;</p><%
 
@@ -105,9 +102,9 @@ function toggleRecorder(checkbox)
 
             if (checked)
             {
-                var t = document.getElementById(<%=q(emailRegion.getDomId())%>);
+                var t = document.getElementById(<%=q(tableId)%>);
                 var len = t.rows.length;
-                for (var i = len - 2; i > 0; i--)
+                for (var i = len - 1; i > 1; i--)
                     t.deleteRow(i);
                 Ext4.get(<%=q(renderId)%>).setDisplayed("");
             }
@@ -123,18 +120,19 @@ function toggleRecorder(checkbox)
 }
 </script>
 <!--Fake data region for ease of testing.-->
-<table id="<%=h(emailRegion.getDomId())%>" lk-region-name="<%=h(emailRegion.getName())%>" class="labkey-data-region-legacy labkey-show-borders">
-    <colgroup><col width="120"/><col width="120"/><col width="125"/><col width="400"></colgroup>
-    <!-- hidden TRs where the header region and message box would normally be in a real data region -->
-    <tr style="display:none"><td colspan="5">&nbsp;</td></tr>
+<table id="<%=h(tableId)%>" class="labkey-data-region-legacy labkey-show-borders">
+    <colgroup><col style="width: 120px"/><col style="width: 120px"/><col style="width: 125px"/><col style="width: 400px"></colgroup>
+    <thead>
     <tr>
-        <td class="labkey-column-header labkey-col-header-filter" align="left"><div>To</div></td>
-        <td class="labkey-column-header labkey-col-header-filter" align="left"><div>From</div></td>
-        <td class="labkey-column-header labkey-col-header-filter" align="left"><div>Date/Time</div></td>
-        <td class="labkey-column-header labkey-col-header-filter" align="left"><div>Message</div></td>
-        <td class="labkey-column-header labkey-col-header-filter" align="left"><div>Headers</div></td>
-        <td colspan="3" class="labkey-column-header labkey-col-header-filter" align="center"><div>View</div></td>
+        <th class="labkey-column-header labkey-col-header-filter" style="text-align: left;"><div>To</div></th>
+        <th class="labkey-column-header labkey-col-header-filter" style="text-align: left;"><div>From</div></th>
+        <th class="labkey-column-header labkey-col-header-filter" style="text-align: left;"><div>Date/Time</div></th>
+        <th class="labkey-column-header labkey-col-header-filter" style="text-align: left;"><div>Message</div></th>
+        <th class="labkey-column-header labkey-col-header-filter" style="text-align: left;"><div>Headers</div></th>
+        <th colspan="3" class="labkey-column-header labkey-col-header-filter" style="text-align: center;"><div>View</div></th>
     </tr>
+    <tr id="<%=h(renderId)%>" style="display: <%=unsafe(messages.length > 0 ? "none" : "")%>;"><td colspan="6">No email recorded.</td></tr>
+    </thead>
     <%
     if (messages.length > 0)
     {
@@ -148,11 +146,11 @@ function toggleRecorder(checkbox)
 
 
             StringBuilder headers = new StringBuilder();
-            Iterator i = m.getHeaderNames();
+            Iterator<String> i = m.getHeaderNames();
 
             while (i.hasNext())
             {
-                String header = (String)i.next();
+                String header = i.next();
                 headers.append(h(header));
                 headers.append(": ");
                 headers.append(h(m.getHeaderValue(header)));
@@ -201,15 +199,14 @@ function toggleRecorder(checkbox)
                 <div id="email_body_<%=rowIndex%>" style="display: none;"><hr><%=body%></div></td>
             <td><a id="<%=h(idHeaders)%>">View headers</a>
                 <div id="email_headers_<%=rowIndex%>" style="display: none;"><hr><%=unsafe(headers.toString())%></div></td>
-            <%=hasHtml ? createHtml(TD(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "html")).at(target, "_messageHtml"), "HTML"))) : createHtml(TD())%>
-            <%=hasText ? createHtml(TD(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "text")).at(target, "_messageText"), "Text"))) : createHtml(TD())%>
+            <%=hasHtml ? createHtml(TD(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "html")).at(target, "_messageHtml"), "HTML"))) : createHtml(TD(SPAN(cl("text-muted"), "HTML")))%>
+            <%=hasText ? createHtml(TD(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "text")).at(target, "_messageText"), "Text"))) : createHtml(TD(SPAN(cl("text-muted"), "Text")))%>
             <%=createHtml(TD(A(at(href, DumbsterController.getViewMessageURL(c, rowIndex - 1, "raw")).at(target, "_messageText"), "Raw")))%>
         </tr>
 <%
         }
     }
 %>
-    <tr id="<%=h(renderId)%>" style="display: <%=unsafe(messages.length > 0 ? "none" : "")%>;"><td colspan="6">No email recorded.</td></tr>
 </table>
 <%
     if (getUser().hasRootAdminPermission())

--- a/src/org/labkey/test/components/dumbster/EmailRecordTable.java
+++ b/src/org/labkey/test/components/dumbster/EmailRecordTable.java
@@ -36,13 +36,11 @@ public class EmailRecordTable extends Table
 {
     private static final String RECORDER_CHECKBOX_NAME = "emailRecordOn";
     private static final String _regionName = "EmailRecord";
-    private static final Locator gridLocator = Locator.xpath("//table[@lk-region-name='"+ _regionName +"']");
-    private static final int _headerRows = 2;
-    private static final int _footerRows = 1;
+    private static final Locator gridLocator = Locator.tagWithAttributeContaining("table", "id", _regionName);
 
     public EmailRecordTable(WebDriver driver)
     {
-        super(driver, new RefindingWebElement(gridLocator, driver).withTimeout(WAIT_FOR_JAVASCRIPT), _headerRows);
+        super(driver, new RefindingWebElement(gridLocator, driver).withTimeout(WAIT_FOR_JAVASCRIPT), 0);
         ((RefindingWebElement) getComponentElement()).withRefindListener(el -> clearElementCache());
     }
 
@@ -73,8 +71,7 @@ public class EmailRecordTable extends Table
 
     public int getEmailCount()
     {
-        //3 rows in the table do not contain email messages
-        return getRowCount() - (_headerRows + _footerRows);
+        return getRowCount();
     }
 
     public void startRecording()
@@ -138,12 +135,12 @@ public class EmailRecordTable extends Table
     private List<EmailMessage> getMessages(Predicate<String> subjectFilter)
     {
         List<EmailMessage> messages = new ArrayList<>();
-        int rows = getRowCount() - _footerRows;
+        int rows = getRowCount();
 
         if (rows > 0)
         {
             int colMessage = getColumnIndex("Message");
-            for (int i = _headerRows + 1; i <= rows; i++)
+            for (int i = 1; i <= rows; i++)
             {
                 String message = getDataAsText(i, colMessage);
                 String[] lines = trimAll(StringUtils.split(message, "\n"));
@@ -176,7 +173,7 @@ public class EmailRecordTable extends Table
         for(int i = 1; i <= columnText.size(); i++)
         {
             int arrayIndex = i-1;
-            if(columnText.get(arrayIndex).equals(text)){colsWithString.add(i + _headerRows);}
+            if(columnText.get(arrayIndex).equals(text)){colsWithString.add(i);}
         }
         return colsWithString;
     }

--- a/src/org/labkey/test/components/dumbster/EmailRecordTable.java
+++ b/src/org/labkey/test/components/dumbster/EmailRecordTable.java
@@ -20,6 +20,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.components.html.Table;
 import org.labkey.test.selenium.RefindingWebElement;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -212,17 +213,28 @@ public class EmailRecordTable extends Table
     private void parseViewCell(EmailMessage emailMessage)
     {
         List<String> views = new ArrayList<>();
-        String view;
+        boolean done = false;
         int rowIndex = emailMessage.getRowIndex();
         int colIndex = EmailColumn.View.getIndex();
         do
         {
-            view = getDataAsText(rowIndex, colIndex++);
-            if (view != null && !view.isBlank())
+            try
             {
-                views.add(view.trim());
+                WebElement viewEl = getDataAsElement(rowIndex, colIndex++);
+                if (Locator.tag("a").existsIn(viewEl))
+                {
+                    String view = viewEl.getText();
+                    if (!view.isBlank())
+                    {
+                        views.add(view.trim());
+                    }
+                }
             }
-        } while (view != null);
+            catch (NoSuchElementException nse)
+            {
+                done = true;
+            }
+        } while (!done);
         emailMessage.setViews(views);
     }
 


### PR DESCRIPTION
#### Rationale
After my last change, `EmailRecordTable.getColumnDataAsText` wasn't accounting for the extra, hidden row at the bottom of the table.
```
org.openqa.selenium.NoSuchElementException: Unable to locate element: ./tbody/tr[8]/td[4]
  [...]
  at app//org.labkey.test.components.html.Table._getDataAsElement(Table.java:207)
  at app//org.labkey.test.components.html.Table.getDataAsElement(Table.java:212)
  at app//org.labkey.test.components.html.Table.getColumnAsElement(Table.java:250)
  at app//org.labkey.test.components.html.Table.getColumnAsText(Table.java:217)
  at app//org.labkey.test.components.html.Table.getColumnAsText(Table.java:233)
  at app//org.labkey.test.components.dumbster.EmailRecordTable.getColumnDataAsText(EmailRecordTable.java:234)
  at app//org.labkey.test.tests.biologics.BiologicsWorkflowIntegrationTest.checkForEmailNotification(BiologicsWorkflowIntegrationTest.java:1389)
  at app//org.labkey.test.tests.biologics.BiologicsWorkflowIntegrationTest.checkForEmailNotification(BiologicsWorkflowIntegrationTest.java:1383)
  at app//org.labkey.test.tests.biologics.BiologicsWorkflowIntegrationTest.testJobTaskCommentsAreSearchIndexed(BiologicsWorkflowIntegrationTest.java:196)
```

This change fixes `EmailRecordTable`, largely by cleaning up the server-side component. There was a bunch of cruft that was, long ago, intended to make it compatible with the `DataRegionTable` test helper at the time.
This also cleans up a bunch of IDE warnings in Dumbster classes.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2313

#### Changes
- Fix EmailRecordTable row indexing
- Clean up dumbster classes and emailWebPart
