### PR TITLE
Use latin character codes to fix test build on Windows

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -226,7 +226,6 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     public static final String TRICKY_CHARACTERS = "><&/%\\' \"1\u00E4\u00F6\u00FC\u00C5";
     public static final String TRICKY_CHARACTERS_NO_QUOTES = "></% 1\u00E4\u00F6\u00FC\u00C5";
     public static final String TRICKY_CHARACTERS_FOR_PROJECT_NAMES = "\u2603~!@$&()_+{}-=[],.#\u00E4\u00F6\u00FC\u00C5"; // No slash or space
-    // TODO using </script> breaks CustomizeViewTest because of the '/'
     public static final String INJECT_CHARS_1 = Crawler.injectScriptBlock;
     public static final String INJECT_CHARS_2 = Crawler.injectAttributeScript;
 

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -72,9 +72,9 @@ import static org.labkey.test.util.data.TestDataUtils.REALISTIC_SOURCE_FIELDS;
  */
 public class TestDataGenerator
 {
-    private static final String WIDE_CHAR = "👾";
-    private static final char WIDE_PLACEHOLDER = 'Π'; // Wide character can't be picked from the string with 'charAt'
-    private static final String NON_LATIN_STRING = "и안は";
+    private static final String WIDE_CHAR = "\uD83D\uDC7E"; // 👾
+    private static final char WIDE_PLACEHOLDER = '\u03A0'; // 'Π' - Wide character can't be picked from the string with 'charAt'
+    private static final String NON_LATIN_STRING = "\u0438\uC548\u306F"; // "и안は"
     // chose a Character random from this String
     public static final String CHARSET_STRING = "ABCDEFG01234abcdefvxyz~!@#$%^&*()-+=_{}[]|:;\"',.<>" + NON_LATIN_STRING + WIDE_PLACEHOLDER;
     public static final String ALPHANUMERIC_STRING = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvxyz";


### PR DESCRIPTION
#### Rationale
Test build mangles UTF character literals on Windows.
```
[ant:iajc] private static final char WIDE_PLACEHOLDER = 'Î '; // Wide character can't be picked from the string with 'charAt'
[ant:iajc]                                              ^^^^
[ant:iajc] D:\teamcity\work\8063137bf091310a\server\testAutomation\src\org\labkey\test\util\TestDataGenerator.java:76:0::0 Invalid character constant
```

#### Related Pull Requests
- #2450 

#### Changes
- Use latin character codes to fix test build on Windows
