### PR TITLE
Disable crawler for WikiCspTest

### DIFF
--- a/src/org/labkey/test/tests/wiki/WikiCspTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiCspTest.java
@@ -1,7 +1,6 @@
 package org.labkey.test.tests.wiki;
 
 import org.jetbrains.annotations.Nullable;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -54,7 +53,7 @@ public class WikiCspTest extends BaseWebDriverTest
     }
 
     @Override
-    protected void checkLeaks()
+    protected void checkLinks()
     {
         // No-op to avoid triggering the CSP violation during the crawl
     }


### PR DESCRIPTION
#### Rationale
The crawler can trigger a CSP warning if it hits the wiki created by this test. The crawler was intended to be skipped but the wrong method was overridden (disabling the mem check instead of the link check).

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2156

#### Changes
- Disable crawler for WikiCspTest
