### PR TITLE
Issue 52527: Implement new method for determining primary app id

### DIFF
--- a/src/org/labkey/test/components/ui/navigation/NavBar.java
+++ b/src/org/labkey/test/components/ui/navigation/NavBar.java
@@ -39,7 +39,7 @@ public abstract class NavBar extends WebDriverComponent<NavBar.ElementCache>
 
     public String getHeaderLogoImgSrc()
     {
-        return elementCache().headerLogo.getAttribute("src");
+        return elementCache().headerLogoImage.getAttribute("src");
     }
 
     public HasSearchResults searchFor(String searchString)


### PR DESCRIPTION
#### Rationale
Issue [52527](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52527): Since the LIMS product is served from the same module as the LKSM product, our checks to determine whether in a LIMS project or not have relied on the folder type. This works fine when in the project, but when a folder, which doesn't typically have the LIMS folder type, this check fails. This PR and its relatives introduce a new `primaryApplicationId` member of the `LABKEY` object that will have the proper application id for the project and its subfolders, including folders nested under non-application folders.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6726
- https://github.com/LabKey/labkey-ui-components/pull/1805
- https://github.com/LabKey/labkey-ui-premium/pull/765

#### Changes
- Fix `getHeaderLogoImageSrc` to use in automated test
