### PR TITLE
Fix tricky field name test failures

### DIFF
--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -494,19 +494,22 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         for (WebElement el : elements)
         {
             _driver.fireEvent(el, WebDriverWrapper.SeleniumEvent.blur);
-            for (int i = 0; i < 10; i++)
+            try
             {
-                try
+                for (int i = 0; i < 10; i++)
                 {
-                    ScrollUtils.scrollIntoView(el);
-                    builder.moveToElement(el).click().build().perform();
-                }
-                catch (StaleElementReferenceException ignore) {}
-                catch (WebDriverException ignore)
-                {
-                    ScrollUtils.scrollUnderFloatingHeader(el);
+                    try
+                    {
+                        ScrollUtils.scrollIntoView(el);
+                        builder.moveToElement(el).click().build().perform();
+                    }
+                    catch (WebDriverException ignore)
+                    {
+                        ScrollUtils.scrollUnderFloatingHeader(el);
+                    }
                 }
             }
+            catch (StaleElementReferenceException ignore) {}
             _driver.shortWait().until(ExpectedConditions.stalenessOf(el));
         }
     }

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -494,22 +494,19 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         for (WebElement el : elements)
         {
             _driver.fireEvent(el, WebDriverWrapper.SeleniumEvent.blur);
-            try
+            for (int i = 0; i < 10; i++)
             {
-                for (int i = 0; i < 10; i++)
+                try
                 {
-                    try
-                    {
-                        ScrollUtils.scrollIntoView(el);
-                        builder.moveToElement(el).click().build().perform();
-                    }
-                    catch (WebDriverException ignore)
-                    {
-                        ScrollUtils.scrollUnderFloatingHeader(el);
-                    }
+                    ScrollUtils.scrollIntoView(el);
+                    builder.moveToElement(el).click().build().perform();
+                }
+                catch (StaleElementReferenceException ignore) {}
+                catch (WebDriverException ignore)
+                {
+                    ScrollUtils.scrollUnderFloatingHeader(el);
                 }
             }
-            catch (StaleElementReferenceException ignore) {}
             _driver.shortWait().until(ExpectedConditions.stalenessOf(el));
         }
     }

--- a/src/org/labkey/test/tests/CustomizeViewTest.java
+++ b/src/org/labkey/test/tests/CustomizeViewTest.java
@@ -305,11 +305,11 @@ public class CustomizeViewTest extends BaseWebDriverTest
         String value = "J";
         String[] viewNames = {TRICKY_CHARACTERS + "view", "AAC", "aaa", "aad", "zzz"};
 
-        setColumns(fieldKey);
+        setColumns(LAST_NAME_COLUMN);
         for(String name : viewNames)
         {
             _customizeViewsHelper.openCustomizeViewPanel();
-            _customizeViewsHelper.addFilter(fieldKey, fieldKey, op, value);
+            _customizeViewsHelper.addFilter(new String[]{fieldKey}, fieldKey, op, value);
             _customizeViewsHelper.saveCustomView(name);
         }
 

--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -23,6 +23,7 @@ import org.labkey.test.components.ui.grids.QueryGrid;
 import org.labkey.test.components.ui.search.FilterExpressionPanel;
 import org.labkey.test.components.ui.search.FilterFacetedPanel;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldKey;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.SampleTypeHelper;
@@ -63,11 +64,11 @@ public class GridPanelTest extends GridPanelBaseTest
     // Column names.
     private static final String FILTER_NAME_COL = "Name";
     private static final String FILTER_EXPDATE_COL = "Expiration Date";
-    private static final String FILTER_STRING_COL = TestDataGenerator.randomFieldName("Str", 0, 5);
-    private static final String FILTER_INT_COL = TestDataGenerator.randomFieldName("Int", 0, 5);
-    private static final String FILTER_EXTEND_CHAR_COL = TestDataGenerator.randomFieldName("\u0106\u00D8\u0139", 0, 5);
-    private static final String FILTER_BOOL_COL = TestDataGenerator.randomFieldName("Bool", 0, 5);
-    private static final String FILTER_DATE_COL = TestDataGenerator.randomFieldName("Date", 0, 5);
+    private static final String FILTER_STRING_COL = "Str";
+    private static final String FILTER_INT_COL = "Int";
+    private static final String FILTER_EXTEND_CHAR_COL = "\u0106\u00D8\u0139";
+    private static final String FILTER_BOOL_COL = "Bool";
+    private static final String FILTER_DATE_COL = "Date";
     private static final String FILTER_STORED_AMOUNT_COL = "Amount";
 
     // Views and columns used in the views. The views are only applied to the small sample type (Small_SampleType).
@@ -117,7 +118,7 @@ public class GridPanelTest extends GridPanelBaseTest
     @BeforeClass
     public static void setupProject() throws IOException, CommandException
     {
-        GridPanelTest init = (GridPanelTest) getCurrentTest();
+        GridPanelTest init = getCurrentTest();
 
         init.doSetup();
     }
@@ -196,7 +197,7 @@ public class GridPanelTest extends GridPanelBaseTest
         cv.saveCustomView(VIEW_FEWER_COLUMNS);
 
         log(String.format("Finally create a view named '%s' for '%s' that only has a filter.", VIEW_FILTERED_COLUMN, SMALL_SAMPLE_TYPE));
-        drtSamples.setFilter(FILTER_STRING_COL, "Contains One Of", String.format("%1$s\n%1$s%2$s", stringSetMembers.get(0), stringSetMembers.get(1)));
+        drtSamples.setFilter(FieldKey.encodePart(FILTER_STRING_COL), "Contains One Of", String.format("%1$s\n%1$s%2$s", stringSetMembers.get(0), stringSetMembers.get(1)));
         cv = drtSamples.openCustomizeGrid();
         cv.saveCustomView(VIEW_FILTERED_COLUMN);
 

--- a/src/org/labkey/test/tests/list/ListLookupTest.java
+++ b/src/org/labkey/test/tests/list/ListLookupTest.java
@@ -1,5 +1,6 @@
 package org.labkey.test.tests.list;
 
+import org.apache.commons.csv.CSVFormat;
 import org.jetbrains.annotations.Nullable;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -16,10 +17,12 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.TestDataGenerator;
+import org.labkey.test.util.data.TestDataUtils;
 import org.labkey.test.util.query.QueryApiHelper;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -55,11 +58,12 @@ public class ListLookupTest extends BaseWebDriverTest
         log("Create a list to use as a lookup table with some number-like names.");
         _listHelper.createList(getProjectName(), lookToListName, lookToKeyFieldName,
                 new FieldDefinition(lookToFieldName, FieldDefinition.ColumnType.String));
-        String bulkData = lookToFieldName + "\n" +
-                "1E2\n" +
-                "102\n" +
-                "Lookup\n" +
-                ".123";
+        String bulkData = tsvFromColumn(List.of(
+            lookToFieldName,
+            "1E2",
+            "102",
+            "Lookup",
+            ".123"));
         _listHelper.bulkImportData(bulkData);
 
         DataRegionTable dataRegionTable = new DataRegionTable("query", getDriver());
@@ -85,11 +89,12 @@ public class ListLookupTest extends BaseWebDriverTest
     @Test
     public void testWithoutValidatorOrAlternateKeys() throws IOException, CommandException
     {
+        goToProjectHome();
         setLookupValidatorEnabled(false);
         resetList();
 
         log("Import data into the second list without alternate keys.");
-        String bulkData = lookFromLookupFieldName + "\n" + lookupKeyAsNameNumber;
+        String bulkData = tsvFromColumn(List.of(lookFromLookupFieldName, lookupKeyAsNameNumber));
         _listHelper.clickImportData()
                 .setText(bulkData)
                 .submit();
@@ -102,7 +107,7 @@ public class ListLookupTest extends BaseWebDriverTest
         log("Clean out list before next import.");
         resetList();
         log("Import data into second list without alternate keys supplying invalid primary key");
-        bulkData = lookFromLookupFieldName + "\n1000";
+        bulkData = tsvFromColumn(List.of(lookFromLookupFieldName, "1000"));
         _listHelper.clickImportData()
                 .setText(bulkData)
                 .submit();
@@ -113,7 +118,7 @@ public class ListLookupTest extends BaseWebDriverTest
         validateListValues(expectedData);
 
         log("Check for error if not using alternate key and type does not match");
-        bulkData = lookFromLookupFieldName + "\nnoneSuch";
+        bulkData = tsvFromColumn(List.of(lookFromLookupFieldName, "noneSuch"));
         ImportDataPage importDataPage = _listHelper.clickImportData();
         String error = importDataPage
                 .setText(bulkData)
@@ -124,20 +129,22 @@ public class ListLookupTest extends BaseWebDriverTest
     @Test
     public void testWithoutValidatorWithAlternateKeys() throws IOException, CommandException
     {
+        goToProjectHome();
         setLookupValidatorEnabled(false);
         log("Clean out list before next import.");
         resetList();
         log("Import data into the second list using number-like lookup values expecting alternate keys but also accepting primary keys.");
-        String bulkData = lookFromLookupFieldName + "\n" +
-                "1E2\n" + // valid alternate key looking like a number
-                lookupKeyAsNameNumber + "\n" + // valid alternate key same value as a primary key
-                ".123\n" + // valid alternate key looking like a float
-                "Lookup\n" + // valid alternate key that is a string
-                lookupKeyAsNameNumber + "\n" + // another copy
-                "102\n" + // valid number-like alternate key
-                lookToListValues.get(1).get(EscapeUtil.fieldKeyEncodePart(lookToKeyFieldName)) + "\n" + // primary key value not matching an alternate key
-                "1000" // primary key-type value that doesn't match
-                ;
+        String bulkData = tsvFromColumn(List.of(
+            lookFromLookupFieldName,
+            "1E2", // valid alternate key looking like a number
+            lookupKeyAsNameNumber, // valid alternate key same value as a primary key
+            ".123", // valid alternate key looking like a float
+            "Lookup", // valid alternate key that is a string
+            lookupKeyAsNameNumber, // another copy
+            "102", // valid number-like alternate key
+            lookToListValues.get(1).get(EscapeUtil.fieldKeyEncodePart(lookToKeyFieldName)), // primary key value not matching an alternate key
+            "1000" // primary key-type value that doesn't match
+        ));
         _listHelper.clickImportData()
                 .setText(bulkData)
                 .setImportLookupByAlternateKey(true)
@@ -156,7 +163,7 @@ public class ListLookupTest extends BaseWebDriverTest
         validateListValues(expectedData);
 
         log("Check for error if providing non-matching string value that is not a number");
-        bulkData = lookFromLookupFieldName + "\nNotAValue";
+        bulkData = tsvFromColumn(List.of(lookFromLookupFieldName, "NotAValue"));
         ImportDataPage importDataPage = _listHelper.clickImportData();
         String error = importDataPage
                 .setText(bulkData)
@@ -168,13 +175,14 @@ public class ListLookupTest extends BaseWebDriverTest
     @Test
     public void testWithLookupValidatorWithoutAlternateKeys() throws IOException, CommandException
     {
+        goToProjectHome();
         setLookupValidatorEnabled(true);
         log("Clean out list before next import.");
         resetList();
 
         //   without alternate keys
         log("With lookup validation on, import data into the second list without alternate keys.");
-        String bulkData = lookFromLookupFieldName + "\n" + lookupKeyAsNameNumber;
+        String bulkData = tsvFromColumn(List.of(lookFromLookupFieldName, lookupKeyAsNameNumber));
         _listHelper.clickImportData()
                 .setText(bulkData)
                 .submit();
@@ -187,13 +195,13 @@ public class ListLookupTest extends BaseWebDriverTest
         log("With lookup validation on, import data and provide an invalid primary key.");
         ImportDataPage importDataPage = _listHelper.clickImportData();
         String error = importDataPage
-                .setText(lookFromLookupFieldName + "\n1000")
+                .setText(tsvFromColumn(List.of(lookFromLookupFieldName, "1000")))
                 .submitExpectingError();
-        checker().withScreenshot().verifyEquals("Error message for invalid primary key value not as expected", "Value '1000' was not present in lookup target 'lists." + lookToListName + "' for field '" + lookFromLookupFieldName + "'", error);
+        checker().withScreenshot().verifyEquals("Error message for invalid primary key value not as expected", "Value '1000' was not present in lookup target 'lists." + lookToListName + "' for field '" + FieldDefinition.labelFromName(lookFromLookupFieldName) + "'", error);
 
         log("With lookup validation on, import data and provide an invalid primary key of type string.");
         error = importDataPage
-                .setText(lookFromLookupFieldName + "\nLook")
+                .setText(tsvFromColumn(List.of(lookFromLookupFieldName, "Look")))
                 .submitExpectingError();
         checker().withScreenshot().verifyEquals("Error message for invalid primary key type not as expected", "Could not convert value 'Look' (String) for Integer field '" + lookFromLookupFieldName + "'", error);
     }
@@ -201,20 +209,22 @@ public class ListLookupTest extends BaseWebDriverTest
     @Test
     public void testWithLookupValidatorAndAlternateKeys() throws IOException, CommandException
     {
+        goToProjectHome();
         setLookupValidatorEnabled(true);
         log("Clean out list before next import.");
         resetList();
 
         log("With lookup validation on, import data into the second list using number-like lookup values expecting alternate keys but also accepting primary keys.");
-        String bulkData = lookFromLookupFieldName + "\n" +
-                "1E2\n" + // valid alternate key looking like a number
-                lookupKeyAsNameNumber + "\n" + // valid alternate key same value as a primary key
-                ".123\n" + // valid alternate key looking like a float
-                "Lookup\n" + // valid alternate key that is a string
-                lookupKeyAsNameNumber + "\n" + // another copy
-                "102\n" + // valid number-like alternate key
-                lookToListValues.get(1).get(EscapeUtil.fieldKeyEncodePart(lookToKeyFieldName)) + "\n" // primary key value not matching an alternate key
-        ;
+        String bulkData = tsvFromColumn(List.of(
+            lookFromLookupFieldName,
+            "1E2", // valid alternate key looking like a number
+            lookupKeyAsNameNumber, // valid alternate key same value as a primary key
+            ".123", // valid alternate key looking like a float
+            "Lookup", // valid alternate key that is a string
+            lookupKeyAsNameNumber, // another copy
+            "102", // valid number-like alternate key
+            lookToListValues.get(1).get(EscapeUtil.fieldKeyEncodePart(lookToKeyFieldName)) // primary key value not matching an alternate key
+        ));
         _listHelper.clickImportData()
                 .setText(bulkData)
                 .setImportLookupByAlternateKey(true)
@@ -231,7 +241,7 @@ public class ListLookupTest extends BaseWebDriverTest
         );
         validateListValues(expectedData);
 
-        bulkData = lookFromLookupFieldName + "\nInvalid";
+        bulkData = tsvFromColumn(List.of(lookFromLookupFieldName, "Invalid"));
         ImportDataPage importDataPage = _listHelper.clickImportData();
         String error = importDataPage
                 .setText(bulkData)
@@ -239,12 +249,12 @@ public class ListLookupTest extends BaseWebDriverTest
                 .submitExpectingError();
         checker().withScreenshot().verifyEquals("Error message for invalid string alternate key not as expected", "Value 'Invalid' not found for field " + lookFromLookupFieldName + " in the current context.", error);
 
-        bulkData = lookFromLookupFieldName + "\n1234";
+        bulkData = tsvFromColumn(List.of(lookFromLookupFieldName, "1234"));
         error = importDataPage
                 .setText(bulkData)
                 .setImportLookupByAlternateKey(true)
                 .submitExpectingError();
-        checker().withScreenshot().verifyEquals("Error message for invalid number-like alternate key not as expected", "Value '1234' was not present in lookup target 'lists." + lookToListName + "' for field '" + lookFromLookupFieldName + "'", error);
+        checker().withScreenshot().verifyEquals("Error message for invalid number-like alternate key not as expected", "Value '1234' was not present in lookup target 'lists." + lookToListName + "' for field '" + FieldDefinition.labelFromName(lookFromLookupFieldName) + "'", error);
 
     }
 
@@ -271,6 +281,12 @@ public class ListLookupTest extends BaseWebDriverTest
 
         assertEquals("List data not as expected after action.",
                 expectedValue, actualValue);
+    }
+
+    private String tsvFromColumn(List<String> column)
+    {
+        List<List<String>> rows = column.stream().map(Collections::singletonList).toList();
+        return TestDataUtils.stringFromRows(rows, CSVFormat.TDF);
     }
 
     @Override

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -582,7 +582,8 @@ public class TestDataGenerator
     public static String randomFieldName(@NotNull String part, int numStartChars, int numEndChars, @Nullable String exclusion)
     {
         // use the characters that we know are encoded in fieldKeys plus characters that we know clients are using
-        String chars = ALL_ILLEGAL_QUERY_KEY_CHARACTERS + " %()=+-[]_|*`'\":;<>?!@#^" + NON_LATIN_STRING + WIDE_PLACEHOLDER ;
+        // Issue 53197: Field name with double byte character can cause client side exception in Firefox when trying to customize grid view.
+        String chars = ALL_ILLEGAL_QUERY_KEY_CHARACTERS + " %()=+-[]_|*`'\":;<>?!@#^" + NON_LATIN_STRING;// + WIDE_PLACEHOLDER ;
 
         String randomFieldName = randomName(part, numStartChars, numEndChars, chars, exclusion);
         TestLogger.log("Generated random field name: " + randomFieldName);


### PR DESCRIPTION
#### Rationale

##### CustomizeViewTest
`FieldKey` didn't fully encode field keys. Now that it does, `CustomizeViewTest.setColumns` can end up double-encoding them. Test cases shouldn't pass encoded fieldKeys to that method.
<ul><li><details><summary>stacktrace</summary>

```
org.openqa.selenium.NoSuchElementException: Unable to find element: css=tr.x4-grid-data-row[data-recordid="LASTNAME\">'>'\"<$DSSCRIPT><IMG SRC=\"X\" ONERROR=\"ALERT('8(')\">"]
  at app//org.labkey.test.Locator.lambda$2(Locator.java:391)
  at java.base@17.0.7/java.util.Optional.orElseThrow(Optional.java:403)
  at app//org.labkey.test.Locator.findElement(Locator.java:390)
  at app//org.labkey.test.components.CustomizeView.expandPivots(CustomizeView.java:371)
  at app//org.labkey.test.components.CustomizeView.addItem(CustomizeView.java:382)
  at app//org.labkey.test.components.CustomizeView.addColumn(CustomizeView.java:397)
  at app//org.labkey.test.components.CustomizeView.addColumn(CustomizeView.java:318)
  at app//org.labkey.test.tests.CustomizeViewTest.setColumns(CustomizeViewTest.java:346)
  at app//org.labkey.test.tests.CustomizeViewTest.saveFilterTest(CustomizeViewTest.java:308)
```
</details></li></ul>

##### ListLookupTest
The TSV Strings used for data import aren't properly quoted and end up importing nothing when the field name starts with a `"`. Need to use `TestDataUtils` to generate properly formatted TSVs.
<ul><li><details><summary>stacktrace</summary>

```
java.lang.AssertionError: List data not as expected after action. expected:<[{"は안%^Look From Lookup Field!#=1E2}]> but was:<[{"は안%^Look From Lookup Field!#= }]>
  at org.junit.Assert.fail(Assert.java:89)
  at org.junit.Assert.failNotEquals(Assert.java:835)
  at org.junit.Assert.assertEquals(Assert.java:120)
  at org.labkey.test.tests.list.ListLookupTest.validateListValues(ListLookupTest.java:272)
  at org.labkey.test.tests.list.ListLookupTest.testWithoutValidatorOrAlternateKeys(ListLookupTest.java:100)
```
</details></li></ul>

##### GridPanelTest
`DataRegionTable` expects encoded fieldKeys. Updating `doSetup` to encode properly revealed numerous other failures. This test requires a significant overhaul to support tricky characters. Removing random character names temporarily.
<ul><li><details><summary>stacktrace</summary>

```
org.openqa.selenium.NoSuchElementException: Column header named Str[?,и# not found
For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors#no-such-element-exception
Build info: version: '4.33.0', revision: '2c6aaad03a'
System info: os.name: 'Linux', os.arch: 'amd64', os.version: '6.8.0-1029-aws', java.version: '17.0.7'
Driver info: driver.version: unknown
  at app//org.labkey.test.Locator.findAnyElement(Locator.java:265)
  at app//org.labkey.test.util.DataRegionTable$Elements.getColumnHeader(DataRegionTable.java:1633)
  at app//org.labkey.test.util.DataRegionTable.openFilterDialog(DataRegionTable.java:1034)
  at app//org.labkey.test.util.DataRegionTable.setUpFilter(DataRegionTable.java:1101)
  at app//org.labkey.test.util.DataRegionTable.setUpFilter(DataRegionTable.java:1089)
  at app//org.labkey.test.util.DataRegionTable.setFilter(DataRegionTable.java:1058)
  at app//org.labkey.test.tests.component.GridPanelTest.createSmallSampleType(GridPanelTest.java:199)
  at app//org.labkey.test.tests.component.GridPanelTest.doSetup(GridPanelTest.java:135)
  at app//org.labkey.test.tests.component.GridPanelTest.setupProject(GridPanelTest.java:122)
```
</details></li></ul>

##### Misc
Including the `👾` character in random field names breaks the Customize View dialog ([issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53197)). Removing temporarily to reduce test noise before we branch for 25.6.

#### Related Pull Requests
- #2460 
- #2399 

#### Changes
- Remove unnecessary fieldKey encoding from `CustomizeViewTest`
- Fix TSV generation in `ListLookupTest`
- Revert addition of random field names to `GridPanelTest`
- Exclude emoji character from random field names
