### PR TITLE
Add test util for generating naming expression containing special characters

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
+++ b/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
@@ -59,6 +59,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.params.FieldDefinition.DOMAIN_TRICKY_CHARACTERS;
+import static org.labkey.test.util.TestDataUtils.getEscapedNameExpression;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
@@ -68,7 +69,7 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
     private static final String DEFAULT_SAMPLE_PARENT_VALUE = "SS";
 
     private static final String PARENT_SAMPLE_TYPE = "PS" + DOMAIN_TRICKY_CHARACTERS;
-    private static final String PARENT_SAMPLE_TYPE_INPUT = "PS" + DOMAIN_TRICKY_CHARACTERS.replace("/", "$S");
+    private static final String PARENT_SAMPLE_TYPE_INPUT = "PS" + getEscapedNameExpression(DOMAIN_TRICKY_CHARACTERS);
 
     private static final String PARENT_SAMPLE_01 = "parent01";
     private static final String PARENT_SAMPLE_02 = "parent02";

--- a/src/org/labkey/test/util/TestDataUtils.java
+++ b/src/org/labkey/test/util/TestDataUtils.java
@@ -191,4 +191,12 @@ public class TestDataUtils
             return StringUtils.containsAny(value, _escapedChars);
         }
     }
+
+    public static final String[] DECODED = {"\\", "$", "/", "&", "}", "~", ",", "."};
+    public static final String[] ENCODED = {"\\\\", "\\$", "\\/", "\\&", "\\}", "\\~", "\\,", "\\."};
+    public static String getEscapedNameExpression(String encoded)
+    {
+        return StringUtils.replaceEach(encoded, DECODED, ENCODED);
+    }
+
 }


### PR DESCRIPTION
#### Rationale
[SampleTypeNameExpressionTest.testDeriveFromCommentLikeParents, SampleTypeNameExpressionTest.testDeriveSampleFromSampleDetailsPage and SampleTypeNameExpressionTest.testNameExpressionPreview](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyPostgres/3420962)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1752
- https://github.com/LabKey/labkey-ui-premium/pull/712
- https://github.com/LabKey/limsModules/pull/1248
- https://github.com/LabKey/testAutomation/pull/2354

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
