### PR TITLE
25.3 fb fix intermittent failing tc tests

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -26,6 +26,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+
 /**
  * automates /QueryModel/DetailPanel.tsx in its editable mode
  */
@@ -34,7 +36,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     private final WebElement _formElement;
     private final WebDriver _driver;
     private String _title;
-    private int _readyTimeout = WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+    private int _readyTimeout = WAIT_FOR_JAVASCRIPT;
 
     protected DetailTableEdit(WebElement formElement, WebDriver driver)
     {
@@ -452,12 +454,16 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     public DetailDataPanel clickSave()
     {
         String title = getSourceTitle();
+        var componentEl = getComponentElement();
         getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().saveButton));
         elementCache().saveButton.click();
 
         // If save causes some update, wait until it is completed.
         getWrapper().longWait().withMessage("Update took too long to complete.")
                 .until(ExpectedConditions.stalenessOf(elementCache().saveButton));
+
+        // ensure we don't find the current component; wait for it to become stale before searching
+        getWrapper().shortWait().until(ExpectedConditions.stalenessOf(componentEl));
 
         return new DetailDataPanel.DetailDataPanelFinder(getDriver()).withTitle(title).waitFor();
     }

--- a/src/org/labkey/test/tests/ClientAPITest.java
+++ b/src/org/labkey/test/tests/ClientAPITest.java
@@ -300,7 +300,7 @@ public class ClientAPITest extends BaseWebDriverTest
     private void createStudies()
     {
         // create time-based study
-        projectMenu().navigateToFolder(getProjectName(), TIME_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), TIME_STUDY_FOLDER);
         navBar().goToModule("Study");
         CreateStudyPage createStudyPage = _studyHelper.startCreateStudy();
         createStudyPage.setLabel(TIME_STUDY_NAME)
@@ -336,7 +336,7 @@ public class ClientAPITest extends BaseWebDriverTest
     {
         // this test case attempts to create a time-keyed dataset in a visit-based study folder, which should
         // fail on create.
-        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -379,7 +379,7 @@ public class ClientAPITest extends BaseWebDriverTest
     public void validateStudyDatasetDateDomainKindInVisitBasedStudy()
     {
         // make sure you can't use StudyDatasetDate domain kind in a visit-based study
-        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetDate\",\n" +
@@ -399,7 +399,7 @@ public class ClientAPITest extends BaseWebDriverTest
     public void validateUseTimeKeyFieldWithKeyPropertyName()
     {
         // make sure you can't set the useTimeKeyField and keyPropertyName at the same time
-        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -423,7 +423,7 @@ public class ClientAPITest extends BaseWebDriverTest
     public void validateUseTimeKeyFieldWithKeyPropertyManaged()
     {
         // make sure you can't set the useTimeKeyField and keyPropertyName at the same time
-        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -447,7 +447,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateDemographicDataWithKeyPropertyName()
     {
-        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -470,7 +470,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateKeyPropertyManagedDataType()
     {
-        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -493,7 +493,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateKeyPropertyManagedWithoutKeyPropertyName()
     {
-        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -515,7 +515,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateKeyPropertyNameExistsInDomain()
     {
-        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -537,7 +537,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateKeyPropertyNameIsNotBlank()
     {
-        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -559,7 +559,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateDatasetDuplicateName()
     {
-        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "DatasetDuplicateNameCheck";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -578,7 +578,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateDatasetDuplicateLabel()
     {
-        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "DatasetDuplicateLabelCheck";
         String dataSetLabel = "Dataset Duplicate Label Check";
         String create = "LABKEY.Domain.create({\n" +
@@ -616,7 +616,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateDatasetNameIsNotBlank()
     {
-        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
                 "   domainDesign: {\n" +
@@ -634,7 +634,7 @@ public class ClientAPITest extends BaseWebDriverTest
     public void validateDatasetNameMaxLength()
     {
         // max length allowed should be 200, this name's length is 201
-        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
                 "   domainDesign: {\n" +
@@ -651,7 +651,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void createVisitBasedDomain()
     {
-        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "MyVisitBasedDataSet";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +

--- a/src/org/labkey/test/tests/ClientAPITest.java
+++ b/src/org/labkey/test/tests/ClientAPITest.java
@@ -308,7 +308,7 @@ public class ClientAPITest extends BaseWebDriverTest
                 .createStudy();
 
         // create a visit-based study in a different container
-        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
         navBar().goToModule("Study");
         CreateStudyPage createVisitStudyPage = _studyHelper.startCreateStudy();
         createVisitStudyPage.setLabel(VISIT_STUDY_NAME)
@@ -336,7 +336,7 @@ public class ClientAPITest extends BaseWebDriverTest
     {
         // this test case attempts to create a time-keyed dataset in a visit-based study folder, which should
         // fail on create.
-        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -379,7 +379,7 @@ public class ClientAPITest extends BaseWebDriverTest
     public void validateStudyDatasetDateDomainKindInVisitBasedStudy()
     {
         // make sure you can't use StudyDatasetDate domain kind in a visit-based study
-        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetDate\",\n" +
@@ -399,7 +399,7 @@ public class ClientAPITest extends BaseWebDriverTest
     public void validateUseTimeKeyFieldWithKeyPropertyName()
     {
         // make sure you can't set the useTimeKeyField and keyPropertyName at the same time
-        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -423,7 +423,7 @@ public class ClientAPITest extends BaseWebDriverTest
     public void validateUseTimeKeyFieldWithKeyPropertyManaged()
     {
         // make sure you can't set the useTimeKeyField and keyPropertyName at the same time
-        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -447,7 +447,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateDemographicDataWithKeyPropertyName()
     {
-        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -470,7 +470,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateKeyPropertyManagedDataType()
     {
-        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -493,7 +493,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateKeyPropertyManagedWithoutKeyPropertyName()
     {
-        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -515,7 +515,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateKeyPropertyNameExistsInDomain()
     {
-        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -537,7 +537,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateKeyPropertyNameIsNotBlank()
     {
-        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "ThisShouldBlowUp";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -559,7 +559,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateDatasetDuplicateName()
     {
-        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "DatasetDuplicateNameCheck";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
@@ -578,7 +578,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateDatasetDuplicateLabel()
     {
-        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "DatasetDuplicateLabelCheck";
         String dataSetLabel = "Dataset Duplicate Label Check";
         String create = "LABKEY.Domain.create({\n" +
@@ -616,7 +616,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void validateDatasetNameIsNotBlank()
     {
-        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
                 "   domainDesign: {\n" +
@@ -634,7 +634,7 @@ public class ClientAPITest extends BaseWebDriverTest
     public void validateDatasetNameMaxLength()
     {
         // max length allowed should be 200, this name's length is 201
-        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +
                 "   domainDesign: {\n" +
@@ -651,7 +651,7 @@ public class ClientAPITest extends BaseWebDriverTest
     @Test
     public void createVisitBasedDomain()
     {
-        projectMenu().navigateToFolder(getProjectName(), VISIT_STUDY_FOLDER);
+        goToProjectFolder(getProjectName(), VISIT_STUDY_FOLDER);
         String dataSetName = "MyVisitBasedDataSet";
         String create = "LABKEY.Domain.create({\n" +
                 "   kind: \"StudyDatasetVisit\",\n" +

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -467,6 +467,8 @@ public class SimpleModuleTest extends BaseWebDriverTest
         assertTextPresentInThisOrder("A customized web part", "Data Pipeline", "Experiment Runs", "Sample Type", "Assay List");
         assertTextPresent("Run Groups");
         assertElementNotPresent(Locator.linkWithText("Create Run Group")); // Not in small Run Groups web-part.
+        // ensure the mouse isn't inadvertently hovering something else, causing obscuring popup
+        mouseOver(portalHelper.getBodyWebPart("A customized web part").getComponentElement());
         portalHelper.checkWebpartPermission("A customized web part", "Read", null);
         portalHelper.checkWebpartPermission("Data Pipeline", "Read", null);
     }
@@ -1050,7 +1052,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
     {
         log("Testing web parts in modules...");
         //go to project portal
-        clickProject(getProjectName());
+        goToProjectHome();
 
         //add Simple Module Web Part
         new PortalHelper(this).addWebPart("Simple Module Web Part");
@@ -1064,7 +1066,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
     protected void createList() throws Exception
     {
         //create a list for our query
-        clickProject(getProjectName());
+        goToProjectHome();
         new PortalHelper(this).addWebPart("Lists");
 
         log("Creating list for query/view/report test...");
@@ -1090,7 +1092,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
         log("Testing queries in modules...");
 
         //go to query module portal
-        clickProject(getProjectName());
+        goToProjectHome();
         goToModule("Query");
         viewQueryData("lists", "TestQuery");
 
@@ -1102,7 +1104,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
     private void doTestQueryViews()
     {
         log("Testing module-based custom query views...");
-        clickProject(getProjectName());
+        goToProjectHome();
         clickAndWait(Locator.linkWithText(LIST_NAME));
 
         DataRegionTable table = new DataRegionTable("query", getDriver());
@@ -1133,13 +1135,13 @@ public class SimpleModuleTest extends BaseWebDriverTest
         _rReportHelper.ensureRConfig();
 
         log("Testing module-based JS reports...");
-        clickProject(getProjectName());
+        goToProjectHome();
         clickAndWait(Locator.linkWithText(LIST_NAME));
         DataRegionTable table = new DataRegionTable("query", getDriver());
         table.goToReport("Want To Be Cool");
         waitForText(WAIT_FOR_JAVASCRIPT, "Less cool than expected. Loaded dependent scripts.");
 
-        clickProject(getProjectName());
+        goToProjectHome();
         portalHelper.addWebPart("Report");
         setFormElement(Locator.name("title"), "Report Tester Part");
         selectOptionByValue(Locator.name("reportId"), "module:simpletest/reports/schemas/lists/People/Less Cool JS Report.js");
@@ -1241,7 +1243,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
         log("Testing import templates...");
 
         //go to query module portal
-        clickProject(getProjectName());
+        goToProjectHome();
         goToModule("Query");
         viewQueryData(VEHICLE_SCHEMA, "Vehicles");
         DataRegionTable table = new DataRegionTable("query", getDriver());
@@ -1848,7 +1850,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
     private void doTestRestrictedModule()
     {
         log("Create folder with restricted");
-        clickProject(getProjectName());
+        goToProjectHome();
         _containerHelper.createSubfolder(getProjectName(), RESTRICTED_FOLDER_NAME, RESTRICTED_FOLDER_TYPE);
         PortalHelper portalHelper = new PortalHelper(this);
         portalHelper.addWebPart("Restricted Module Web Part");
@@ -1860,7 +1862,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
         impersonateRole("Reader");
         assertTextPresent("This is a web part view in the restricted module.");     // Can still see web part
         stopImpersonating();
-        clickProject(getProjectName());
+        goToProjectHome();
         navigateToFolder(getProjectName(), RESTRICTED_FOLDER_NAME);
         impersonateRole("Folder Administrator");
         goToFolderManagement();

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -468,7 +468,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
         assertTextPresent("Run Groups");
         assertElementNotPresent(Locator.linkWithText("Create Run Group")); // Not in small Run Groups web-part.
         // ensure the mouse isn't inadvertently hovering something else, causing obscuring popup
-        mouseOver(portalHelper.getBodyWebPart("A customized web part").getComponentElement());
+        mouseOver(Locator.tagWithClass("a", "brand-logo"));
         portalHelper.checkWebpartPermission("A customized web part", "Read", null);
         portalHelper.checkWebpartPermission("Data Pipeline", "Read", null);
     }


### PR DESCRIPTION
#### Rationale
This change attempts to stabilize a couple of recently-failing tests on TeamCity

[SimpleModuleTest](https://teamcity.labkey.org/viewLog.html?buildId=3458584&tab=buildResultsDiv&buildTypeId=LabKey_253Release_Community_DailySuites_DailyBPostgres#testNameId5981971736586896608) fails intermittently because at the moment the test needs to interact with a webPart permissions menu, there's a tooltop hovering over it. 

[ClientAPITest](https://teamcity.labkey.org/viewLog.html?buildId=3453890#testNameId5684422414308035516), one of our BVT tests, failed recently attempting to navigate via the project menu in a test that isn't actually about navigating that way. This replaces that call (and several like it) with beginAt actions.

#### Related Pull Requests
n/a

#### Changes
try to make these tests more reliable
