### PR TITLE
Log API domain and assay creation

### DIFF
--- a/src/org/labkey/test/params/assay/AssayDesign.java
+++ b/src/org/labkey/test/params/assay/AssayDesign.java
@@ -8,6 +8,7 @@ import org.labkey.remoteapi.assay.ProtocolResponse;
 import org.labkey.remoteapi.assay.SaveProtocolCommand;
 import org.labkey.remoteapi.domain.Domain;
 import org.labkey.remoteapi.domain.PropertyDescriptor;
+import org.labkey.test.util.TestLogger;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -27,7 +28,7 @@ public abstract class AssayDesign<T extends AssayDesign<T>>
 
     public static AssayDesign<?> of(String providerName, String name)
     {
-        return new AssayDesignImpl(name, providerName);
+        return new AssayDesignImpl(providerName, name);
     }
 
     public T addProtocolTransformer(Consumer<Protocol> transformer)
@@ -60,15 +61,20 @@ public abstract class AssayDesign<T extends AssayDesign<T>>
 
     public Protocol createAssay(String containerPath, Connection connection) throws IOException, CommandException
     {
+        TestLogger.info(String.format("Creating %s assay in '%s'", _providerName, containerPath));
+
         GetProtocolCommand getProtocolCommand = new GetProtocolCommand(_providerName);
         ProtocolResponse getProtocolResponse = getProtocolCommand.execute(connection, containerPath);
 
-        Protocol protocol = getProtocolResponse.getProtocol();
+        Protocol protocol = updateProtocol(containerPath, connection, getProtocolResponse.getProtocol());
 
-        return updateProtocol(containerPath, connection, protocol);
+        TestLogger.info(String.format("Successfully created %s assay '%s' in '%s':\n%s", _providerName,
+            protocol.getName(), containerPath, protocol.toJSONObject().toString(2)));
+
+        return protocol;
     }
 
-    public Protocol updateProtocol(String containerPath, Connection connection, Protocol protocol) throws IOException, CommandException
+    private Protocol updateProtocol(String containerPath, Connection connection, Protocol protocol) throws IOException, CommandException
     {
         for (var transformer : _transformers)
         {
@@ -100,7 +106,7 @@ public abstract class AssayDesign<T extends AssayDesign<T>>
 
 class AssayDesignImpl extends AssayDesign<AssayDesignImpl>
 {
-    public AssayDesignImpl(String name, String providerName)
+    public AssayDesignImpl(String providerName, String name)
     {
         super(providerName, name);
     }

--- a/src/org/labkey/test/params/property/DomainProps.java
+++ b/src/org/labkey/test/params/property/DomainProps.java
@@ -5,6 +5,7 @@ import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.domain.CreateDomainCommand;
 import org.labkey.remoteapi.domain.Domain;
+import org.labkey.remoteapi.domain.DomainResponse;
 import org.labkey.test.util.TestDataGenerator;
 import org.labkey.test.util.TestLogger;
 
@@ -26,7 +27,23 @@ public abstract class DomainProps
 
     public final CreateDomainCommand getCreateCommand()
     {
-        CreateDomainCommand command = new CreateDomainCommand(getKind(), getDomainDesign().getName());
+        CreateDomainCommand command = new CreateDomainCommand(getKind(), getDomainDesign().getName())
+        {
+            @Override
+            public DomainResponse execute(Connection connection, String folderPath) throws IOException, CommandException
+            {
+                TestLogger.info(String.format("Creating %s domain '%s.%s' in '%s'", getKind(), getSchemaName(), getQueryName(), folderPath));
+
+                DomainResponse response = super.execute(connection, folderPath);
+
+                TestLogger.log("Successfully created domain, '%s':\n%s"
+                    .formatted(
+                        response.getDomain().getName(),
+                        response.getDomain().toJSONObject().toString(2)));
+
+                return response;
+            }
+        };
         command.setOptions(new HashMap<>(getOptions()));
         command.setDomainDesign(getDomainDesign());
         return command;
@@ -39,7 +56,6 @@ public abstract class DomainProps
 
     public final TestDataGenerator create(Connection connection, String containerPath) throws IOException, CommandException
     {
-        TestLogger.info(String.format("Creating %s domain '%s.%s' in '%s'", getKind(), getSchemaName(), getQueryName(), containerPath));
         getCreateCommand().execute(connection, containerPath);
         return getTestDataGenerator(containerPath);
     }

--- a/src/org/labkey/test/tests/FileAttachmentColumnTest.java
+++ b/src/org/labkey/test/tests/FileAttachmentColumnTest.java
@@ -20,8 +20,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.labkey.api.util.FileUtil;
-import org.labkey.api.util.Path;
 import org.labkey.remoteapi.assay.ImportRunCommand;
 import org.labkey.remoteapi.assay.Protocol;
 import org.labkey.remoteapi.domain.CreateDomainCommand;
@@ -44,7 +42,6 @@ import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
 import org.labkey.test.util.StudyHelper;
-import org.labkey.test.util.TestDataUtils;
 import org.labkey.test.util.core.webdav.WebDavUploadHelper;
 import org.labkey.test.util.exp.SampleTypeAPIHelper;
 import org.openqa.selenium.By;
@@ -459,15 +456,12 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
     private Protocol makeGeneralAssay(String assayName, List<PropertyDescriptor> runFields, List<PropertyDescriptor> dataFields,
                                       String folderPath) throws Exception
     {
-        var assayDesign =  new GeneralAssayDesign(assayName)
+        return new GeneralAssayDesign(assayName)
                 .setBatchFields(List.of(new FieldDefinition("batchData", FieldDefinition.ColumnType.String)), false)
                 .setRunFields(runFields, false)
-                .setDataFields(dataFields, false);
-
-
-        var protocol = assayDesign.createAssay(folderPath, createDefaultConnection());
-        var updateProtocol = protocol.setEditableRuns(true).setEditableResults(true);
-        return assayDesign.updateProtocol(folderPath, createDefaultConnection(), updateProtocol);
+                .setDataFields(dataFields, false)
+                .addProtocolTransformer(protocol -> protocol.setEditableRuns(true).setEditableResults(true))
+                .createAssay(folderPath, createDefaultConnection());
     }
 
     private void addRunData(Integer protocolId, String folderPath) throws Exception


### PR DESCRIPTION
#### Rationale
With increased use of randomized field names and the like, logging domains and assay protocols created via API could be useful for recreating failures encountered on TeamCity.

#### Related Pull Requests
- N/A

#### Changes
- Log API domain and assay creation
