### PR TITLE
Fix improperly defined lookup in SampleTypeNameExpressionTest

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
+++ b/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
@@ -452,7 +452,7 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
     public void testLookupNameExpression() throws Exception
     {
         String lookupList = "Colors";
-        FieldDefinition.LookupInfo colorsLookup = new FieldDefinition.IntLookup("lists", lookupList, getProjectName());
+        FieldDefinition.LookupInfo colorsLookup = new FieldDefinition.IntLookup(getProjectName(), "lists", lookupList);
         String nameExpSamples = "NameExpressionSamples";
 
         // begin by creating a lookupList of colors, the sampleType will reference it


### PR DESCRIPTION
#### Rationale
Parameter order was messed up during a refactor.
```
java.lang.RuntimeException: Failed to create sample type. Invalid Name Expression:Lookup field does not exist: ColorLookup/ColorCode
  at org.labkey.test.util.exp.SampleTypeAPIHelper.createEmptySampleType(SampleTypeAPIHelper.java:51)
  at org.labkey.test.tests.SampleTypeNameExpressionTest.testLookupNameExpression(SampleTypeNameExpressionTest.java:481)
```

#### Related Pull Requests
- #2479 

#### Changes
- Fix improperly defined lookup in SampleTypeNameExpressionTest
