### PR TITLE
Collapse multiple spaces to one in random domain names

### DIFF
--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -354,7 +354,8 @@ public class TestDataGenerator
         }
         while (domainName.length() < size || Pattern.matches("(.*\\s--[^ ].*)|(.*\\s-[^- ].*)", domainName)); // domain name must not contain space followed by dash. (command like: Issue 49161)
 
-        return domainName;
+        // Multiple spaces in the UI are collapsed into a single space. If we need to test for handling of multiple spaces, we'll not use this generator
+        return domainName.replaceAll("\\s+", " ");
     }
 
     public static String randomFieldName(String part)


### PR DESCRIPTION
#### Rationale
Multiple spaces in names are collapsed into single spaces in the UI. Change the domain name generator to also do this collapsing so we can find the entities that are generated with usual UI locators.

#### Changes
- Update `TestDataGenrator.randomDomainName` to collapse multiple spaces into one.
