### PR TITLE
Fix DataRegionTest - data load is typically taking 55-61 seconds

### DIFF
--- a/src/org/labkey/test/tests/AbstractQWPTest.java
+++ b/src/org/labkey/test/tests/AbstractQWPTest.java
@@ -46,7 +46,7 @@ public abstract class AbstractQWPTest extends BaseWebDriverTest
         waitForElement(Locator.button("Populate test data"));
         clickButton("Populate test data");
         WebElement populateMessage = Locator.id("populatemessage").waitForElement(shortWait());
-        new WebDriverWait(getDriver(), Duration.ofSeconds(60)).until(ExpectedConditions.visibilityOf(populateMessage)).getText();
+        new WebDriverWait(getDriver(), Duration.ofSeconds(90)).until(ExpectedConditions.visibilityOf(populateMessage)).getText();
         assertEquals("Test data is populated!", populateMessage.getText());
 
         log("Testing " + QWP_SCHEMA_LISTING.getLeft());


### PR DESCRIPTION
#### Rationale
Don't fail when it takes 61 seconds. Give it a little more grace period to finish. It's loading 5,001 rows.

#### Changes
- Change the timeout