### PR TITLE
expose grid headers to tests

### DIFF
--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -642,6 +642,16 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
         return elementCache().getColumnLabels();
     }
 
+    public List<String> getColumnNames()
+    {
+        return elementCache().getColumnNames();
+    }
+
+    public List<FieldKey> getColumnFieldKeys()
+    {
+        return elementCache().getColumnFieldKeys();
+    }
+
     /**
      * Get data from a row
      * @param rowIndex  the index of the desired row
@@ -859,6 +869,16 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
         protected List<String> getColumnLabels()
         {
             return findHeaders().stream().map(FieldReferenceManager.FieldReference::getLabel).collect(Collectors.toList());
+        }
+
+        protected List<String> getColumnNames()
+        {
+            return findHeaders().stream().map(FieldReferenceManager.FieldReference::getName).collect(Collectors.toList());
+        }
+
+        protected List<FieldKey> getColumnFieldKeys()
+        {
+            return findHeaders().stream().map(FieldReferenceManager.FieldReference::getFieldKey).collect(Collectors.toList());
         }
 
         protected GridRow getRow(int index)

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -773,7 +773,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
         return msg;
     }
 
-    List<FieldReference> getHeaders()
+    public List<FieldReference> getHeaders()
     {
         return Collections.unmodifiableList(elementCache().findHeaders());
     }

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -642,11 +642,19 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
         return elementCache().getColumnLabels();
     }
 
+    /**
+     *
+     * @return a List&#60;String&#62; containing the names of the fields for each column header
+     */
     public List<String> getColumnNames()
     {
         return elementCache().getColumnNames();
     }
 
+    /**
+     *
+     * @return a List&#60;FieldKey&#62; containing the fieldKeys for each column header
+     */
     public List<FieldKey> getColumnFieldKeys()
     {
         return elementCache().getColumnFieldKeys();


### PR DESCRIPTION
#### Rationale
This change exposes the recently-added `getHeaders()` method on `ResponsiveGrid` to tests, such that they can resolve fields for which the test might only have fieldKeys or names.  This will be helpful for tests using randomly-generated/tricky field names, as some tricky chars that are legal for field names but aren't in field labels can mean the field I created (either via UI or API) won't match any in the grid if what the grid shows in its headers is labels.

#### Related Pull Requests
example usages are in https://github.com/LabKey/limsModules/pull/1481

#### Changes
Make `ResponsiveGrid.getHeaders()` public
