### PR TITLE
Don't check the new "CSP Report" link for a navtrail

### DIFF
--- a/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
@@ -77,6 +77,7 @@ public class AdminConsoleNavigationTest extends BaseWebDriverTest
                 "Memory Usage",                     // Slow to load
                 "View All Site Errors",             // No nav trail
                 "View All Site Errors Since Reset", // No nav trail
+                "View CSP Report Log File",         // No nav trail
                 "View Primary Site Log File"        // No nav trail
         ));
         List<WebElement> adminLinks = ShowAdminPage.beginAt(this).getAllAdminConsoleLinks();

--- a/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
@@ -55,7 +55,6 @@ public class AdminConsoleNavigationTest extends BaseWebDriverTest
         _apiPermissionsHelper.addMemberToRole(TROUBLESHOOTER, "Troubleshooter", PermissionsHelper.MemberType.user, "/");
 
         _userHelper.createUser(NON_ADMIN);
-        _apiPermissionsHelper.setUserPermissions(NON_ADMIN, "Reader");
     }
 
     @Override

--- a/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleNavigationTest.java
@@ -18,7 +18,6 @@ import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.Crawler;
 import org.labkey.test.util.PermissionsHelper;
 import org.labkey.test.util.TestLogger;
-import org.openqa.selenium.JavascriptException;
 import org.openqa.selenium.WebElement;
 
 import java.io.IOException;


### PR DESCRIPTION
#### Rationale
Fix `AdminConsoleNavigationTest.testAdminNavTrails()` -- new action doesn't have a navtrail, so ignore that check

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6769