### PR TITLE
Hack to fetch clipboard contents when running headless on Windows

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -84,6 +84,7 @@ import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WindowType;
 import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeDriverService;
@@ -3569,13 +3570,48 @@ public abstract class WebDriverWrapper implements WrapsDriver
             }
             else
             {
-                throw new UnsupportedOperationException("There are no clipboard DataFlavors to use");
+                // No available flavors, try pasting into a new input.
+                String value = doInNewTab(() -> {
+                    String inputId = "testClipboardInput";
+                    executeScript("""
+                        let input = document.createElement('input');
+                        input.id = arguments[0];
+                        document.getElementsByTagName('body')[0].appendChild(input);""", inputId);
+
+                    WebElement inputElement = Locator.id(inputId).findElement(getDriver());
+                    new Actions(getDriver())
+                        .keyDown(WebDriverUtils.MODIFIER_KEY)
+                        .sendKeys(inputElement, "v")
+                        .keyUp(WebDriverUtils.MODIFIER_KEY)
+                        .perform();
+
+                    return inputElement.getDomProperty("value");
+                });
+                if (StringUtils.isEmpty(value))
+                {
+                    throw new UnsupportedFlavorException(null);
+                }
+                return value;
             }
         }
         else
         {
             return null;
         }
+    }
+
+    @Nullable
+    public <T> T doInNewTab(Supplier<T> supplier)
+    {
+        String initialWindow = getDriver().getWindowHandle();
+        getDriver().switchTo().newWindow(WindowType.TAB);
+
+        T result = supplier.get();
+
+        getDriver().close();
+        getDriver().switchTo().window(initialWindow);
+
+        return result;
     }
 
     private static final List<String> html5InputTypes = Arrays.asList("color", "date", "datetime-local", "email", "month", "number", "range", "search", "tel", "time", "url", "week");

--- a/src/org/labkey/test/tests/core/admin/ShortUrlTest.java
+++ b/src/org/labkey/test/tests/core/admin/ShortUrlTest.java
@@ -1,6 +1,5 @@
 package org.labkey.test.tests.core.admin;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.NotNull;
 import org.junit.BeforeClass;
@@ -9,7 +8,6 @@ import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.Connection;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.BootstrapLocators;
-import org.labkey.test.TestProperties;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.admin.ShortUrlAdminPage;
@@ -83,11 +81,8 @@ public class ShortUrlTest extends BaseWebDriverTest
         assertThat(adminPage.getUrlsFromGrid()).as("short Urls").containsEntry(shortUrl, targetUrl);
         String absoluteShortUrl = getAbsoluteShortUrl(shortUrl);
 
-        if (!SystemUtils.IS_OS_WINDOWS || !TestProperties.isTestRunningOnTeamCity()) // Can't inspect clipboard on headless Windows
-        {
-            String urlFromClipboard = adminPage.clickCopyToClipboard(shortUrl);
-            assertEquals("Url copied to clipboard", absoluteShortUrl, urlFromClipboard);
-        }
+        String urlFromClipboard = adminPage.clickCopyToClipboard(shortUrl);
+        assertEquals("Url copied to clipboard", absoluteShortUrl, urlFromClipboard);
 
         log("Test shortUrl as another user");
         doAsUser(USER, () ->


### PR DESCRIPTION
#### Rationale
Java AWT can't extract clipboard data when running on Windows agents on TeamCity. However, it is possible to just paste that data into an input and pull the value through Selenium.

#### Related Pull Requests
- N/A

#### Changes
- Hack to fetch clipboard contents when running headless on Windows