### PR TITLE
clean up the right schema this time

### DIFF
--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -895,7 +895,7 @@ public class LinkedSchemaTest extends BaseWebDriverTest
                 .isGreaterThan(-1));
 
         // clean up after ourselves
-        _schemaHelper.deleteSchema(sourceContainerPath, A_PEOPLE_SCHEMA_NAME);
+        _schemaHelper.deleteSchema(sourceContainerPath, linkedSchemaName);
     }
 
     /*


### PR DESCRIPTION
#### Rationale
Recently, [LinkedSchemaTest.testCoreLinkedSchemaFilters](https://teamcity.labkey.org/buildConfiguration/bt20/3512466?buildTab=tests&status=failed&name=LinkedSchemaTest.testCoreLinkedSchemaFilters) has been failing because at the end of the test where it should be cleaning up the schema it created in the current test, it's cleaning up another one 🤦 

#### Related Pull Requests
n/a

#### Changes
clean up the schema created in this test case, not the other