### PR TITLE
Selenium tests for various sample status issues.

### DIFF
--- a/src/org/labkey/test/components/ManageSampleStatusesPanel.java
+++ b/src/org/labkey/test/components/ManageSampleStatusesPanel.java
@@ -81,6 +81,12 @@ public class ManageSampleStatusesPanel extends WebDriverComponent<ManageSampleSt
         return selectStatus(name, null);
     }
 
+    public boolean isStatusLocked(String name)
+    {
+        selectStatus(name);
+        return isLocked();
+    }
+
     public SampleStatus selectStatus(String name, SampleTypeHelper.StatusType statusType)
     {
         elementCache().statusItem(name).click();

--- a/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
+++ b/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
@@ -66,7 +66,7 @@ import static org.labkey.test.util.TestDataUtils.getEscapedNameExpression;
 public class SampleTypeNameExpressionTest extends BaseWebDriverTest
 {
     private static final String PROJECT_NAME = "SampleType_Name_Expression_Test";
-    private static final String DEFAULT_SAMPLE_PARENT_VALUE = "SS" + TestDataGenerator.randomString(3);
+    private static final String DEFAULT_SAMPLE_PARENT_VALUE = "SS" + TestDataGenerator.randomString(3).replaceAll("_", "."); // '_' is used as delimiter to get batchRandomId
 
     private static final String PARENT_SAMPLE_TYPE = "PS" + DOMAIN_TRICKY_CHARACTERS;
     private static final String PARENT_SAMPLE_TYPE_INPUT = "PS" + getEscapedNameExpression(DOMAIN_TRICKY_CHARACTERS);


### PR DESCRIPTION
- Issue 47595: Manage Sample Statuses page in LKS should not allow adding new status in child folder
- Fix random SampleTypeNameExpressionTest test failure due to presence of '_' in static string

#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1769
- https://github.com/LabKey/labkey-ui-premium/pull/729
- https://github.com/LabKey/limsModules/pull/1306
- https://github.com/LabKey/testAutomation/pull/2392

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
