### PR TITLE
surface a method to empty the clipboard contents

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3553,7 +3553,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
     public void clearClipboardContent()
     {
-        setClipboardContent("");
+        setClipboardContent(" ");
     }
 
     protected void setClipboardContent(String text)

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3530,9 +3530,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
     {
         Keys cmdKey = WebDriverUtils.MODIFIER_KEY;
 
-        Clipboard c = Toolkit.getDefaultToolkit().getSystemClipboard();
-        StringSelection sel = new StringSelection(text);
-        c.setContents(sel, sel);
+        setClipboardContent(text);
 
         if (input == null)
         {
@@ -3551,6 +3549,18 @@ public abstract class WebDriverWrapper implements WrapsDriver
                     .keyUp(cmdKey)
                     .perform();
         }
+    }
+
+    public void clearClipboardContent()
+    {
+        setClipboardContent("");
+    }
+
+    protected void setClipboardContent(String text)
+    {
+        Clipboard c = Toolkit.getDefaultToolkit().getSystemClipboard();
+        StringSelection sel = new StringSelection(text);
+        c.setContents(sel, sel);
     }
 
     public String getClipboardContent() throws IOException, UnsupportedFlavorException


### PR DESCRIPTION
#### Rationale
This change adds a public method to allow tests to clear the clipboard without resorting to copying empty grid cells

#### Related Pull Requests
https://github.com/LabKey/limsModules/pull/1355

#### Changes
- pull the implementation of setting the clipboard out into its own protected method
- surface a public method to allow clearing the clipboard
