### PR TITLE
Issue 52793: KnitrReportTest fails intermittently with client error 

### DIFF
--- a/data/knitr/knitr.lib.xml
+++ b/data/knitr/knitr.lib.xml
@@ -1,7 +1,10 @@
 <libraries xmlns="http://labkey.org/clientLibrary/xml/">
-    <library compileInProductionMode="false"/>
+    <library compileInProductionMode="false">
+        <script path="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css"/>
+        <script path="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"/>
+    </library>
     <dependencies>
-        <dependency path="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"/>
+        <dependency path="internal/jQuery"/>
     </dependencies>
 </libraries>
 

--- a/modules/scriptpad/resources/reports/schemas/kable.rmd
+++ b/modules/scriptpad/resources/reports/schemas/kable.rmd
@@ -10,7 +10,9 @@ kable(mtcars, 'html', table.attr='id="mtcars_table"')
 If we hadn't included jquery, this will not render correctly.
 
 <script type="text/javascript" charset="utf-8">
-  $(document).ready(function() {
+  // Issue 52793: KnitrReportTest fails intermittently with client error
+  // Wait for assets to load (i.e. jquery.dataTables)
+  $(window).on('load', function() {
 		$('#mtcars_table').dataTable();
 	} );
 </script>

--- a/src/org/labkey/test/tests/AbstractKnitrReportTest.java
+++ b/src/org/labkey/test/tests/AbstractKnitrReportTest.java
@@ -201,6 +201,6 @@ public abstract class AbstractKnitrReportTest extends BaseWebDriverTest
         _ext4Helper.waitForMaskToDisappear();
         waitAndClickAndWait(Locator.linkWithText("kable"));
         _ext4Helper.waitForMaskToDisappear(3 * BaseWebDriverTest.WAIT_FOR_JAVASCRIPT);
-        waitForElement(Locator.id("mtcars_table_wrapper"));
+        waitForElement(Locator.id("mtcars_table"));
     }
 }

--- a/src/org/labkey/test/tests/KnitrReportTest.java
+++ b/src/org/labkey/test/tests/KnitrReportTest.java
@@ -16,7 +16,6 @@
 package org.labkey.test.tests;
 
 import org.apache.hc.core5.http.HttpStatus;
-import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assume;
 import org.junit.Test;
@@ -203,13 +202,6 @@ public class KnitrReportTest extends AbstractKnitrReportTest
         _rReportHelper.clickReportTab();
         waitForElement(Locator.id("mtcars_table"));
         assertElementNotPresent(Locator.id("mtcars_table_wrapper")); // Created by jQuery
-        String serverErrors = getServerErrors();
-        if (!serverErrors.isEmpty())
-        {
-            // Client-side error doesn't always happen but, if it does, make sure it is the one we expect.
-            Assertions.assertThat(serverErrors).as("Server errors").contains("$(...).dataTable is not a function");
-            checkExpectedErrors(1); // JavaScript error: "$(...).dataTable is not a function"
-        }
 
         // now set the dependencies
         _rReportHelper.clickSourceTab();

--- a/src/org/labkey/test/tests/KnitrReportTest.java
+++ b/src/org/labkey/test/tests/KnitrReportTest.java
@@ -203,6 +203,13 @@ public class KnitrReportTest extends AbstractKnitrReportTest
         _rReportHelper.clickReportTab();
         waitForElement(Locator.id("mtcars_table"));
         assertElementNotPresent(Locator.id("mtcars_table_wrapper")); // Created by jQuery
+
+        // now set the dependencies
+        _rReportHelper.clickSourceTab();
+        _rReportHelper.ensureFieldSetExpanded("knitr");
+        setFormElement(Locator.name("scriptDependencies"), dependencies);
+        saveAndVerifyKnitrReport(rmdDependenciesReport.getFileName() + " " + viewName, reportContains, reportNotContains);
+
         String serverErrors = getServerErrors();
         if (!serverErrors.isEmpty())
         {
@@ -210,11 +217,5 @@ public class KnitrReportTest extends AbstractKnitrReportTest
             Assertions.assertThat(serverErrors).as("Server errors").contains("$(...).dataTable is not a function");
             checkExpectedErrors(1); // JavaScript error: "$(...).dataTable is not a function"
         }
-
-        // now set the dependencies
-        _rReportHelper.clickSourceTab();
-        _rReportHelper.ensureFieldSetExpanded("knitr");
-        setFormElement(Locator.name("scriptDependencies"), dependencies);
-        saveAndVerifyKnitrReport(rmdDependenciesReport.getFileName() + " " + viewName, reportContains, reportNotContains);
     }
 }

--- a/src/org/labkey/test/tests/KnitrReportTest.java
+++ b/src/org/labkey/test/tests/KnitrReportTest.java
@@ -203,13 +203,6 @@ public class KnitrReportTest extends AbstractKnitrReportTest
         _rReportHelper.clickReportTab();
         waitForElement(Locator.id("mtcars_table"));
         assertElementNotPresent(Locator.id("mtcars_table_wrapper")); // Created by jQuery
-
-        // now set the dependencies
-        _rReportHelper.clickSourceTab();
-        _rReportHelper.ensureFieldSetExpanded("knitr");
-        setFormElement(Locator.name("scriptDependencies"), dependencies);
-        saveAndVerifyKnitrReport(rmdDependenciesReport.getFileName() + " " + viewName, reportContains, reportNotContains);
-
         String serverErrors = getServerErrors();
         if (!serverErrors.isEmpty())
         {
@@ -217,5 +210,11 @@ public class KnitrReportTest extends AbstractKnitrReportTest
             Assertions.assertThat(serverErrors).as("Server errors").contains("$(...).dataTable is not a function");
             checkExpectedErrors(1); // JavaScript error: "$(...).dataTable is not a function"
         }
+
+        // now set the dependencies
+        _rReportHelper.clickSourceTab();
+        _rReportHelper.ensureFieldSetExpanded("knitr");
+        setFormElement(Locator.name("scriptDependencies"), dependencies);
+        saveAndVerifyKnitrReport(rmdDependenciesReport.getFileName() + " " + viewName, reportContains, reportNotContains);
     }
 }

--- a/src/org/labkey/test/tests/KnitrReportTest.java
+++ b/src/org/labkey/test/tests/KnitrReportTest.java
@@ -194,7 +194,7 @@ public class KnitrReportTest extends AbstractKnitrReportTest
         setPandocEnabled(true);
 
         // just do a sanity check of the report's contents.  If the dependencies aren't loaded then we'll throw an alert
-        Locator[] reportContains = {Locator.id("mtcars_table_wrapper"), Locator.css("h1").withText("jQuery DataTables")};
+        Locator[] reportContains = {Locator.id("mtcars_table"), Locator.css("h1").withText("jQuery DataTables")};
         String[] reportNotContains = {"```", "{r",};
 
         createKnitrReport(rmdDependenciesReport, RReportHelper.ReportOption.knitrMarkdown);


### PR DESCRIPTION
#### Rationale
We're testing for external resources in a knitr report by way of a jQuery library that depends on jQuery being available on the page. One thing that could possibly help is having the lib.xml declared for the tests explicitly depend on jQuery. An additional headwind for this feature is strict CSP which is going to make loading these external resources less/not-at-all tolerant.

#### Related Pull Requests
- #1612 
- https://github.com/LabKey/premiumModules/pull/225

#### Changes
- Add `internal/jQuery` dependency in `knitr.lib.xml`
- Use `$(window).on('load)` instead of `$(document).ready()` to wait for resources rather than DOM.
- Remove test check for error as this is no longer necessary.
