### PR TITLE
Ignore `webtest.browser.tz` property on Windows

### DIFF
--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -16,6 +16,7 @@
 package org.labkey.test;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.labkey.serverapi.reader.Readers;
 import org.labkey.test.util.TestLogger;
 import org.openqa.selenium.Dimension;
@@ -171,7 +172,8 @@ public abstract class TestProperties
         if (browserZoneId == null)
         {
             String tz = StringUtils.trimToNull(System.getProperty("webtest.browser.tz"));
-            if (tz != null)
+            // TZ environment variable doesn't work on Windows
+            if (tz != null && !SystemUtils.IS_OS_WINDOWS)
             {
                 String[] split = tz.split("[,\\s]+");
                 tz = split[LocalDateTime.now().getDayOfMonth() % split.length];


### PR DESCRIPTION
#### Rationale
Before each test, the harness checks whether the browser in in the expected time zone. If it isn't, the harness starts a fresh browser.
Since the `TZ` environment variable doesn't work on Windows, the browser is **never** in the expected time zone when time zone shifting is configured.
We should ignore the `webtest.browser.tz` property on Windows until we can determine how to make it function there.

#### Related Pull Requests
- #2258

#### Changes
- Ignore `webtest.browser.tz` property on Windows
