### PR TITLE
Avoid crawling base URL

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -477,7 +477,7 @@ public class Crawler
                 String relativeURL;
                 try
                 {
-                    relativeURL = "/" + WebTestHelper.makeRelativeUrl(urlText);
+                    relativeURL = WebTestHelper.makeRelativeUrl(urlText);
                 }
                 catch (IllegalArgumentException iae)
                 {


### PR DESCRIPTION
#### Rationale
`_relativeUrl` should be `null` for uncrawlable URLs (such as `http://localhost:8111/`). `WebTestHelper.makeRelativeUrl` strips the base URL from absolute URLs found on pages. This should result in an empty relative URL, which the crawler knows to ignore. Prepending a "`/`" after stripping the base URL is causing the crawler to not ignore them.

```
java.lang.IllegalArgumentException: Failed to parse action from URL [http://localhost:8111/] found on page [http://localhost:8111/home/login-initialMount.view
  at org.labkey.test.util.Crawler$UrlToCheck.<init>(Crawler.java:539)
  at org.labkey.test.util.Crawler.crawlLink(Crawler.java:1085)
  ... 12 more
Caused by: java.lang.NullPointerException: Cannot invoke "org.labkey.test.util.Crawler$ControllerActionId.getController()" because the return value of "org.labkey.test.util.Crawler$UrlToCheck.getActionId()" is null
  at org.labkey.test.util.Crawler$UrlToCheck.isVisitableURL(Crawler.java:646)
  at org.labkey.test.util.Crawler$UrlToCheck.<init>(Crawler.java:534)
  ... 13 more
```

#### Related Pull Requests
- #2350 

#### Changes
- Don't prepend '/' to relative URL
