### PR TITLE
EditableGridTest: Disable the test cases that drag fill multiline column values

### DIFF
--- a/src/org/labkey/test/tests/component/EditableGridTest.java
+++ b/src/org/labkey/test/tests/component/EditableGridTest.java
@@ -288,7 +288,8 @@ public class EditableGridTest extends BaseWebDriverTest
                 testGrid.getColumnData(DESC_STRING));
     }
 
-    @Test
+    // Test disabled until Issue 52226, Issue 51927 are resolved
+//    @Test
     public void testDragFillSingleRow()
     {
         final LocalDateTime now = LocalDate.of(2019, 1, 30).atTime(16, 30);
@@ -349,7 +350,8 @@ public class EditableGridTest extends BaseWebDriverTest
                         totalHeightBefore.size + (3 * rowHeightBefore) >= totalHeightAfter.size);
     }
 
-    @Test
+    // Test disabled until Issue 52226, Issue 51927 are resolved
+//    @Test
     public void testDragFillMultipleRows()
     {
         final LocalDateTime now = LocalDate.of(2019, 1, 30).atTime(14, 30);

--- a/src/org/labkey/test/tests/component/EditableGridTest.java
+++ b/src/org/labkey/test/tests/component/EditableGridTest.java
@@ -2,6 +2,7 @@ package org.labkey.test.tests.component;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
@@ -288,8 +289,8 @@ public class EditableGridTest extends BaseWebDriverTest
                 testGrid.getColumnData(DESC_STRING));
     }
 
-    // Test disabled until Issue 52226, Issue 51927 are resolved
-//    @Test
+    @Test
+    @Ignore  // Test disabled until Issue 52226, Issue 51927 are resolved
     public void testDragFillSingleRow()
     {
         final LocalDateTime now = LocalDate.of(2019, 1, 30).atTime(16, 30);
@@ -350,8 +351,8 @@ public class EditableGridTest extends BaseWebDriverTest
                         totalHeightBefore.size + (3 * rowHeightBefore) >= totalHeightAfter.size);
     }
 
-    // Test disabled until Issue 52226, Issue 51927 are resolved
-//    @Test
+    @Test
+    @Ignore  // Test disabled until Issue 52226, Issue 51927 are resolved
     public void testDragFillMultipleRows()
     {
         final LocalDateTime now = LocalDate.of(2019, 1, 30).atTime(14, 30);


### PR DESCRIPTION
#### Rationale
This PR disables the test cases in EditableGridTest that drag fill a column with a multiline text value. Our drag fill code now uses our paste handling code (in order to reduce complexity, and in order to address other issues with drag fill), but unfortunately we cannot handle pasting multiline text fields. See Issues [52226](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52226), [51927](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51927), which are slated to be fixed in 25.7.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1751

#### Changes
- EditableGridTest: Disable the test cases that drag fill multiline column values

