### PR TITLE
Make UserTest.testCustomFieldLogin Re-runable

### DIFF
--- a/src/org/labkey/test/tests/UserTest.java
+++ b/src/org/labkey/test/tests/UserTest.java
@@ -274,9 +274,14 @@ public class UserTest extends BaseWebDriverTest
         log("Adding the custom field to core.Users");
         DomainDesignerPage domainDesignerPage = new DomainDesignerPage(getDriver());
         DomainFormPanel domainFormPanel = domainDesignerPage.fieldsPanel();
-        domainFormPanel.addField("UID")
-                .setType(FieldDefinition.ColumnType.String);
-        domainDesignerPage.clickSave();
+        if (!domainFormPanel.fieldNames().contains("UID"))
+        {
+            domainFormPanel.addField("UID")
+                    .setType(FieldDefinition.ColumnType.String);
+            domainDesignerPage.clickSave();
+        }
+        else
+            domainDesignerPage.clickCancel();
 
         log("Adding value to the custom field");
         navigateToUserDetails(NORMAL_USER);


### PR DESCRIPTION
#### Rationale
Make UserTest.testCustomFieldLogin re-runable on local machines.

#### Related Pull Requests
- None

#### Changes
- Check for existence of UID field before adding it.
