### PR TITLE
Exclude close parens from name expression default value

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
+++ b/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
@@ -66,7 +66,7 @@ import static org.labkey.test.util.TestDataUtils.getEscapedNameExpression;
 public class SampleTypeNameExpressionTest extends BaseWebDriverTest
 {
     private static final String PROJECT_NAME = "SampleType_Name_Expression_Test";
-    private static final String DEFAULT_SAMPLE_PARENT_VALUE = "SS" + TestDataGenerator.randomString(3).replaceAll("_", "."); // '_' is used as delimiter to get batchRandomId
+    private static final String DEFAULT_SAMPLE_PARENT_VALUE = "SS" + TestDataGenerator.randomString(3).replaceAll("[_)]", "."); // '_' is used as delimiter to get batchRandomId and ) is used to close the defaultValue()
 
     private static final String PARENT_SAMPLE_TYPE = "PS" + DOMAIN_TRICKY_CHARACTERS;
     private static final String PARENT_SAMPLE_TYPE_INPUT = "PS" + getEscapedNameExpression(DOMAIN_TRICKY_CHARACTERS);


### PR DESCRIPTION
#### Rationale
Close parens are problematic for default values since they are seen as closing the `defaultValue()` expression. When entered through the UI, we correctly show an error message. This PR excludes the close paren from the valid characters for the testing of the default value.

#### Changes
- Update `SampleTypeNameExpressionTest` to remove close parens
