### PR TITLE
Update LabkeyErrorPageTest to match new error page content

### DIFF
--- a/src/org/labkey/test/tests/LabkeyErrorPageTest.java
+++ b/src/org/labkey/test/tests/LabkeyErrorPageTest.java
@@ -101,8 +101,8 @@ public class LabkeyErrorPageTest extends BaseWebDriverTest
 
         checker().verifyEquals("Incorrect error heading message", "Oops! An error has occurred.",
                 errorPage.getErrorHeading());
-        checker().verifyEquals("Incorrect error instructions", "Please report this bug to LabKey Support by copying " +
-                        "and pasting both your unique reference code and the full stack trace in the View Details section below.",
+        checker().verifyEquals("Incorrect error instructions", "You can find help resources here and may " +
+                "find troubleshooting hints by reading the full stack trace in the View Details section below.",
                 errorPage.getErrorInstruction());
         checker().verifyThat("Incorrect error image", errorPage.getErrorImage(), CoreMatchers.containsString(imageTitle));
 


### PR DESCRIPTION
#### Rationale
Error page content changed based on https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52495

LabkeyErrorPageTest didn't get the memo

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6437