### PR TITLE
Improve failure behavior in AssayTransformImportUpdateTest

### DIFF
--- a/src/org/labkey/test/tests/assay/AssayTransformImportUpdateTest.java
+++ b/src/org/labkey/test/tests/assay/AssayTransformImportUpdateTest.java
@@ -286,7 +286,7 @@ public class AssayTransformImportUpdateTest extends BaseWebDriverTest
         Instant before = Instant.now();
         importPage.clickSaveAndFinish();
 
-        waitAndClickAndWait(Locator.linkWithText("Assay upload RUNNING"));
+        waitAndClick(WAIT_FOR_JAVASCRIPT, Locator.linkWithText("Assay upload RUNNING"), WAIT_FOR_JAVASCRIPT);
         PipelineStatusDetailsPage pipelineStatusDetailsPage = new PipelineStatusDetailsPage(getDriver());
         pipelineStatusDetailsPage.clickCancel();
 


### PR DESCRIPTION
#### Rationale
Improve failure condition when AssayTransformImportUpdateTest fails to kill the job

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6752

#### Changes
- Shorten the wait for killing the job, enabling the test to fail when it doesn't cancel and capture a thread dump from the server
