### PR TITLE
Wait for specialty assays to load

### DIFF
--- a/src/org/labkey/test/pages/assay/ChooseAssayTypePage.java
+++ b/src/org/labkey/test/pages/assay/ChooseAssayTypePage.java
@@ -62,11 +62,15 @@ public class ChooseAssayTypePage extends LabKeyPage<ChooseAssayTypePage.ElementC
             return selectStandardAssay();
         }
 
-        WebElement activeTab = elementCache().assayTypeTabs.selectTab("Specialty Assays");
+        WebElement specialtySelect = Locator.id("specialty-assay-type-select")
+                .waitForElement(elementCache().assayTypeTabs.findPanelForTab("Specialty Assays"), 2_000);
+        // Ensure that assay types have loaded before attempting to switch tabs
+        Locator.tagWithAttribute("option", "value", name).waitForElement(specialtySelect, 2_000);
 
-        WebElement specialtySelect = Locator.id("specialty-assay-type-select").findWhenNeeded(activeTab);
+        elementCache().assayTypeTabs.selectTab("Specialty Assays");
+
         shortWait().until(ExpectedConditions.visibilityOf(specialtySelect));
-        selectOptionByText(specialtySelect, name);
+        selectOptionByValue(specialtySelect, name);
 
         waitFor(()->
            elementCache().selectButton.getText().toLowerCase().contains(name.toLowerCase()),


### PR DESCRIPTION
#### Rationale
[Issue 52921: Longstanding intermittent test failure involving ChooseAssayTypePage](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52921)
This helper seems to click the "Specialty Assay" tab before the page is ready and it stays on the "Standard Assay" tab.
Hopefully, waiting for the assay selector to load will be sufficient to ensure that the test can select the tab.

TeamCity failure state:
![image](https://github.com/user-attachments/assets/4516f6c9-c113-4054-a517-8bd330143a20)
```
org.openqa.selenium.TimeoutException: Expected condition failed: waiting for visibility of [[[[[[FirefoxDriver: firefox on windows (79cd1de2-310d-41bb-a24c-419415cc7374)] -> xpath: ((.//*[@id="assay-picker-tabs"])|(.//*[contains(concat(' ',normalize-space(@class),' '), " lk-tabs ")]))]] -> xpath: (div|div/div)[contains(concat(' ',normalize-space(@class),' '), " tab-content ")]]] -> id: tabs0-pane-specialty] (tried for 10 second(s) with 500 milliseconds interval)
  at app//org.openqa.selenium.support.ui.WebDriverWait.timeoutException(WebDriverWait.java:84)
  at app//org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:228)
  at app//org.labkey.test.components.react.Tabs.selectTab(Tabs.java:67)
  at app//org.labkey.test.pages.assay.ChooseAssayTypePage.selectAssayType(ChooseAssayTypePage.java:65)
  at app//org.labkey.test.util.AbstractAssayHelper.createAssayDesign(AbstractAssayHelper.java:84)
  at app//org.labkey.test.util.AbstractAssayHelper.createAssayDesignWithDefaults(AbstractAssayHelper.java:72)
  at app//org.labkey.test.util.external.labModules.LabModuleHelper.defineAssay(LabModuleHelper.java:71)
```

#### Related Pull Requests
- N/A

#### Changes
- Wait for specialty assays to load
