### PR TITLE
Fixing DateTime test for DST and other fixes for 25.3

### DIFF
--- a/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
+++ b/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
@@ -18,8 +18,8 @@ import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.admin.FolderFormatsPage;
 import org.labkey.test.pages.admin.FolderManagementPage;
 import org.labkey.test.pages.core.admin.BaseSettingsPage;
-import org.labkey.test.pages.core.admin.BaseSettingsPage.TIME_FORMAT;
 import org.labkey.test.pages.core.admin.BaseSettingsPage.DATE_FORMAT;
+import org.labkey.test.pages.core.admin.BaseSettingsPage.TIME_FORMAT;
 import org.labkey.test.pages.core.admin.LookAndFeelSettingsPage;
 import org.labkey.test.pages.core.admin.ProjectSettingsPage;
 import org.labkey.test.pages.experiment.CreateDataClassPage;
@@ -256,10 +256,13 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         Calendar calDateTime02 = Calendar.getInstance();
         calDateTime02.set(2024, Calendar.JUNE, 1, 10, 0);
 
+        // Time only fields do not reflect daylight saving time.
+        // Note: that TIME_ZONE.getDisplayName gets local machine info. It may not be accurate if you are running
+        // against a remote server or running your server in a different timezone.
         Map<String, String> expectedRowValues = Map.of(dateCol01, "April 01, 2021",
                 dateCol02, "2019-52 AD",
                 timeCol01, "12:32:00.00 AM",
-                timeCol02, String.format("2:42 PM %s", getTimezoneDesc(calTime02.getTime())),
+                timeCol02, String.format("2:42 PM %s", TIME_ZONE.getDisplayName(false, 0, Locale.getDefault())),
                 dateTimeCol01, "May 01, 2005 06:32:00.00 PM",
                 dateTimeCol02, String.format("10:00 AM %s 2024-22 AD", getTimezoneDesc(calDateTime02.getTime())));
 
@@ -297,7 +300,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
 
         expectedRowValues = new HashMap<>();
         expectedRowValues.put(dateCol01, "01/04/21");
-        expectedRowValues.put(timeCol01, String.format("0:32:0 AM %s00", getTimezoneOffset(calTime01.getTime())));
+        expectedRowValues.put(timeCol01, String.format("0:32:0 AM %s00", getTimezoneOffset(TIME_ZONE.getRawOffset())));
 
         if (SystemUtils.IS_OS_WINDOWS)
         {
@@ -553,7 +556,10 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         Map<String, String> expectedInheritedData = new HashMap<>();
         expectedInheritedData.put("Name", "A");
         expectedInheritedData.put(dateCol, "23/12/24");
-        expectedInheritedData.put(timeCol, String.format("2:45:0 PM %s00", getTimezoneOffset(calTime.getTime())));
+        // The offset of Time only fields are not impacted by daylight saving time.
+        // Note: that TIME_ZONE.getRawOffset gets local machine info. It may not be accurate if you are running
+        // against a remote server or running your server in a different timezone.
+        expectedInheritedData.put(timeCol, String.format("2:45:0 PM %s00", getTimezoneOffset(TIME_ZONE.getRawOffset())));
         expectedInheritedData.put("Flag", "");
 
         if (SystemUtils.IS_OS_WINDOWS)
@@ -794,10 +800,14 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         calTime.set(Calendar.MINUTE, 45);
 
         log("Sanity check that the DataClass data is formatted in the project and subfolder.");
+
+        // Time only fields do not reflect daylight saving time.
+        // Note: that TIME_ZONE.getDisplayName gets local machine info. It may not be accurate if you are running
+        // against a remote server or running your server in a different timezone.
         Map<String, String> expectedFormatData = Map.of("Name", "P1",
                 dateTimeCol, String.format("December 23, 2024 14:45 %s", getTimezoneDesc(calDateTime.getTime())),
                 dateCol, "December 23, 2024",
-                timeCol, String.format("14:45 %s", getTimezoneDesc(calTime.getTime())),
+                timeCol, String.format("14:45 %s", TIME_ZONE.getDisplayName(false, 0, Locale.getDefault())),
                 "Flag", "");
 
         validateDataIsFormatted(folderProject, dcInProj, expectedFormatData);
@@ -810,7 +820,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         expectedFormatData = Map.of("Name", "C1",
                 dateTimeCol, String.format("November 28, 2024 11:11 %s", getTimezoneDesc(calDateTime.getTime())),
                 dateCol, "November 28, 2024",
-                timeCol, String.format("11:11 %s", getTimezoneDesc(calTime.getTime())),
+                timeCol, String.format("11:11 %s", TIME_ZONE.getDisplayName(false, 0, Locale.getDefault())),
                 "Flag", "");
         validateDataIsFormatted(subFolderPath, dcInSub, expectedFormatData);
         validateDataIsFormatted(subFolderPath, dcInProj, expectedFormatData);
@@ -834,7 +844,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         expectedFormatData = Map.of("Name", "C1",
                 dateTimeCol, String.format("Thursday November 28, 2024 11:11 (%s)", getTimezoneDesc(calDateTime.getTime())),
                 dateCol, "Thursday November 28, 2024",
-                timeCol, String.format("11:11 (%s)", getTimezoneDesc(calTime.getTime())),
+                timeCol, String.format("11:11 (%s)", TIME_ZONE.getDisplayName(false, 0, Locale.getDefault())),
                 "Flag", "");
         validateDataIsFormatted(subFolderPath, dcInSub, expectedFormatData);
         validateDataIsFormatted(subFolderPath, dcInProj, expectedFormatData);
@@ -1409,10 +1419,16 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
         return TIME_ZONE.getDisplayName(isDT, 0, Locale.getDefault());
     }
 
-    // Timezone offset from GMT is dependent on the date
+    // Timezone offset from GMT dependent on the date (covers daylight saving time).
     private String getTimezoneOffset(Date date)
     {
-        return String.format("%+03d", TIME_ZONE.getOffset(date.getTime()) / 1000 / 60 / 60);
+        return getTimezoneOffset(TIME_ZONE.getOffset(date.getTime()));
+    }
+
+    // Timezone offset from GMT using the raw offset
+    private String getTimezoneOffset(int rawOffset)
+    {
+        return String.format("%+03d", rawOffset / 1000 / 60 / 60);
     }
 
 }

--- a/src/org/labkey/test/util/ExcelHelper.java
+++ b/src/org/labkey/test/util/ExcelHelper.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -145,7 +146,24 @@ public abstract class ExcelHelper
                 return cell.getStringCellValue();
             }
             else if (isCellNumeric(cell) && DateUtil.isCellDateFormatted(cell) && cell.getDateCellValue() != null)
-                return DATE_TIME_FORMAT.format(cell.getDateCellValue());
+            {
+
+                // Dealing with Date and Time only fields in Excel is fun!
+                // If the time value of the cell is 00:00 assume it to be a Date only field.
+                // If the date value of the field is January 1, 1970 assume it to be a Time only field.
+                Calendar cal = Calendar.getInstance();
+                cal.setTime(cell.getDateCellValue());
+                if ((cal.get(Calendar.HOUR_OF_DAY) == 0) && (cal.get(Calendar.MINUTE) == 0)||
+                        (cal.get(Calendar.YEAR) == 1970 && cal.get(Calendar.MONTH) == Calendar.JANUARY && cal.get(Calendar.DAY_OF_MONTH) == 1))
+                {
+                    return new SimpleDateFormat(cell.getCellStyle().getDataFormatString()).format(cell.getDateCellValue());
+                }
+                else
+                {
+                    return DATE_TIME_FORMAT.format(cell.getDateCellValue());
+                }
+
+            }
             else if (cell.getCellType() == CellType.FORMULA && cell.getCachedFormulaResultType() == CellType.STRING)
                 return cell.getStringCellValue();
             else

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -365,7 +365,13 @@ public class TestDataGenerator
     {
         // use the characters that we know are encoded in fieldKeys plus characters that we know clients are using
         String chars = ALL_ILLEGAL_QUERY_KEY_CHARACTERS + " %()=+-[]_|*`'\":;<>?!@#^";
-        String randomFieldName = (randomString(numStartChars, null, chars) + part + randomString(numEndChars, null, chars)).trim();
+
+        // Having double space is allowed in a field name but is a problem for automation.
+        // We render double spaces as a single space as column headers in grids and the like, but we maintain the double
+        // space in the name. This trips up helpers for various components. See Issue 52193 for details.
+        String randomFieldName = (randomString(numStartChars, null, chars).replace("  ", " ") +
+                part +
+                randomString(numEndChars, null, chars).replaceAll("\\s\\s+"," ")).trim();
         TestLogger.log("Generated random field name: " + randomFieldName);
         return randomFieldName;
     }

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -369,7 +369,7 @@ public class TestDataGenerator
         // Having double space is allowed in a field name but is a problem for automation.
         // We render double spaces as a single space as column headers in grids and the like, but we maintain the double
         // space in the name. This trips up helpers for various components. See Issue 52193 for details.
-        String randomFieldName = (randomString(numStartChars, null, chars).replace("  ", " ") +
+        String randomFieldName = (randomString(numStartChars, null, chars).replaceAll("\\s\\s+"," ") +
                 part +
                 randomString(numEndChars, null, chars).replaceAll("\\s\\s+"," ")).trim();
         TestLogger.log("Generated random field name: " + randomFieldName);


### PR DESCRIPTION
Retargeting 25.3 release.

#### Rationale
Fix NonStandardDateAndTime test to work with DST.
Fix ExcelHelper to work better with Date only and Time only fields. 
Updated TestDataGenerator.randomFieldName to not create field names with double spaces.

@labkey-susanh as FYI only

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2339

#### Changes
- Update test so time only fields work correctly and ignore daylight savings.
- Update ExcelHelper.getCellStringValue to work correctly with date only and time only fields.
- Modify TestDataGenerator.randomFieldName to not include double spaces (it's just easier).
