### PR TITLE
Click report details link in a more reliable fashion

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -2979,10 +2979,11 @@ public abstract class WebDriverWrapper implements WrapsDriver
         catch (WebDriverException ignore) { }
     }
 
-    public void mouseOver(Locator l)
+    public WebElement mouseOver(Locator l)
     {
         WebElement el = l.findElement(getDriver());
         mouseOver(el);
+        return el;
     }
 
     public void mouseOver(WebElement el)

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -56,6 +56,7 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.list.IntListDefinition;
 import org.labkey.test.params.list.ListDefinition;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.LabKeyExpectedConditions;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.Maps;
@@ -1215,8 +1216,8 @@ public class SimpleModuleTest extends BaseWebDriverTest
     private void doTestReportCreatedDate()
     {
         log("Verify module report \"created\" date");
-        click(Locator.byClass("dataset-search"));
-        clickAndWait(Locator.tag("span").withClass("fa-list-ul").notHidden()); // Report details link
+        WebElement detailsLink = Locator.tag("span").withClass("fa-list-ul").notHidden().findElement(getDriver());
+        doAndWaitForPageToLoad(() -> shortWait().until(LabKeyExpectedConditions.clickUntilStale(detailsLink)));
         waitForText("August 01 2015");
     }
 

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -1215,7 +1215,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
     private void doTestReportCreatedDate()
     {
         log("Verify module report \"created\" date");
-        click(Locator.tag("span").withClass("fa-list-ul").notHidden());
+        clickAndWait(mouseOver(Locator.tag("span").withClass("fa-list-ul").notHidden())); // Report details link
         waitForText("August 01 2015");
     }
 

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -1215,7 +1215,8 @@ public class SimpleModuleTest extends BaseWebDriverTest
     private void doTestReportCreatedDate()
     {
         log("Verify module report \"created\" date");
-        clickAndWait(mouseOver(Locator.tag("span").withClass("fa-list-ul").notHidden())); // Report details link
+        click(Locator.byClass("dataset-search"));
+        clickAndWait(Locator.tag("span").withClass("fa-list-ul").notHidden()); // Report details link
         waitForText("August 01 2015");
     }
 


### PR DESCRIPTION
#### Rationale
My previous fix to avoid triggering tooltips accidentally, left the data views webpart farther down the page. That seems to be causing a subsequent click to fail to open the report details page.

```
java.lang.AssertionError: Text 'August 01 2015' was not present
  at org.junit.Assert.fail(Assert.java:89)
  at org.labkey.test.WebDriverWrapper.assertTextPresent(WebDriverWrapper.java:1726)
  at org.labkey.test.WebDriverWrapper.assertTextPresent(WebDriverWrapper.java:1715)
  at org.labkey.test.WebDriverWrapper.waitForText(WebDriverWrapper.java:2649)
  at org.labkey.test.WebDriverWrapper.waitForText(WebDriverWrapper.java:2643)
  at org.labkey.test.tests.SimpleModuleTest.doTestReportCreatedDate(SimpleModuleTest.java:1219)
  at org.labkey.test.tests.SimpleModuleTest.doTestReports(SimpleModuleTest.java:1175)
  at org.labkey.test.tests.SimpleModuleTest.doVerifySteps(SimpleModuleTest.java:273)
  at org.labkey.test.tests.SimpleModuleTest.testSteps(SimpleModuleTest.java:258)
```

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2495

#### Changes
- Click report details link in a more reliable fashion
