### PR TITLE
Remove unnecessary QueryWebPart renders

### DIFF
--- a/modules/miniassay/resources/assay/simple/views/upload.html
+++ b/modules/miniassay/resources/assay/simple/views/upload.html
@@ -223,8 +223,10 @@ function renderRunsWebPart()
       showRecordSelectors: false
     });
   }
-
-  if (webpart) webpart.render();
+  else
+  {
+    if (webpart) webpart.render();
+  }
 }
 
 // Assume the test sample type exists for the purposes of the ModuleAssayTest


### PR DESCRIPTION
#### Rationale
If `renderTo` is defined in a QueryWebPart config, it is automatically rendered. Calling `render()` explicitly will request the data again and re-render the grid. This is inefficient at best but I suspect this re-render is behind some intermittent failures we've been seeing on TeamCity.
I'm cleaning up all that I could find.

#### Related Pull Requests
* N/A

#### Changes
* Remove unnecessary QueryWebPart renders