### PR TITLE
Issue 52556: Add data-fieldkey attribute to grid header elements and input elements

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkInsertDialog.java
@@ -233,7 +233,7 @@ public class EntityBulkInsertDialog extends ModalDialog
             else if (field.getType() == FieldDefinition.ColumnType.Integer || field.getType() == FieldDefinition.ColumnType.Decimal || field.getType() == FieldDefinition.ColumnType.Double)
                 setNumericField(fieldKey, String.valueOf(value));
             else if (field.getType() == FieldDefinition.ColumnType.Date || field.getType() == FieldDefinition.ColumnType.DateAndTime || field.getType() == FieldDefinition.ColumnType.Time)
-                setDateTimeField(field.getName(), value, fieldKey);
+                setDateTimeField(fieldKey, value);
             else if (field.getType() == FieldDefinition.ColumnType.TextChoice)
                 setSelectionField(field.getLabel(), (List<String>) value);
             else
@@ -246,24 +246,20 @@ public class EntityBulkInsertDialog extends ModalDialog
      * object to use the picker to set the field. If a text value is passed in it is used as a literal and jut typed
      * into the textbox.
      *
-     * @param fieldName Field to update.
+     * @param fieldKey Field to update.
      * @param dateTime A LocalDateTime, LocalDate, LocalTime or String.
      * @return A reference to this page.
      */
-    public EntityBulkInsertDialog setDateTimeField(String fieldName, Object dateTime)
+    public EntityBulkInsertDialog setDateTimeField(String fieldKey, Object dateTime)
     {
-        return setDateTimeField(fieldName, dateTime, null);
-    }
-    public EntityBulkInsertDialog setDateTimeField(String fieldName, Object dateTime, @Nullable String fieldKey)
-    {
-        ReactDateTimePicker dateTimePicker = elementCache().dateInput(fieldName, fieldKey);
+        ReactDateTimePicker dateTimePicker = elementCache().dateInput(fieldKey);
         dateTimePicker.select(dateTime);
         return this;
     }
 
-    public String getDateTimeField(String fieldName, @Nullable String fieldKey)
+    public String getDateTimeField(String fieldKey)
     {
-        return elementCache().dateInput(fieldName, fieldKey).get();
+        return elementCache().dateInput(fieldKey).get();
     }
 
     public EntityBulkInsertDialog setBooleanField(String fieldKey, boolean checked)
@@ -410,13 +406,10 @@ public class EntityBulkInsertDialog extends ModalDialog
             return new Input(inputEl, getDriver());
         }
 
-        public ReactDateTimePicker dateInput(String fieldName, @Nullable String fieldKey)
+        public ReactDateTimePicker dateInput(String fieldKey)
         {
-            if (fieldKey == null)
-                fieldKey = fieldName;
-
             return new ReactDateTimePicker.ReactDateTimeInputFinder(getDriver())
-                    .withInputId(fieldKey).find(formRow(fieldName));
+                    .withInputId(fieldKey).find(formRow(fieldKey));
         }
 
         public List<WebElement> fieldLabels()

--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -85,7 +85,7 @@ public class EntityBulkUpdateDialog extends ModalDialog
         else if (field.getType() == FieldDefinition.ColumnType.Integer || field.getType() == FieldDefinition.ColumnType.Decimal || field.getType() == FieldDefinition.ColumnType.Double)
             setNumericField(EscapeUtil.fieldKeyEncodePart(field.getName()), String.valueOf(newValue));
         else if (field.getType() == FieldDefinition.ColumnType.Date || field.getType() == FieldDefinition.ColumnType.DateAndTime || field.getType() == FieldDefinition.ColumnType.Time)
-            setDateField(field.getLabel() == null ? field.getName() : field.getLabel(), (String) newValue);
+            setDateField(EscapeUtil.fieldKeyEncodePart(field.getName()), (String) newValue);
         else if (field.getType() == FieldDefinition.ColumnType.Boolean)
             setBooleanField(EscapeUtil.fieldKeyEncodePart(field.getName()), (Boolean) newValue);
         else if (field.getType() == FieldDefinition.ColumnType.MultiLine)
@@ -151,9 +151,9 @@ public class EntityBulkUpdateDialog extends ModalDialog
         return elementCache().numericInput(fieldKey).get();
     }
 
-    public EntityBulkUpdateDialog setDateField(String fieldLabel, String dateString)
+    public EntityBulkUpdateDialog setDateField(String fieldKey, String dateString)
     {
-        enableAndWait(fieldLabel, elementCache().dateInput(fieldLabel)).set(dateString);
+        enableAndWait(fieldKey, elementCache().dateInput(fieldKey)).set(dateString);
         return this;
     }
 
@@ -360,10 +360,10 @@ public class EntityBulkUpdateDialog extends ModalDialog
             return new Input(inputEl, getDriver());
         }
 
-        public ReactDateTimePicker dateInput(String fieldLabel)
+        public ReactDateTimePicker dateInput(String fieldKey)
         {
             return new ReactDateTimePicker.ReactDateTimeInputFinder(getDriver())
-                    .withInputId(EscapeUtil.fieldKeyEncodePart(fieldLabel)).waitFor(formRow(fieldLabel));
+                    .withInputId(fieldKey).waitFor(formRow(fieldKey));
         }
 
         public FileAttachmentContainer fileUploadField(String fieldKey)

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -592,7 +592,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
 
         public WebElement valueCellWithName(String fieldName)
         {
-            return Locator.tagWithAttribute("td", "data-fieldkey", EscapeUtil.fieldKeyEncodePart(fieldName).toLowerCase()).findElement(editPanel);
+            return Locator.tagWithAttribute("td", "data-fieldkey", EscapeUtil.fieldKeyEncodePart(fieldName)).findElement(editPanel);
         }
 
         public FileUploadField fileField(String label)

--- a/src/org/labkey/test/components/ui/grids/FieldSelectionDialog.java
+++ b/src/org/labkey/test/components/ui/grids/FieldSelectionDialog.java
@@ -260,7 +260,7 @@ public class FieldSelectionDialog extends ModalDialog
 
         if(active.isDisplayed())
         {
-            return getTextContent(Locator.tagWithClass("div", "field-name").findElement(active));
+            return getTextContent(Locator.tagWithClass("div", "field-caption").findElement(active));
         }
         else
         {
@@ -601,7 +601,7 @@ public class FieldSelectionDialog extends ModalDialog
         protected WebElement selectedFieldsPanel = contentPanelLocator.index(1).findWhenNeeded(this);
 
         // This is present to items in both panels.
-        protected final Locator listItemName = Locator.tagWithClass("div", "field-name");
+        protected final Locator listItemName = Locator.tagWithClass("div", "field-caption");
 
         protected final WebElement undoEditsButton = Locator.tagWithText("span", "Undo edits")
                 .refindWhenNeeded(this);
@@ -624,7 +624,7 @@ public class FieldSelectionDialog extends ModalDialog
         protected List<WebElement> getListItemElements(WebElement panel, String fieldLabel)
         {
             return Locator.tagWithClass("div", "list-group-item")
-                    .withDescendant(Locator.tagWithClass("div", "field-name").withText(fieldLabel))
+                    .withDescendant(Locator.tagWithClass("div", "field-caption").withText(fieldLabel))
                     .findElements(panel);
         }
 
@@ -632,7 +632,7 @@ public class FieldSelectionDialog extends ModalDialog
         protected WebElement getListItemElement(WebElement panel, String fieldLabel)
         {
             return Locator.tagWithClass("div", "list-group-item")
-                    .withDescendant(Locator.tagWithClass("div", "field-name").withText(fieldLabel))
+                    .withDescendant(Locator.tagWithClass("div", "field-caption").withText(fieldLabel))
                     .findElement(panel);
         }
 


### PR DESCRIPTION
#### Rationale
Issue [52556](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52556): Add non-prettified field names to grid components

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1789

#### Changes
- DetailTableEdit valueCellWithName locator removal of toLowerCase() for data-fieldkey
- FieldSelectionDialog location class name change to field-caption
- BatchUpdateSamplesDialog and EntityBulkInsertDialog update to helpers to get/set date/time fields based on fieldKey
- EntityBulkUpdateDialog setDateField() to use fieldKey now
