### PR TITLE
go back to covering pipelineStatusDetailsPage pathway (Issue 51630 coverage)

### DIFF
--- a/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
+++ b/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
@@ -112,7 +112,9 @@ public class UploadLargeExcelAssayTest extends BaseWebDriverTest
         clickButton("Save and Finish");
 
         // wait for import complete
-        waitForPipelineJobsToComplete(1, "200k", false, 12 * 60000);
+        var assayJobsPage1 = new AssayUploadJobsPage(getDriver());
+        var pipelineDetailsPage1 = assayJobsPage1.clickJobStatus("200k", 3 * WebDriverWrapper.WAIT_FOR_PAGE);
+        pipelineDetailsPage1.waitForComplete(12 * WebDriverWrapper.WAIT_FOR_PAGE);
 
         // export assay1 data to excel
         log("exporting samples fields to excel");
@@ -133,7 +135,9 @@ public class UploadLargeExcelAssayTest extends BaseWebDriverTest
         setFormElement(Locator.input("__primaryFile__"), largeExportExcelFile);
         clickButton("Save and Finish");
 
-        waitForPipelineJobsToComplete(2, "200k take 2", false, 12 * 60000);
+        var assayJobsPage2 = new AssayUploadJobsPage(getDriver());
+        var pipelineDetailsPage2 = assayJobsPage2.clickJobStatus("200k take 2", 3 * getDefaultWaitForPage());
+        pipelineDetailsPage2.waitForComplete(12 * WebDriverWrapper.WAIT_FOR_PAGE);
 
         var qPage = SourceQueryPage.beginAt(this, getProjectName(), "assay.General.large_assay_2", "Data");
         var dataregion  = qPage.viewData(Duration.ofSeconds(60));


### PR DESCRIPTION
#### Rationale
This change restores `UploadLargeExcelAssayTest `to verify we're not hanging or unresponsive in `pipelineStatusDetails `page, in effect un-doing the workaround introduced in https://github.com/LabKey/testAutomation/pull/2149.
Related issue: [51630](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51630)

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/2133

#### Changes
Rather than use `waitForPipelineJobsToComplete `(as many tests do), navigate the lesser-travelled clicking of job status to monitor assay import progress
