### PR TITLE
use webDriverWrapper to get clipboard content

### DIFF
--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -871,8 +871,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
                 .build()
                 .perform();
 
-        return (String) Toolkit.getDefaultToolkit().getSystemClipboard()
-                .getData(DataFlavor.stringFlavor);
+        return getWrapper().getClipboardContent();
     }
 
     public void dragFill(WebElement startCell, WebElement endCell)


### PR DESCRIPTION
#### Rationale
Recently, we updated `WebDriverWrapper.getClipboardContent()` to work around `UnsupportedFlavorExceptions` when copying unicode text via the clipboard on some TeamCity agents (namely, our headless windows agents)
[PlateEditorTest.testQuadrantStampCompress](https://teamcity.labkey.org/viewLog.html?buildId=3444372&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsWindows&fromSakuraUI=true#testNameId-3571905294891531510) failed on its most-recent run in develop, probably because it's loading the clipboard itself and not using the method Trey updated in https://github.com/LabKey/testAutomation/pull/2338 to get the clipboard contents.

This change updates` EditableGrid.copyCurrentSelection()` to use `WebDriverWrapper.getClipboardContent()` to get the benefit of the work that went into https://github.com/LabKey/testAutomation/pull/2338

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/2338
https://github.com/LabKey/limsModules/pull/1305

#### Changes
use` WebDriverWrapper.getClipboardContent` to retrieve clipboard contents
