### PR TITLE
Add cancel capabilities to `ImportsPage`

### DIFF
--- a/src/org/labkey/test/components/ui/pipeline/ImportsPage.java
+++ b/src/org/labkey/test/components/ui/pipeline/ImportsPage.java
@@ -61,6 +61,12 @@ public class ImportsPage extends LabKeyPage<LabKeyPage<?>.ElementCache>
         return grid;
     }
 
+    public ImportsPage clickCancel()
+    {
+        elementCache().cancelButton.click();
+        return new ImportsPage(this);
+    }
+
     @Override
     protected ElementCache elementCache()
     {
@@ -82,6 +88,8 @@ public class ImportsPage extends LabKeyPage<LabKeyPage<?>.ElementCache>
                     .child(Locator.tagWithClass("h2", "no-margin-top"))
                     .findWhenNeeded(this);
         }
+
+        final WebElement cancelButton = Locator.button("Cancel").findWhenNeeded(this);
 
         final QueryGrid pipelineJobsGrid()
         {


### PR DESCRIPTION
#### Rationale
Cannot cancel a job, even if we want to.

#### Changes
- Update `ImportsPage` with `clickCancel` ethod
