### PR TITLE
Get raw field labels from app grids and tables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ project.dependencies {
     implementation("commons-io:commons-io:${commonsIoVersion}")
     implementation("com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}")
     implementation("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")
+    implementation("org.apache.commons:commons-csv:${apacheCommonsCsvVersion}")
 
     //api "org.seleniumhq.selenium:selenium-server:${seleniumVersion}"
     implementation("org.seleniumhq.selenium:selenium-firefox-driver:${seleniumVersion}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,17 @@
+apacheCommonsCsvVersion=1.14.0
+
 aspectjVersion=1.9.23
+
 assertjVersion=3.27.3
+
 awaitilityVersion=4.3.0
 
 lookfirstSardineVersion=5.13
+
 jettyVersion=12.0.18
+
 seleniumVersion=4.27.0
+
 mockserverNettyVersion=5.15.0
 
 labkeySchemasTestVersion=25.3-SNAPSHOT

--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -25,6 +25,7 @@ import org.labkey.test.selenium.LazyWebElement;
 import org.labkey.test.selenium.ReclickingWebElement;
 import org.labkey.test.selenium.RefindingWebElement;
 import org.labkey.test.util.TestLogger;
+import org.labkey.test.util.TextUtils;
 import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.InvalidSelectorException;
@@ -185,23 +186,30 @@ public abstract class Locator extends By
      */
     public static WebElement waitForAnyElement(FluentWait<? extends SearchContext> wait, final Locator... locators)
     {
-        return wait.until(new Function<SearchContext, WebElement>()
+        try
         {
-            @Override
-            public WebElement apply(SearchContext context)
+            return wait.until(new Function<SearchContext, WebElement>()
             {
-                return findAnyElementOrNull(context, locators);
-            }
+                @Override
+                public WebElement apply(SearchContext context)
+                {
+                    return findAnyElementOrNull(context, locators);
+                }
 
-            @Override
-            public String toString()
-            {
-                List<String> locDescriptions = new ArrayList<>();
-                Arrays.stream(locators).forEach(loc -> locDescriptions.add(loc.getLoggableDescription()));
-                SearchContext searchContext = extractInputFromFluentWait(wait);
-                return String.join("\n--OR--\n", locDescriptions) + (searchContext instanceof WebDriver ? "" : "\nIN: " + searchContext.toString());
-            }
-        });
+                @Override
+                public String toString()
+                {
+                    List<String> locDescriptions = new ArrayList<>();
+                    Arrays.stream(locators).forEach(loc -> locDescriptions.add(loc.getLoggableDescription()));
+                    SearchContext searchContext = extractInputFromFluentWait(wait);
+                    return String.join("\n--OR--\n", locDescriptions) + (searchContext instanceof WebDriver ? "" : "\nIN: " + searchContext.toString());
+                }
+            });
+        }
+        catch (TimeoutException e)
+        {
+            throw new NoSuchElementException(e.getMessage(), e);
+        }
     }
 
     /**
@@ -210,28 +218,34 @@ public abstract class Locator extends By
      */
     public static List<WebElement> waitForElements(FluentWait<? extends SearchContext> wait, final Locator... locators)
     {
-        return wait.until(new Function<SearchContext, List<WebElement>>()
+        try
         {
-            @Override
-            public List<WebElement> apply(SearchContext context)
+            return wait.until(new Function<SearchContext, List<WebElement>>()
             {
-                List<WebElement> els = findElements(context, locators);
-                if (els.size() > 0)
-                    return els;
-                else
-                    return null;
-            }
+                @Override
+                public List<WebElement> apply(SearchContext context)
+                {
+                    List<WebElement> els = findElements(context, locators);
+                    if (!els.isEmpty())
+                        return els;
+                    else
+                        return null;
+                }
 
-            @Override
-            public String toString()
-            {
-                List<String> locDescriptions = new ArrayList<>();
-                Arrays.stream(locators).forEach(loc -> locDescriptions.add(loc.getLoggableDescription()));
-                SearchContext searchContext = extractInputFromFluentWait(wait);
-                return String.join("\n--OR--\n", locDescriptions) + (searchContext instanceof WebDriver ? "" : "\nIN: " + searchContext.toString());
-            }
-        });
-
+                @Override
+                public String toString()
+                {
+                    List<String> locDescriptions = new ArrayList<>();
+                    Arrays.stream(locators).forEach(loc -> locDescriptions.add(loc.getLoggableDescription()));
+                    SearchContext searchContext = extractInputFromFluentWait(wait);
+                    return String.join("\n--OR--\n", locDescriptions) + (searchContext instanceof WebDriver ? "" : "\nIN: " + searchContext.toString());
+                }
+            });
+        }
+        catch (TimeoutException e)
+        {
+            throw new NoSuchElementException(e.getMessage(), e);
+        }
     }
 
     public static List<WebElement> findElements(SearchContext context, final Locator... locators)
@@ -984,7 +998,7 @@ public abstract class Locator extends By
      */
     private static String ns(String value)
     {
-        return value.replaceAll("\\s+", " ").trim();
+        return TextUtils.normalizeSpace(value);
     }
 
     public static String cq(String value)

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -19,6 +19,7 @@ import org.labkey.test.pages.core.admin.BaseSettingsPage.DATE_FORMAT;
 import org.labkey.test.pages.core.admin.BaseSettingsPage.TIME_FORMAT;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.LabKeyExpectedConditions;
+import org.labkey.test.util.selenium.WebElementUtils;
 import org.openqa.selenium.ElementNotInteractableException;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.SearchContext;
@@ -1795,8 +1796,8 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
 
         public List<String> hitSelectionCriteria()
         {
-            return getWrapper().getTexts(Locator.tagWithClass("li", "hit-criteria-renderer__field-value")
-                    .findElements(this));
+            return Locator.tagWithClass("li", "hit-criteria-renderer__field-value")
+                    .findElements(this).stream().map(WebElementUtils::getTextContent).toList();
         }
 
         public RadioButton aliquotOption(ExpSchema.DerivationDataScopeType option)

--- a/src/org/labkey/test/components/domain/HitSelectionDialog.java
+++ b/src/org/labkey/test/components/domain/HitSelectionDialog.java
@@ -1,18 +1,13 @@
 package org.labkey.test.components.domain;
 
 import org.labkey.test.Locator;
-import org.labkey.test.components.Component;
-import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.bootstrap.ModalDialog;
-import org.labkey.test.components.html.Input;
 import org.labkey.test.components.ui.search.FilterExpressionPanel;
-import org.labkey.test.pages.LabKeyPage;
+import org.labkey.test.util.selenium.WebElementUtils;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
-
-import static org.labkey.test.components.html.Input.Input;
 
 
 public class HitSelectionDialog extends ModalDialog
@@ -23,9 +18,9 @@ public class HitSelectionDialog extends ModalDialog
         super(new ModalDialogFinder(driver));
     }
 
-    public List<String> getAvailableFields()
+    public List<String> getAvailableFieldLabels()
     {
-        return getWrapper().getTexts(elementCache().findFieldOptions());
+        return elementCache().findFieldOptions().stream().map(WebElementUtils::getTextContent).toList();
     }
 
     public FilterExpressionPanel selectField(String fieldName)

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -23,6 +23,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
@@ -365,7 +366,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
      *
      * @return List of strings for the values in the list.
      */
-    public List<String> getOptions()
+    public List<String> getOptions(Function<WebElement, String> optionMapper)
     {
 
         boolean alreadyOpened = isExpanded();
@@ -374,16 +375,20 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
         if (!alreadyOpened)
             open();
 
-        List<WebElement> selectedItems = Locators.listItems.findElements(getComponentElement());
-        List<String> rawItems = getWrapper().getTexts(selectedItems);
+        List<WebElement> optionElements = Locators.listItems.findElements(getComponentElement());
+        List<String> rawItems = optionElements.stream().map(optionMapper).toList();
 
         // If it wasn't open before close it, otherwise leave it in the open state.
         if (!alreadyOpened)
             close();
 
-        return rawItems.stream().map(String::trim).collect(Collectors.toList());
+        return rawItems;
     }
 
+    public List<String> getOptions()
+    {
+        return getOptions(el -> el.getText().trim());
+    }
 
     public String getName()
     {

--- a/src/org/labkey/test/components/react/FilteringReactSelect.java
+++ b/src/org/labkey/test/components/react/FilteringReactSelect.java
@@ -163,7 +163,7 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
         return this;
     }
 
-    private List<WebElement> setFilter(String value)
+    public List<WebElement> setFilter(String value)
     {
         open();
         elementCache().input.sendKeys(value);

--- a/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
@@ -13,7 +13,6 @@ import org.labkey.test.components.html.SelectWrapper;
 import org.labkey.test.components.html.ValidatingInput;
 import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.params.FieldDefinition;
-import org.labkey.test.util.selenium.WebElementUtils;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -130,7 +129,7 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
     {
         getWrapper().mouseOver(elementCache().helpTarget("Naming "));
         waitFor(()->elementCache().popover.isDisplayed(), "No tooltip was shown for the Name Expression.", 1_000);
-        return WebElementUtils.getTextContent(Locator.tag("p").index(1).findElement(elementCache().popover)).split(": ", 2)[1];
+        return elementCache().popover.getText();
     }
 
     public T dismissToolTip()

--- a/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
@@ -13,6 +13,7 @@ import org.labkey.test.components.html.SelectWrapper;
 import org.labkey.test.components.html.ValidatingInput;
 import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.util.selenium.WebElementUtils;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -129,7 +130,7 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
     {
         getWrapper().mouseOver(elementCache().helpTarget("Naming "));
         waitFor(()->elementCache().popover.isDisplayed(), "No tooltip was shown for the Name Expression.", 1_000);
-        return elementCache().popover.getText();
+        return WebElementUtils.getTextContent(Locator.tag("p").index(1).findElement(elementCache().popover)).split(": ", 2)[1];
     }
 
     public T dismissToolTip()

--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -212,9 +212,8 @@ public class EntityBulkUpdateDialog extends ModalDialog
     {
         List<WebElement> labels = Locator.tagWithClass("label", "control-label").withAttribute("for")
                 .waitForElements(elementCache(), 2_000);
-        List<String> columns = new ArrayList<>();
-        labels.forEach(a -> columns.add(a.getDomAttribute("for")));
-        return columns;
+
+        return labels.stream().map(a -> EscapeUtil.fieldKeyDecodePart(a.getDomAttribute("for"))).toList();
     }
 
     public EntityBulkUpdateDialog waitForFieldsToBe(List<String> expectedFieldNames, int waitMilliseconds)

--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -44,6 +44,7 @@ public class EntityBulkUpdateDialog extends ModalDialog
     {
         super(new ModalDialogFinder(driver).withTitle("Update "));
         _updatingComponent = updatingComponent;
+        getWrapper().mouseOver(elementCache().title); // avoid accidentally triggering tooltips
     }
 
     /**

--- a/src/org/labkey/test/components/ui/grids/DetailTable.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTable.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+import static org.labkey.test.util.selenium.WebDriverUtils.getTextContent;
 
 /**
  * This is a 'special' table that has only two columns, and no header. An example of this table can be seen in the
@@ -155,7 +156,7 @@ public class DetailTable extends WebDriverComponent<DetailTable.ElementCache>
         {
             List<WebElement> tds = tableRow.findElements(By.tagName("td"));
 
-            tableData.put(tds.get(0).getText(), tds.get(1).getText());
+            tableData.put(getTextContent(tds.get(0)), tds.get(1).getText());
         }
 
         return tableData;

--- a/src/org/labkey/test/components/ui/grids/DetailTable.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTable.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
-import static org.labkey.test.util.selenium.WebDriverUtils.getTextContent;
+import static org.labkey.test.util.selenium.WebElementUtils.getTextContent;
 
 /**
  * This is a 'special' table that has only two columns, and no header. An example of this table can be seen in the

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -1,7 +1,6 @@
 package org.labkey.test.components.ui.grids;
 
 import org.junit.Assert;
-import org.labkey.api.query.QueryKey;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
@@ -16,6 +15,7 @@ import org.labkey.test.components.react.ReactSelect;
 import org.labkey.test.components.ui.files.FileUploadField;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.AuditLogHelper;
+import org.labkey.test.util.EscapeUtil;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
@@ -87,7 +87,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
 
     public boolean isFieldPresent(String fieldLabel)
     {
-        return elementCache().fieldValue(fieldLabel) != null;
+        return elementCache().valueCellWithLabel(fieldLabel) != null;
     }
     /**
      * Check to see if a field is editable. Could be state dependent, that is it returns false if the field is
@@ -99,7 +99,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     public boolean isFieldEditable(String fieldLabel)
     {
         // TODO Could put a check here to see if a field is loading then return false, or wait.
-        WebElement fieldValueElement = elementCache().fieldValue(fieldLabel);
+        WebElement fieldValueElement = elementCache().valueCellWithLabel(fieldLabel);
         return isEditableField(fieldValueElement);
     }
 
@@ -117,7 +117,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
      **/
     public String getReadOnlyField(String fieldLabel)
     {
-        WebElement fieldValueElement = elementCache().fieldValue(fieldLabel);
+        WebElement fieldValueElement = elementCache().valueCellWithLabel(fieldLabel);
         return fieldValueElement.findElement(By.xpath("./div/*")).getText();
     }
 
@@ -129,7 +129,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
      **/
     public String getTextField(String fieldLabel)
     {
-        WebElement fieldValueElement = elementCache().fieldValue(fieldLabel);
+        WebElement fieldValueElement = elementCache().valueCellWithLabel(fieldLabel);
         WebElement textElement = fieldValueElement.findElement(By.xpath("./div/div/*"));
         if(textElement.getTagName().equalsIgnoreCase("textarea"))
             return textElement.getText();
@@ -148,7 +148,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     {
         if(isFieldEditable(fieldLabel))
         {
-            WebElement fieldValueElement = elementCache().fieldValue(fieldLabel);
+            WebElement fieldValueElement = elementCache().valueCellWithLabel(fieldLabel);
 
             WebElement editableElement = fieldValueElement.findElement(By.xpath("./div/div/*"));
             String elementType = editableElement.getTagName().toLowerCase().trim();
@@ -205,7 +205,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     public boolean getBooleanField(String fieldLabel)
     {
         // The text used in the field label and the value of the name attribute in the checkbox don't always have the same case.
-        WebElement editableElement = Locator.tag("input").findElement(elementCache().fieldValue(fieldLabel));
+        WebElement editableElement = Locator.tag("input").findElement(elementCache().valueCellWithLabel(fieldLabel));
         String elementType = editableElement.getDomAttribute("type").toLowerCase().trim();
 
         Assert.assertEquals(String.format("Field '%s' is not a checkbox. Cannot be get true/false value.", fieldLabel), "checkbox", elementType);
@@ -223,7 +223,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
     public DetailTableEdit setBooleanField(String fieldLabel, boolean value)
     {
 
-        WebElement fieldValueElement = elementCache().fieldValue(fieldLabel);
+        WebElement fieldValueElement = elementCache().valueCellWithLabel(fieldLabel);
         Assert.assertTrue(String.format("Field '%s' is not editable and cannot be set.", fieldLabel), isEditableField(fieldValueElement));
         getWrapper().scrollIntoView(fieldValueElement);
 
@@ -387,7 +387,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
 
     /**
      * Set a DateTime, Date or Time field.
-     * @param fieldKey The encoded fieldKey of the field to set.
+     * @param fieldName The name of the field to set.
      * @param dateTime Will be used to determine what kind of field is being set and how to set it. If the parameter
      *                 is a LocalDateTime object then it is assumed that field is a DateTime field. If the parameter is
      *                 a LocalDate object then it is assumed to be a date-only field. And I think you can guess what
@@ -395,9 +395,9 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
      *                 is typed into the field (no picker is used).
      * @return A reference to this DetailTableEdit object.
      */
-    public DetailTableEdit setDateTimeField(String fieldKey, Object dateTime)
+    public DetailTableEdit setDateTimeField(String fieldName, Object dateTime)
     {
-        ReactDateTimePicker dateTimePicker = getDateTimePicker(fieldKey);
+        ReactDateTimePicker dateTimePicker = getDateTimePicker(fieldName);
         if(dateTime instanceof LocalDateTime localDateTime)
         {
             dateTimePicker.select(localDateTime);
@@ -424,23 +424,22 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         return this;
     }
 
-    public String getDateTimeField(String fieldLabel)
+    public String getDateTimeField(String fieldName)
     {
-        ReactDateTimePicker dateTimePicker = getDateTimePicker(fieldLabel);
+        ReactDateTimePicker dateTimePicker = getDateTimePicker(fieldName);
         return dateTimePicker.get();
     }
 
-    public void clearDateTimeField(String fieldLabel)
+    public void clearDateTimeField(String fieldName)
     {
-        ReactDateTimePicker dateTimePicker = getDateTimePicker(fieldLabel);
+        ReactDateTimePicker dateTimePicker = getDateTimePicker(fieldName);
         dateTimePicker.clear();
         _changeCounter++;
     }
 
-    private ReactDateTimePicker getDateTimePicker(String fieldLabel)
+    private ReactDateTimePicker getDateTimePicker(String fieldName)
     {
-        return new ReactDateTimePicker.ReactDateTimeInputFinder(getDriver())
-                .withInputId(fieldLabel).find(this);
+        return new ReactDateTimePicker.ReactDateTimeInputFinder(getDriver()).find(elementCache().valueCellWithName(fieldName));
     }
 
     // For use when the field is of an unknown type, as can occur in fuzz tests
@@ -452,7 +451,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         if (field.getType() == FieldDefinition.ColumnType.TextChoice)
             setSelectValue(field.getLabel(), (List<String>) newValue);
         else if (field.getType() == FieldDefinition.ColumnType.Date || field.getType() == FieldDefinition.ColumnType.DateAndTime || field.getType() == FieldDefinition.ColumnType.Time)
-            setDateTimeField(QueryKey.encodePart(field.getName()), newValue);
+            setDateTimeField(field.getName(), newValue);
         else if (field.getType() == FieldDefinition.ColumnType.Boolean)
             setBooleanField(field.getLabel(), (Boolean) newValue);
         else
@@ -586,14 +585,19 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         public WebElement editPanel = Locator.tagWithClass("div", "detail__editing")
                 .findWhenNeeded(this);
 
-        public WebElement fieldValue(String label)
+        public WebElement valueCellWithLabel(String label)
         {
             return Locator.tagWithAttribute("td", "data-caption", label).findElementOrNull(editPanel);
         }
 
+        public WebElement valueCellWithName(String fieldName)
+        {
+            return Locator.tagWithAttribute("td", "data-fieldkey", EscapeUtil.fieldKeyEncodePart(fieldName)).findElement(editPanel);
+        }
+
         public FileUploadField fileField(String label)
         {
-            return new FileUploadField(fieldValue(label), getDriver());
+            return new FileUploadField(valueCellWithLabel(label), getDriver());
         }
 
         public Locator validationMsg = Locator.tagWithClass("span", "validation-message");

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -592,7 +592,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
 
         public WebElement valueCellWithName(String fieldName)
         {
-            return Locator.tagWithAttribute("td", "data-fieldkey", EscapeUtil.fieldKeyEncodePart(fieldName)).findElement(editPanel);
+            return Locator.tagWithAttribute("td", "data-fieldkey", EscapeUtil.fieldKeyEncodePart(fieldName).toLowerCase()).findElement(editPanel);
         }
 
         public FileUploadField fileField(String label)

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -49,6 +49,7 @@ import static org.labkey.test.WebDriverWrapper.waitFor;
 import static org.labkey.test.util.TestLogger.log;
 import static org.labkey.test.util.selenium.ScrollUtils.Alignment.center;
 import static org.labkey.test.util.selenium.WebDriverUtils.MODIFIER_KEY;
+import static org.labkey.test.util.selenium.WebDriverUtils.getTextContent;
 
 public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 {
@@ -1136,7 +1137,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
             {
                 for (WebElement el : headerCells)
                 {
-                    fieldLabels.add(el.getText().trim());
+                    fieldLabels.add(getTextContent(el));
                 }
 
                 int rowNumberColumn = 0;

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -15,7 +15,7 @@ import org.labkey.test.components.ui.entities.EntityBulkInsertDialog;
 import org.labkey.test.components.ui.entities.EntityBulkUpdateDialog;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.selenium.ScrollUtils;
-import org.labkey.test.util.selenium.WebDriverUtils;
+import org.labkey.test.util.selenium.WebElementUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
@@ -1163,7 +1163,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         private String getLabelFromHeaderCell(WebElement el)
         {
             // Use text nodes to ignore browser whitespace formatting
-            List<String> textNodes = WebDriverUtils.getTextNodesWithin(el);
+            List<String> textNodes = WebElementUtils.getTextNodesWithin(el);
             if (textNodes.isEmpty())
             {
                 List<WebElement> children = Locator.xpath("./*").findElements(el);

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -15,6 +15,7 @@ import org.labkey.test.components.ui.entities.EntityBulkInsertDialog;
 import org.labkey.test.components.ui.entities.EntityBulkUpdateDialog;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.selenium.ScrollUtils;
+import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
@@ -49,7 +50,6 @@ import static org.labkey.test.WebDriverWrapper.waitFor;
 import static org.labkey.test.util.TestLogger.log;
 import static org.labkey.test.util.selenium.ScrollUtils.Alignment.center;
 import static org.labkey.test.util.selenium.WebDriverUtils.MODIFIER_KEY;
-import static org.labkey.test.util.selenium.WebDriverUtils.getTextContent;
 
 public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
 {
@@ -1137,7 +1137,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
             {
                 for (WebElement el : headerCells)
                 {
-                    fieldLabels.add(getTextContent(el));
+                    fieldLabels.add(getLabelFromHeaderCell(el));
                 }
 
                 int rowNumberColumn = 0;
@@ -1154,6 +1154,35 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
             }
 
             return fieldLabels;
+        }
+
+        /**
+         * Extract label from header cell. Editable grid header cells have several different layouts. What they have in
+         * common is that the label is the first text node in the cell, possibly within a &lt;span&gt;
+         */
+        private String getLabelFromHeaderCell(WebElement el)
+        {
+            // Use text nodes to ignore browser whitespace formatting
+            List<String> textNodes = WebDriverUtils.getTextNodesWithin(el);
+            if (textNodes.isEmpty())
+            {
+                List<WebElement> children = Locator.xpath("./*").findElements(el);
+                if (children.isEmpty())
+                {
+                    return ""; // probably the selection checkbox column
+                }
+                else
+                {
+                    // Depth-first search until we find some text
+                    return getLabelFromHeaderCell(children.get(0));
+                }
+            }
+            else
+            {
+                boolean required = Locator.byClass("required-symbol").existsIn(el);
+                String label = textNodes.get(0).trim(); // trim trailing NBSP
+                return label + (required ? " *" : ""); // re-add required asterisk for tests that expect it
+            }
         }
 
         public WebElement inputCell()

--- a/src/org/labkey/test/components/ui/grids/FieldSelectionDialog.java
+++ b/src/org/labkey/test/components/ui/grids/FieldSelectionDialog.java
@@ -7,6 +7,7 @@ import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.UpdatingComponent;
 import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.components.html.Checkbox;
+import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -19,6 +20,8 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.labkey.test.util.selenium.WebDriverUtils.getTextContent;
 
 /**
  * Wraps ColumnSelectionModal.tsx in UI components.
@@ -88,7 +91,7 @@ public class FieldSelectionDialog extends ModalDialog
     public List<String> getAvailableFieldLabels()
     {
         List<WebElement> listItemElements = elementCache().getListItemNameElements(elementCache().availableFieldsPanel);
-        return listItemElements.stream().map(WebElement::getText).collect(Collectors.toList());
+        return listItemElements.stream().map(WebDriverUtils::getTextContent).collect(Collectors.toList());
     }
 
     /**
@@ -240,7 +243,7 @@ public class FieldSelectionDialog extends ModalDialog
     public List<String> getSelectedFieldLabels()
     {
         List<WebElement> listItemElements = elementCache().getListItemNameElements(elementCache().selectedFieldsPanel);
-        return listItemElements.stream().map(WebElement::getText).collect(Collectors.toList());
+        return listItemElements.stream().map(WebDriverUtils::getTextContent).collect(Collectors.toList());
     }
 
     /**
@@ -256,7 +259,7 @@ public class FieldSelectionDialog extends ModalDialog
 
         if(active.isDisplayed())
         {
-            return Locator.tagWithClass("div", "field-name").findElement(active).getText();
+            return getTextContent(Locator.tagWithClass("div", "field-name").findElement(active));
         }
         else
         {

--- a/src/org/labkey/test/components/ui/grids/FieldSelectionDialog.java
+++ b/src/org/labkey/test/components/ui/grids/FieldSelectionDialog.java
@@ -7,7 +7,7 @@ import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.UpdatingComponent;
 import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.components.html.Checkbox;
-import org.labkey.test.util.selenium.WebDriverUtils;
+import org.labkey.test.util.selenium.WebElementUtils;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -21,7 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.labkey.test.util.selenium.WebDriverUtils.getTextContent;
+import static org.labkey.test.util.selenium.WebElementUtils.getTextContent;
 
 /**
  * Wraps ColumnSelectionModal.tsx in UI components.
@@ -91,7 +91,7 @@ public class FieldSelectionDialog extends ModalDialog
     public List<String> getAvailableFieldLabels()
     {
         List<WebElement> listItemElements = elementCache().getListItemNameElements(elementCache().availableFieldsPanel);
-        return listItemElements.stream().map(WebDriverUtils::getTextContent).collect(Collectors.toList());
+        return listItemElements.stream().map(WebElementUtils::getTextContent).collect(Collectors.toList());
     }
 
     /**
@@ -243,7 +243,7 @@ public class FieldSelectionDialog extends ModalDialog
     public List<String> getSelectedFieldLabels()
     {
         List<WebElement> listItemElements = elementCache().getListItemNameElements(elementCache().selectedFieldsPanel);
-        return listItemElements.stream().map(WebDriverUtils::getTextContent).collect(Collectors.toList());
+        return listItemElements.stream().map(WebElementUtils::getTextContent).collect(Collectors.toList());
     }
 
     /**

--- a/src/org/labkey/test/components/ui/grids/GridFilterModal.java
+++ b/src/org/labkey/test/components/ui/grids/GridFilterModal.java
@@ -7,7 +7,7 @@ import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.react.Tabs;
 import org.labkey.test.components.ui.search.FilterExpressionPanel;
 import org.labkey.test.components.ui.search.FilterFacetedPanel;
-import org.labkey.test.util.selenium.WebDriverUtils;
+import org.labkey.test.util.selenium.WebElementUtils;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -68,7 +68,7 @@ public class GridFilterModal extends ModalDialog
      */
     public List<String> getAvailableFieldLabels()
     {
-        return elementCache().findFieldOptions().stream().map(WebDriverUtils::getTextContent).collect(Collectors.toList());
+        return elementCache().findFieldOptions().stream().map(WebElementUtils::getTextContent).collect(Collectors.toList());
     }
 
     public List<String> getFilteredFieldLabels()
@@ -77,7 +77,7 @@ public class GridFilterModal extends ModalDialog
                 Locator.tagWithClass("span", "field-modal__field_dot"))
                 .findElements(elementCache().fieldsSelectionPanel);
 
-        return filteredElements.stream().map(WebDriverUtils::getTextContent).collect(Collectors.toList());
+        return filteredElements.stream().map(WebElementUtils::getTextContent).collect(Collectors.toList());
     }
 
     /**

--- a/src/org/labkey/test/components/ui/grids/GridFilterModal.java
+++ b/src/org/labkey/test/components/ui/grids/GridFilterModal.java
@@ -7,6 +7,7 @@ import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.react.Tabs;
 import org.labkey.test.components.ui.search.FilterExpressionPanel;
 import org.labkey.test.components.ui.search.FilterFacetedPanel;
+import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -67,7 +68,7 @@ public class GridFilterModal extends ModalDialog
      */
     public List<String> getAvailableFieldLabels()
     {
-        return getWrapper().getTexts(elementCache().findFieldOptions());
+        return elementCache().findFieldOptions().stream().map(WebDriverUtils::getTextContent).collect(Collectors.toList());
     }
 
     public List<String> getFilteredFieldLabels()
@@ -76,7 +77,7 @@ public class GridFilterModal extends ModalDialog
                 Locator.tagWithClass("span", "field-modal__field_dot"))
                 .findElements(elementCache().fieldsSelectionPanel);
 
-        return filteredElements.stream().map(WebElement::getText).collect(Collectors.toList());
+        return filteredElements.stream().map(WebDriverUtils::getTextContent).collect(Collectors.toList());
     }
 
     /**

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -14,7 +14,7 @@ import org.labkey.test.components.react.QueryChartDialog;
 import org.labkey.test.components.react.QueryChartPanel;
 import org.labkey.test.components.react.ReactCheckBox;
 import org.labkey.test.components.ui.FilterStatusValue;
-import org.labkey.test.util.selenium.WebDriverUtils;
+import org.labkey.test.util.selenium.WebElementUtils;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -587,7 +587,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         if(panelHeader.isDisplayed())
         {
             // The view name in the header is not in a separate element.
-            viewName = WebDriverUtils.getTextNodeWithin(panelHeader);
+            viewName = WebElementUtils.getTextNodeWithin(panelHeader);
         }
         else
         {

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -15,7 +15,7 @@ import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.html.RadioButton;
 import org.labkey.test.components.react.ReactCheckBox;
 import org.labkey.test.components.ui.search.FilterExpressionPanel;
-import org.labkey.test.util.selenium.WebDriverUtils;
+import org.labkey.test.util.selenium.WebElementUtils;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.NotFoundException;
@@ -319,7 +319,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
                 .until(ExpectedConditions.stalenessOf(textEdit));
 
         doAndWaitForUpdate(()->
-                WebDriverWrapper.waitFor(()-> WebDriverUtils.getTextContent(headerCell).equals(newColumnLabel),
+                WebDriverWrapper.waitFor(()-> WebElementUtils.getTextContent(headerCell).equals(newColumnLabel),
                         "Column header not updated.", 1_000)
         );
         waitForLoaded();
@@ -830,7 +830,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
                     headerCellElements.remove(0);
                     offset = 1;
                 }
-                fieldLabels = headerCellElements.stream().map(WebDriverUtils::getTextContent).toList();
+                fieldLabels = headerCellElements.stream().map(WebElementUtils::getTextContent).toList();
                 indexes = new HashMap<>();
                 for (int i = 0; i < headerCellElements.size(); i++)
                 {

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -830,7 +830,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
                     headerCellElements.remove(0);
                     offset = 1;
                 }
-                fieldLabels = headerCellElements.stream().map(WebElementUtils::getTextContent).toList();
+                fieldLabels = headerCellElements.stream().map(el -> WebElementUtils.getTextContent(el).trim()).toList();
                 indexes = new HashMap<>();
                 for (int i = 0; i < headerCellElements.size(); i++)
                 {

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -15,6 +15,7 @@ import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.html.RadioButton;
 import org.labkey.test.components.react.ReactCheckBox;
 import org.labkey.test.components.ui.search.FilterExpressionPanel;
+import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.NotFoundException;
@@ -318,7 +319,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
                 .until(ExpectedConditions.stalenessOf(textEdit));
 
         doAndWaitForUpdate(()->
-                WebDriverWrapper.waitFor(()->headerCell.getText().equals(newColumnLabel),
+                WebDriverWrapper.waitFor(()-> WebDriverUtils.getTextContent(headerCell).equals(newColumnLabel),
                         "Column header not updated.", 1_000)
         );
         waitForLoaded();
@@ -829,7 +830,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid> extends WebDriverComponent
                     headerCellElements.remove(0);
                     offset = 1;
                 }
-                fieldLabels = getWrapper().getTexts(headerCellElements);
+                fieldLabels = headerCellElements.stream().map(WebDriverUtils::getTextContent).toList();
                 indexes = new HashMap<>();
                 for (int i = 0; i < headerCellElements.size(); i++)
                 {

--- a/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
+++ b/src/org/labkey/test/components/ui/grids/TabbedGridPanel.java
@@ -9,6 +9,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +48,15 @@ public class TabbedGridPanel extends WebDriverComponent<TabbedGridPanel.ElementC
 
     public List<String> getTabs()
     {
-        return getWrapper().getTexts(elementCache().navTabs());
+        List<WebElement> tabElements = elementCache().navTabs();
+        List<String> tabLabels = new ArrayList<>();
+        //noinspection ResultOfMethodCallIgnored
+        WebDriverWrapper.waitFor(() -> {
+            tabLabels.clear();
+            tabLabels.addAll(tabElements.stream().map(WebElement::getText).toList());
+            return tabLabels.stream().noneMatch(String::isBlank);
+        }, 5_000);
+        return tabLabels;
     }
 
     public List<String> getTabsWithoutCounts()

--- a/src/org/labkey/test/pages/ReactAssayDesignerPage.java
+++ b/src/org/labkey/test/pages/ReactAssayDesignerPage.java
@@ -29,6 +29,7 @@ import org.labkey.test.components.html.OptionSelect;
 import org.labkey.test.components.ui.files.AttachmentCard;
 import org.labkey.test.pages.assay.plate.PlateTemplateListPage;
 import org.labkey.test.util.Maps;
+import org.labkey.test.util.selenium.WebElementUtils;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.Select;
@@ -237,7 +238,7 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
     public List<String> getHitCriteria()
     {
         expandPropertiesPanel();
-        return getWrapper().getTexts(elementCache().hitSelectionCriteriaLoc.findElements(elementCache().propertiesPanel));
+        return elementCache().hitSelectionCriteriaLoc.findElements(elementCache().propertiesPanel).stream().map(WebElementUtils::getTextContent).toList();
     }
 
     public ReactAssayDesignerPage setStatus(boolean checked)

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -16,6 +16,7 @@
 package org.labkey.test.params;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -31,6 +32,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.labkey.test.util.TestDataGenerator.DOMAIN_SPECIAL_STRING;
 
@@ -60,7 +62,7 @@ public class FieldDefinition extends PropertyDescriptor
      * @param name field name
      * @param type field type
      */
-    public FieldDefinition(String name, ColumnType type)
+    public FieldDefinition(@NotNull String name, @NotNull ColumnType type)
     {
         setName(name);
         setType(type);
@@ -91,7 +93,7 @@ public class FieldDefinition extends PropertyDescriptor
         if (name == null)
             return null;
 
-        if (name.length() == 0)
+        if (name.isEmpty())
             return name;
 
         StringBuilder buf = new StringBuilder(name.length() + 10);
@@ -119,6 +121,11 @@ public class FieldDefinition extends PropertyDescriptor
         }
 
         return buf.toString();
+    }
+
+    public String getEffectiveLabel()
+    {
+        return Objects.requireNonNullElseGet(getLabel(), () -> labelFromName(getName()));
     }
 
     @Override

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -118,9 +118,7 @@ public class FieldDefinition extends PropertyDescriptor
             }
         }
 
-        // This differs from BaseColumnInfo.labelForName because for testing purposes
-        // we need the label as shown in the UI, which will contract multiple spaces
-        return buf.toString().replaceAll("\\s+", " ");
+        return buf.toString();
     }
 
     @Override

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -85,13 +85,8 @@ public class FieldDefinition extends PropertyDescriptor
         this(name, ColumnType.String);
     }
 
-    public static String labelFromName(String name)
-    {
-        return labelFromName(name, true);
-    }
-
     // See BaseColumnInfo.labelFromName
-    public static String labelFromName(String name, boolean collapseSpaces)
+    public static String labelFromName(String name)
     {
         if (name == null)
             return null;
@@ -123,13 +118,9 @@ public class FieldDefinition extends PropertyDescriptor
             }
         }
 
-        if (collapseSpaces)
-        {
-            // This differs from BaseColumnInfo.labelForName because for testing purposes
-            // we need the label as shown in the UI, which will contract multiple spaces
-            return buf.toString().replaceAll("\\s+", " ");
-        }
-        return buf.toString();
+        // This differs from BaseColumnInfo.labelForName because for testing purposes
+        // we need the label as shown in the UI, which will contract multiple spaces
+        return buf.toString().replaceAll("\\s+", " ");
     }
 
     @Override

--- a/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
+++ b/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
@@ -38,6 +38,7 @@ import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
 import org.labkey.test.util.TestDataGenerator;
+import org.labkey.test.util.TextUtils;
 import org.labkey.test.util.exp.SampleTypeAPIHelper;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
@@ -696,7 +697,7 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
         if(expectedPreview != null)
         {
             expectedToolTip.append("Example of name that will be generated from the current pattern: ");
-            expectedToolTip.append(expectedPreview);
+            expectedToolTip.append(TextUtils.normalizeSpace(expectedPreview));
             expectedToolTip.append("\n");
         }
 

--- a/src/org/labkey/test/util/DeferredErrorCollector.java
+++ b/src/org/labkey/test/util/DeferredErrorCollector.java
@@ -1,8 +1,6 @@
 package org.labkey.test.util;
 
 import org.apache.commons.lang3.StringUtils;
-import org.assertj.core.api.Assertions;
-import org.assertj.core.api.ObjectAssert;
 import org.awaitility.core.ConditionTimeoutException;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
@@ -17,7 +15,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Consumer;
 
 import static org.awaitility.Awaitility.await;
 

--- a/src/org/labkey/test/util/DeferredErrorCollector.java
+++ b/src/org/labkey/test/util/DeferredErrorCollector.java
@@ -1,6 +1,8 @@
 package org.labkey.test.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ObjectAssert;
 import org.awaitility.core.ConditionTimeoutException;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
@@ -15,6 +17,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import static org.awaitility.Awaitility.await;
 

--- a/src/org/labkey/test/util/EscapeUtil.java
+++ b/src/org/labkey/test/util/EscapeUtil.java
@@ -119,28 +119,17 @@ public class EscapeUtil
         return URIUtil.decodePath(path);
     }
 
-    public static String fieldKeyEncodePart(String str)
+    private static final String[] ILLEGAL = {"$", "/", "&", "}", "~", ",", "."};
+    private static final String[] REPLACEMENT = {"$D", "$S", "$A", "$B", "$T", "$C", "$P"};
+
+    static public String fieldKeyEncodePart(String str)
     {
-        str = StringUtils.replace(str, "$", "$D");
-        str = StringUtils.replace(str, "/", "$S");
-        str = StringUtils.replace(str, "&", "$A");
-        str = StringUtils.replace(str, "}", "$B");
-        str = StringUtils.replace(str, "~", "$T");
-        str = StringUtils.replace(str, ",", "$C");
-        str = StringUtils.replace(str, ".", "$P");
-        return str;
+        return StringUtils.replaceEach(str, ILLEGAL, REPLACEMENT);
     }
 
-    public static String fieldKeyDecodePart(String str)
+    static public String fieldKeyDecodePart(String str)
     {
-        str = StringUtils.replace(str, "$C", ",");
-        str = StringUtils.replace(str, "$T", "~");
-        str = StringUtils.replace(str, "$B", "}");
-        str = StringUtils.replace(str, "$A", "&");
-        str = StringUtils.replace(str, "$S", "/");
-        str = StringUtils.replace(str, "$D", "$");
-        str = StringUtils.replace(str, "$P", ".");
-        return str;
+        return StringUtils.replaceEach(str, REPLACEMENT, ILLEGAL);
     }
 
     public static String getTextChoiceValidatorExpression(List<String> options)

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -594,7 +594,7 @@ public class TestDataGenerator
         // use the characters that we know are encoded in fieldKeys plus characters that we know clients are using
         String chars = ALL_ILLEGAL_QUERY_KEY_CHARACTERS + " %()=+-[]_|*`'\":;<>?!@#^";
 
-        String randomFieldName = randomName(part + "  ", numStartChars, numEndChars, chars, exclusion);
+        String randomFieldName = randomName(part, numStartChars, numEndChars, chars, exclusion);
         TestLogger.log("Generated random field name: " + randomFieldName);
         return randomFieldName;
     }

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -523,7 +523,7 @@ public class TestDataGenerator
      */
     public static String randomName(@NotNull String part, int numStartChars, int numEndChars, String charSet, @Nullable String exclusions)
     {
-        return randomString(numStartChars, exclusions, charSet) + part + randomString(numEndChars, exclusions, charSet);
+        return (randomString(numStartChars, exclusions, charSet) + part + randomString(numEndChars, exclusions, charSet)).trim();
     }
 
     public static String randomDomainName()

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -581,7 +581,7 @@ public class TestDataGenerator
 
     public static String randomFieldName(String part, @Nullable String exclusion)
     {
-        return randomFieldName(part, randomInt(0, 5), randomInt(0, 5), exclusion);
+        return randomFieldName(part, randomInt(0, 5), randomInt(1, 5), exclusion);
     }
 
     public static String randomFieldName(String part, int numStartChars, int numEndChars)
@@ -594,7 +594,7 @@ public class TestDataGenerator
         // use the characters that we know are encoded in fieldKeys plus characters that we know clients are using
         String chars = ALL_ILLEGAL_QUERY_KEY_CHARACTERS + " %()=+-[]_|*`'\":;<>?!@#^";
 
-        String randomFieldName = randomName(part, numStartChars, numEndChars, chars, exclusion);
+        String randomFieldName = randomName(part + "  ", numStartChars, numEndChars, chars, exclusion);
         TestLogger.log("Generated random field name: " + randomFieldName);
         return randomFieldName;
     }

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -523,13 +523,7 @@ public class TestDataGenerator
      */
     public static String randomName(@NotNull String part, int numStartChars, int numEndChars, String charSet, @Nullable String exclusions)
     {
-        String name = randomString(numStartChars, exclusions, charSet) + part + randomString(numEndChars, exclusions, charSet);
-
-        // Multiple spaces in the UI are collapsed into a single space so we collapse them here so we can find things by name.
-        // See Issue 52193 for details.
-        // If we need to test for handling of multiple spaces, we'll not use this generator.
-        name = name.trim().replaceAll("\\s+", " ");
-        return name;
+        return randomString(numStartChars, exclusions, charSet) + part + randomString(numEndChars, exclusions, charSet);
     }
 
     public static String randomDomainName()

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -581,7 +581,7 @@ public class TestDataGenerator
 
     public static String randomFieldName(String part, @Nullable String exclusion)
     {
-        return randomFieldName(part, randomInt(0, 5), randomInt(1, 5), exclusion);
+        return randomFieldName(part, randomInt(0, 5), randomInt(0, 5), exclusion);
     }
 
     public static String randomFieldName(String part, int numStartChars, int numEndChars)

--- a/src/org/labkey/test/util/TestDataUtils.java
+++ b/src/org/labkey/test/util/TestDataUtils.java
@@ -188,11 +188,15 @@ public class TestDataUtils
             List<String> rowList = new ArrayList<>();
             for (String column : columns)
             {
-                var value = rowMap.getOrDefault(column, preserveEmptyValues ? "" : null);
+                var value = rowMap.get(column);
                 if (value == null)
-                    throw new IllegalArgumentException("Missing value for column '" + column + "' in row: " +  rowMap);
-                else
-                    rowList.add(value.toString());
+                {
+                    if (preserveEmptyValues)
+                        value = "";
+                    else
+                        throw new IllegalArgumentException("Missing value for column '" + column + "' in row: " +  rowMap);
+                }
+                rowList.add(value.toString());
             }
             lists.add(rowList);
         }

--- a/src/org/labkey/test/util/TestDataUtils.java
+++ b/src/org/labkey/test/util/TestDataUtils.java
@@ -1,10 +1,16 @@
 package org.labkey.test.util;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.labkey.serverapi.reader.TabLoader;
+import org.labkey.test.TestFileUtils;
 import org.labkey.test.params.FieldDefinition;
 
+import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -231,6 +237,21 @@ public class TestDataUtils
             builder.append("\n");
         }
         return builder.toString();
+    }
+
+    public static File writeRowsToTsv(String fileName, List<List<String>> rows) throws IOException
+    {
+        File file = new File(TestFileUtils.getTestTempDir(), fileName);
+        FileUtils.forceMkdirParent(file);
+
+        try (CSVPrinter printer = new CSVPrinter(new FileWriter(file, StandardCharsets.UTF_8), CSVFormat.TDF)) {
+            for (List<String> row : rows)
+            {
+                printer.printRecord(row);
+            }
+        }
+
+        return file;
     }
 
     /**

--- a/src/org/labkey/test/util/TestDataUtils.java
+++ b/src/org/labkey/test/util/TestDataUtils.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -150,13 +151,13 @@ public class TestDataUtils
     public static String tsvStringFromRowMaps(List<Map<String, Object>> rowMaps, List<String> columns,
                                               boolean includeHeaders)
     {
-        return toTabular(rowMaps, columns, '\t', includeHeaders);
+        return writeRowsToString(rowListsFromMaps(rowMaps, columns, includeHeaders, true), CSVFormat.TDF);
     }
 
     public static String csvStringFromRowMaps(List<Map<String, Object>> rowMaps, List<String> columns,
                                               boolean includeHeaders)
     {
-        return toTabular(rowMaps, columns, ',', includeHeaders);
+        return writeRowsToString(rowListsFromMaps(rowMaps, columns, includeHeaders, true), CSVFormat.DEFAULT);
     }
 
 
@@ -170,7 +171,6 @@ public class TestDataUtils
      * @param rowMaps   Source data
      * @param columns   keys contained in each map, will copy values associated with them to the resulting list
      * @return A List<List<String>> containing values
-     * @throws IOException
      */
     public static List<List<String>> rowListsFromMaps(List<Map<String, Object>> rowMaps, List<String> columns, boolean includeHeaders, boolean preserveEmptyValues)
     {
@@ -178,65 +178,25 @@ public class TestDataUtils
 
         if (includeHeaders)
         {
-            List<String> headers = new ArrayList<>();
-            for(String col : columns)
-                headers.add(col);
+            List<String> headers = new ArrayList<>(columns);
 
             lists.add(headers);
         }
 
-        for (int i=0; i<rowMaps.size(); i++)
+        for (Map<String, Object> rowMap : rowMaps)
         {
             List<String> rowList = new ArrayList<>();
-            var rowMap = rowMaps.get(i);
-            for(String column : columns)
+            for (String column : columns)
             {
-                var value = (String) rowMap.get(column);
-                if (value == null && preserveEmptyValues)
-                    rowList.add("");
+                var value = rowMap.getOrDefault(column, preserveEmptyValues ? "" : null);
+                if (value == null)
+                    throw new IllegalArgumentException("Missing value for column '" + column + "' in row: " +  rowMap);
                 else
-                    rowList.add(value);
+                    rowList.add(value.toString());
             }
             lists.add(rowList);
         }
         return lists;
-    }
-
-    /**
-     * Convert a list of Map<String, Object>> to tabluar (tsv, csv) format
-     * (assumes the rowMaps all share the same keyset/schema)
-     * can be used to generate edit-grid paste data, if delimiter is \t and includeHeaders is false
-     *
-     * @param rowMaps data to be written into tabular format
-     * @param columns the fields (in order) from the rowMaps to include in tabular output
-     * @param delimiter comma [,] for csv tab [\t] for tsv
-     * @param includeHeaders    whether to write the keys as column names on the first line of the output string
-     * @return
-     */
-    private static String toTabular(List<Map<String, Object>> rowMaps, List<String> columns,
-                                    char delimiter, boolean includeHeaders)
-    {
-        StringBuilder builder = new StringBuilder();
-        TsvQuoter q = new TsvQuoter(delimiter);
-
-        if (includeHeaders)
-        {
-            builder.append(String.join(String.valueOf(delimiter), columns.stream().map(q::quoteValue).toList()));
-            builder.append("\n");
-        }
-
-        for (Map<String, Object> row : rowMaps)
-        {
-            List<String> values = new ArrayList<>();
-            for (String name : columns)
-            {
-                String value = q.quoteValue(row.get(name));
-                values.add(value);
-            }
-            builder.append(String.join(String.valueOf(delimiter), values));
-            builder.append("\n");
-        }
-        return builder.toString();
     }
 
     public static File writeRowsToTsv(String fileName, List<List<String>> rows) throws IOException
@@ -252,6 +212,29 @@ public class TestDataUtils
         }
 
         return file;
+    }
+
+    public static String writeRowsToTsvString(List<List<String>> rows) throws IOException
+    {
+        return writeRowsToString(rows, CSVFormat.TDF);
+    }
+
+    public static String writeRowsToString(List<List<String>> rows, CSVFormat format)
+    {
+        StringWriter stringWriter = new StringWriter();
+
+        try (CSVPrinter printer = new CSVPrinter(stringWriter, format)) {
+            for (List<String> row : rows)
+            {
+                printer.printRecord(row);
+            }
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+
+        return stringWriter.toString();
     }
 
     /**

--- a/src/org/labkey/test/util/TextUtils.java
+++ b/src/org/labkey/test/util/TextUtils.java
@@ -1,0 +1,30 @@
+package org.labkey.test.util;
+
+import java.util.regex.Pattern;
+
+public class TextUtils
+{
+    private static final Pattern NS_PATTERN = Pattern.compile("\\s+");
+
+    private TextUtils() {}
+
+    /**
+     * Equivalent to XPath {@code normalize-space()}:<br>
+     * "The normalize-space function strips leading and trailing white-space from a string, replaces sequences of
+     * whitespace characters by a single space, and returns the resulting string."
+     */
+    public static String normalizeSpace(String value)
+    {
+        return NS_PATTERN.matcher(value).replaceAll(" ").trim();
+    }
+
+    public static String normalizeSpaceMultiline(String value)
+    {
+        String[] lines = value.split("\n");
+        for (int i = 0; i < lines.length; i++)
+        {
+            lines[i] = normalizeSpace(lines[i]);
+        }
+        return String.join("\n", lines);
+    }
+}

--- a/src/org/labkey/test/util/TextUtils.java
+++ b/src/org/labkey/test/util/TextUtils.java
@@ -1,5 +1,6 @@
 package org.labkey.test.util;
 
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class TextUtils
@@ -18,6 +19,11 @@ public class TextUtils
         return NS_PATTERN.matcher(value).replaceAll(" ").trim();
     }
 
+    public static List<String> normalizeSpace(List<String> values)
+    {
+        return values.stream().map(TextUtils::normalizeSpace).toList();
+    }
+
     public static String normalizeSpaceMultiline(String value)
     {
         String[] lines = value.split("\n");
@@ -26,5 +32,10 @@ public class TextUtils
             lines[i] = normalizeSpace(lines[i]);
         }
         return String.join("\n", lines);
+    }
+
+    public static List<String> normalizeSpaceMultiline(List<String> values)
+    {
+        return values.stream().map(TextUtils::normalizeSpaceMultiline).toList();
     }
 }

--- a/src/org/labkey/test/util/selenium/WebDriverUtils.java
+++ b/src/org/labkey/test/util/selenium/WebDriverUtils.java
@@ -147,6 +147,23 @@ public abstract class WebDriverUtils
     }
 
     /**
+     * {@link WebElement#getText()} matches the browser's rendering, which collapses and trims whitespace.
+     * If you need the actual text written by the server, the element's {@code textContent} property is unmodified.<br>
+     * Given a WebElement representing the following div:
+     * <pre>{@code
+     * <div> three   spaces </div>
+     * }</pre>
+     * {@link WebElement#getText()} would return {@code "three spaces"} but this method will retain the extra spaces.
+     * @param element element to inspect
+     * @return textContent for the given element
+     */
+    @SuppressWarnings("unchecked")
+    public static String getTextContent(WebElement element)
+    {
+        return element.getDomProperty("textContent");
+    }
+
+    /**
      * Attempts to get alert text from an {@link UnhandledAlertException}. If exception does not supply the alert text,
      * attempt to get it from the alert directly (requires {@link org.openqa.selenium.UnexpectedAlertBehaviour#IGNORE}).
      * Either way, the alert will be dismissed if present.

--- a/src/org/labkey/test/util/selenium/WebDriverUtils.java
+++ b/src/org/labkey/test/util/selenium/WebDriverUtils.java
@@ -17,20 +17,13 @@ package org.labkey.test.util.selenium;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.intellij.lang.annotations.Language;
 import org.openqa.selenium.Alert;
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoAlertPresentException;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebDriverException;
-import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.WrapsElement;
-
-import java.util.List;
 
 public abstract class WebDriverUtils
 {
@@ -79,88 +72,6 @@ public abstract class WebDriverUtils
             return webDriver;
         else
             return null;
-    }
-
-    /**
-     * {@link WebElement} cannot represent a text node. JavaScript can though, so we can use it to isolate the text
-     * children of a WebElement and get their text.
-     * Given a WebElement representing the following div:
-     * <pre>{@code
-     * <div>
-     *     <span>A</span>
-     *     B
-     *     <button>C</button>
-     *     D
-     *     <span>D</span>
-     * </div>
-     * }</pre>
-     * This method will return a list containing {@code ["B", "D"]}
-     * @param element element to search
-     * @return text from all child text nodes
-     */
-    @SuppressWarnings("unchecked")
-    public static List<String> getTextNodesWithin(WebElement element)
-    {
-        JavascriptExecutor executor = (JavascriptExecutor) extractWrappedDriver(element);
-
-        @Language("JavaScript")
-        final String script = """
-                var iterator = document.evaluate("text()", arguments[0]);
-                var texts = [];
-
-                let thisNode = iterator.iterateNext();
-
-                while (thisNode) {
-                    texts.push(thisNode.textContent);
-                    thisNode = iterator.iterateNext();
-                }
-                return texts;
-                """;
-
-        List<Object> nodeTexts;
-        try
-        {
-            nodeTexts = (List<Object>) executor.executeScript(script, element);
-        }
-        catch (WebDriverException retry)
-        {
-            // Script might throw if the document tree is modified during iteration. Retry once.
-            nodeTexts = (List<Object>) executor.executeScript(script, element);
-        }
-
-        return nodeTexts.stream().map(t -> (String) t).toList();
-    }
-
-    /**
-     * Gets text from the first text node under the specified WebElement.
-     *
-     * @see #getTextNodesWithin(WebElement)
-     */
-    public static String getTextNodeWithin(WebElement element)
-    {
-        List<String> textChildren = getTextNodesWithin(element);
-        if (textChildren.isEmpty())
-        {
-            throw new NoSuchElementException("Element does not have any text children: " + element.toString());
-        }
-        return textChildren.get(0);
-    }
-
-    /**
-     * {@link WebElement#getText()} matches the browser's rendering, which collapses and trims whitespace.
-     * If you need the actual text written by the server, the element's {@code textContent} property is unmodified.<br>
-     * Given a WebElement representing the following div:
-     * <pre>{@code
-     * <div> three   spaces </div>
-     * }</pre>
-     * {@link WebElement#getText()} would return {@code "three spaces"} but this method will retain the extra spaces.
-     * @param element element to inspect
-     * @return textContent for the given element
-     */
-    @SuppressWarnings("unchecked")
-    public static String getTextContent(WebElement element)
-    {
-        return element.getDomProperty("textContent");
     }
 
     /**

--- a/src/org/labkey/test/util/selenium/WebElementUtils.java
+++ b/src/org/labkey/test/util/selenium/WebElementUtils.java
@@ -1,0 +1,95 @@
+package org.labkey.test.util.selenium;
+
+import org.intellij.lang.annotations.Language;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+public abstract class WebElementUtils
+{
+    private WebElementUtils() {}
+
+    /**
+     * {@link WebElement} cannot represent a text node. JavaScript can though, so we can use it to isolate the text
+     * children of a WebElement and get their text.
+     * Given a WebElement representing the following div:
+     * <pre>{@code
+     * <div>
+     *     <span>A</span>
+     *     B
+     *     <button>C</button>
+     *     D
+     *     <span>D</span>
+     * </div>
+     * }</pre>
+     * This method will return a list containing {@code ["B", "D"]}
+     * @param element element to search
+     * @return text from all child text nodes
+     */
+    @SuppressWarnings("unchecked")
+    public static List<String> getTextNodesWithin(WebElement element)
+    {
+        JavascriptExecutor executor = (JavascriptExecutor) WebDriverUtils.extractWrappedDriver(element);
+
+        @Language("JavaScript")
+        final String script = """
+                var iterator = document.evaluate("text()", arguments[0]);
+                var texts = [];
+
+                let thisNode = iterator.iterateNext();
+
+                while (thisNode) {
+                    texts.push(thisNode.textContent);
+                    thisNode = iterator.iterateNext();
+                }
+                return texts;
+                """;
+
+        List<Object> nodeTexts;
+        try
+        {
+            nodeTexts = (List<Object>) executor.executeScript(script, element);
+        }
+        catch (WebDriverException retry)
+        {
+            // Script might throw if the document tree is modified during iteration. Retry once.
+            nodeTexts = (List<Object>) executor.executeScript(script, element);
+        }
+
+        return nodeTexts.stream().map(t -> (String) t).toList();
+    }
+
+    /**
+     * Gets text from the first text node under the specified WebElement.
+     *
+     * @see #getTextNodesWithin(WebElement)
+     */
+    public static String getTextNodeWithin(WebElement element)
+    {
+        List<String> textChildren = getTextNodesWithin(element);
+        if (textChildren.isEmpty())
+        {
+            throw new NoSuchElementException("Element does not have any text children: " + element.toString());
+        }
+        return textChildren.get(0);
+    }
+
+    /**
+     * {@link WebElement#getText()} matches the browser's rendering, which collapses and trims whitespace.
+     * If you need the actual text written by the server, the element's {@code textContent} property is unmodified.<br>
+     * Given a WebElement representing the following div:
+     * <pre>{@code
+     * <div> three   spaces </div>
+     * }</pre>
+     * {@link WebElement#getText()} would return {@code "three spaces"} but this method will retain the extra spaces.
+     * @param element element to inspect
+     * @return textContent for the given element
+     */
+    public static String getTextContent(WebElement element)
+    {
+        return element.getDomProperty("textContent");
+    }
+}

--- a/src/org/labkey/test/util/selenium/WebElementUtils.java
+++ b/src/org/labkey/test/util/selenium/WebElementUtils.java
@@ -9,6 +9,8 @@ import org.openqa.selenium.WebElement;
 import java.util.Collections;
 import java.util.List;
 
+import static org.labkey.test.Locator.NBSP;
+
 public abstract class WebElementUtils
 {
     private WebElementUtils() {}
@@ -91,6 +93,6 @@ public abstract class WebElementUtils
      */
     public static String getTextContent(WebElement element)
     {
-        return element.getDomProperty("textContent");
+        return element.getDomProperty("textContent").replace(NBSP, " ");
     }
 }

--- a/src/org/labkey/test/util/selenium/WebElementUtils.java
+++ b/src/org/labkey/test/util/selenium/WebElementUtils.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
+import java.util.Collections;
 import java.util.List;
 
 public abstract class WebElementUtils
@@ -59,7 +60,7 @@ public abstract class WebElementUtils
             nodeTexts = (List<Object>) executor.executeScript(script, element);
         }
 
-        return nodeTexts.stream().map(t -> (String) t).toList();
+        return nodeTexts != null ? nodeTexts.stream().map(t -> (String) t).toList() : Collections.emptyList();
     }
 
     /**


### PR DESCRIPTION
#### Rationale
[[Story](https://github.com/LabKey/kanban/issues/620)] (Phase 2)
The browser modifies whitespace when rendering text (removing duplicate spaces and trimming leading/trailing whitespace). As such, we can't trust it to accurately represent field labels. Currently, we use `WebElement.getText` to extract field labels from the page which might not match a field's actual label. We should be able to extract accurate labels from the page via the `testContext` property or by inspecting HTML text nodes. This will allow us to remove the multi-space restriction from `TestDataGenerator.randomName` and `FieldDefinition.labelFromName`.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Get raw field labels from app grids and tables
