### PR TITLE
fix AttachmentFieldTest intermittent failure

### DIFF
--- a/src/org/labkey/test/tests/AttachmentFieldTest.java
+++ b/src/org/labkey/test/tests/AttachmentFieldTest.java
@@ -62,6 +62,7 @@ public class AttachmentFieldTest extends BaseWebDriverTest
         String sampleTypeName = "Sample type with attachment";
         String fieldName = "testFile";
         SampleTypeHelper sampleTypeHelper = new SampleTypeHelper(this);
+        goToProjectHome();
 
         log("Create a sample type with attachment field");
         sampleTypeHelper.createSampleType(new SampleTypeDefinition(sampleTypeName)

--- a/src/org/labkey/test/tests/SurveyTest.java
+++ b/src/org/labkey/test/tests/SurveyTest.java
@@ -121,6 +121,7 @@ public class SurveyTest extends BaseWebDriverTest
         final String dateSurveyDesign = "My extDate Survey Design";
 
         File metadata = TestFileUtils.getSampleData("survey/DateAndDateTimeSurvey.json");
+        navigateToFolder(getProjectName(), FOLDER_NAME);
         createSurveyDesign(getProjectName(), null, null, dateSurveyDesign, null, LIST_SCHEMA, LIST_NAME, metadata);
 
         clickProject(getProjectName());

--- a/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
+++ b/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
@@ -263,6 +263,18 @@ public class AssayMissingValuesTest extends MissingValueIndicatorsTest
         clickAndWait(Locator.linkWithText("view results"));
         var dataRegion = DataRegionTable.DataRegion(getDriver()).waitFor();
 
+        // if the test gets to the dataregion before the data is there, refresh and re-check
+        for (int i = 0; i < 3; i++)
+        {
+            if (dataRegion.getDataRowCount() == 0)
+            {
+                sleep(500);
+                refresh();
+            }
+            else
+                break;
+        }
+
         // expect 3 rows in this assay, p2 and p3 should get mv indicators in the count column
         Map<String, List<String>> expectedData = new HashMap<>();
         expectedData.put("Participant ID", List.of("p1", "p2", "p3"));

--- a/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
+++ b/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
@@ -264,16 +264,11 @@ public class AssayMissingValuesTest extends MissingValueIndicatorsTest
         var dataRegion = DataRegionTable.DataRegion(getDriver()).waitFor();
 
         // if the test gets to the dataregion before the data is there, refresh and re-check
-        for (int i = 0; i < 3; i++)
-        {
-            if (dataRegion.getDataRowCount() == 0)
-            {
-                sleep(500);
-                refresh();
-            }
-            else
-                break;
-        }
+        waitFor(()-> {
+            sleep(500);
+            refresh();
+            return dataRegion.getDataRowCount() > 0;
+        }, "Data did not appear in dataregion in time", 2000);
 
         // expect 3 rows in this assay, p2 and p3 should get mv indicators in the count column
         Map<String, List<String>> expectedData = new HashMap<>();

--- a/src/org/labkey/test/tests/filecontent/FilesQueryTest.java
+++ b/src/org/labkey/test/tests/filecontent/FilesQueryTest.java
@@ -98,7 +98,6 @@ public class FilesQueryTest extends BaseWebDriverTest
         log("Upload a file to file root from file browser");
         final File testFile1 = TestFileUtils.getSampleData("security/InlineFile.html");
         final String customPropValue1 = "CustomPropValue1";
-        goToProjectHome();
         uploadFile(testFile1, customPropValue1, "This is an html file");
 
         log("Create a sub directory and upload a file to the sub directory");

--- a/src/org/labkey/test/tests/filecontent/FilesQueryTest.java
+++ b/src/org/labkey/test/tests/filecontent/FilesQueryTest.java
@@ -98,6 +98,7 @@ public class FilesQueryTest extends BaseWebDriverTest
         log("Upload a file to file root from file browser");
         final File testFile1 = TestFileUtils.getSampleData("security/InlineFile.html");
         final String customPropValue1 = "CustomPropValue1";
+        goToProjectHome();
         uploadFile(testFile1, customPropValue1, "This is an html file");
 
         log("Create a sub directory and upload a file to the sub directory");


### PR DESCRIPTION
#### Rationale
[AttachmentFieldTest.testFileFieldInSampleType](https://teamcity.labkey.org/investigations.html?init=1#testNameId-7953000240887939862) fails intermittently because it assumes it will start at its projectHome, but occasionally the previous test will leave the browser at the home project instead.  This causes the test to explicitly start out where it expects to be

#### Related Pull Requests
n/a

#### Changes
explicitly start the test out where it expects to be
