### PR TITLE
Collapse consecutive spaces after all characters are known

### DIFF
--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -370,9 +370,10 @@ public class TestDataGenerator
         // Having double space is allowed in a field name but is a problem for automation.
         // We render double spaces as a single space as column headers in grids and the like, but we maintain the double
         // space in the name. This trips up helpers for various components. See Issue 52193 for details.
-        String randomFieldName = (randomString(numStartChars, null, chars).replaceAll("\\s\\s+"," ") +
+        String randomFieldName = (randomString(numStartChars, null, chars) +
                 part +
-                randomString(numEndChars, null, chars).replaceAll("\\s\\s+"," ")).trim();
+                randomString(numEndChars, null, chars));
+        randomFieldName = randomFieldName.replaceAll("\\s+", " ").trim();
         TestLogger.log("Generated random field name: " + randomFieldName);
         return randomFieldName;
     }


### PR DESCRIPTION
#### Rationale
Double spaces in the middle cause problems too.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1275

#### Changes
- Update `randomFieldName` to relocate where fat space trimming happens.
