### PR TITLE
Issue 53313: Fields with non alpha/numeric chars not shown in Custom Props

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -247,10 +247,14 @@ public class SampleTypeTest extends BaseWebDriverTest
     public void testCustomProperties()
     {
         final String sampleTypeName = "SampleTypeCustomProps" + DOMAIN_TRICKY_CHARACTERS;
+        FieldInfo stringCol1 = new FieldInfo(TestDataGenerator.randomFieldName("StringColPlain", "\""), ColumnType.String);
+        FieldInfo stringCol2 = new FieldInfo(TestDataGenerator.randomFieldName("StringCol%"), ColumnType.String);
+        FieldInfo calcCol = new FieldInfo(TestDataGenerator.randomFieldName("CalcCol"), ColumnType.Calculation);
         final List<FieldDefinition> fields = List.of(
-                new FieldDefinition("StringColPlain", FieldDefinition.ColumnType.String),
-                new FieldDefinition("StringCol%", FieldDefinition.ColumnType.String),
-                new FieldDefinition("CalcCol", ColumnType.Calculation).setValueExpression("StringColPlain || 'Concat'"));
+                stringCol1.getFieldDefinition(),
+                stringCol2.getFieldDefinition(),
+                calcCol.getFieldDefinition().setValueExpression("\"" + stringCol1.getName() + "\" || 'Concat'")
+        );
 
         SampleTypeDefinition sampleTypeDefinition = new SampleTypeDefinition(sampleTypeName).setFields(fields);
 
@@ -262,13 +266,16 @@ public class SampleTypeTest extends BaseWebDriverTest
         sampleTypeHelper.goToSampleType(sampleTypeName);
 
         log("Add a single row to the sample type, with trailing spaces");
-        Map<String, String> fieldMap = Map.of("Name", "CustomPropsSample", "StringColPlain", "PlainValue", "StringCol%", "PercentValue");
+        Map<String, String> fieldMap = Map.of("Name", "CustomPropsSample", stringCol1.getName(), "PlainValue", stringCol2.getName(), "PercentValue");
         sampleTypeHelper.insertRow(fieldMap);
 
         log("Verify custom properties, both name and values, are shown in both the grid and detail pages");
-        assertTextPresent("String Col Plain", "String Col%", "Calc Col", "PlainValue", "PercentValue", "PlainValueConcat");
+        var dataRegion = DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
+        checker().verifyEquals("Row data does not contain expected custom properties", "PlainValue", dataRegion.getDataAsText(0, stringCol1.getLabel()));
+        checker().verifyEquals("Row data does not contain expected custom properties", "PercentValue", dataRegion.getDataAsText(0, stringCol2.getLabel()));
+        checker().verifyEquals("Row data does not contain expected custom properties", "PlainValueConcat", dataRegion.getDataAsText(0, calcCol.getLabel()));
         clickAndWait(Locator.linkWithText("CustomPropsSample"));
-        assertTextPresent("String Col Plain", "String Col%", "Calc Col", "PlainValue", "PercentValue", "PlainValueConcat");
+        assertTextPresent(stringCol1.getLabel(), stringCol2.getLabel(), calcCol.getLabel(), "PlainValue", "PercentValue", "PlainValueConcat");
     }
 
         // Issue 47280: LKSM: Trailing/Leading whitespace in Source name won't resolve when deriving samples

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -79,6 +79,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.params.FieldDefinition.DOMAIN_TRICKY_CHARACTERS;
 import static org.labkey.test.util.DataRegionTable.DataRegion;
 
 @Category({Daily.class})
@@ -241,7 +242,36 @@ public class SampleTypeTest extends BaseWebDriverTest
         sampleTypeHelper.verifyDataValues(data);
     }
 
-    // Issue 47280: LKSM: Trailing/Leading whitespace in Source name won't resolve when deriving samples
+    // Issue 53313: LKS doesn't show Sample Type fields with special characters in Custom Properties
+    @Test
+    public void testCustomProperties()
+    {
+        final String sampleTypeName = "SampleTypeCustomProps" + DOMAIN_TRICKY_CHARACTERS;
+        final List<FieldDefinition> fields = List.of(
+                new FieldDefinition("StringColPlain", FieldDefinition.ColumnType.String),
+                new FieldDefinition("StringCol%", FieldDefinition.ColumnType.String),
+                new FieldDefinition("CalcCol", ColumnType.Calculation).setValueExpression("StringColPlain || 'Concat'"));
+
+        SampleTypeDefinition sampleTypeDefinition = new SampleTypeDefinition(sampleTypeName).setFields(fields);
+
+        SampleTypeAPIHelper.createEmptySampleType(getProjectName(), sampleTypeDefinition);
+
+        log("Create a new sample type");
+        projectMenu().navigateToFolder(PROJECT_NAME, FOLDER_NAME);
+        SampleTypeHelper sampleTypeHelper = new SampleTypeHelper(this);
+        sampleTypeHelper.goToSampleType(sampleTypeName);
+
+        log("Add a single row to the sample type, with trailing spaces");
+        Map<String, String> fieldMap = Map.of("Name", "CustomPropsSample", "StringColPlain", "PlainValue", "StringCol%", "PercentValue");
+        sampleTypeHelper.insertRow(fieldMap);
+
+        log("Verify custom properties, both name and values, are shown in both the grid and detail pages");
+        assertTextPresent("String Col Plain", "String Col%", "Calc Col", "PlainValue", "PercentValue", "PlainValueConcat");
+        clickAndWait(Locator.linkWithText("CustomPropsSample"));
+        assertTextPresent("String Col Plain", "String Col%", "Calc Col", "PlainValue", "PercentValue", "PlainValueConcat");
+    }
+
+        // Issue 47280: LKSM: Trailing/Leading whitespace in Source name won't resolve when deriving samples
     @Test
     public void testImportSamplesWithTrailingSpace()
     {

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -52,6 +52,7 @@ import org.labkey.test.params.FieldInfo;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.ExcelHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
@@ -248,7 +249,7 @@ public class SampleTypeTest extends BaseWebDriverTest
     public void testCustomProperties()
     {
         final String sampleTypeName = "SampleTypeCustomProps" + DOMAIN_TRICKY_CHARACTERS;
-        FieldInfo stringCol1 = new FieldInfo(TestDataGenerator.randomFieldName("StringColPlain", "\""), ColumnType.String);
+        FieldInfo stringCol1 = new FieldInfo(TestDataGenerator.randomFieldName("StringColPlain"), ColumnType.String);
         FieldInfo stringCol2 = new FieldInfo(TestDataGenerator.randomFieldName("StringCol%"), ColumnType.String);
         // Used to make sure the details page shows properties with null values
         FieldInfo stringCol3 = new FieldInfo(TestDataGenerator.randomFieldName("StringColNull"), ColumnType.String);
@@ -257,7 +258,7 @@ public class SampleTypeTest extends BaseWebDriverTest
                 stringCol1.getFieldDefinition(),
                 stringCol2.getFieldDefinition(),
                 stringCol3.getFieldDefinition(),
-                calcCol.getFieldDefinition().setValueExpression("\"" + stringCol1.getName() + "\" || 'Concat'")
+                calcCol.getFieldDefinition().setValueExpression(EscapeUtil.getSqlQuotedValue(stringCol1.getName()) + " || 'Concat'")
         );
 
         SampleTypeDefinition sampleTypeDefinition = new SampleTypeDefinition(sampleTypeName).setFields(fields);

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -48,6 +48,7 @@ import org.labkey.test.pages.experiment.UpdateSampleTypePage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.params.FieldDefinition.LookupInfo;
+import org.labkey.test.params.FieldInfo;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
@@ -249,10 +250,13 @@ public class SampleTypeTest extends BaseWebDriverTest
         final String sampleTypeName = "SampleTypeCustomProps" + DOMAIN_TRICKY_CHARACTERS;
         FieldInfo stringCol1 = new FieldInfo(TestDataGenerator.randomFieldName("StringColPlain", "\""), ColumnType.String);
         FieldInfo stringCol2 = new FieldInfo(TestDataGenerator.randomFieldName("StringCol%"), ColumnType.String);
+        // Used to make sure the details page shows properties with null values
+        FieldInfo stringCol3 = new FieldInfo(TestDataGenerator.randomFieldName("StringColNull"), ColumnType.String);
         FieldInfo calcCol = new FieldInfo(TestDataGenerator.randomFieldName("CalcCol"), ColumnType.Calculation);
         final List<FieldDefinition> fields = List.of(
                 stringCol1.getFieldDefinition(),
                 stringCol2.getFieldDefinition(),
+                stringCol3.getFieldDefinition(),
                 calcCol.getFieldDefinition().setValueExpression("\"" + stringCol1.getName() + "\" || 'Concat'")
         );
 
@@ -273,9 +277,10 @@ public class SampleTypeTest extends BaseWebDriverTest
         var dataRegion = DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
         checker().verifyEquals("Row data does not contain expected custom properties", "PlainValue", dataRegion.getDataAsText(0, stringCol1.getLabel()));
         checker().verifyEquals("Row data does not contain expected custom properties", "PercentValue", dataRegion.getDataAsText(0, stringCol2.getLabel()));
+        checker().verifyEquals("Row data does not contain expected custom properties", " ", dataRegion.getDataAsText(0, stringCol3.getLabel()));
         checker().verifyEquals("Row data does not contain expected custom properties", "PlainValueConcat", dataRegion.getDataAsText(0, calcCol.getLabel()));
         clickAndWait(Locator.linkWithText("CustomPropsSample"));
-        assertTextPresent(stringCol1.getLabel(), stringCol2.getLabel(), calcCol.getLabel(), "PlainValue", "PercentValue", "PlainValueConcat");
+        assertTextPresent(stringCol1.getLabel(), stringCol2.getLabel(), stringCol3.getLabel(), calcCol.getLabel(), "PlainValue", "PercentValue", "PlainValueConcat");
     }
 
         // Issue 47280: LKSM: Trailing/Leading whitespace in Source name won't resolve when deriving samples


### PR DESCRIPTION
#### Rationale
We're intending to show all of the admin-defined sample fields on its LKS details page but aren't looking them up in the map correctly.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6802

#### Changes
- New test coverage to ensure we're displaying calculated and non-calculated values as expected