### PR TITLE
Issue 52485: App admins can create and edit shorturls but can't view

### DIFF
--- a/src/org/labkey/test/tests/core/admin/ShortUrlTest.java
+++ b/src/org/labkey/test/tests/core/admin/ShortUrlTest.java
@@ -186,10 +186,15 @@ public class ShortUrlTest extends BaseWebDriverTest
             log("As app admin, update shortUrl created by another user");
             adminPage.submitShortUrl(shortUrl_a, targetUrl2);
 
-            // Issue #52485 "App admins can create and edit shorturls but can't view them"
-            assertElementPresent(BootstrapLocators.errorBanner.withText("Table or query not found: ShortURL"));
+            // Issue #52485 "App admins can create and edit shorturls but can't view them" (but now they can!)
+            verifyShortUrlsInGrid(shortUrl_a, targetUrl2, shortUrl_b);
         });
 
+        verifyShortUrlsInGrid(shortUrl_a, targetUrl2, shortUrl_b);
+    }
+
+    private void verifyShortUrlsInGrid(String shortUrl_a, String targetUrl2, String shortUrl_b)
+    {
         Assertions.assertThat(ShortUrlAdminPage.beginAt(this).getUrlsFromGrid())
                 .as("short URLs")
                 .containsAllEntriesOf(Map.of(


### PR DESCRIPTION
#### Rationale
Add test coverage for app admins being able to see the short URLs configured on a server

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6672

#### Changes
- Do the same checks for app admins and site admins
