### PR TITLE
Make more Locators work with tricky characters

### DIFF
--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -46,8 +46,10 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -975,6 +977,16 @@ public abstract class Locator extends By
         return Quotes.escape(value);
     }
 
+    /**
+     * Equivalent to XPath {@code normalize-space()}:<br>
+     * "The normalize-space function strips leading and trailing white-space from a string, replaces sequences of
+     * whitespace characters by a single space, and returns the resulting string."
+     */
+    private static String ns(String value)
+    {
+        return value.replaceAll("\\s+", " ").trim();
+    }
+
     public static String cq(String value)
     {
         return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
@@ -1189,7 +1201,7 @@ public abstract class Locator extends By
         public XPathLocator containing(String contains)
         {
             if (contains != null && !contains.isEmpty())
-                return this.withPredicate("contains(normalize-space(), "+xq(contains)+")");
+                return this.withPredicate("contains(normalize-space(), "+xq(ns(contains))+")");
             else
                 return this;
         }
@@ -1197,20 +1209,20 @@ public abstract class Locator extends By
         public XPathLocator containingIgnoreCase(String contains)
         {
             if (contains != null && !contains.isEmpty())
-                return this.withPredicate("contains(translate(normalize-space(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), "+xq(contains.toLowerCase())+")");
+                return this.withPredicate("contains(" + toLowerCase("normalize-space()", contains) + ", "+xq(ns(contains.toLowerCase()))+")");
             else
                 return this;
         }
 
         public XPathLocator notContaining(String contains)
         {
-            return this.withPredicate("not(contains(normalize-space(), "+xq(contains)+"))");
+            return this.withPredicate("not(contains(normalize-space(), "+xq(ns(contains))+"))");
         }
 
         public XPathLocator notContainingIgnoreCase(String contains)
         {
             if (contains != null && !contains.isEmpty())
-                return this.withPredicate("not(contains(translate(normalize-space(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), "+xq(contains.toLowerCase())+"))");
+                return this.withPredicate("not(contains(" + toLowerCase("normalize-space()", contains) + ", "+xq(ns(contains.toLowerCase()))+"))");
             else
                 return this;
         }
@@ -1218,7 +1230,7 @@ public abstract class Locator extends By
         @Override
         public XPathLocator withText(String text)
         {
-            return this.withPredicate("normalize-space()="+xq(text));
+            return this.withPredicate("normalize-space()="+xq(ns(text)));
         }
 
         public XPathLocator withText()
@@ -1228,7 +1240,7 @@ public abstract class Locator extends By
 
         public XPathLocator withoutText(String text)
         {
-            return this.withPredicate("not(normalize-space()=" + xq(text) + ")");
+            return this.withPredicate("not(normalize-space()=" + xq(ns(text)) + ")");
         }
 
         public XPathLocator withoutText()
@@ -1238,17 +1250,17 @@ public abstract class Locator extends By
 
         public XPathLocator withTextMatching(String regex)
         {
-            return this.withPredicate("matches(normalize-space(), " + xq(regex) + ")");
+            return this.withPredicate("matches(normalize-space(), " + xq(ns(regex)) + ")");
         }
 
         public XPathLocator startsWith(String text)
         {
-            return this.withPredicate("starts-with(normalize-space(), "+xq(text)+")");
+            return this.withPredicate("starts-with(normalize-space(), "+xq(ns(text))+")");
         }
 
         public XPathLocator startsWithIgnoreCase(String text)
         {
-            return this.withPredicate("starts-with(translate(normalize-space(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), "+xq(text.toLowerCase())+")");
+            return this.withPredicate("starts-with(" + toLowerCase("normalize-space()", text) + ", "+xq(ns(text.toLowerCase()))+")");
         }
 
         @Override
@@ -1404,7 +1416,7 @@ public abstract class Locator extends By
 
         public XPathLocator endsWith(String substring)
         {
-            return this.endsWith("normalize-space()", substring);
+            return this.endsWith("normalize-space()", ns(substring));
         }
 
         private XPathLocator endsWith(String expression, String substring)
@@ -1451,9 +1463,48 @@ public abstract class Locator extends By
 
         public XPathLocator withAttributeIgnoreCase(String attrName, String attrVal)
         {
-            return this.withPredicate(
-                    String.format("translate(@%s, 'ABCDEFGHIJKLMNOPQRSTUVWXYZÅ', 'abcdefghijklmnopqrstuvwxyzå')=%s",
-                            attrName, xq(attrVal.toLowerCase())));
+            return this.withPredicate(toLowerCase("@" + attrName, attrVal) + "=" + xq(attrVal.toLowerCase()));
+        }
+
+        /**
+         * Generate an XPath 'translate' statement that will convert the provided statement to lowerCase so that it can
+         * be compared to the target value. Allow case-insensitive comparison with values containing tricky characters.
+         * The Locator "{@code Locator.tag("span").containingIgnoreCase("test")}", produces an XPath like:
+         * "{@code //span[contains(translate(normalize-space(), 'TES', 'tes'), 'test')]}"<br>
+         * This would find "{@code <span>test</span}" or "{@code <span>TESTING</span}"
+         *
+         * @param sourceStatement XPath statement to apply the translation to
+         * @param targetValue String that 'sourceStatement' will be compared to
+         * @return translate statement to be used in XPath predicate
+         */
+        private String toLowerCase(String sourceStatement, String targetValue)
+        {
+            Map<Character, Character> caseMap = new HashMap<>(); // upperCase -> lowerCase
+            char[] upperCase = targetValue.toUpperCase().toCharArray();
+            char[] lowerCase = targetValue.toLowerCase().toCharArray();
+            for (int i = 0; i < targetValue.length(); i++)
+            {
+                if (upperCase[i] != lowerCase[i])
+                {
+                    caseMap.put(Character.valueOf(upperCase[i]), Character.valueOf(lowerCase[i]));
+                }
+            }
+            if (caseMap.isEmpty())
+            {
+                return sourceStatement;
+            }
+            else
+            {
+                StringBuilder upperCaseBuilder = new StringBuilder();
+                StringBuilder lowerCaseBuilder = new StringBuilder();
+                caseMap.forEach((u, l) -> {
+                    upperCaseBuilder.append(u);
+                    lowerCaseBuilder.append(l);
+                });
+                return "translate(" + sourceStatement + ", " +
+                        "'" + upperCaseBuilder + "' ," +
+                        "'" + lowerCaseBuilder + "')";
+            }
         }
 
         public XPathLocator withoutAttribute(String attrName, String attrVal)


### PR DESCRIPTION
#### Rationale
Wider use of tricky characters and string has revealed some defects in how we construct Locators.

We use XPath's `normalize-space()` method for most text matching but we don't normalize whitespace in the text we are comparing to. We need to perform normalization to both sides of comparisons we perform.

We have some Locators that do case-insensitive text matching. The current implementation only works for `A-Z`; an XPath translate statement that simulates a toLowerCase sort of operation (`translate(normalize-space(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')`). We know the String the Locator will be comparing to, so we can construct a translate statement that does a `toLowerCase` for just the characters we care about matching, including ones with diacritics (e.g. `Ä` -> `ä`).

#### Related Pull Requests
- #2189 

#### Changes
- Consistently normalize whitespace of strings
- Support a wider set of characters for case-insensitive text matching
