### PR TITLE
Fix FilesQueryTest.testFileRecordsWithCustomProp() - nav to project

### DIFF
--- a/src/org/labkey/test/tests/filecontent/FilesQueryTest.java
+++ b/src/org/labkey/test/tests/filecontent/FilesQueryTest.java
@@ -95,6 +95,7 @@ public class FilesQueryTest extends BaseWebDriverTest
     @Test
     public void testFileRecordsWithCustomProp()
     {
+        goToProjectHome();
         log("Upload a file to file root from file browser");
         final File testFile1 = TestFileUtils.getSampleData("security/InlineFile.html");
         final String customPropValue1 = "CustomPropValue1";


### PR DESCRIPTION
#### Rationale
Each test needs to make sure it starts at the project it's expecting.

#### Changes
- Navigate at the start of `testFileRecordsWithCustomProp()`
