### PR TITLE
TestDateUtils formatISODateTime/parseISODateTime

### DIFF
--- a/src/org/labkey/test/util/TestDateUtils.java
+++ b/src/org/labkey/test/util/TestDateUtils.java
@@ -1,5 +1,7 @@
 package org.labkey.test.util;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -10,6 +12,9 @@ public class TestDateUtils
 {
     // Stash a consistent "today" date to allow tests to work when spanning midnight
     private static final Date TODAY = Calendar.getInstance().getTime();
+
+    // Match the DateUtil.ISO_DATE_TIME_FORMAT_STRING defined on the server
+    private static final SimpleDateFormat ISO_DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
     private TestDateUtils()
     {
@@ -79,5 +84,15 @@ public class TestDateUtils
     public static String dateTimeFileName()
     {
         return fileDateFormat.format(LocalDateTime.now());
+    }
+
+    public static String formatISODateTime(Date date)
+    {
+        return ISO_DATE_TIME_FORMAT.format(date);
+    }
+
+    public static Date parseISODateTime(String s) throws ParseException
+    {
+        return ISO_DATE_TIME_FORMAT.parse(s);
     }
 }


### PR DESCRIPTION
#### Rationale
Adds a couple of utility methods to `TestDateUtils` to assist in the generation/handling of dates on the test-side.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1749
- https://github.com/LabKey/labkey-ui-premium/pull/711
- https://github.com/LabKey/limsModules/pull/1244
- https://github.com/LabKey/platform/pull/6441
- https://github.com/LabKey/testAutomation/pull/2361

#### Changes
- Add `formatISODateTime` and `parseISODateTime` utility methods