### PR TITLE
Fix incorrect error log iteration

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -972,7 +972,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                 else if (currentError.size() == 1)
                 {
                     // Line after the ERROR usually has the exception type and error message
-                    TestLogger.error("    " + iterator.next());
+                    TestLogger.error("    " + line);
                 }
                 else if (line.startsWith("Caused by:"))
                 {


### PR DESCRIPTION
#### Rationale
This loop makes an unnecessary call to `iterator.next()`. At best, this will skip a line we mean to log. At worst, we're at the end of the collection and it throws an exception.
```
java.util.NoSuchElementException
  at java.base/java.util.Spliterators$1Adapter.next(Spliterators.java:688)
  at org.labkey.test.LabKeySiteWrapper.checkErrors(LabKeySiteWrapper.java:975)
```

#### Related Pull Requests
- N/A

#### Changes
- Fix incorrect error log iteration
