### PR TITLE
Use absolute URLs for Apache HTTP requests in crawler

### DIFF
--- a/src/org/labkey/test/WebTestHelper.java
+++ b/src/org/labkey/test/WebTestHelper.java
@@ -355,6 +355,29 @@ public class WebTestHelper
         return StringUtils.stripStart(url, "/");
     }
 
+    /**
+     * Append the test server's base URL to the front of a relative URL. Absolute URLs will be returned unchanged.
+     * @param url Absolute or relative URL
+     * @return Absolute URL
+     */
+    public static String makeAbsoluteUrl(String url)
+    {
+        if (isAbsoluteUrl(url))
+        {
+            return url;
+        }
+        else
+        {
+            StringBuilder sb = new StringBuilder(getBaseURL());
+            if (!url.startsWith("/"))
+            {
+                sb.append("/");
+            }
+            sb.append(url);
+            return sb.toString();
+        }
+    }
+
     public static boolean isAbsoluteUrl(String url)
     {
         return url.startsWith("http://") || url.startsWith("https://");

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -1190,7 +1190,7 @@ public class Crawler
 
     private boolean doesUrlExist(UrlToCheck urlToCheck)
     {
-        final String url = stripQueryParams(urlToCheck.getRelativeURL());
+        final String url = WebTestHelper.makeAbsoluteUrl(stripQueryParams(urlToCheck.getRelativeURL()));
 
         // Check whether 404 was due to a missing action
         HttpContext context = WebTestHelper.getBasicHttpContext();


### PR DESCRIPTION
#### Rationale
Now that `UrlToCheck.getRelativeUrl` actually returns relative URLs consistently, `doesUrlExist` needs to turn them into absolute URLs for use with the Apache HTTP client.

```
java.lang.RuntimeException: Crawler threw NullPointerException.
Originating page: http://localhost:8111/StudyDemoMode%20Project/My%20Study/experiment-deriveSamplesChooseTarget.view?rowIds=21697&targetSampleTypeId=24
Target Page: StudyDemoMode%20Project/My%20Study/experiment-deriveSamples.view?rowIds=21697&inputRole0=&customRole0=&outputCount=1&targetSampleTypeId=
	at org.labkey.test.util.Crawler.crawlLink(Crawler.java:1129)
	at org.labkey.test.util.Crawler.crawl(Crawler.java:838)
	at org.labkey.test.util.Crawler.crawlAllLinks(Crawler.java:801)
	[...]
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.hc.core5.http.HttpHost.getSchemeName()" because "resolvedTarget" is null
	[...]
	at org.apache.hc.client5.http.impl.classic.CloseableHttpClient.execute(CloseableHttpClient.java:188)
	at org.labkey.test.util.Crawler.doesUrlExist(Crawler.java:1199)
	at org.labkey.test.util.Crawler.isIgnoredError(Crawler.java:1175)
	at org.labkey.test.util.Crawler.crawlLink(Crawler.java:1005)
	... 19 more
```

#### Related Pull Requests
- #2378 

#### Changes
- Use absolute URLs for Apache HTTP requests in crawler
- Define `WebTestHelper.makeAbsoluteUrl`
