### PR TITLE
Fix MalformedUrlException in crawler

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -43,7 +43,6 @@ import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.core.ProjectMenu;
 import org.labkey.test.util.selenium.WebDriverUtils;
-import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
@@ -489,13 +488,13 @@ public class Crawler
             {
                 // Make sure it is correctly formatted
                 if (urlText.startsWith("/"))
-                    _relativeURL = urlText;
+                    _relativeURL = urlText.substring(1);
                 else if (urlText.startsWith("#"))
-                    _relativeURL = stripHash(origin.toString()) + urlText;
+                    _relativeURL = makeRelativeUrl(stripHash(origin.toString())) + urlText;
                 else if (urlText.startsWith("?"))
-                    _relativeURL = stripQueryParams(origin.toString()) + urlText;
+                    _relativeURL = makeRelativeUrl(stripQueryParams(origin.toString())) + urlText;
                 else
-                    _relativeURL = getURLBase(origin) + urlText;
+                    _relativeURL = makeRelativeUrl(getURLBase(origin)) + urlText;
             }
 
             if (_relativeURL != null)
@@ -1107,7 +1106,7 @@ public class Crawler
             else
             {
                 // Did not navigate. Test download URL for injection
-                actualUrl = new URL(WebTestHelper.getBaseURL() + relativeURL);
+                actualUrl = new URL(WebTestHelper.getBaseURL() + "/" + relativeURL);
             }
         }
         catch (RuntimeException | AssertionError rethrow)
@@ -1129,9 +1128,6 @@ public class Crawler
 
             if (rethrow instanceof AssertionError)
                 throw rethrow; // AssertionErrors already contain page and origin information.
-            else if (rethrow instanceof TimeoutException)
-                throw new RuntimeException(relativeURL + " failed to render. " + originMessage +
-                        " It may be a file download which is unsupported by the crawler", rethrow); // Improve error reporting for downloads, see issue 42661
             else
                 throw new RuntimeException("Crawler threw " + rethrow.getClass().getSimpleName() + ".\n" +
                     "Target page: " + relativeURL + "\n" +


### PR DESCRIPTION
#### Rationale
`UrlToCheck._relativeURL` has inconsistent format. It might have a leading '/' or not and it might not even be relative. Attempting to to create a `URL` with a relative URL that doesn't have a leading '/' is causing errors. We should make `UrlToCheck._relativeURL` has a consistent format (actually relative and no leading '/') and account for that structure elswhere.

```
java.lang.RuntimeException: java.net.MalformedURLException: Error at index 4 in: "8111FilesQueryTestProject"
  at org.labkey.test.util.Crawler.crawlLink(Crawler.java:1142)
  at org.labkey.test.util.Crawler.crawl(Crawler.java:842)
  at org.labkey.test.util.Crawler.crawlAllLinks(Crawler.java:805)
```

#### Related Pull Requests
- #2369 

#### Changes
- Fix MalformedUrlException in crawler
- Make `UrlToCheck._relativeURL` has a consistent format
- Remove workaround for fixed issue: [42661](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42661)