### PR TITLE
Export default template name for reuse

### DIFF
--- a/src/org/labkey/test/components/react/Tabs.java
+++ b/src/org/labkey/test/components/react/Tabs.java
@@ -118,7 +118,9 @@ public class Tabs extends WebDriverComponent<Tabs.ElementCache>
                 WebElement tabEl;
                 try
                 {
-                    tabEl = tabLoc.withText(tabText).findElement(tabList);
+                    // Use 'containing' here because it may happen that the counts get loaded into the tabs after the call to this method,
+                    // which causes the name to change from, say 'Included Samples' to 'Included Samples (7)'.
+                    tabEl = tabLoc.containing(tabText).findElement(tabList);
                 }
                 catch (NoSuchElementException ex)
                 {

--- a/src/org/labkey/test/components/react/TemplateDownloadButton.java
+++ b/src/org/labkey/test/components/react/TemplateDownloadButton.java
@@ -21,7 +21,7 @@ import static org.labkey.test.WebDriverWrapper.waitFor;
  */
 public class TemplateDownloadButton extends MultiMenu
 {
-    private static final String DEFAULT_TEMPLATE_NAME = "Default Template";
+    public static final String DEFAULT_TEMPLATE_NAME = "Default Template";
     private static final String BUTTON_CLASS = "template-download-button";
     public static final Locator LOCATOR = Locator.tagWithClass("button", BUTTON_CLASS);
 

--- a/src/org/labkey/test/util/URLBuilder.java
+++ b/src/org/labkey/test/util/URLBuilder.java
@@ -55,7 +55,7 @@ public class URLBuilder
     private Map<String, ?> _secondaryQuery;
 
     /**
-     * Intialize a URLBuilder for a LabKey URL
+     * Initialize a URLBuilder for a LabKey URL
      * @param controller the controller name (e.g. "login" for "LoginController")
      * @param action the action name (e.g. "whoami" for "WhoAmIAction")
      *              The action type will be assumed to be ".view" if not specified.


### PR DESCRIPTION
#### Rationale
Let's use our constants where we can.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1262

#### Changes
- Update tab locator to use "contains" instead of exact text match to account for names of tabs being somewhat dynamic
- Export a constant.
