### PR TITLE
Exclude POST-only confirmation actions from crawler

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -199,6 +199,8 @@ public class Crawler
             // Tested directly in XTandemTest
             new ControllerActionId("protein", "doProteinSearch"),
             new ControllerActionId("protein", "pepSearch"), // TODO: Issue 36995: Check for SQL injection in StatementWrapper is not precise enough
+            new ControllerActionId("publish", "sampleTypePublishConfirm"), // POST-only
+            new ControllerActionId("publish", "assayPublishConfirm"), // POST-only
             new ControllerActionId("query", "printRows"), // Data region print button. 404s on "TargetedMS Runs" grid
             new ControllerActionId("reports", "streamFile"),
             new ControllerActionId("study", "manageStudyProperties"), // Intermittently triggers form dirty alert


### PR DESCRIPTION
#### Rationale
These actions only respond to POST. The crawler hits an NPE when deciding what to do with the `405` response. Since the crawler can't do anything useful with actions that don't respond to GET, we should just exclude them.
```
java.lang.RuntimeException: Crawler threw NullPointerException.
Target Page: Dataset%20Download%20Test/publish-assayPublishConfirm.view
  at org.labkey.test.util.Crawler.crawlLink(Crawler.java:1129)
  at org.labkey.test.util.Crawler.crawl(Crawler.java:838)
  at org.labkey.test.util.Crawler.crawlAllLinks(Crawler.java:801)
  at org.labkey.test.BaseWebDriverTest.checkLinks(BaseWebDriverTest.java:1648)
  at org.labkey.test.BaseWebDriverTest.doPostamble(BaseWebDriverTest.java:1265)
  [...]
Caused by: java.lang.NullPointerException: Cannot invoke "java.net.URL.toString()" because "url" is null
  at org.labkey.test.util.Crawler.isAdminSpiderAction(Crawler.java:1159)
  at org.labkey.test.util.Crawler.isIgnoredError(Crawler.java:1182)
  at org.labkey.test.util.Crawler.crawlLink(Crawler.java:1005)
```

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6691

#### Changes
- Exclude POST-only confirmation actions from crawler
