### PR TITLE
Skip audit diff checks based on TestProperties.isTrialServer()

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
+import org.labkey.test.TestProperties;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.Component;
@@ -390,7 +391,7 @@ public class EntityBulkUpdateDialog extends ModalDialog
         // check for the expected number of Data Changes in the latest audit event records
         AuditLogHelper auditLogHelper = new AuditLogHelper(getWrapper(), () -> WebTestHelper.getRemoteApiConnection(false));
         String auditEventName = auditLogHelper.getAuditEventNameFromURL();
-        if (!skipAuditEventCheck && auditEventName != null)
+        if (!skipAuditEventCheck && auditEventName != null && !TestProperties.isTrialServer())
         {
             try
             {

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
+import org.labkey.test.TestProperties;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.Component;
@@ -511,7 +512,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         // check for the expected number of Data Changes in the latest audit event records
         AuditLogHelper auditLogHelper = new AuditLogHelper(getWrapper(), () -> WebTestHelper.getRemoteApiConnection(false));
         String auditEventName = auditLogHelper.getAuditEventNameFromURL();
-        if (!skipAuditEventCheck && auditEventName != null)
+        if (!skipAuditEventCheck && auditEventName != null && !TestProperties.isTrialServer())
         {
             try
             {


### PR DESCRIPTION
#### Rationale
Trial tests are failing when they try to do sample action audit diff checks because we use a new remote API connection for getting the audit events. This fails on trial instances because they use CAS for authentication. This PR updates those checks to skip them in the isTrialServer() case.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1444

#### Changes
- Don't do audit diff checks for TestProperties.isTrialServer()
