### PR TITLE
Fix some recent/intermittent teamcity test failures

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -116,6 +116,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -460,6 +461,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
         String browserVersion = caps.getBrowserVersion();
         log("Browser: " + browserName + " " + browserVersion);
         log("Started browser with TZ = " + targetBrowserTimeZone + (targetBrowserTimeZone != ZoneId.systemDefault() ? "" : " (system default)"));
+        log(String.format("charset is %s", Charset.defaultCharset().displayName()));
 
         return result;
     }

--- a/src/org/labkey/test/pages/assay/RunQCPage.java
+++ b/src/org/labkey/test/pages/assay/RunQCPage.java
@@ -16,6 +16,7 @@
 package org.labkey.test.pages.assay;
 
 import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.PlateGrid;
 import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.selenium.LazyWebElement;
@@ -33,6 +34,14 @@ public class RunQCPage<EC extends RunQCPage.ElementCache> extends LabKeyPage<EC>
     public RunQCPage(WebDriver driver){
         super(driver);
         _driver = driver;
+    }
+
+    @Override
+    protected void waitForPage()
+    {
+        Locator waitMsg = Locator.tagWithClass("div", "x4-mask-msg-text").withText("Requesting QC information");
+        WebDriverWrapper.waitFor(()-> !waitMsg.isDisplayed(getDriver()),
+                "Took too long to display the page", WAIT_FOR_JAVASCRIPT);
     }
 
     public WebElement getSpecimenSection(String sectionTitle)
@@ -74,7 +83,7 @@ public class RunQCPage<EC extends RunQCPage.ElementCache> extends LabKeyPage<EC>
         String xpath = elementCache().PLATE_CONTROLS_VALUES_XPATH.replace("$", plateTitle);
         for(String value : valuesToIgnore)
         {
-            click(Locator.xpath(xpath + "//label[text()='" + value + "']"));
+            waitAndClick(Locator.xpath(xpath + "//label[text()='" + value + "']"));
         }
     }
 
@@ -83,7 +92,7 @@ public class RunQCPage<EC extends RunQCPage.ElementCache> extends LabKeyPage<EC>
         String xpath = elementCache().DILUTION_SUMMARY_VALUES_XPATH.replace("$", sectionTitle);
         for(String value : valuesToIgnore)
         {
-            click(Locator.xpath(xpath + "//label[text()='" + value + "']"));
+            waitAndClick(Locator.xpath(xpath + "//label[text()='" + value + "']"));
         }
     }
 

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -461,7 +461,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
     @LogMethod
     private void doTestCustomFolder()
     {
-        clickProject(getProjectName());
+        goToProjectHome();
         PortalHelper portalHelper = new PortalHelper(this);
 
         assertTextPresentInThisOrder("A customized web part", "Data Pipeline", "Experiment Runs", "Sample Type", "Assay List");


### PR DESCRIPTION
#### Rationale
Recently, [NabAssayTest.runUITests](https://teamcity.labkey.org/viewLog.html?buildId=3449775&buildTypeId=LabKey_253Release_Community_DailySqlServer&fromSakuraUI=true#testNameId8595270879536594693) failed due to what appears to be the QC data taking time to appear on windows agents

[SimpleModuleTest.testSteps](https://teamcity.labkey.org/viewLog.html?buildId=3449745&buildTypeId=LabKey_253Release_Community_DailyPostgres2&fromSakuraUI=true#testNameId5981971736586896608) has been failing intermittently for some time, probably because after using the project menu to navigate, the mouse is left in a hover-target, causing a tooltip to obstruct the next action in the test

#### Related Pull Requests
n/a

#### Changes
- have the `RunQCPage `wait until the notification "Requesting QC information" is no longer there
- have `RunQCPage.selectPlateItemsToIgnore` await the items to ignore
- for consistency, have `RunQCPage.selectDilutionItemsToIgnore` wait for the items too
