### PR TITLE
Support for clearing more form input elements

### DIFF
--- a/src/org/labkey/test/components/html/FileInput.java
+++ b/src/org/labkey/test/components/html/FileInput.java
@@ -33,11 +33,6 @@ public class FileInput extends Input
         getWrapper().setFormElement(getComponentElement(), file);
     }
 
-    public void clear()
-    {
-        getComponentElement().clear();
-    }
-
     @Override
     protected void assertElementType(WebElement el)
     {

--- a/src/org/labkey/test/components/html/Input.java
+++ b/src/org/labkey/test/components/html/Input.java
@@ -91,6 +91,11 @@ public class Input extends WebDriverComponent<Component<?>.ElementCache> impleme
         getWrapper().setFormElement(getComponentElement(), value);
     }
 
+    public void clear()
+    {
+        getComponentElement().clear();
+    }
+
     public void setWithPaste(String value)
     {
         getWrapper().actionClear(getComponentElement());


### PR DESCRIPTION
#### Rationale
It's handy to clear values from more than just file `<input>` elements

#### Changes
- Move `clear()` method up the hierarchy