### PR TITLE
Rearrange the interaction with the Manually Define button to make sure it's ready

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -256,8 +256,8 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
      */
     public DomainFormPanel clickManuallyDefineFields()
     {
-        getWrapper().scrollIntoView(elementCache().manuallyDefineButton, true);
         getWrapper().shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().manuallyDefineButton)); // give modal dialogs time to disappear
+        getWrapper().scrollIntoView(elementCache().manuallyDefineButton, true);
         elementCache().manuallyDefineButton.click();
 
         return this;


### PR DESCRIPTION
#### Rationale
WNPRC_PurchasingTest is failing occasionally in 24.11 and regularly in 25.3 because it's not finding the Manually Define Fields button. We should be able to rearrange the sequence to ensure it's present before we try scrolling.

Failures in 25.3:
https://teamcity.labkey.org/test/3941050768454738144?currentProjectId=LabKey_253Release_External_Wnprc

Failure in 24.11:
https://teamcity.labkey.org/buildConfiguration/LabKey_2411_External_Wnprc_WnprcEhrPostgres2/3547229

Verification run in 24.11:
https://teamcity.labkey.org/buildConfiguration/LabKey_2411_External_Wnprc_WnprcEhrPostgres2/3551043

#### Changes
- Wait for button before scrolling