### PR TITLE
Selenium test for Issue 51979 and 52961

### DIFF
--- a/src/org/labkey/test/tests/DataClassFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/DataClassFolderExportImportTest.java
@@ -1,5 +1,6 @@
 package org.labkey.test.tests;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -17,10 +18,12 @@ import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.TestDataGenerator;
 import org.labkey.test.util.exp.DataClassAPIHelper;
+import org.labkey.test.util.search.SearchAdminAPIHelper;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -99,11 +102,11 @@ public class DataClassFolderExportImportTest extends BaseWebDriverTest
 
         TestDataGenerator testDgen = DataClassAPIHelper.createEmptyDataClass(subfolderPath, testType);
 
-        testDgen.addCustomRow(Map.of("Name", "class1", "intColumn", 1, "decimalColumn", 1.1, "stringColumn", "one"));
-        testDgen.addCustomRow(Map.of("Name", "class2", "intColumn", 2, "decimalColumn", 2.2, "stringColumn", "two"));
-        testDgen.addCustomRow(Map.of("Name", "class3", "intColumn", 3, "decimalColumn", 3.3, "stringColumn", "three"));
-        testDgen.addCustomRow(Map.of("Name", "class4", "intColumn", 4, "decimalColumn", 4.4, "stringColumn", "four"));
-        testDgen.addCustomRow(Map.of("Name", "class5", "intColumn", 5, "decimalColumn", 5.5, "stringColumn", "five"));
+        testDgen.addCustomRow(Map.of("Name", "class1", "intColumn", 7771, "decimalColumn", 1.1, "stringColumn", "one"));
+        testDgen.addCustomRow(Map.of("Name", "class2", "intColumn", 7772, "decimalColumn", 2.2, "stringColumn", "two"));
+        testDgen.addCustomRow(Map.of("Name", "class3", "intColumn", 7773, "decimalColumn", 3.3, "stringColumn", "three"));
+        testDgen.addCustomRow(Map.of("Name", "class4", "intColumn", 7774, "decimalColumn", 4.4, "stringColumn", "four"));
+        testDgen.addCustomRow(Map.of("Name", "class5", "intColumn", 7775, "decimalColumn", 5.5, "stringColumn", "five"));
         testDgen.insertRows();
 
         PortalHelper portalHelper = new PortalHelper(this);
@@ -158,6 +161,14 @@ public class DataClassFolderExportImportTest extends BaseWebDriverTest
             assertNotNull("expect all matching rows to come through", matchingMap);
             assertEquals("Expect imported rows to be equivalent to exported ones", exportedRow, matchingMap);
         }
+
+        SearchAdminAPIHelper.waitForIndexer();
+
+        var searchResultPage = navBar().search("7774");
+        // Issue 52961: DataClass: Integer fields are not index for data class, unlike sample types
+        checker().withScreenshot("Search by int value after folder import").awaiting(Duration.ofSeconds(2),
+                ()-> Assertions.assertThat(searchResultPage.getResultCount() >= 2).isTrue());
+
     }
 
     @Test

--- a/src/org/labkey/test/tests/SampleTypeRenameTest.java
+++ b/src/org/labkey/test/tests/SampleTypeRenameTest.java
@@ -1,5 +1,6 @@
 package org.labkey.test.tests;
 
+import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -18,9 +19,11 @@ import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
 import org.labkey.test.util.TestDataGenerator;
 import org.labkey.test.util.exp.SampleTypeAPIHelper;
+import org.labkey.test.util.search.SearchAdminAPIHelper;
 import org.openqa.selenium.WebElement;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -81,6 +84,48 @@ public class SampleTypeRenameTest extends BaseWebDriverTest
         testDataGenerator.addCustomRow(Map.of(FIELD_STR, "B", FIELD_INT, 25));
         testDataGenerator.addCustomRow(Map.of(FIELD_STR, "C", FIELD_INT, 30));
         testDataGenerator.insertRows();
+    }
+
+    // Issue 51979: BadSqlGrammarException indexing sample types immediately after a field rename
+    @Test
+    public void testSampleTypeFieldRename() throws IOException, CommandException
+    {
+        final String sampleTypeName = "SampleTypeWithFieldRename" + FieldDefinition.DOMAIN_TRICKY_CHARACTERS;
+        SampleTypeDefinition sampleTypeDefinition = new SampleTypeDefinition(sampleTypeName);
+        sampleTypeDefinition.setNameExpression("S-FieldRename-${int}");
+        sampleTypeDefinition.addField(new FieldDefinition(FIELD_INT, FieldDefinition.ColumnType.Integer));
+
+        log("Give the sample type some data, will be used to create a chart.");
+        TestDataGenerator testDataGenerator = SampleTypeAPIHelper.createEmptySampleType(getCurrentContainerPath(), sampleTypeDefinition);
+        int intVal = 1000;
+        for (int i = 0; i < 1000; i++)
+            testDataGenerator.addCustomRow(Map.of(FIELD_INT, intVal++));
+        testDataGenerator.insertRows();
+
+        goToProjectHome();
+        SampleTypeHelper sampleHelper = new SampleTypeHelper(this);
+        UpdateSampleTypePage updatePage = sampleHelper.goToEditSampleType(sampleTypeName);
+        updatePage.getFieldsPanel().getField(FIELD_INT).setName(FIELD_INT + " Updated");
+        updatePage.setNameExpression("S-${genId}");
+        updatePage.clickSave();
+        goToProjectHome();
+        updatePage = sampleHelper.goToEditSampleType(sampleTypeName);
+        updatePage.getFieldsPanel().getField(FIELD_INT + " Updated").setName(FIELD_INT + " 2nd update");
+        updatePage.clickSave();
+        goToProjectHome();
+        updatePage = sampleHelper.goToEditSampleType(sampleTypeName);
+        updatePage.getFieldsPanel().getField(FIELD_INT + " 2nd update").setName(FIELD_INT + " 3rd");
+        updatePage.clickSave();
+
+        SearchAdminAPIHelper.waitForIndexer();
+
+        var searchResultPage = navBar().search("S-FieldRename-1999");
+        checker().withScreenshot("Search by sample name after field renaming").awaiting(Duration.ofSeconds(2),
+                ()-> Assertions.assertThat(searchResultPage.hasResultLocatedBy(Locator.linkWithText("Sample - S-FieldRename-1999"))).isTrue());
+
+        var searchResultPage2 = navBar().search("1599");
+        checker().withScreenshot("Search by int value after field renaming").awaiting(Duration.ofSeconds(2),
+                ()-> Assertions.assertThat(searchResultPage2.hasResultLocatedBy(Locator.linkWithText("Sample - S-FieldRename-1599"))).isTrue());
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
Issue [51979](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51979): BadSqlGrammarException indexing sample types immediately after a field rename
Issue [52961](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52961): DataClass: Integer fields are not index for data class, unlike sample types

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6611
- https://github.com/LabKey/testAutomation/pull/2431

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
