### PR TITLE
Move study design features into a new module

### DIFF
--- a/src/org/labkey/test/tests/AdvancedImportOptionsTest.java
+++ b/src/org/labkey/test/tests/AdvancedImportOptionsTest.java
@@ -71,7 +71,6 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest implements Post
     private static final boolean EXPECTED_IMPORT_ERRORS = false;
     private static final int EXPECTED_COMPLETED_IMPORT_JOBS = 1;
     private static final int EXPECTED_COMPLETED_MULTI_FOLDER_JOBS = 2;
-    private Boolean _studyDesignPreviouslyEnabled;
     private Boolean _advancedImportOptionsEnabled;
 
     @Override
@@ -96,7 +95,6 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest implements Post
     public static void doSetup()
     {
         AdvancedImportOptionsTest test = getCurrentTest();
-        test._studyDesignPreviouslyEnabled = OptionalFeatureHelper.enableOptionalFeature(test.createDefaultConnection(), "studyDesignFlag");
         test._advancedImportOptionsEnabled = OptionalFeatureHelper.enableOptionalFeature(test.createDefaultConnection(), "advancedImportFlag");
     }
 
@@ -108,8 +106,6 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest implements Post
         _containerHelper.deleteProject(IMPORT_PROJECT_FILE02, false);
         _containerHelper.deleteProject(IMPORT_PROJECT_FILE03, false);
         _containerHelper.deleteProject(IMPORT_PROJECT_MULTI, false);
-        if (_studyDesignPreviouslyEnabled != null)
-            OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "studyDesignFlag", _studyDesignPreviouslyEnabled);
 
         if (_advancedImportOptionsEnabled != null)
             OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "advancedImportFlag", _advancedImportOptionsEnabled);

--- a/src/org/labkey/test/util/StudyHelper.java
+++ b/src/org/labkey/test/util/StudyHelper.java
@@ -561,13 +561,16 @@ public class StudyHelper
     public boolean isSpecimenModulePresent()
     {
         if (null == _specimenModulePresent)
-        {
-            AbstractContainerHelper containerHelper = new APIContainerHelper(_test);
-            Set<String> allModules = containerHelper.getAllModules();
-            _specimenModulePresent = allModules.contains("specimen");
-        }
+            _specimenModulePresent = isModulePresent("specimen");
 
         return _specimenModulePresent;
+    }
+
+    public boolean isModulePresent(String moduleName)
+    {
+        AbstractContainerHelper containerHelper = new APIContainerHelper(_test);
+        Set<String> allModules = containerHelper.getAllModules();
+        return allModules.contains(moduleName);
     }
 
     public boolean isSpecimenModuleActive()


### PR DESCRIPTION
#### Rationale
The deprecated flag is no longer available, access to the feature is now controlled by the presence of the `StudyDesign` module.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6686
- https://github.com/LabKey/clientModules/pull/23
- https://github.com/LabKey/testAutomation/pull/2459
- https://github.com/LabKey/customModules/pull/227
