### PR TITLE
Issue 53254: Multi-value lookups should reselect values in form

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -2738,6 +2738,12 @@ public abstract class WebDriverWrapper implements WrapsDriver
         return select.getFirstSelectedOption().getText();
     }
 
+    public List<String> getSelectedOptionTexts(Locator loc)
+    {
+        Select select = new Select(loc.findElement(getDriver()));
+        return select.getAllSelectedOptions().stream().map(WebElement::getText).collect(Collectors.toList());
+    }
+
     public String getSelectedOptionValue(Locator loc)
     {
         return getSelectedOptionValue(loc.findElement(getDriver()));


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53254](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53254) by comparing against a collection of values that may contain non-string values.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6776
- https://github.com/LabKey/limsModules/pull/1479
- https://github.com/LabKey/testAutomation/pull/2505

#### Changes
- Expose `getSelectedOptionTexts` on `WebDriverWrapper`.
