### PR TITLE
Fix custom data class fuzz tests

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
@@ -10,6 +10,8 @@ import org.labkey.test.components.html.Input;
 import org.labkey.test.components.html.RadioButton;
 import org.labkey.test.components.react.FilteringReactSelect;
 import org.labkey.test.components.react.ReactDateTimePicker;
+import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.util.EscapeUtil;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -17,6 +19,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class EntityBulkInsertDialog extends ModalDialog
@@ -215,6 +218,27 @@ public class EntityBulkInsertDialog extends ModalDialog
     public String getFieldWithId(String id)
     {
         return getWrapper().getFormElement(Locator.tagWithId("input", id));
+    }
+
+    public void setInsertFieldValues(List<FieldDefinition> fields, Map<String, Object> data)
+    {
+        for (FieldDefinition field : fields)
+        {
+            String fieldKey = EscapeUtil.fieldKeyEncodePart(field.getName());
+            Object value = data.get(field.getLabel() != null ? field.getLabel() : FieldDefinition.labelFromName(field.getName()));
+            if (value == null)
+                continue;
+            if (field.getType() == FieldDefinition.ColumnType.Boolean)
+                setBooleanField(fieldKey, (Boolean) value);
+            else if (field.getType() == FieldDefinition.ColumnType.Integer || field.getType() == FieldDefinition.ColumnType.Decimal || field.getType() == FieldDefinition.ColumnType.Double)
+                setNumericField(fieldKey, String.valueOf(value));
+            else if (field.getType() == FieldDefinition.ColumnType.Date || field.getType() == FieldDefinition.ColumnType.DateAndTime || field.getType() == FieldDefinition.ColumnType.Time)
+                setDateTimeField(field.getName(), value, fieldKey);
+            else if (field.getType() == FieldDefinition.ColumnType.TextChoice)
+                setSelectionField(field.getLabel(), (List<String>) value);
+            else
+                setTextField(fieldKey, (String) value);
+        }
     }
 
     /**

--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -1,6 +1,5 @@
 package org.labkey.test.components.ui.entities;
 
-import org.labkey.api.query.QueryKey;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
@@ -62,18 +61,18 @@ public class EntityBulkUpdateDialog extends ModalDialog
     }
 
     // For use when the field is of an unknown type, as can occur in fuzz tests
-    public void setValue(FieldDefinition field, Object newValue, EntityBulkUpdateDialog bulkEditDialog)
+    public void setValue(FieldDefinition field, Object newValue)
     {
         if (field.getType() == FieldDefinition.ColumnType.TextChoice)
-            bulkEditDialog.setSelectionField(EscapeUtil.fieldKeyEncodePart(field.getName()), newValue instanceof String ? List.of((String) newValue) : (List<String>) newValue);
+            setSelectionField(EscapeUtil.fieldKeyEncodePart(field.getName()), newValue instanceof String ? List.of((String) newValue) : (List<String>) newValue);
         else if (field.getType() == FieldDefinition.ColumnType.Integer || field.getType() == FieldDefinition.ColumnType.Decimal || field.getType() == FieldDefinition.ColumnType.Double)
-            bulkEditDialog.setNumericField(EscapeUtil.fieldKeyEncodePart(field.getName()), String.valueOf(newValue));
+            setNumericField(EscapeUtil.fieldKeyEncodePart(field.getName()), String.valueOf(newValue));
         else if (field.getType() == FieldDefinition.ColumnType.Date || field.getType() == FieldDefinition.ColumnType.DateAndTime || field.getType() == FieldDefinition.ColumnType.Time)
-            bulkEditDialog.setCustomDateField(EscapeUtil.fieldKeyEncodePart(field.getName()), (String) newValue);
+            setDateField(field.getLabel() == null ? field.getName() : field.getLabel(), (String) newValue);
         else if (field.getType() == FieldDefinition.ColumnType.Boolean)
-            bulkEditDialog.setBooleanField(EscapeUtil.fieldKeyEncodePart(field.getName()), (Boolean) newValue);
+            setBooleanField(EscapeUtil.fieldKeyEncodePart(field.getName()), (Boolean) newValue);
         else
-            bulkEditDialog.setTextField(EscapeUtil.fieldKeyEncodePart(field.getName()), (String) newValue);
+            setTextField(EscapeUtil.fieldKeyEncodePart(field.getName()), (String) newValue);
     }
 
     // interact with selection fields
@@ -136,12 +135,6 @@ public class EntityBulkUpdateDialog extends ModalDialog
     public EntityBulkUpdateDialog setDateField(String fieldLabel, String dateString)
     {
         enableAndWait(fieldLabel, elementCache().dateInput(fieldLabel)).set(dateString);
-        return this;
-    }
-
-    public EntityBulkUpdateDialog setCustomDateField(String fieldKey, String dateString)
-    {
-        enableAndWait(fieldKey, elementCache().dateInput(fieldKey)).set(dateString);
         return this;
     }
 

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -418,19 +418,19 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     }
 
     // For use when the field is of an unknown type, as can occur in fuzz tests
-    public void setDetails(FieldDefinition field, Object newValue, DetailTableEdit editTable)
+    public void setDetails(FieldDefinition field, Object newValue)
     {
         if (newValue == null)
             return;
 
         if (field.getType() == FieldDefinition.ColumnType.TextChoice)
-            editTable.setSelectValue(field.getLabel(), (List<String>) newValue);
+            setSelectValue(field.getLabel(), (List<String>) newValue);
         else if (field.getType() == FieldDefinition.ColumnType.Date || field.getType() == FieldDefinition.ColumnType.DateAndTime || field.getType() == FieldDefinition.ColumnType.Time)
-            editTable.setDateTimeField(QueryKey.encodePart(field.getName()), newValue);
+            setDateTimeField(QueryKey.encodePart(field.getName()), newValue);
         else if (field.getType() == FieldDefinition.ColumnType.Boolean)
-            editTable.setBooleanField(field.getLabel(), (Boolean) newValue);
+            setBooleanField(field.getLabel(), (Boolean) newValue);
         else
-            editTable.setTextField(field.getLabel(), String.valueOf(newValue));
+            setTextField(field.getLabel(), String.valueOf(newValue));
     }
 
     /**

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -420,6 +420,9 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     // For use when the field is of an unknown type, as can occur in fuzz tests
     public void setDetails(FieldDefinition field, Object newValue, DetailTableEdit editTable)
     {
+        if (newValue == null)
+            return;
+
         if (field.getType() == FieldDefinition.ColumnType.TextChoice)
             editTable.setSelectValue(field.getLabel(), (List<String>) newValue);
         else if (field.getType() == FieldDefinition.ColumnType.Date || field.getType() == FieldDefinition.ColumnType.DateAndTime || field.getType() == FieldDefinition.ColumnType.Time)

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -1,6 +1,7 @@
 package org.labkey.test.components.ui.grids;
 
 import org.junit.Assert;
+import org.labkey.api.query.QueryKey;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
@@ -420,13 +421,13 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     public void setDetails(FieldDefinition field, Object newValue, DetailTableEdit editTable)
     {
         if (field.getType() == FieldDefinition.ColumnType.TextChoice)
-            editTable.setSelectValue(field.getName(), (List<String>) newValue);
+            editTable.setSelectValue(field.getLabel(), (List<String>) newValue);
         else if (field.getType() == FieldDefinition.ColumnType.Date || field.getType() == FieldDefinition.ColumnType.DateAndTime || field.getType() == FieldDefinition.ColumnType.Time)
-            editTable.setDateTimeField(field.getName(), newValue);
+            editTable.setDateTimeField(QueryKey.encodePart(field.getName()), newValue);
         else if (field.getType() == FieldDefinition.ColumnType.Boolean)
-            editTable.setBooleanField(field.getName(), (Boolean) newValue);
+            editTable.setBooleanField(field.getLabel(), (Boolean) newValue);
         else
-            editTable.setTextField(field.getName(), String.valueOf(newValue));
+            editTable.setTextField(field.getLabel(), String.valueOf(newValue));
     }
 
     /**

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -13,6 +13,7 @@ import org.labkey.test.components.react.ReactDateTimePicker;
 import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.components.ui.entities.EntityBulkInsertDialog;
 import org.labkey.test.components.ui.entities.EntityBulkUpdateDialog;
+import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.selenium.ScrollUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -527,6 +528,20 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
             }
         }
         return gridCell;
+    }
+
+    public void setEntityData(List<Map<String, Object> >data, List<FieldDefinition> fields)
+    {
+        for (int i = 0; i < data.size(); i++)
+        {
+            Map<String, Object> rowData = data.get(i);
+            for (FieldDefinition field : fields) {
+                String key = field.getLabel() != null ? field.getLabel() : field.getName();
+                Object value = rowData.get(key);
+                if (value != null)
+                    setCellValue(i, key, value);
+            }
+        }
     }
 
     public EditableGrid setRecordValues(List<Map<String, Object>> rowValues)

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -41,6 +41,7 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.query.QueryApiHelper;
+import org.labkey.test.util.samplemanagement.SMTestUtils;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -49,6 +50,7 @@ import java.io.PrintWriter;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -58,8 +60,12 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.labkey.test.BaseWebDriverTest.ALL_ILLEGAL_QUERY_KEY_CHARACTERS;
+import static org.labkey.test.util.TestDataUtils.REALISTIC_ASSAY_FIELDS;
+import static org.labkey.test.util.TestDataUtils.REALISTIC_SAMPLE_FIELDS;
+import static org.labkey.test.util.TestDataUtils.REALISTIC_SOURCE_FIELDS;
 
 
 /**
@@ -105,6 +111,160 @@ public class TestDataGenerator
     public TestDataGenerator(FieldDefinition.LookupInfo lookupInfo)
     {
         this(lookupInfo.getSchema(), lookupInfo.getTable(), lookupInfo.getFolder());
+    }
+
+    public static File writeCsvFile(List<FieldDefinition> fields, List<Map<String, Object>> entityData, String fileName) throws IOException
+    {
+        List<Map<String, Object>> fileData = new ArrayList<>();
+        List<String> fieldNamesForFile = fields.stream().map(FieldDefinition::getName).collect(Collectors.toList());
+        for (Map<String, Object> row : entityData)
+        {
+            Map<String, Object> fileRow = new HashMap<>();
+            for (FieldDefinition field : fields)
+            {
+                String key = field.getLabel() == null ? field.getName() : field.getLabel();
+                Object value = row.get(key);
+                Object valueToWrite = value;
+                if (value instanceof List<?>)
+                    valueToWrite = StringUtils.join((List<?>)value, ",");
+                fileRow.put(field.getName(), valueToWrite);
+            }
+            fileData.add(fileRow);
+        }
+        var fileContents = TestDataUtils.csvStringFromRowMaps(fileData, fieldNamesForFile, true);
+        return TestFileUtils.writeTempFile(fileName, fileContents);
+    }
+
+    public static List<Map<String, Object>> generateEntityData(List<FieldDefinition> fields, String nameField, String namePrefix, int startingCount, int size, boolean addLineage, boolean includeAliquots, String queryName, boolean forGridInsert)
+    {
+        // Hard to deal with plain PropertyDescriptors and we're unlikely to need to
+        List<FieldDefinition> populatableFields = new ArrayList<>(fields);
+
+        populatableFields.removeIf(field -> field.getLookup() != null);
+
+        List<Map<String, Object>> allEntityData = new ArrayList<>();
+        for (int i = startingCount; i < (size + startingCount); i++)
+        {
+            Map<String, Object> entityData = new HashMap<>();
+
+            // Since this will be using the api to populate the sample type need to pass in the column name
+            // as it appears in the schema, for example COL_STR_NAME.
+            if (nameField != null)
+                entityData.put(nameField, namePrefix + i);
+
+            for (FieldDefinition fieldDefinition : populatableFields)
+            {
+                if (!fieldDefinition.getName().equalsIgnoreCase(nameField)) // Name already set
+                {
+                    String key = fieldDefinition.getLabel() != null ? fieldDefinition.getLabel() : FieldDefinition.labelFromName(fieldDefinition.getName());
+                    if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.Date))
+                        entityData.put(key, SMTestUtils.UI_DATE_FORMAT.get().format(TestDateUtils.diffFromTodaysDate(Calendar.HOUR, i * 24)));
+                    else if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.DateAndTime))
+                        entityData.put(key, SMTestUtils.UI_DATE_TIME_FORMAT.get().format(TestDateUtils.diffFromTodaysDate(Calendar.HOUR, i * 24)));
+                    else if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.Time))
+                        entityData.put(key, SMTestUtils.TIME_FORMAT.get().format(TestDateUtils.diffFromTodaysDate(Calendar.HOUR, i * 24)));
+                    else if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.Integer))
+                    {
+                        entityData.put(key, i);
+                    }
+                    else if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.Decimal))
+                    {
+                        entityData.put(key, (i + (i * .10)));
+                    }
+                    else if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.Boolean))
+                    {
+                        entityData.put(key, i % 2 == 0);
+                    }
+                    else if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.String))
+                    {
+                        entityData.put(key, "Entity " + i);
+                    }
+                    else if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.TextChoice))
+                    {
+                        FieldDefinition.TextChoiceValidator validator =
+                                (FieldDefinition.TextChoiceValidator) fieldDefinition.getValidators().get(0);
+                        List<String> textChoices = validator.getValues();
+                        int textChoiceIndex = i % textChoices.size();
+                        if (forGridInsert)
+                            entityData.put(key, List.of(textChoices.get(textChoiceIndex)));
+                        else
+                            entityData.put(key, textChoices.get(textChoiceIndex));
+                    }
+                }
+            }
+
+            // Caution if you change this code. There are one or two places in the test code that are expecting lineage
+            // or aliquots based on this calculation.
+            if (addLineage && (i > (size / 2)))
+            {
+                if (i < size * 0.9 || !includeAliquots)
+                {
+                    entityData.put("materialInputs/" + queryName, namePrefix + (i - (size / 3)));
+                }
+                else
+                {
+                    entityData.put("AliquotedFrom", namePrefix + (i >= size * 0.95 ? 1 : 0));
+                }
+            }
+            allEntityData.add(entityData);
+        }
+        return allEntityData;
+    }
+
+    public static List<FieldDefinition> createSourceTypeFieldList(int numFields, int minNumRandomFields)
+    {
+        return createFieldList(numFields, minNumRandomFields, REALISTIC_SOURCE_FIELDS);
+    }
+
+    public static List<FieldDefinition> createSampleTypeFieldList(int numFields, int minNumRandomFields)
+    {
+        return createFieldList(numFields, minNumRandomFields, REALISTIC_SAMPLE_FIELDS);
+    }
+
+    public static List<FieldDefinition> createAssayDataFieldList(int numFields, int minNumRandomFields)
+    {
+        return createFieldList(numFields, minNumRandomFields, REALISTIC_ASSAY_FIELDS);
+    }
+
+    public static List<FieldDefinition> createFieldList(int numFields, int minNumRandomFields, List<Supplier<
+    FieldDefinition>> fieldChoices)
+    {
+        // first choose numFields - numRandomFields from given field choices
+        List<FieldDefinition> fields = new ArrayList<>(shuffleSelect(fieldChoices, Math.min(numFields - minNumRandomFields, fieldChoices.size())).stream().map(Supplier::get).toList());
+        // fill in the rest with random field names
+        for (int i = 0; i < Math.max(minNumRandomFields, numFields - fields.size()); i++)
+        {
+            String randomField = randomFieldName(String.format(" random %d ", i + 1));
+
+            FieldDefinition fieldDefinition;
+            if (i % 5 == 0)
+                fieldDefinition = new FieldDefinition(randomField, FieldDefinition.ColumnType.Decimal);
+            else if (i % 5 == 1)
+                fieldDefinition = new FieldDefinition(randomField, FieldDefinition.ColumnType.Time);
+            else if (i % 5 == 2)
+                fieldDefinition = new FieldDefinition(randomField, FieldDefinition.ColumnType.Date);
+            else if (i % 5 == 3)
+                fieldDefinition = new FieldDefinition(randomField, FieldDefinition.ColumnType.DateAndTime);
+            else
+                fieldDefinition = new FieldDefinition(randomField, FieldDefinition.ColumnType.Integer);
+
+            fields.add(fieldDefinition);
+        }
+        Collections.shuffle(fields);
+
+        TestLogger.log("Creating fields: ");
+        fields.forEach(obj -> {
+            TestLogger.log(obj.getName() + " : " + obj.getType().getLabel());
+        });
+        return fields;
+    }
+
+    public static void setFieldCaptionsFromNames(List<FieldDefinition> fields)
+    {
+        fields.forEach(f -> {
+            if (f.getLabel() == null)
+                f.setLabel(FieldDefinition.labelFromName(f.getName()));
+        });
     }
 
     public String getSchema()

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -41,7 +41,6 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.query.QueryApiHelper;
-import org.labkey.test.util.samplemanagement.SMTestUtils;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -78,6 +77,13 @@ public class TestDataGenerator
     public static final String ALPHANUMERIC_STRING = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvxyz";
     public static final String DOMAIN_SPECIAL_STRING =  "+- _.:&()/";
     public static final String ILLEGAL_DOMAIN_NAME_CHARSET = "<>[]{};,`\"~!@#$%^*=|?\\";
+    // Used to set value of date pickers
+    public static final Supplier<SimpleDateFormat> INPUT_DATE_FORMAT = () -> new SimpleDateFormat("MM/dd/yyyy");
+    public static final Supplier<SimpleDateFormat> INPUT_DATETIME_FORMAT = () -> new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
+    // Default display format
+    public static final Supplier<SimpleDateFormat> UI_DATE_FORMAT = () -> new SimpleDateFormat("yyyy-MM-dd");
+    public static final Supplier<SimpleDateFormat> UI_DATE_TIME_FORMAT = () -> new SimpleDateFormat("yyyy-MM-dd HH:mm");
+    public static final Supplier<SimpleDateFormat> TIME_FORMAT = () -> new SimpleDateFormat("HH:mm:ss");
 
     private final Map<String, PropertyDescriptor> _columns = new CaseInsensitiveLinkedHashMap<>();
     private final Map<String, Supplier<Object>> _dataSuppliers = new CaseInsensitiveHashMap<>();
@@ -158,11 +164,11 @@ public class TestDataGenerator
                 {
                     String key = fieldDefinition.getLabel() != null ? fieldDefinition.getLabel() : FieldDefinition.labelFromName(fieldDefinition.getName());
                     if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.Date))
-                        entityData.put(key, SMTestUtils.UI_DATE_FORMAT.get().format(TestDateUtils.diffFromTodaysDate(Calendar.HOUR, i * 24)));
+                        entityData.put(key, UI_DATE_FORMAT.get().format(TestDateUtils.diffFromTodaysDate(Calendar.HOUR, i * 24)));
                     else if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.DateAndTime))
-                        entityData.put(key, SMTestUtils.UI_DATE_TIME_FORMAT.get().format(TestDateUtils.diffFromTodaysDate(Calendar.HOUR, i * 24)));
+                        entityData.put(key, UI_DATE_TIME_FORMAT.get().format(TestDateUtils.diffFromTodaysDate(Calendar.HOUR, i * 24)));
                     else if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.Time))
-                        entityData.put(key, SMTestUtils.TIME_FORMAT.get().format(TestDateUtils.diffFromTodaysDate(Calendar.HOUR, i * 24)));
+                        entityData.put(key, TIME_FORMAT.get().format(TestDateUtils.diffFromTodaysDate(Calendar.HOUR, i * 24)));
                     else if (fieldDefinition.getType().equals(FieldDefinition.ColumnType.Integer))
                     {
                         entityData.put(key, i);

--- a/src/org/labkey/test/util/TestDataUtils.java
+++ b/src/org/labkey/test/util/TestDataUtils.java
@@ -197,14 +197,13 @@ public class TestDataUtils
                                     char delimiter, boolean includeHeaders)
     {
         StringBuilder builder = new StringBuilder();
+        TsvQuoter q = new TsvQuoter(delimiter);
 
         if (includeHeaders)
         {
-            builder.append(String.join(String.valueOf(delimiter), columns));
+            builder.append(String.join(String.valueOf(delimiter), columns.stream().map(q::quoteValue).toList()));
             builder.append("\n");
         }
-
-        TsvQuoter q = new TsvQuoter(delimiter);
 
         for (Map<String, Object> row : rowMaps)
         {


### PR DESCRIPTION
#### Rationale
In the details panel, we need to use labels or fieldKeys when setting values.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1304

#### Changes
- Update `DetailTableEdit.setDetails` method to not attempt any setting if given a null value
- Update keys used in `DetailTableEidt.setDetails` method.
