### PR TITLE
Test more bad credentials messages

### DIFF
--- a/src/org/labkey/test/tests/core/login/PasswordTest.java
+++ b/src/org/labkey/test/tests/core/login/PasswordTest.java
@@ -33,6 +33,7 @@ import org.labkey.test.components.core.login.SetPasswordForm;
 import org.labkey.test.pages.core.login.DatabaseAuthConfigureDialog;
 import org.labkey.test.pages.core.login.LoginConfigurePage;
 import org.labkey.test.params.login.DatabaseAuthenticationProvider;
+import org.labkey.test.util.APIUserHelper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.core.login.DbLoginUtils;
@@ -256,7 +257,11 @@ public class PasswordTest extends BaseWebDriverTest
     @Test
     public void testChooseNewPasswordMessages() throws IOException
     {
-        // Hold an admin connection open, allowing us to reset the config regardless of what happens during the test
+        // Test bad API key
+        signOut();
+        signInShouldFailUiAndApi("apikey", "abc123", "The API key you provided is invalid.");
+
+        // Hold an admin API connection open, allowing us to reset the config without the browser session interfering
         Connection adminConnection = WebTestHelper.getRemoteApiConnection();
         DbLoginProperties savedProperties = DbLoginUtils.getDbLoginConfig(adminConnection);
 
@@ -268,25 +273,28 @@ public class PasswordTest extends BaseWebDriverTest
             );
 
             // Set a weak password
-            signOut();
             String resetUrl = userInitiatePasswordReset(USER);
             beginAt(resetUrl);
             new SetPasswordForm(getDriver())
                 .setNewPassword(WEAK_PASSWORD)
                 .clickSubmit();
 
-            // Test bogus password first
+            // Test bogus password
             signOut();
-            signInShouldFail("bogus", "The email address and password you entered did not match any accounts on file.");
-            signIn(USER, WEAK_PASSWORD);
-            signOut();
+            signInShouldFailUiAndApi(USER, "bogus", "The email address and password you entered did not match any accounts on file.");
+
+            // Test deactivated user
+            APIUserHelper helper = new APIUserHelper(() -> adminConnection);
+            helper.deactivateUsers(_userId);
+            signInShouldFailUiAndApi(USER, WEAK_PASSWORD, "Your account has been deactivated.");
+            helper.activateUsers(_userId);
 
             // Change the configuration and test password that no longer meets complexity requirements
             DbLoginUtils.setDbLoginConfig(adminConnection,
                 PasswordStrength.Strong,
                 PasswordExpiration.Never
             );
-            signInShouldFail(WEAK_PASSWORD, "Your password does not meet the complexity requirements; please choose a new password.");
+            signInShouldFailUiAndApi(USER, WEAK_PASSWORD, "Your password does not meet the complexity requirements; please choose a new password.");
             String strongPassword = VERY_STRONG_PASSWORD + "!";
             changeInvalidPassword(WEAK_PASSWORD, strongPassword);
 
@@ -297,7 +305,7 @@ public class PasswordTest extends BaseWebDriverTest
             );
             // Wait six seconds for expiration
             sleep(6000);
-            signInShouldFail(strongPassword, "Your password has expired; please choose a new password.");
+            signInShouldFailUiAndApi(USER, strongPassword, "Your password has expired; please choose a new password.");
             changeInvalidPassword(strongPassword, VERY_STRONG_PASSWORD + "@");
         }
         finally
@@ -307,10 +315,10 @@ public class PasswordTest extends BaseWebDriverTest
     }
 
     // Attempt to sign in via UI and API, expecting both to fail with the specified message
-    private void signInShouldFail(String password, String expectedMessage) throws IOException
+    private void signInShouldFailUiAndApi(String email, String password, String expectedMessage) throws IOException
     {
-        signInShouldFail(USER, password, expectedMessage);
-        Connection userConnection = new Connection(WebTestHelper.getBaseURL(), USER, password);
+        signInShouldFail(email, password, expectedMessage);
+        Connection userConnection = new Connection(WebTestHelper.getBaseURL(), email, password);
         EnsureLoginCommand ensureLoginCommand = new EnsureLoginCommand();
         try
         {

--- a/src/org/labkey/test/util/APIUserHelper.java
+++ b/src/org/labkey/test/util/APIUserHelper.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.util;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
@@ -239,15 +240,17 @@ public class APIUserHelper extends AbstractUserHelper
     protected void _deleteUsers(boolean failIfNotFound, String... userEmails)
     {
         Map<String, Integer> userIds = getUserIds(Arrays.asList(userEmails), true);
-        // TODO: instead of calling deleteUser() one-by-one, should build an array of userIds and call deleteUsers(int...)
+        List<Integer> validUserIds = new ArrayList<>();
         for (String userEmail : new HashSet<>(Arrays.asList(userEmails)))
         {
             Integer userId = userIds.get(userEmail);
             if (failIfNotFound)
                 assertNotNull(userEmail + " was not present", userId);
             if (userId != null)
-                deleteUser(userId);
+                validUserIds.add(userId);
         }
+        if (!validUserIds.isEmpty())
+            deleteUsers(ArrayUtils.toPrimitive(validUserIds.toArray(new Integer[0])));
     }
 
     private static final Pattern regEmailVerification = Pattern.compile("verification=([A-Za-z0-9]+)");

--- a/src/org/labkey/test/util/APIUserHelper.java
+++ b/src/org/labkey/test/util/APIUserHelper.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.test.util;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
@@ -31,6 +30,7 @@ import org.labkey.remoteapi.SimpleGetCommand;
 import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.security.CreateUserCommand;
 import org.labkey.remoteapi.security.CreateUserResponse;
+import org.labkey.remoteapi.security.DeleteUserCommand;
 import org.labkey.remoteapi.security.GetUsersCommand;
 import org.labkey.remoteapi.security.GetUsersResponse;
 import org.labkey.remoteapi.security.GetUsersResponse.UserInfo;
@@ -222,21 +222,32 @@ public class APIUserHelper extends AbstractUserHelper
         deleteUsers(false, userEmail);
     }
 
+    private void deleteUser(@NotNull Integer userId)
+    {
+        DeleteUserCommand command = new DeleteUserCommand(userId);
+        try
+        {
+            command.execute(connectionSupplier.get(), "/");
+        }
+        catch (IOException|CommandException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     protected void _deleteUsers(boolean failIfNotFound, String... userEmails)
     {
         Map<String, Integer> userIds = getUserIds(Arrays.asList(userEmails), true);
-        ArrayList<Integer> idsToDelete = new ArrayList<>();
+        // TODO: instead of calling deleteUser() one-by-one, should build an array of userIds and call deleteUsers(int...)
         for (String userEmail : new HashSet<>(Arrays.asList(userEmails)))
         {
             Integer userId = userIds.get(userEmail);
             if (failIfNotFound)
                 assertNotNull(userEmail + " was not present", userId);
             if (userId != null)
-                idsToDelete.add(userId);
+                deleteUser(userId);
         }
-        int[] idsArray = ArrayUtils.toPrimitive(idsToDelete.toArray(new Integer[0]));
-        deleteUsers(idsArray);
     }
 
     private static final Pattern regEmailVerification = Pattern.compile("verification=([A-Za-z0-9]+)");
@@ -298,7 +309,7 @@ public class APIUserHelper extends AbstractUserHelper
     private void updateUsersState(boolean activate, boolean delete, int... userIds)
     {
         SimplePostCommand updateUsers = new SimplePostCommand("user", "updateUsersStateApi");
-        updateUsers.setJsonObject(new JSONObject(Map.of("userId",userIds, "activate", activate, "delete", delete)));
+        updateUsers.setJsonObject(new JSONObject(Map.of("userId", userIds, "activate", activate, "delete", delete)));
         try
         {
             updateUsers.execute(connectionSupplier.get(), null);

--- a/src/org/labkey/test/util/APIUserHelper.java
+++ b/src/org/labkey/test/util/APIUserHelper.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.util;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
@@ -27,9 +28,9 @@ import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.PostCommand;
 import org.labkey.remoteapi.SimpleGetCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.security.CreateUserCommand;
 import org.labkey.remoteapi.security.CreateUserResponse;
-import org.labkey.remoteapi.security.DeleteUserCommand;
 import org.labkey.remoteapi.security.GetUsersCommand;
 import org.labkey.remoteapi.security.GetUsersResponse;
 import org.labkey.remoteapi.security.GetUsersResponse.UserInfo;
@@ -52,7 +53,6 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class APIUserHelper extends AbstractUserHelper
 {
@@ -222,31 +222,21 @@ public class APIUserHelper extends AbstractUserHelper
         deleteUsers(false, userEmail);
     }
 
-    private void deleteUser(@NotNull Integer userId)
-    {
-        DeleteUserCommand command = new DeleteUserCommand(userId);
-        try
-        {
-            command.execute(connectionSupplier.get(), "/");
-        }
-        catch (IOException|CommandException e)
-        {
-            throw new RuntimeException(e);
-        }
-    }
-
     @Override
     protected void _deleteUsers(boolean failIfNotFound, String... userEmails)
     {
         Map<String, Integer> userIds = getUserIds(Arrays.asList(userEmails), true);
+        ArrayList<Integer> idsToDelete = new ArrayList<>();
         for (String userEmail : new HashSet<>(Arrays.asList(userEmails)))
         {
             Integer userId = userIds.get(userEmail);
             if (failIfNotFound)
-                assertTrue(userEmail + " was not present", userId != null);
+                assertNotNull(userEmail + " was not present", userId);
             if (userId != null)
-                deleteUser(userId);
+                idsToDelete.add(userId);
         }
+        int[] idsArray = ArrayUtils.toPrimitive(idsToDelete.toArray(new Integer[0]));
+        deleteUsers(idsArray);
     }
 
     private static final Pattern regEmailVerification = Pattern.compile("verification=([A-Za-z0-9]+)");
@@ -283,6 +273,35 @@ public class APIUserHelper extends AbstractUserHelper
             String password = PasswordUtil.getPassword();
             new SetPasswordCommand(password, verification).execute(connectionSupplier.get(), null);
             return password;
+        }
+        catch (IOException | CommandException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void deleteUsers(int... userIds)
+    {
+        updateUsersState(false, true, userIds);
+    }
+
+    public void deactivateUsers(int... userIds)
+    {
+        updateUsersState(false, false, userIds);
+    }
+
+    public void activateUsers(int... userIds)
+    {
+        updateUsersState(true, false, userIds);
+    }
+
+    private void updateUsersState(boolean activate, boolean delete, int... userIds)
+    {
+        SimplePostCommand updateUsers = new SimplePostCommand("user", "updateUsersStateApi");
+        updateUsers.setJsonObject(new JSONObject(Map.of("userId",userIds, "activate", activate, "delete", delete)));
+        try
+        {
+            updateUsers.execute(connectionSupplier.get(), null);
         }
         catch (IOException | CommandException e)
         {


### PR DESCRIPTION
#### Rationale
It's useful to verify the messages returned for more authentication failure cases. In this case: inactive user and invalid API key

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6771
- https://github.com/LabKey/testAutomation/pull/2498