### PR TITLE
Add version of `randomFieldName` that allows for excluding characters

### DIFF
--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -361,11 +361,17 @@ public class TestDataGenerator
     {
         return randomFieldName(part, randomInt(0, 5), randomInt(0, 5));
     }
+
     public static String randomFieldName(String part, int numStartChars, int numEndChars)
+    {
+       return randomFieldName(part, numStartChars, numEndChars, null);
+    }
+
+    public static String randomFieldName(String part, int numStartChars, int numEndChars, @Nullable String exclusion)
     {
         // use the characters that we know are encoded in fieldKeys plus characters that we know clients are using
         String chars = ALL_ILLEGAL_QUERY_KEY_CHARACTERS + " %()=+-[]_|*`'\":;<>?!@#^";
-        String randomFieldName = (randomString(numStartChars, null, chars) + part + randomString(numEndChars, null, chars)).trim();
+        String randomFieldName = (randomString(numStartChars, exclusion, chars) + part + randomString(numEndChars, null, chars)).trim();
         TestLogger.log("Generated random field name: " + randomFieldName);
         return randomFieldName;
     }


### PR DESCRIPTION
#### Rationale
Sometimes we want names that exclude characters (e.g., when generating import aliases, quotes require special treatment)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1220

#### Changes
- Add new version of `randomFieldName` that accepts a string of excluded characters
