### PR TITLE
Issue 53012: Edit parent details dropdown remembers cancelled option updates re-edit

### DIFF
--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -6,6 +6,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.react.BaseReactSelect;
 import org.labkey.test.components.react.FilteringReactSelect;
 import org.labkey.test.components.react.ReactSelect;
 import org.openqa.selenium.NoSuchElementException;
@@ -303,6 +304,11 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
                 .findAll(elementCache());
     }
 
+    private BaseReactSelect.BaseReactSelectFinder<FilteringReactSelect> getParentFinder(String typeName)
+    {
+        return FilteringReactSelect.finder(getDriver()).withNamedInput(String.format("parentEntityValue_%s", typeName));
+    }
+
     /**
      * Get a select for a given parent entity type.
      *
@@ -311,8 +317,7 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
      */
     public FilteringReactSelect getParent(String typeName)
     {
-        return FilteringReactSelect.finder(getDriver()).withNamedInput(String.format("parentEntityValue_%s", typeName))
-                .find(elementCache());
+        return getParentFinder(typeName).find(elementCache());
     }
 
     /**
@@ -353,7 +358,7 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
         if (getEntityType(typeName) == null)
             getAddNewEntityTypeSelect().select(typeName);
 
-        var selectParent = getParent(typeName);
+        var selectParent = getParentFinder(typeName).waitFor(elementCache());
 
         // Adding for debugging (trying to understand why save button is not enabled after setting).
         getWrapper().log(String.format("Selections before adding: %s", selectParent.getSelections()));

--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -501,7 +501,7 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
     protected class ElementCache extends Component<?>.ElementCache
     {
         final WebElement saveButton = Locator.byClass("btn-success").withText("Save").findWhenNeeded(this);
-        final WebElement cancelButton = Locator.byClass("btn-default").withText("Cancel").findWhenNeeded(this);
+        final WebElement cancelButton = Locator.byClass("btn-default").withText("Cancel").refindWhenNeeded(this);
 
         // This is the 'Add' button that is contained inside the panel.
         final WebElement addButton = Locator


### PR DESCRIPTION
#### Rationale
This addresses an element usage change I made which caused a regression in the BiologicsSampleTimelineTest.testCrossFolderLineageLinks.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/749
- https://github.com/LabKey/limsModules/pull/1395
- https://github.com/LabKey/testAutomation/pull/2441

#### Changes
- Revise usage of finder to how it was but share the finder
