### PR TITLE
Fix ExportOptionsMetadataOnlyTest.testAssayRunsExportOptions

### DIFF
--- a/src/org/labkey/test/tests/ExportOptionsMetadataOnlyTest.java
+++ b/src/org/labkey/test/tests/ExportOptionsMetadataOnlyTest.java
@@ -170,6 +170,7 @@ public class ExportOptionsMetadataOnlyTest extends BaseWebDriverTest
     {
         String assayName = "Export Assay";
         File runFile = TestFileUtils.getSampleData("AssayImportExport/GenericAssay_Run1.xlsx");
+        goToProjectHome();
 
         goToManageAssays();
         _assayHelper.createAssayDesign("General", assayName).clickSave();


### PR DESCRIPTION
#### Rationale
Fixes test by ensuring it navigate to the project to begin the test case. All other test cases in this test already do this.

See https://teamcity.labkey.org/buildConfiguration/LabKey_253Release_Premium_CommunitySqlserver_DailyASqlserver/3411621

#### Changes
- Add call to `goToProjectHome()`