### PR TITLE
add escape util methods for sql and markup

### DIFF
--- a/src/org/labkey/test/pages/dataintegration/ETLSchedulerPage.java
+++ b/src/org/labkey/test/pages/dataintegration/ETLSchedulerPage.java
@@ -50,6 +50,27 @@ public class ETLSchedulerPage extends LabKeyPage<ETLSchedulerPage.Elements>
         return new ETLSchedulerPage(test);
     }
 
+    /**
+     * gets the ETL given its name.
+     * @param transformName
+     * @return
+     */
+    public TransformRow getTransform(String transformName)
+    {
+        var queryRowLoc = Locator.tag("tr").withDescendant(Locator.tagWithText("td", transformName));
+
+        if (!queryRowLoc.isDisplayed(getDriver()) && Locator.lkButton("View ETL Scheduler").isDisplayed(getDriver()))
+        {
+            clickButton("View ETL Scheduler");
+        }
+        else if (!queryRowLoc.isDisplayed(getDriver()) && Locator.lkButton("View Custom ETL Definitions").isDisplayed(getDriver()))
+        {
+            clickButton("View Custom ETL Definitions");
+            clickButton("View ETL Scheduler");
+        }
+        return new TransformRow(queryRowLoc.findElement(getDriver()));
+    }
+
     public TransformRow transform(String transformId)
     {
         return elementCache().findTransformRow(transformId);

--- a/src/org/labkey/test/pages/dataintegration/ETLSchedulerPage.java
+++ b/src/org/labkey/test/pages/dataintegration/ETLSchedulerPage.java
@@ -57,17 +57,9 @@ public class ETLSchedulerPage extends LabKeyPage<ETLSchedulerPage.Elements>
      */
     public TransformRow getTransform(String transformName)
     {
-        var queryRowLoc = Locator.tag("tr").withDescendant(Locator.tagWithText("td", transformName));
+        var queryRowLoc = Locator.tag("tr").withAttribute("transformid")
+                .withChild(Locator.tagWithText("td", transformName));
 
-        if (!queryRowLoc.isDisplayed(getDriver()) && Locator.lkButton("View ETL Scheduler").isDisplayed(getDriver()))
-        {
-            clickButton("View ETL Scheduler");
-        }
-        else if (!queryRowLoc.isDisplayed(getDriver()) && Locator.lkButton("View Custom ETL Definitions").isDisplayed(getDriver()))
-        {
-            clickButton("View Custom ETL Definitions");
-            clickButton("View ETL Scheduler");
-        }
         return new TransformRow(queryRowLoc.findElement(getDriver()));
     }
 

--- a/src/org/labkey/test/util/EscapeUtil.java
+++ b/src/org/labkey/test/util/EscapeUtil.java
@@ -16,6 +16,7 @@
 package org.labkey.test.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.jetty.util.URIUtil;
 
 import java.net.URLDecoder;
@@ -157,11 +158,6 @@ public class EscapeUtil
 
     public static String getMarkupEscapedValue(String value)
     {
-        return value
-                .replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;")
-                .replace("\"", "&quot;")
-                .replace("'", "&apos;");
+        return StringEscapeUtils.escapeXml11(value);
     }
 }

--- a/src/org/labkey/test/util/EscapeUtil.java
+++ b/src/org/labkey/test/util/EscapeUtil.java
@@ -150,24 +150,11 @@ public class EscapeUtil
                 .collect(Collectors.joining("|"));
     }
 
-    /**
-     * Takes an identifier (a field or domain value) and enquotes it, while also escaping any quotes
-     * it might have.  This his helpful for using randomly-generated identifiers in sql queries.
-     * @param value
-     * @return
-     */
     public static String getSqlQuotedValue(String value)
     {
         return String.format("\"%s\"", value.replaceAll("\"", "\"\""));
     }
 
-    /**
-     * Takes an identifier (say, a field value) to be used in XML configuration or as HTML and escapes
-     * reserved markup language characters.  This is helpful for configuring randomly-generated identifiers
-     * in configXml
-     * @param value
-     * @return
-     */
     public static String getMarkupEscapedValue(String value)
     {
         return value

--- a/src/org/labkey/test/util/EscapeUtil.java
+++ b/src/org/labkey/test/util/EscapeUtil.java
@@ -149,4 +149,32 @@ public class EscapeUtil
                 .map(value -> value.replaceAll("([\\\\|])", "\\\\$1"))
                 .collect(Collectors.joining("|"));
     }
+
+    /**
+     * Takes an identifier (a field or domain value) and enquotes it, while also escaping any quotes
+     * it might have.  This his helpful for using randomly-generated identifiers in sql queries.
+     * @param value
+     * @return
+     */
+    public static String getSqlQuotedValue(String value)
+    {
+        return String.format("\"%s\"", value.replaceAll("\"", "\"\""));
+    }
+
+    /**
+     * Takes an identifier (say, a field value) to be used in XML configuration or as HTML and escapes
+     * reserved markup language characters.  This is helpful for configuring randomly-generated identifiers
+     * in configXml
+     * @param value
+     * @return
+     */
+    public static String getMarkupEscapedValue(String value)
+    {
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
+    }
 }


### PR DESCRIPTION
#### Rationale
This change adds very basic escape/enquote helpers to EscapeUtil to safely use randomly-generated identifiers (such as field names and domain names) in sql queries and in xml markup like ETL definitions or query metadata.

It also adds a quick-and-dirty method to ETLSchedulerPage to navigate to the transform view if it's not there already and to return a transform/etl schedule by its name.

#### Related Pull Requests
https://github.com/LabKey/premiumModules/pull/211

#### Changes
Helper methods to escape text inputs for sql and markup languages
