### PR TITLE
Create wiki in correct project

### DIFF
--- a/src/org/labkey/test/tests/wiki/WikiTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiTest.java
@@ -99,6 +99,8 @@ public class WikiTest extends BaseWebDriverTest
     @Test
     public void testSteps()
     {
+        goToProjectHome();
+
         log("test create new html page with a webpart");
         WikiHelper wikiHelper = new WikiHelper(this);
         wikiHelper.createNewWikiPage("HTML");


### PR DESCRIPTION
#### Rationale
This test was creating a wiki in whichever project the previous test left off in. It then searches for that wiki in the test project. This started failing in 25.3 due to ~different test execution order~ frequent browser restarts.
The browser restarts are fixed in https://github.com/LabKey/testAutomation/pull/2335 but we should make this test behave properly.

#### Related Pull Requests
- N/A

#### Changes
- Navigate to test project before creating wiki.
