### PR TITLE
log character set during test setup

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -116,6 +116,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -460,6 +461,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
         String browserVersion = caps.getBrowserVersion();
         log("Browser: " + browserName + " " + browserVersion);
         log("Started browser with TZ = " + targetBrowserTimeZone + (targetBrowserTimeZone != ZoneId.systemDefault() ? "" : " (system default)"));
+        log(String.format("charset is %s", Charset.defaultCharset().displayName()));
 
         return result;
     }


### PR DESCRIPTION
#### Rationale
This introduces a change to log the current (default) character set, which will be useful to know when troubleshooting encoding issues, particularly in tests running on Windows agents.
On Linux, the default seems to be reliably `UTF-8` and on some (?) Windows agents the default is `windows-1252` (I say "some" here because locally I get UTF-8 when running on Windows 🤷 

#### Related Pull Requests
n/a

#### Changes
add log entry to record the character set
