### PR TITLE
Issue 53306: Some LKS forms don't distinguish between fields properly

### DIFF
--- a/src/org/labkey/test/AssayAPITest.java
+++ b/src/org/labkey/test/AssayAPITest.java
@@ -27,6 +27,7 @@ import org.labkey.remoteapi.assay.ProtocolResponse;
 import org.labkey.remoteapi.assay.SaveProtocolCommand;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.APIAssayHelper;
@@ -111,7 +112,7 @@ public class AssayAPITest extends BaseWebDriverTest
         _uiAssayHelper.uploadXarFileAsAssayDesign(assayPath, pipelineCount, container);
 
         APIAssayHelper _apiAssayHelper = new APIAssayHelper(this);
-        _apiAssayHelper.importAssay(assayName, runPath, getProjectName(), Collections.singletonMap("ParticipantVisitResolver", "SampleInfo"));
+        _apiAssayHelper.importAssay(assayName, runPath, getProjectName(), Collections.singletonMap(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME, "SampleInfo"));
 
         log("verify import worked");
         goToProjectHome();

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -2709,15 +2709,6 @@ public abstract class WebDriverWrapper implements WrapsDriver
     }
 
     /**
-     * @deprecated Use {@link org.junit.Assert#assertEquals(String, Object, Object) and {@link #getFormElement(Locator)}}
-     */
-    @Deprecated
-    public void assertFormElementEquals(Locator loc, String value)
-    {
-        assertEquals(value, getFormElement(loc));
-    }
-
-    /**
      * @deprecated Use {@link org.junit.Assert#assertEquals(String, Object, Object)} and
      * {@link #getSelectedOptionText(Locator)}
      */

--- a/src/org/labkey/test/components/assay/AssayConstants.java
+++ b/src/org/labkey/test/components/assay/AssayConstants.java
@@ -4,9 +4,13 @@ import org.labkey.test.Locator;
 
 public class AssayConstants
 {
+    public static final String PARTICIPANT_VISIT_RESOLVER_FIELD_NAME = "ParticipantVisitResolver";
+    public static final String THAW_LIST_TYPE_FIELD_NAME = "ThawListType";
+    public static final String TARGET_STUDY_FIELD_NAME = "TargetStudy";
+
     public static final Locator ASSAY_NAME_FIELD_LOCATOR = Locator.name("Name");
     public static final Locator COMMENTS_FIELD_LOCATOR = Locator.name("Comments");
-    public static final Locator TARGET_STUDY_FIELD_LOCATOR = Locator.name("TargetStudy");
+    public static final Locator TARGET_STUDY_FIELD_LOCATOR = Locator.name(TARGET_STUDY_FIELD_NAME);
     public static final Locator TEXT_AREA_DATA_PROVIDER_LOCATOR = Locator.xpath("//input[@value='textAreaDataProvider']");
     public static final Locator TEXT_AREA_DATA_COLLECTOR_LOCATOR = Locator.textarea("TextAreaDataCollector.textArea");
 }

--- a/src/org/labkey/test/components/assay/AssayConstants.java
+++ b/src/org/labkey/test/components/assay/AssayConstants.java
@@ -6,6 +6,7 @@ public class AssayConstants
 {
     public static final Locator ASSAY_NAME_FIELD_LOCATOR = Locator.name("Name");
     public static final Locator COMMENTS_FIELD_LOCATOR = Locator.name("Comments");
+    public static final Locator TARGET_STUDY_FIELD_LOCATOR = Locator.name("TargetStudy");
     public static final Locator TEXT_AREA_DATA_PROVIDER_LOCATOR = Locator.xpath("//input[@value='textAreaDataProvider']");
     public static final Locator TEXT_AREA_DATA_COLLECTOR_LOCATOR = Locator.textarea("TextAreaDataCollector.textArea");
 }

--- a/src/org/labkey/test/components/assay/AssayConstants.java
+++ b/src/org/labkey/test/components/assay/AssayConstants.java
@@ -1,0 +1,11 @@
+package org.labkey.test.components.assay;
+
+import org.labkey.test.Locator;
+
+public class AssayConstants
+{
+    public static final Locator ASSAY_NAME_FIELD_LOCATOR = Locator.name("Name");
+    public static final Locator COMMENTS_FIELD_LOCATOR = Locator.name("Comments");
+    public static final Locator TEXT_AREA_DATA_PROVIDER_LOCATOR = Locator.xpath("//input[@value='textAreaDataProvider']");
+    public static final Locator TEXT_AREA_DATA_COLLECTOR_LOCATOR = Locator.textarea("TextAreaDataCollector.textArea");
+}

--- a/src/org/labkey/test/pages/issues/BaseUpdatePage.java
+++ b/src/org/labkey/test/pages/issues/BaseUpdatePage.java
@@ -110,8 +110,8 @@ public abstract class BaseUpdatePage<EC extends BaseUpdatePage.ElementCache> ext
     {
         protected ElementCache()
         {
-            assignedTo = getSelect("assignedTo");
-            priority = getSelect("priority");
+            assignedTo = getSelect("AssignedTo");
+            priority = getSelect("Priority");
             related = getInput("related");
             notifyList = getInput("notifyList");
         }

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -83,7 +83,7 @@ public class FieldDefinition extends PropertyDescriptor
      * Define a String field
      * @param name field name
      */
-    public FieldDefinition(String name)
+    public FieldDefinition(@NotNull String name)
     {
         this(name, ColumnType.String);
     }

--- a/src/org/labkey/test/tests/AssayExportImportTest.java
+++ b/src/org/labkey/test/tests/AssayExportImportTest.java
@@ -38,6 +38,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.components.ext4.Checkbox;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.admin.ExportFolderPage;
@@ -240,7 +241,7 @@ public class AssayExportImportTest extends BaseWebDriverTest
             clickAndWait(Locator.lkButton("Import Data"));
         }
 
-        waitForElement(Locator.tagWithName("select", "targetStudy"));
+        waitForElement(AssayConstants.TARGET_STUDY_FIELD_LOCATOR);
 
         if(null != batchProperties)
         {

--- a/src/org/labkey/test/tests/AssayExportImportTest.java
+++ b/src/org/labkey/test/tests/AssayExportImportTest.java
@@ -68,6 +68,10 @@ import static org.labkey.test.util.AbstractDataRegionExportOrSignHelper.XarLsidO
 @BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class AssayExportImportTest extends BaseWebDriverTest
 {
+    public static final String INSTRUMENT_SETTING_FIELD_NAME = "instrumentSetting";
+    public static final String RUN_FILE_FIELD_NAME = "runFileField";
+    public static final String OPERATOR_EMAIL_FIELD_NAME = "operatorEmail";
+    public static final String INSTRUMENT_FIELD_NAME = "instrument";
     private final String ASSAY_PROJECT_FOR_EXPORT_01 = "Assay_Project_For_Export_ByFilesWebPart";
     private final String ASSAY_PROJECT_FOR_IMPORT_01 = "Assay_Project_For_Import_ByFilesWebPart";
     private final String ASSAY_PROJECT_FOR_EXPORT_02 = "Assay_Project_For_Export_ByFile";
@@ -170,16 +174,16 @@ public class AssayExportImportTest extends BaseWebDriverTest
         protocol.getDomains().forEach(domain -> domains.put(domain.getName(), domain));
 
         Domain batchDomain = domains.get("Batch Fields");
-        batchDomain.getFields().add(new FieldDefinition("operatorEmail", ColumnType.String));
-        batchDomain.getFields().add(new FieldDefinition("instrument", ColumnType.String)
+        batchDomain.getFields().add(new FieldDefinition(OPERATOR_EMAIL_FIELD_NAME, ColumnType.String));
+        batchDomain.getFields().add(new FieldDefinition(INSTRUMENT_FIELD_NAME, ColumnType.String)
                 .setDescription("The diagnostic test instrument."));
 
         Domain runDomain = domains.get("Run Fields");
         List<PropertyDescriptor>  runFields = runDomain.getFields();
-        runFields.add(new FieldDefinition("instrumentSetting", ColumnType.Integer)
+        runFields.add(new FieldDefinition(INSTRUMENT_SETTING_FIELD_NAME, ColumnType.Integer)
                 .setDescription("The configuration setting on the instrument."));
         if (hasRunFileField)
-            runFields.add(new FieldDefinition("runFileField", ColumnType.File)
+            runFields.add(new FieldDefinition(RUN_FILE_FIELD_NAME, ColumnType.File)
                 .setDescription("File for the run."));
         domains.get("Run Fields").setFields(runFields);
 
@@ -267,7 +271,7 @@ public class AssayExportImportTest extends BaseWebDriverTest
                 if (fileIndex < runProperties.size())
                 {
                     clickAndWait(Locator.lkButton("Save and Import Another Run"));
-                    waitForElement(Locator.tagWithName("input", "instrumentSetting"));
+                    waitForElement(Locator.tagWithName("input", INSTRUMENT_SETTING_FIELD_NAME));
                 }
 
             }
@@ -276,7 +280,7 @@ public class AssayExportImportTest extends BaseWebDriverTest
                 if (isElementPresent(Locator.lkButton("Save and Import Another Run")))
                 {
                     clickAndWait(Locator.lkButton("Save and Import Another Run"));
-                    waitForElement(Locator.tagWithName("input", "instrumentSetting"));
+                    waitForElement(Locator.tagWithName("input", INSTRUMENT_SETTING_FIELD_NAME));
                 }
             }
 
@@ -383,14 +387,14 @@ public class AssayExportImportTest extends BaseWebDriverTest
                 RUN04_FILE);
 
         Map<String, String> batchProperties = new HashMap<>();
-        batchProperties.put("operatorEmail", OPERATOR_EMAIL_01);
-        batchProperties.put("instrument", INSTRUMENT_NAME_01);
+        batchProperties.put(OPERATOR_EMAIL_FIELD_NAME, OPERATOR_EMAIL_01);
+        batchProperties.put(INSTRUMENT_FIELD_NAME, INSTRUMENT_NAME_01);
 
         List<Map<String, String>> runProperties = new ArrayList<>();
-        runProperties.add(Maps.of("name", RUN01_NAME, "comments", COMMENT_BASIC_01 + RUN01_NAME, "instrumentSetting", INSTRUMENT_SETTING_01));
-        runProperties.add(Maps.of("name", RUN02_NAME, "comments", COMMENT_BASIC_01 + RUN02_NAME, "instrumentSetting", INSTRUMENT_SETTING_01));
-        runProperties.add(Maps.of("name", RUN03_NAME, "comments", COMMENT_BASIC_01 + RUN03_NAME, "instrumentSetting", INSTRUMENT_SETTING_01));
-        runProperties.add(Maps.of("name", RUN04_NAME, "comments", COMMENT_BASIC_01 + RUN04_NAME, "instrumentSetting", INSTRUMENT_SETTING_01));
+        runProperties.add(Maps.of("Name", RUN01_NAME, "Comments", COMMENT_BASIC_01 + RUN01_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_01));
+        runProperties.add(Maps.of("Name", RUN02_NAME, "Comments", COMMENT_BASIC_01 + RUN02_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_01));
+        runProperties.add(Maps.of("Name", RUN03_NAME, "Comments", COMMENT_BASIC_01 + RUN03_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_01));
+        runProperties.add(Maps.of("Name", RUN04_NAME, "Comments", COMMENT_BASIC_01 + RUN04_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_01));
 
         log("Populate the assay '" + SIMPLE_ASSAY_FOR_EXPORT + "' by using files in the Files WebPart.");
         populateAssay(ASSAY_PROJECT_FOR_EXPORT_01, SIMPLE_ASSAY_FOR_EXPORT, true, runFiles, batchProperties, runProperties, SAMPLE_TXT_FILE);
@@ -478,14 +482,14 @@ public class AssayExportImportTest extends BaseWebDriverTest
                 RUN04_FILE);
 
         Map<String, String> batchProperties = new HashMap<>();
-        batchProperties.put("operatorEmail", OPERATOR_EMAIL_02);
-        batchProperties.put("instrument", INSTRUMENT_NAME_02);
+        batchProperties.put(OPERATOR_EMAIL_FIELD_NAME, OPERATOR_EMAIL_02);
+        batchProperties.put(INSTRUMENT_FIELD_NAME, INSTRUMENT_NAME_02);
 
         List<Map<String, String>> runProperties = new ArrayList<>();
-        runProperties.add(Maps.of("name", RUN01_NAME, "comments", COMMENT_BASIC_02 + RUN01_NAME, "instrumentSetting", INSTRUMENT_SETTING_02));
-        runProperties.add(Maps.of("name", RUN02_NAME, "comments", COMMENT_BASIC_02 + RUN02_NAME, "instrumentSetting", INSTRUMENT_SETTING_02));
-        runProperties.add(Maps.of("name", RUN03_NAME, "comments", COMMENT_BASIC_02 + RUN03_NAME, "instrumentSetting", INSTRUMENT_SETTING_02));
-        runProperties.add(Maps.of("name", RUN04_NAME, "comments", COMMENT_BASIC_02 + RUN04_NAME, "instrumentSetting", INSTRUMENT_SETTING_02));
+        runProperties.add(Maps.of("name", RUN01_NAME, "comments", COMMENT_BASIC_02 + RUN01_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_02));
+        runProperties.add(Maps.of("name", RUN02_NAME, "comments", COMMENT_BASIC_02 + RUN02_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_02));
+        runProperties.add(Maps.of("name", RUN03_NAME, "comments", COMMENT_BASIC_02 + RUN03_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_02));
+        runProperties.add(Maps.of("name", RUN04_NAME, "comments", COMMENT_BASIC_02 + RUN04_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_02));
 
         log("Populate the assay '" + SIMPLE_ASSAY_FOR_EXPORT + "' by importing the file through the 'Run Properties'.");
         populateAssay(ASSAY_PROJECT_FOR_EXPORT_02, SIMPLE_ASSAY_FOR_EXPORT, false, runFiles, batchProperties, runProperties, null);
@@ -665,25 +669,25 @@ public class AssayExportImportTest extends BaseWebDriverTest
         ImportRunCommand run1 = new ImportRunCommand(assayId, RUN01_FILE);
         run1.setName(RUN01_NAME);
         run1.setComment(commentPrefix + RUN01_NAME);
-        run1.setProperties(Maps.of("instrumentSetting", instrumentSetting));
+        run1.setProperties(Maps.of(INSTRUMENT_SETTING_FIELD_NAME, instrumentSetting));
         run1.execute(cn, exportProject);
 
         ImportRunCommand run2 = new ImportRunCommand(assayId, RUN02_FILE);
         run2.setName(RUN02_NAME);
         run2.setComment(commentPrefix + RUN02_NAME);
-        run2.setProperties(Maps.of("instrumentSetting", instrumentSetting));
+        run2.setProperties(Maps.of(INSTRUMENT_SETTING_FIELD_NAME, instrumentSetting));
         run2.execute(cn, exportProject);
 
         ImportRunCommand run3 = new ImportRunCommand(assayId, RUN03_FILE);
         run3.setName(RUN03_NAME);
         run3.setComment(commentPrefix + RUN03_NAME);
-        run3.setProperties(Maps.of("instrumentSetting", instrumentSetting));
+        run3.setProperties(Maps.of(INSTRUMENT_SETTING_FIELD_NAME, instrumentSetting));
         run3.execute(cn, exportProject);
 
         ImportRunCommand run4 = new ImportRunCommand(assayId, RUN04_XLSX_FILE);
         run4.setName(RUN04_NAME);
         run4.setComment(commentPrefix + RUN04_NAME);
-        run4.setProperties(Maps.of("instrumentSetting", instrumentSetting));
+        run4.setProperties(Maps.of(INSTRUMENT_SETTING_FIELD_NAME, instrumentSetting));
         run4.execute(cn, exportProject);
 
         List<String> runColumns = Arrays.asList("adjustedM1", "M2");

--- a/src/org/labkey/test/tests/AssayExportImportTest.java
+++ b/src/org/labkey/test/tests/AssayExportImportTest.java
@@ -588,8 +588,8 @@ public class AssayExportImportTest extends BaseWebDriverTest
         ReactAssayDesignerPage assayDesignerPage = _assayHelper.createAssayDesign("General", assayName);
 
         log("Remove the batch fields we don't care about.");
-        assayDesignerPage.goToBatchFields().removeField("ParticipantVisitResolver")
-                .removeField("TargetStudy");
+        assayDesignerPage.goToBatchFields().removeField(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME)
+                .removeField(AssayConstants.TARGET_STUDY_FIELD_NAME);
 
         assayDesignerPage.goToResultsFields()
                 .removeAllFields(false)

--- a/src/org/labkey/test/tests/AssayExportImportTest.java
+++ b/src/org/labkey/test/tests/AssayExportImportTest.java
@@ -486,10 +486,10 @@ public class AssayExportImportTest extends BaseWebDriverTest
         batchProperties.put(INSTRUMENT_FIELD_NAME, INSTRUMENT_NAME_02);
 
         List<Map<String, String>> runProperties = new ArrayList<>();
-        runProperties.add(Maps.of("name", RUN01_NAME, "comments", COMMENT_BASIC_02 + RUN01_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_02));
-        runProperties.add(Maps.of("name", RUN02_NAME, "comments", COMMENT_BASIC_02 + RUN02_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_02));
-        runProperties.add(Maps.of("name", RUN03_NAME, "comments", COMMENT_BASIC_02 + RUN03_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_02));
-        runProperties.add(Maps.of("name", RUN04_NAME, "comments", COMMENT_BASIC_02 + RUN04_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_02));
+        runProperties.add(Maps.of("Name", RUN01_NAME, "Comments", COMMENT_BASIC_02 + RUN01_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_02));
+        runProperties.add(Maps.of("Name", RUN02_NAME, "Comments", COMMENT_BASIC_02 + RUN02_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_02));
+        runProperties.add(Maps.of("Name", RUN03_NAME, "Comments", COMMENT_BASIC_02 + RUN03_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_02));
+        runProperties.add(Maps.of("Name", RUN04_NAME, "Comments", COMMENT_BASIC_02 + RUN04_NAME, INSTRUMENT_SETTING_FIELD_NAME, INSTRUMENT_SETTING_02));
 
         log("Populate the assay '" + SIMPLE_ASSAY_FOR_EXPORT + "' by importing the file through the 'Run Properties'.");
         populateAssay(ASSAY_PROJECT_FOR_EXPORT_02, SIMPLE_ASSAY_FOR_EXPORT, false, runFiles, batchProperties, runProperties, null);

--- a/src/org/labkey/test/tests/ButtonCustomizationTest.java
+++ b/src/org/labkey/test/tests/ButtonCustomizationTest.java
@@ -188,7 +188,7 @@ public class ButtonCustomizationTest extends BaseWebDriverTest
                 Locator.lkButton(METADATA_LINK_BUTTON).waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT)
                         .getAttribute("class").contains("labkey-disabled-button"));
 
-        buttonRegion.checkCheckbox(buttonRegion.getRowIndex("Portland", "Name"));
+        buttonRegion.checkCheckbox(buttonRegion.getRowIndex("Name", "Portland"));
         // wait for the button to enable:
         waitForElement(Locator.lkButton(METADATA_LINK_BUTTON), 10000);
 

--- a/src/org/labkey/test/tests/DatasetExportTest.java
+++ b/src/org/labkey/test/tests/DatasetExportTest.java
@@ -20,6 +20,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.util.DataRegionTable;
 
 import java.util.Arrays;
@@ -110,7 +111,7 @@ public class DatasetExportTest extends AssayResultsExportTest
         DataRegionTable assayResults = new DataRegionTable(super.getDataRegionId(), this);
         assayResults.checkAllOnPage();
         clickButton("Link to Study");
-        selectOptionByText(Locator.name("targetStudy"), "/" + getProjectName() + "/" + getFolderName() + " (" + getFolderName() + " Study)");
+        selectOptionByText(AssayConstants.TARGET_STUDY_FIELD_LOCATOR, "/" + getProjectName() + "/" + getFolderName() + " (" + getFolderName() + " Study)");
         clickButton("Next");
         clickButton("Link to Study");
     }

--- a/src/org/labkey/test/tests/DomainFieldTypeChangeTest.java
+++ b/src/org/labkey/test/tests/DomainFieldTypeChangeTest.java
@@ -17,6 +17,7 @@ import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.query.UpdateQueryRowPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldInfo;
+import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.APIAssayHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PortalHelper;
@@ -178,7 +179,7 @@ public class DomainFieldTypeChangeTest extends BaseWebDriverTest
         checkCheckbox(Locator.name("batchTestBoolean"));
         clickButton("Next");
 
-        setFormElement(Locator.name("name"), runName);
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
         setFormElement(Locator.name("runTestInteger"), "12");
         setFormElement(Locator.name("runTestDecimal"), "1.12");
         setFormElement(Locator.name("runTestDate"), "01-03-2022");

--- a/src/org/labkey/test/tests/DomainFieldTypeChangeTest.java
+++ b/src/org/labkey/test/tests/DomainFieldTypeChangeTest.java
@@ -12,12 +12,12 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.DomainDesignerPage;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.query.UpdateQueryRowPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldInfo;
-import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.APIAssayHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PortalHelper;
@@ -179,7 +179,7 @@ public class DomainFieldTypeChangeTest extends BaseWebDriverTest
         checkCheckbox(Locator.name("batchTestBoolean"));
         clickButton("Next");
 
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, runName);
         setFormElement(Locator.name("runTestInteger"), "12");
         setFormElement(Locator.name("runTestDecimal"), "1.12");
         setFormElement(Locator.name("runTestDate"), "01-03-2022");

--- a/src/org/labkey/test/tests/FileAttachmentColumnTest.java
+++ b/src/org/labkey/test/tests/FileAttachmentColumnTest.java
@@ -29,6 +29,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.pages.admin.FolderManagementPage;
 import org.labkey.test.pages.assay.AssayRunsPage;
 import org.labkey.test.pages.files.FileContentPage;
@@ -37,7 +38,6 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.params.assay.GeneralAssayDesign;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
-import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.PortalHelper;
@@ -283,7 +283,7 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
         clickButton("Next");    // batch properties
 
         // run properties
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, runName);
         setFormElement(Locator.input(RUN_TXT_COL), "run text");
         setFormElement(Locator.input(RUN_FILE_COL), runFileFieldFile);
         checkRadioButton(Locator.inputById("Fileupload"));

--- a/src/org/labkey/test/tests/FileAttachmentColumnTest.java
+++ b/src/org/labkey/test/tests/FileAttachmentColumnTest.java
@@ -37,6 +37,7 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.params.assay.GeneralAssayDesign;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
+import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.PortalHelper;
@@ -282,7 +283,7 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
         clickButton("Next");    // batch properties
 
         // run properties
-        setFormElement(Locator.input("name"), runName);
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
         setFormElement(Locator.input(RUN_TXT_COL), "run text");
         setFormElement(Locator.input(RUN_FILE_COL), runFileFieldFile);
         checkRadioButton(Locator.inputById("Fileupload"));

--- a/src/org/labkey/test/tests/FilterTest.java
+++ b/src/org/labkey/test/tests/FilterTest.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.labkey.test.params.FieldDefinition.ColumnType;
 import static org.labkey.test.params.FieldDefinition.DOMAIN_TRICKY_CHARACTERS;
-import static org.labkey.test.params.FieldDefinition.LookupInfo;
 import static org.labkey.test.util.PermissionsHelper.MemberType;
 
 @Category({Daily.class, Data.class})
@@ -80,7 +79,7 @@ public class FilterTest extends BaseWebDriverTest
     protected final static String[] CONVERTED_MONTHS = { "2000-01-01", "2000-04-04", "2000-03-03", "2000-02-02" };
 
     protected final FieldDefinition _list2ColKey = new FieldDefinition("Car", ColumnType.String);
-    protected final FieldDefinition _list2Col1 = new FieldDefinition(LIST_KEY_NAME2, new LookupInfo(null, "lists", LIST_NAME_COLORS).setTableType(ColumnType.String)).setDescription("The color of the car");
+    protected final FieldDefinition _list2Col1 = new FieldDefinition(LIST_KEY_NAME2, new FieldDefinition.StringLookup(null, "lists", LIST_NAME_COLORS)).setDescription("The color of the car");
     protected final FieldDefinition _list2ColYear = new FieldDefinition("year", ColumnType.Integer).setLabel("year");
 
     @Override
@@ -284,15 +283,15 @@ public class FilterTest extends BaseWebDriverTest
 
         HashMap<String, String> projectIssue = new HashMap<>();
         projectIssue.put("title", "project issue1");
-        projectIssue.put("assignedTo", getDisplayName());
-        projectIssue.put("type", "typea");
-        projectIssue.put("priority", "1");
+        projectIssue.put("AssignedTo", getDisplayName());
+        projectIssue.put("Type", "typea");
+        projectIssue.put("Priority", "1");
         issuesHelper.addIssue(projectIssue);
         HashMap<String, String> projectIssue2 = new HashMap<>();
         projectIssue2.put("title", "project issue2");
-        projectIssue2.put("assignedTo", getDisplayName());
-        projectIssue2.put("type", "typeb");
-        projectIssue2.put("priority", "2");
+        projectIssue2.put("AssignedTo", getDisplayName());
+        projectIssue2.put("Type", "typeb");
+        projectIssue2.put("Priority", "2");
         issuesHelper.addIssue(projectIssue2);
 
         _containerHelper.createSubfolder(getProjectName(), "subfolder");
@@ -310,15 +309,15 @@ public class FilterTest extends BaseWebDriverTest
 
         HashMap<String, String> subfolderIssue = new HashMap<>();
         subfolderIssue.put("title", "subfolder issue1");
-        subfolderIssue.put("assignedTo", getDisplayName());
-        subfolderIssue.put("type", "typed");
-        subfolderIssue.put("priority", "3");
+        subfolderIssue.put("AssignedTo", getDisplayName());
+        subfolderIssue.put("Type", "typed");
+        subfolderIssue.put("Priority", "3");
         issuesHelper.addIssue(subfolderIssue);
         HashMap<String, String> subfolderIssue2 = new HashMap<>();
         subfolderIssue2.put("title", "subfolder issue2");
-        subfolderIssue2.put("assignedTo", getDisplayName());
-        subfolderIssue2.put("type", "typee");
-        subfolderIssue2.put("priority", "4");
+        subfolderIssue2.put("AssignedTo", getDisplayName());
+        subfolderIssue2.put("Type", "typee");
+        subfolderIssue2.put("Priority", "4");
         issuesHelper.addIssue(subfolderIssue2);
 
         goToProjectHome();
@@ -337,16 +336,16 @@ public class FilterTest extends BaseWebDriverTest
         assertElementPresent(Locator.linkWithText(subfolderIssue2.get("title")));
 
         verifyFacetOptions(region, "Type",
-                projectIssue.get("type"),
-                projectIssue2.get("type"),
-                subfolderIssue.get("type"),
-                subfolderIssue2.get("type"));
+                projectIssue.get("Type"),
+                projectIssue2.get("Type"),
+                subfolderIssue.get("Type"),
+                subfolderIssue2.get("Type"));
 
         verifyFacetOptions(region, "Priority",
-                projectIssue.get("priority"),
-                projectIssue2.get("priority"),
-                subfolderIssue.get("priority"),
-                subfolderIssue2.get("priority"));
+                projectIssue.get("Priority"),
+                projectIssue2.get("Priority"),
+                subfolderIssue.get("Priority"),
+                subfolderIssue2.get("Priority"));
 
         region.setFacetedFilter("Priority", projectIssue2.get("priority"), subfolderIssue.get("priority"));
         assertElementNotPresent(Locator.linkWithText(projectIssue.get("title")));
@@ -355,8 +354,8 @@ public class FilterTest extends BaseWebDriverTest
         assertElementNotPresent(Locator.linkWithText(subfolderIssue2.get("title")));
 
         verifyFacetOptions(region, "Type",
-                projectIssue2.get("type"),
-                subfolderIssue.get("type"));
+                projectIssue2.get("Type"),
+                subfolderIssue.get("Type"));
     }
 
     private void verifyFacetOptions(DataRegionTable dataRegion, String column, String... options)

--- a/src/org/labkey/test/tests/FilterTest.java
+++ b/src/org/labkey/test/tests/FilterTest.java
@@ -347,7 +347,7 @@ public class FilterTest extends BaseWebDriverTest
                 subfolderIssue.get("Priority"),
                 subfolderIssue2.get("Priority"));
 
-        region.setFacetedFilter("Priority", projectIssue2.get("priority"), subfolderIssue.get("priority"));
+        region.setFacetedFilter("Priority", projectIssue2.get("Priority"), subfolderIssue.get("Priority"));
         assertElementNotPresent(Locator.linkWithText(projectIssue.get("title")));
         assertElementPresent(Locator.linkWithText(projectIssue2.get("title")));
         assertElementPresent(Locator.linkWithText(subfolderIssue.get("title")));

--- a/src/org/labkey/test/tests/FlagColumnTest.java
+++ b/src/org/labkey/test/tests/FlagColumnTest.java
@@ -11,8 +11,8 @@ import org.labkey.test.Locator;
 import org.labkey.test.SortDirection;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.params.FieldDefinition;
-import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.RelativeUrl;
 
@@ -101,15 +101,15 @@ public class FlagColumnTest extends BaseWebDriverTest
         clickButton("Import Data");
 
         log("Import run1...");
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, "Run01");
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR,
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, "Run01");
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR,
             "SomeData\nrun1-data1\nrun1-data2");
         clickButton("Save and Import Another Run");
 
         log("Import run2...");
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, "Run02");
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, "Run02");
         setFormElement(Locator.name("AnotherRunFlag"), "run has flag");
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR,
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR,
                 "SomeData\nrun2-data1\nrun2-data2");
         clickButton("Save and Finish");
 

--- a/src/org/labkey/test/tests/FlagColumnTest.java
+++ b/src/org/labkey/test/tests/FlagColumnTest.java
@@ -12,6 +12,7 @@ import org.labkey.test.SortDirection;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.RelativeUrl;
 
@@ -100,15 +101,15 @@ public class FlagColumnTest extends BaseWebDriverTest
         clickButton("Import Data");
 
         log("Import run1...");
-        setFormElement(Locator.name("name"), "Run01");
-        setFormElement(Locator.id("TextAreaDataCollector.textArea"),
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, "Run01");
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR,
             "SomeData\nrun1-data1\nrun1-data2");
         clickButton("Save and Import Another Run");
 
         log("Import run2...");
-        setFormElement(Locator.name("name"), "Run02");
-        setFormElement(Locator.name("anotherRunFlag"), "run has flag");
-        setFormElement(Locator.id("TextAreaDataCollector.textArea"),
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, "Run02");
+        setFormElement(Locator.name("AnotherRunFlag"), "run has flag");
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR,
                 "SomeData\nrun2-data1\nrun2-data2");
         clickButton("Save and Finish");
 

--- a/src/org/labkey/test/tests/GpatAssayTest.java
+++ b/src/org/labkey/test/tests/GpatAssayTest.java
@@ -153,13 +153,13 @@ public class GpatAssayTest extends BaseWebDriverTest
         WebElement runPropertiesPanel = Locator.tagWithAttributeContaining("form", "data-region-form", "Runs")
                 .findElement(getDriver());
 
-        setFormElement(Locator.name("date").findElement(runPropertiesPanel),
+        setFormElement(Locator.name("Date").findElement(runPropertiesPanel),
                 "11/22/24");
 
-        setFormElement(Locator.name("time").findElement(runPropertiesPanel),
+        setFormElement(Locator.name("Time").findElement(runPropertiesPanel),
                 "10:38 am");
 
-        setFormElement(Locator.name("dateTime").findElement(runPropertiesPanel),
+        setFormElement(Locator.name("DateTime").findElement(runPropertiesPanel),
                 "11/22/24 10:38 am");
 
         clickButton("Save and Finish", defaultWaitForPage);

--- a/src/org/labkey/test/tests/InlineImagesAssayTest.java
+++ b/src/org/labkey/test/tests/InlineImagesAssayTest.java
@@ -28,9 +28,9 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.CustomizeView;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
-import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ExcelHelper;
@@ -129,8 +129,8 @@ public class InlineImagesAssayTest extends BaseWebDriverTest
         clickButton("Import Data");
         setFormElement(Locator.name("batchFileField"), XLS_FILE);
         clickButton("Next");
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, importData);
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, runName);
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, importData);
 
         clickButton("Save and Finish");
 

--- a/src/org/labkey/test/tests/InlineImagesAssayTest.java
+++ b/src/org/labkey/test/tests/InlineImagesAssayTest.java
@@ -127,7 +127,7 @@ public class InlineImagesAssayTest extends BaseWebDriverTest
         log("Populate the assay with data.");
         clickAndWait(Locator.linkWithText(assayName));
         clickButton("Import Data");
-        setFormElement(Locator.name("batchFileField"), XLS_FILE);
+        setFormElement(Locator.name("BatchFileField"), XLS_FILE);
         clickButton("Next");
         setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, runName);
         setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, importData);

--- a/src/org/labkey/test/tests/InlineImagesAssayTest.java
+++ b/src/org/labkey/test/tests/InlineImagesAssayTest.java
@@ -30,6 +30,7 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ExcelHelper;
@@ -128,8 +129,8 @@ public class InlineImagesAssayTest extends BaseWebDriverTest
         clickButton("Import Data");
         setFormElement(Locator.name("batchFileField"), XLS_FILE);
         clickButton("Next");
-        setFormElement(Locator.name("name"), runName);
-        setFormElement(Locator.name("TextAreaDataCollector.textArea"), importData);
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, importData);
 
         clickButton("Save and Finish");
 

--- a/src/org/labkey/test/tests/MultiplePKUploadAssayTest.java
+++ b/src/org/labkey/test/tests/MultiplePKUploadAssayTest.java
@@ -23,6 +23,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionTable;
 
 import java.io.File;
@@ -98,12 +99,12 @@ public class MultiplePKUploadAssayTest extends BaseWebDriverTest
 
         log("Specifying the specimenID");
         assertTitleContains("Data Import: Run Properties and Data File");
-        setFormElement(Locator.name("name"), "First run");
-        setFormElement(Locator.id("TextAreaDataCollector.textArea"), "SpecimenID\nS17\nS22");
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, "First run");
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, "SpecimenID\nS17\nS22");
         clickButton("Save and Finish");
         assertElementPresent(Locator.css(".labkey-error").withText("Can not resolve thaw list entry for specimenId: S22"));
 
-        setFormElement(Locator.id("TextAreaDataCollector.textArea"), "SpecimenID\nS17");
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, "SpecimenID\nS17");
         clickButton("Save and Finish");
         log("Verifying the visit ID");
 

--- a/src/org/labkey/test/tests/MultiplePKUploadAssayTest.java
+++ b/src/org/labkey/test/tests/MultiplePKUploadAssayTest.java
@@ -23,7 +23,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.tests.study.AssayTest;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.util.DataRegionTable;
 
 import java.io.File;
@@ -99,12 +99,12 @@ public class MultiplePKUploadAssayTest extends BaseWebDriverTest
 
         log("Specifying the specimenID");
         assertTitleContains("Data Import: Run Properties and Data File");
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, "First run");
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, "SpecimenID\nS17\nS22");
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, "First run");
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, "SpecimenID\nS17\nS22");
         clickButton("Save and Finish");
         assertElementPresent(Locator.css(".labkey-error").withText("Can not resolve thaw list entry for specimenId: S22"));
 
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, "SpecimenID\nS17");
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, "SpecimenID\nS17");
         clickButton("Save and Finish");
         log("Verifying the visit ID");
 

--- a/src/org/labkey/test/tests/ProgrammaticQCTest.java
+++ b/src/org/labkey/test/tests/ProgrammaticQCTest.java
@@ -26,6 +26,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.APIAssayHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.QCAssayScriptHelper;
@@ -165,14 +166,14 @@ public class ProgrammaticQCTest extends AbstractAssayTest
         clickButton("Import Data");
         clickButton("Next");
 
-        click(Locator.xpath("//input[@value='textAreaDataProvider']"));
-        setFormElement(Locator.id("TextAreaDataCollector.textArea"), TEST_RUN1_DATA1);
+        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA1);
         clickButton("Save and Finish");
 
         assertTextPresent("A duplicate PTID was discovered : b", "A duplicate PTID was discovered : e");
 
-        click(Locator.xpath("//input[@value='textAreaDataProvider']"));
-        setFormElement(Locator.id("TextAreaDataCollector.textArea"), TEST_RUN1_DATA2);
+        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA2);
         clickButton("Save and Finish");
 
         // verify the log entry
@@ -190,14 +191,14 @@ public class ProgrammaticQCTest extends AbstractAssayTest
         clickButton("Import Data");
         clickButton("Next");
 
-        click(Locator.xpath("//input[@value='textAreaDataProvider']"));
-        setFormElement(Locator.id("TextAreaDataCollector.textArea"), TEST_RUN1_DATA1);
+        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA1);
         clickButton("Save and Finish");
 
         assertTextPresent("A duplicate PTID was discovered : b", "A duplicate PTID was discovered : e");
 
-        click(Locator.xpath("//input[@value='textAreaDataProvider']"));
-        setFormElement(Locator.id("TextAreaDataCollector.textArea"), TEST_RUN1_DATA2);
+        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA2);
         clickButton("Save and Finish");
 
         clickAndWait(Locator.linkWithText("view results"));
@@ -259,14 +260,14 @@ public class ProgrammaticQCTest extends AbstractAssayTest
         clickButton("Import Data");
         clickButton("Next");
 
-        click(Locator.xpath("//input[@value='textAreaDataProvider']"));
-        setFormElement(Locator.id("TextAreaDataCollector.textArea"), TEST_RUN1_DATA2);
+        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA2);
         clickButton("Save and Finish");
 
         assertTextPresent("The animal column must contain a goat");
 
-        click(Locator.xpath("//input[@value='textAreaDataProvider']"));
-        setFormElement(Locator.id("TextAreaDataCollector.textArea"), TEST_RUN1_DATA3);
+        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA3);
         clickButton("Save and Finish");
 
         clickAndWait(Locator.linkWithText("view results"));

--- a/src/org/labkey/test/tests/ProgrammaticQCTest.java
+++ b/src/org/labkey/test/tests/ProgrammaticQCTest.java
@@ -24,9 +24,9 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
-import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.APIAssayHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.QCAssayScriptHelper;
@@ -166,14 +166,14 @@ public class ProgrammaticQCTest extends AbstractAssayTest
         clickButton("Import Data");
         clickButton("Next");
 
-        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA1);
+        click(AssayConstants.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA1);
         clickButton("Save and Finish");
 
         assertTextPresent("A duplicate PTID was discovered : b", "A duplicate PTID was discovered : e");
 
-        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA2);
+        click(AssayConstants.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA2);
         clickButton("Save and Finish");
 
         // verify the log entry
@@ -191,14 +191,14 @@ public class ProgrammaticQCTest extends AbstractAssayTest
         clickButton("Import Data");
         clickButton("Next");
 
-        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA1);
+        click(AssayConstants.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA1);
         clickButton("Save and Finish");
 
         assertTextPresent("A duplicate PTID was discovered : b", "A duplicate PTID was discovered : e");
 
-        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA2);
+        click(AssayConstants.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA2);
         clickButton("Save and Finish");
 
         clickAndWait(Locator.linkWithText("view results"));
@@ -260,14 +260,14 @@ public class ProgrammaticQCTest extends AbstractAssayTest
         clickButton("Import Data");
         clickButton("Next");
 
-        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA2);
+        click(AssayConstants.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA2);
         clickButton("Save and Finish");
 
         assertTextPresent("The animal column must contain a goat");
 
-        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA3);
+        click(AssayConstants.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN1_DATA3);
         clickButton("Save and Finish");
 
         clickAndWait(Locator.linkWithText("view results"));

--- a/src/org/labkey/test/tests/RlabkeyTest.java
+++ b/src/org/labkey/test/tests/RlabkeyTest.java
@@ -123,15 +123,15 @@ public class RlabkeyTest extends BaseWebDriverTest
 
         clickProject(PROJECT_NAME);
         createNewIssueList(issuesHelper, ISSUE_LIST_NAME);
-        issuesHelper.addIssue(Maps.of("assignedTo", _userHelper.getDisplayNameForEmail(USER), "title", ISSUE_TITLE_0));
+        issuesHelper.addIssue(Maps.of("AssignedTo", _userHelper.getDisplayNameForEmail(USER), "title", ISSUE_TITLE_0));
 
         clickFolder(FOLDER_NAME);
         createNewIssueList(issuesHelper, ISSUE_LIST_NAME);
-        issuesHelper.addIssue(Maps.of("assignedTo", _userHelper.getDisplayNameForEmail(USER), "title", ISSUE_TITLE_1));
+        issuesHelper.addIssue(Maps.of("AssignedTo", _userHelper.getDisplayNameForEmail(USER), "title", ISSUE_TITLE_1));
 
         clickProject(PROJECT_NAME_2);
         createNewIssueList(issuesHelper, ISSUE_LIST_NAME);
-        issuesHelper.addIssue(Maps.of("assignedTo", _userHelper.getDisplayNameForEmail(USER), "title", ISSUE_TITLE_2));
+        issuesHelper.addIssue(Maps.of("AssignedTo", _userHelper.getDisplayNameForEmail(USER), "title", ISSUE_TITLE_2));
     }
 
     /**

--- a/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
@@ -320,9 +320,9 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         clickButtonContainingText("Next");
 
         // TODO: Should validate that the Derive Samples action shows the various fields as expected. That is the required and missing value fields should have the correct input type. Will be fixed in 19.2.
-        setFormElement(Locator.tagWithName("input", "outputSample1_Name"), sampleNames[8]);
-        setFormElement(Locator.tagWithName("input", "outputSample1_" + REQUIRED_FIELD_NAME), "Required text for this field.");
-        setFormElement(Locator.tagWithName("input", "outputSample1_" + MISSING_FIELD_NAME), "Q");
+        setFormElement(Locator.tagWithName("input", "Output Sample 1_Name"), sampleNames[8]);
+        setFormElement(Locator.tagWithName("input", "Output Sample 1_" + REQUIRED_FIELD_NAME), "Required text for this field.");
+        setFormElement(Locator.tagWithName("input", "Output Sample 1_" + MISSING_FIELD_NAME), "Q");
         clickButtonContainingText("Submit");
 
         // TODO: There is a bug where derived values do not honor missing value fields (treat them as a text field). So the indicator field for this sample will be empty. Will be fixed in 19.2.

--- a/src/org/labkey/test/tests/SampleTypeLimitsTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLimitsTest.java
@@ -199,17 +199,17 @@ public class SampleTypeLimitsTest extends BaseWebDriverTest
 
         log("Attempt Derive Samples with invalid lookup value");
         initDeriveSamplesForm(sampleTypeName, "Derivative1");
-        verifyInvalidLookupSample("outputSample1_lookUpField", "Sample3", "Could not convert value 'Sample3' (String) for Integer field 'lookUpField'.");
+        verifyInvalidLookupSample("Output Sample 1_lookUpField", "Sample3", "Could not convert value 'Sample3' (String) for Integer field 'lookUpField'.");
 
         log("Insert Derive Samples with valid lookup display value");
-        verifyValidLookupSample("outputSample1_lookUpField", "Sample2", "Sample2", "Material", true);
+        verifyValidLookupSample("Output Sample 1_lookUpField", "Sample2", "Sample2", "Material", true);
 
         log("Insert Derive Samples with valid lookup to sample RowId");
         initDeriveSamplesForm(sampleTypeName, "Derivative2");
         SelectRowsCommand command = new SelectRowsCommand("samples", SAMPLE_TYPE_NAME);
         command.setFilters(Arrays.asList(new Filter("Name", "Sample1")));
         SelectRowsResponse response = command.execute(createDefaultConnection(), getProjectName());
-        verifyValidLookupSample("outputSample1_lookUpField", response.getRows().get(0).get("RowId").toString(), "Sample1", "Material", true);
+        verifyValidLookupSample("Output Sample 1_lookUpField", response.getRows().get(0).get("RowId").toString(), "Sample1", "Material", true);
     }
 
     private void initDeriveSamplesForm(String sampleTypeName, String sampleName)
@@ -220,7 +220,7 @@ public class SampleTypeLimitsTest extends BaseWebDriverTest
         samplesTable.clickHeaderButtonAndWait("Derive Samples");
         selectOptionByText(Locator.name("targetSampleTypeId"), sampleTypeName + " in /" + getProjectName());
         clickButton("Next");
-        setFormElement(Locator.name("outputSample1_Name"), sampleName);
+        setFormElement(Locator.name("Output Sample 1_Name"), sampleName);
     }
 
     @Test

--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.labkey.test.params.FieldDefinition.DOMAIN_TRICKY_CHARACTERS;
 import static org.labkey.test.util.exp.SampleTypeAPIHelper.SAMPLE_TYPE_DOMAIN_KIND;
 
 @Category({Daily.class})
@@ -1116,31 +1117,37 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
     @Test
     public void testDeleteSamplesSomeWithDerivedSamples()
     {
-        final String SAMPLE_TYPE_NAME = "DeleteSamplesWithParents";
+        final String SAMPLE_TYPE_NAME = "DeleteSamplesWithParents" + DOMAIN_TRICKY_CHARACTERS;
         List<String> parentSampleNames = Arrays.asList("P-1", "P-2", "P-3");
         List<Map<String, String>> sampleData = new ArrayList<>();
-        parentSampleNames.forEach(name -> {
-            sampleData.add(Map.of("Name", name));
-        });
+        parentSampleNames.forEach(name -> sampleData.add(Map.of("Name", name)));
 
         clickProject(PROJECT_NAME);
         SampleTypeHelper sampleHelper = new SampleTypeHelper(this);
         log("Create a sample type with some potential parents");
-        sampleHelper.createSampleType(new SampleTypeDefinition(SAMPLE_TYPE_NAME), sampleData);
+        sampleHelper.createSampleType(new SampleTypeDefinition(SAMPLE_TYPE_NAME).
+                addField(new FieldDefinition("Blood+")).
+                addField(new FieldDefinition("Blood-")),
+            sampleData);
         DataRegionTable drtSamples = sampleHelper.getSamplesDataRegionTable();
         log("Derive one sample from another");
         drtSamples.checkCheckbox(drtSamples.getIndexWhereDataAppears(parentSampleNames.get(0), "Name"));
         clickButton("Derive Samples");
         waitAndClickAndWait(Locator.lkButton("Next"));
         String childName = parentSampleNames.get(0) + ".1";
-        setFormElement(Locator.name("outputSample1_Name"), childName);
+        String nameFieldInputFieldName = "Output Sample 1_Name";
+        String bloodPlusFieldInputFieldName = "Output Sample 1_Blood+";
+        String bloodMinusFieldInputFieldName = "Output Sample 1_Blood-";
+        setFormElement(Locator.name(nameFieldInputFieldName), childName);
+        setFormElement(Locator.name(bloodPlusFieldInputFieldName), "blood plus");
+        setFormElement(Locator.name(bloodMinusFieldInputFieldName), "blood minus");
         clickButton("Submit");
 
         log("Derive a sample from the one just created");
         clickAndWait(Locator.linkContainingText("derive samples from this sample"));
         clickButton("Next");
         String grandchildName = childName + ".1";
-        setFormElement(Locator.name("outputSample1_Name"), grandchildName);
+        setFormElement(Locator.name(nameFieldInputFieldName), grandchildName);
         clickButton("Submit");
 
         log("Derive a sample with two parents");
@@ -1150,10 +1157,15 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         clickButton("Derive Samples");
         waitAndClickAndWait(Locator.lkButton("Next"));
         String twoParentChildName = parentSampleNames.get(1) + "+" + childName + ".1";
-        setFormElement(Locator.name("outputSample1_Name"), twoParentChildName);
+        setFormElement(Locator.name(nameFieldInputFieldName), twoParentChildName);
         clickButton("Submit");
 
         clickAndWait(Locator.linkContainingText(SAMPLE_TYPE_NAME));
+
+        // Issue 53306 - ensure that names differing only by special characters were captured correctly and are being
+        // shown in the grid
+        assertTextPresent("blood plus", "blood minus");
+
 
         log("Try to delete parent sample");
         drtSamples.checkCheckbox(drtSamples.getIndexWhereDataAppears(parentSampleNames.get(0), "Name"));

--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -274,17 +274,17 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
 
         setFormElement(Locator.name("Output Sample 1_Name"), "SampleSetBVT15");
         setFormElement(Locator.name("Output Sample 2_Name"), "SampleSetBVT16");
-        checkCheckbox(Locator.name("Output Sample 1_IntColFolderCheckBox"));
-        setFormElement(Locator.name("Output Sample 1_IntColFolder"), "500a");
-        setFormElement(Locator.name("Output Sample 1_StringColFolder"), "firstOutput");
-        setFormElement(Locator.name("Output Sample 2_StringColFolder"), "secondOutput");
+        checkCheckbox(Locator.name("Output Sample 1_IntCol-FolderCheckBox"));
+        setFormElement(Locator.name("Output Sample 1_IntCol-Folder"), "500a");
+        setFormElement(Locator.name("Output Sample 1_StringCol-Folder"), "firstOutput");
+        setFormElement(Locator.name("Output Sample 2_StringCol-Folder"), "secondOutput");
         clickButton("Submit");
 
         log("Do a simple check that data validation works.");
         checker().verifyTrue("Expected error message '(String) for Integer field' is not present.",
                 isTextPresent("(String) for Integer field"));
-        checkCheckbox(Locator.name("Output Sample 1_IntColFolderCheckBox"));
-        setFormElement(Locator.name("Output Sample 1_IntColFolder"), "500");
+        checkCheckbox(Locator.name("Output Sample 1_IntCol-FolderCheckBox"));
+        setFormElement(Locator.name("Output Sample 1_IntCol-Folder"), "500");
         clickButton("Submit");
 
         clickAndWait(Locator.linkContainingText("Derive 2 samples"));

--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -272,19 +272,19 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         selectOptionByText(Locator.name("targetSampleTypeId"), subFolderSampleType + " in /" + getProjectName() + "/" + SUB_FOLDER_NAME);
         clickButton("Next");
 
-        setFormElement(Locator.name("outputSample1_Name"), "SampleSetBVT15");
-        setFormElement(Locator.name("outputSample2_Name"), "SampleSetBVT16");
-        checkCheckbox(Locator.name("outputSample1_IntColFolderCheckBox"));
-        setFormElement(Locator.name("outputSample1_IntColFolder"), "500a");
-        setFormElement(Locator.name("outputSample1_StringColFolder"), "firstOutput");
-        setFormElement(Locator.name("outputSample2_StringColFolder"), "secondOutput");
+        setFormElement(Locator.name("Output Sample 1_Name"), "SampleSetBVT15");
+        setFormElement(Locator.name("Output Sample 2_Name"), "SampleSetBVT16");
+        checkCheckbox(Locator.name("Output Sample 1_IntColFolderCheckBox"));
+        setFormElement(Locator.name("Output Sample 1_IntColFolder"), "500a");
+        setFormElement(Locator.name("Output Sample 1_StringColFolder"), "firstOutput");
+        setFormElement(Locator.name("Output Sample 2_StringColFolder"), "secondOutput");
         clickButton("Submit");
 
         log("Do a simple check that data validation works.");
         checker().verifyTrue("Expected error message '(String) for Integer field' is not present.",
                 isTextPresent("(String) for Integer field"));
-        checkCheckbox(Locator.name("outputSample1_IntColFolderCheckBox"));
-        setFormElement(Locator.name("outputSample1_IntColFolder"), "500");
+        checkCheckbox(Locator.name("Output Sample 1_IntColFolderCheckBox"));
+        setFormElement(Locator.name("Output Sample 1_IntColFolder"), "500");
         clickButton("Submit");
 
         clickAndWait(Locator.linkContainingText("Derive 2 samples"));
@@ -301,17 +301,17 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         clickButton("Next");
 
         String derivedSampleName = "Only_In_Sub_Folder";
-        setFormElement(Locator.name("outputSample1_Name"), derivedSampleName);
-        setFormElement(Locator.name("outputSample1_IntCol"), "600");
-        setFormElement(Locator.name("outputSample1_StringCol"), "String");
-        setFormElement(Locator.name("outputSample1_DateCol"), "BadDate");
-        uncheckCheckbox(Locator.name("outputSample1_BoolCol"));
+        setFormElement(Locator.name("Output Sample 1_Name"), derivedSampleName);
+        setFormElement(Locator.name("Output Sample 1_IntCol"), "600");
+        setFormElement(Locator.name("Output Sample 1_StringCol"), "String");
+        setFormElement(Locator.name("Output Sample 1_DateCol"), "BadDate");
+        uncheckCheckbox(Locator.name("Output Sample 1_BoolCol"));
         clickButton("Submit");
 
         log("Again check that data validation works as expected.");
         checker().verifyTrue("Expected error message 'is not a valid Date' is not present.",
                 isTextPresent("'BadDate' is not a valid Date for DateCol "));
-        setFormElement(Locator.name("outputSample1_DateCol"), "1/1/2007");
+        setFormElement(Locator.name("Output Sample 1_DateCol"), "1/1/2007");
         clickButton("Submit");
 
         log("Check that the correct sample id is shown as the parent.");

--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -275,7 +275,7 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
 
         setFormElement(Locator.name("Output Sample 1_Name"), "SampleSetBVT15");
         setFormElement(Locator.name("Output Sample 2_Name"), "SampleSetBVT16");
-        checkCheckbox(Locator.name("Output Sample 1_IntCol-FolderCheckBox"));
+        checkCheckbox(Locator.name("outputSample1_IntColFolderCheckBox"));
         setFormElement(Locator.name("Output Sample 1_IntCol-Folder"), "500a");
         setFormElement(Locator.name("Output Sample 1_StringCol-Folder"), "firstOutput");
         setFormElement(Locator.name("Output Sample 2_StringCol-Folder"), "secondOutput");
@@ -284,7 +284,7 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         log("Do a simple check that data validation works.");
         checker().verifyTrue("Expected error message '(String) for Integer field' is not present.",
                 isTextPresent("(String) for Integer field"));
-        checkCheckbox(Locator.name("Output Sample 1_IntCol-FolderCheckBox"));
+        checkCheckbox(Locator.name("outputSample1_IntColFolderCheckBox"));
         setFormElement(Locator.name("Output Sample 1_IntCol-Folder"), "500");
         clickButton("Submit");
 

--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -23,6 +23,7 @@ import org.labkey.test.pages.study.ManageStudyPage;
 import org.labkey.test.pages.study.ManageVisitPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
+import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.PortalHelper;
@@ -312,8 +313,8 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         samplesTable.clickHeaderButtonAndWait("Derive Samples");
         selectOptionByText(Locator.name("targetSampleTypeId"), "Plasma in /" + SAMPLE_TYPE_PROJECT);
         clickButton("Next");
-        setFormElement(Locator.name("outputSample1_Name"), derivedSampleName);
-        setFormElement(Locator.name("outputSample1_Volume"), "1");
+        setFormElement(Locator.name("Output Sample 1_Name"), derivedSampleName);
+        setFormElement(Locator.name("Output Sample 1_Volume"), "1");
         clickButton("Submit");
 
         goToProjectHome(SAMPLE_TYPE_PROJECT);
@@ -361,8 +362,8 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         DataRegionTable table = new DataRegionTable("Runs", getDriver());
         table.clickHeaderButton("Import Data");
         clickButton("Next");
-        setFormElement(Locator.name("name"), runName);
-        setFormElement(Locator.name("TextAreaDataCollector.textArea"), importData);
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, importData);
         clickButton("Save and Finish");
 
         clickAndWait(Locator.linkWithText(runName));
@@ -663,7 +664,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         samplesTable.clickHeaderButtonAndWait("Derive Samples");
         selectOptionByText(Locator.name("targetSampleTypeId"), childSampleType + " in /" + getProjectName());
         clickButton("Next");
-        setFormElement(Locator.name("outputSample1_Name"), "derivedChildSample");
+        setFormElement(Locator.name("Output Sample 1_Name"), "derivedChildSample");
         clickButton("Submit");
 
         log("Verifying the auto link to study by deriving single samples from parent sample");

--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -331,7 +331,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         samplesTable.clickHeaderButtonAndWait("Link to Study");
 
         log("Link to study: Choose target");
-        selectOptionByText(Locator.id("targetStudy"), "/" + DATE_BASED_STUDY + " (" + DATE_BASED_STUDY + " Study)");
+        selectOptionByText(AssayConstants.TARGET_STUDY_FIELD_LOCATOR, "/" + DATE_BASED_STUDY + " (" + DATE_BASED_STUDY + " Study)");
         clickButton("Next");
         new DataRegionTable("query", getDriver()).clickHeaderButtonAndWait("Link to Study");
 
@@ -377,7 +377,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
 
         table.checkCheckbox(0);
         table.clickHeaderButtonAndWait("Link to Study");
-        selectOptionByText(Locator.id("targetStudy"), "/" + DATE_BASED_STUDY + " (" + DATE_BASED_STUDY + " Study)");
+        selectOptionByText(AssayConstants.TARGET_STUDY_FIELD_LOCATOR, "/" + DATE_BASED_STUDY + " (" + DATE_BASED_STUDY + " Study)");
         clickButton("Next");
 
         checker().verifyEquals("Incorrect Participant ID deduced", "P4", Locator.name("participantId").findElement(getDriver()).getAttribute("value"));

--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -12,6 +12,7 @@ import org.labkey.test.SortDirection;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.CustomizeView;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.pages.ImportDataPage;
@@ -23,7 +24,6 @@ import org.labkey.test.pages.study.ManageStudyPage;
 import org.labkey.test.pages.study.ManageVisitPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
-import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.PortalHelper;
@@ -362,8 +362,8 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         DataRegionTable table = new DataRegionTable("Runs", getDriver());
         table.clickHeaderButton("Import Data");
         clickButton("Next");
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, importData);
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, runName);
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, importData);
         clickButton("Save and Finish");
 
         clickAndWait(Locator.linkWithText(runName));

--- a/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
+++ b/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
@@ -704,8 +704,8 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
         selectOptionByText(Locator.name("targetSampleTypeId"),  String.format("%s in /%s", targetSampleType, getProjectName()));
         clickButton("Next");
 
-        setFormElement(Locator.name("outputSample1_%s".formatted(COL_DINT.getName())), intVal);
-        setFormElement(Locator.name("outputSample1_%s".formatted(COL_DSTR.getName())), strVal);
+        setFormElement(Locator.name("Output Sample 1_%s".formatted(COL_DINT.getName())), intVal);
+        setFormElement(Locator.name("Output Sample 1_%s".formatted(COL_DSTR.getName())), strVal);
         clickButton("Submit");
 
         waitForElement(Locator.tagWithText("td", strVal));

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -36,6 +36,7 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.CustomizeView;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.components.domain.BaseDomainDesigner;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.ext4.Window;
@@ -50,7 +51,6 @@ import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.params.FieldDefinition.LookupInfo;
 import org.labkey.test.params.FieldInfo;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
-import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.EscapeUtil;
@@ -662,7 +662,7 @@ public class SampleTypeTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(DATA_ID_ASSAY));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, SAMPLE_ID_TEST_RUN_DATA);
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, SAMPLE_ID_TEST_RUN_DATA);
         clickButton("Save and Finish");
 
         log("Try to delete all samples");
@@ -696,7 +696,7 @@ public class SampleTypeTest extends BaseWebDriverTest
         clickButton("Import Data");
         clickButton("Next");
         setFormElement(Locator.name(SAMPLE_ID_FIELD_NAME), RUN_SAMPLE_NAME);
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN_DATA);
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN_DATA);
         clickButton("Save and Finish");
 
         log("Try to delete the sampleId referenced in the run field");

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -49,6 +49,7 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.params.FieldDefinition.LookupInfo;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
+import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ExcelHelper;
@@ -591,7 +592,7 @@ public class SampleTypeTest extends BaseWebDriverTest
 //        clickButton("Import Data");
 //        setFormElement(Locator.name(SAMPLE_ID_FIELD_NAME), BATCH_SAMPLE_NAME);
 //        clickButton("Next");
-//        setFormElement(Locator.id("TextAreaDataCollector.textArea"), TEST_RUN_DATA);
+//        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN_DATA);
 //        clickButton("Save and Finish");
 //
 //
@@ -618,7 +619,7 @@ public class SampleTypeTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(DATA_ID_ASSAY));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(Locator.id("TextAreaDataCollector.textArea"), SAMPLE_ID_TEST_RUN_DATA);
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, SAMPLE_ID_TEST_RUN_DATA);
         clickButton("Save and Finish");
 
         log("Try to delete all samples");
@@ -652,7 +653,7 @@ public class SampleTypeTest extends BaseWebDriverTest
         clickButton("Import Data");
         clickButton("Next");
         setFormElement(Locator.name(SAMPLE_ID_FIELD_NAME), RUN_SAMPLE_NAME);
-        setFormElement(Locator.id("TextAreaDataCollector.textArea"), TEST_RUN_DATA);
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_RUN_DATA);
         clickButton("Save and Finish");
 
         log("Try to delete the sampleId referenced in the run field");

--- a/src/org/labkey/test/tests/TextChoiceImportExportAndOtherDomainsTest.java
+++ b/src/org/labkey/test/tests/TextChoiceImportExportAndOtherDomainsTest.java
@@ -168,7 +168,7 @@ public class TextChoiceImportExportAndOtherDomainsTest extends TextChoiceTest
         log("Validate that a new issue can be inserted that uses the TextChoice field.");
         IssuesHelper issuesHelper = new IssuesHelper(getDriver());
 
-        Map<String, String> issueDetails = Map.of("title", ISSUE_TITLE, "assignedTo", getDisplayName(), ISSUE_TC_FIELD, ISSUE_VALUE);
+        Map<String, String> issueDetails = Map.of("title", ISSUE_TITLE, "AssignedTo", getDisplayName(), ISSUE_TC_FIELD, ISSUE_VALUE);
 
         issuesHelper.addIssue(issueDetails);
 

--- a/src/org/labkey/test/tests/TextChoiceImportExportAndOtherDomainsTest.java
+++ b/src/org/labkey/test/tests/TextChoiceImportExportAndOtherDomainsTest.java
@@ -168,9 +168,7 @@ public class TextChoiceImportExportAndOtherDomainsTest extends TextChoiceTest
         log("Validate that a new issue can be inserted that uses the TextChoice field.");
         IssuesHelper issuesHelper = new IssuesHelper(getDriver());
 
-        String tcFieldName = getSelectControlName(ISSUE_TC_FIELD);
-
-        Map<String, String> issueDetails = Map.of("title", ISSUE_TITLE, "assignedTo", getDisplayName(), tcFieldName, ISSUE_VALUE);
+        Map<String, String> issueDetails = Map.of("title", ISSUE_TITLE, "assignedTo", getDisplayName(), ISSUE_TC_FIELD, ISSUE_VALUE);
 
         issuesHelper.addIssue(issueDetails);
 

--- a/src/org/labkey/test/tests/TextChoiceTest.java
+++ b/src/org/labkey/test/tests/TextChoiceTest.java
@@ -10,6 +10,7 @@ import org.labkey.test.components.html.OptionSelect;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
+import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.TestDataGenerator;
 import org.labkey.test.util.exp.SampleTypeAPIHelper;
@@ -177,7 +178,7 @@ public abstract class TextChoiceTest extends BaseWebDriverTest
         DataRegionTable runTable = new DataRegionTable("Runs", getDriver());
         runTable.clickHeaderButtonAndWait("Import Data");
 
-        Locator batchLocator = Locator.name(getSelectControlName(BATCH_TC_FIELD));
+        Locator batchLocator = Locator.name(BATCH_TC_FIELD);
         assertSelectOptions(batchLocator, BATCH_FIELD_VALUES,
                 String.format("Options for the batch field '%s' are not as expected. Fatal error.", BATCH_TC_FIELD));
 
@@ -191,7 +192,7 @@ public abstract class TextChoiceTest extends BaseWebDriverTest
 
         setFormElement(Locator.tagWithName("input", "name"), ASSAY_RUN_ID);
 
-        Locator runLocator = Locator.name(getSelectControlName(RUN_TC_FIELD));
+        Locator runLocator = Locator.name(RUN_TC_FIELD);
         assertSelectOptions(runLocator, RUN_FIELD_VALUES,
                 String.format("Options for the '%s' field not as expected. Fatal error.", RUN_TC_FIELD));
 
@@ -221,7 +222,7 @@ public abstract class TextChoiceTest extends BaseWebDriverTest
 
         log("Paste in the results and save.");
 
-        setFormElement(Locator.id("TextAreaDataCollector.textArea"), resultsPasteText.toString());
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, resultsPasteText.toString());
 
         clickButton("Save and Finish");
 
@@ -276,17 +277,4 @@ public abstract class TextChoiceTest extends BaseWebDriverTest
         LabKeyAssert.assertEqualsSorted(failureMsg, expectedOptions, selectOptions);
 
     }
-
-    /**
-     * Simple helper to identify the name of the control on a page based on the field name. The name of the
-     * control is the field but the first letter is lower case. This lets the test not worry about that.
-     *
-     * @param tcFieldName The TextChoice field name.
-     * @return The field name with the first letter lower case.
-     */
-    protected String getSelectControlName(String tcFieldName)
-    {
-        return Character.toLowerCase(tcFieldName.charAt(0)) + tcFieldName.substring(1);
-    }
-
 }

--- a/src/org/labkey/test/tests/TextChoiceTest.java
+++ b/src/org/labkey/test/tests/TextChoiceTest.java
@@ -140,8 +140,8 @@ public abstract class TextChoiceTest extends BaseWebDriverTest
         fieldRow.setTextChoiceValues(BATCH_FIELD_VALUES);
 
         log("Remove the default batch fields.");
-        domainFormPanel.removeField("ParticipantVisitResolver");
-        domainFormPanel.removeField("TargetStudy");
+        domainFormPanel.removeField(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME);
+        domainFormPanel.removeField(AssayConstants.TARGET_STUDY_FIELD_NAME);
 
         log(String.format("Add a TextChoice field named '%s' to the run properties.", RUN_TC_FIELD));
         fieldRow = assayDesignerPage.goToRunFields().addField(RUN_TC_FIELD);

--- a/src/org/labkey/test/tests/TextChoiceTest.java
+++ b/src/org/labkey/test/tests/TextChoiceTest.java
@@ -4,13 +4,13 @@ import org.labkey.junit.LabKeyAssert;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.components.domain.DomainFieldRow;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.html.OptionSelect;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
-import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.TestDataGenerator;
 import org.labkey.test.util.exp.SampleTypeAPIHelper;
@@ -222,7 +222,7 @@ public abstract class TextChoiceTest extends BaseWebDriverTest
 
         log("Paste in the results and save.");
 
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, resultsPasteText.toString());
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, resultsPasteText.toString());
 
         clickButton("Save and Finish");
 

--- a/src/org/labkey/test/tests/TextChoiceTest.java
+++ b/src/org/labkey/test/tests/TextChoiceTest.java
@@ -190,7 +190,7 @@ public abstract class TextChoiceTest extends BaseWebDriverTest
 
         log(String.format("Set the Assay ID to '%s'.", ASSAY_RUN_ID));
 
-        setFormElement(Locator.tagWithName("input", "name"), ASSAY_RUN_ID);
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, ASSAY_RUN_ID);
 
         Locator runLocator = Locator.name(RUN_TC_FIELD);
         assertSelectOptions(runLocator, RUN_FIELD_VALUES,

--- a/src/org/labkey/test/tests/UserTest.java
+++ b/src/org/labkey/test/tests/UserTest.java
@@ -406,7 +406,7 @@ public class UserTest extends BaseWebDriverTest
 
     private Locator createAssignedToOptionLocator(String username)
     {
-        return Locator.xpath("//select[@name='assignedTo']/option[@value='" + username +  "']");
+        return Locator.xpath("//select[@name='AssignedTo']/option[@value='" + username +  "']");
     }
 
     /**

--- a/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
+++ b/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
@@ -13,6 +13,7 @@ import org.labkey.test.pages.admin.ExportFolderPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.assay.GeneralAssayDesign;
 import org.labkey.test.tests.MissingValueIndicatorsTest;
+import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 
@@ -60,25 +61,29 @@ public class AssayMissingValuesTest extends MissingValueIndicatorsTest
         final String ASSAY_EXCEL_RUN_SINGLE_COLUMN = "MVAssayExcelRunSingleColumn";
         final String ASSAY_EXCEL_RUN_TWO_COLUMN = "MVAssayExcelRunTwoColumn";
         final String TEST_DATA_SINGLE_COLUMN_ASSAY =
-                "SpecimenID\tParticipantID\tVisitID\tDate\tage\tsex\n" +
-                        "1\tTed\t1\t01-Jan-09\tN\tmale\n" +
-                        "2\tAlice\t1\t01-Jan-09\t17\tfemale\n" +
-                        "3\tBob\t1\t01-Jan-09\tQ\tN";
+                """
+                        SpecimenID\tParticipantID\tVisitID\tDate\tage\tsex
+                        1\tTed\t1\t01-Jan-09\tN\tmale
+                        2\tAlice\t1\t01-Jan-09\t17\tfemale
+                        3\tBob\t1\t01-Jan-09\tQ\tN""";
         final String TEST_DATA_TWO_COLUMN_ASSAY =
-                "SpecimenID\tParticipantID\tVisitID\tDate\tage\tageMVIndicator\tsex\tsexMVIndicator\n" +
-                        "1\tFranny\t1\t01-Jan-09\t\tN\tmale\t\n" +
-                        "2\tZoe\t1\t01-Jan-09\t25\tQ\tfemale\t\n" +
-                        "3\tJ.D.\t1\t01-Jan-09\t50\t\tmale\tQ";
+                """
+                        SpecimenID\tParticipantID\tVisitID\tDate\tage\tageMVIndicator\tsex\tsexMVIndicator
+                        1\tFranny\t1\t01-Jan-09\t\tN\tmale\t
+                        2\tZoe\t1\t01-Jan-09\t25\tQ\tfemale\t
+                        3\tJ.D.\t1\t01-Jan-09\t50\t\tmale\tQ""";
         final String TEST_DATA_SINGLE_COLUMN_ASSAY_BAD =
-                "SpecimenID\tParticipantID\tVisitID\tDate\tage\tsex\n" +
-                        "1\tTed\t1\t01-Jan-09\t.N\tmale\n" +
-                        "2\tAlice\t1\t01-Jan-09\t17\tfemale\n" +
-                        "3\tBob\t1\t01-Jan-09\tQ\tN";
+                """
+                        SpecimenID\tParticipantID\tVisitID\tDate\tage\tsex
+                        1\tTed\t1\t01-Jan-09\t.N\tmale
+                        2\tAlice\t1\t01-Jan-09\t17\tfemale
+                        3\tBob\t1\t01-Jan-09\tQ\tN""";
         final String TEST_DATA_TWO_COLUMN_ASSAY_BAD =
-                "SpecimenID\tParticipantID\tVisitID\tDate\tage\tageMVIndicator\tsex\tsexMVIndicator\n" +
-                        "1\tFranny\t1\t01-Jan-09\t\tN\tmale\t\n" +
-                        "2\tZoe\t1\t01-Jan-09\t25\tQ\tfemale\t\n" +
-                        "3\tJ.D.\t1\t01-Jan-09\t50\t\tmale\t.Q";
+                """
+                        SpecimenID\tParticipantID\tVisitID\tDate\tage\tageMVIndicator\tsex\tsexMVIndicator
+                        1\tFranny\t1\t01-Jan-09\t\tN\tmale\t
+                        2\tZoe\t1\t01-Jan-09\t25\tQ\tfemale\t
+                        3\tJ.D.\t1\t01-Jan-09\t50\t\tmale\t.Q""";
         final File ASSAY_SINGLE_COLUMN_EXCEL_FILE = TestFileUtils.getSampleData("mvIndicators/assay_single_column.xls");
         final File ASSAY_TWO_COLUMN_EXCEL_FILE = TestFileUtils.getSampleData("mvIndicators/assay_two_column.xls");
         final File ASSAY_SINGLE_COLUMN_EXCEL_FILE_BAD = TestFileUtils.getSampleData("mvIndicators/assay_single_column_bad.xls");
@@ -89,14 +94,14 @@ public class AssayMissingValuesTest extends MissingValueIndicatorsTest
         waitAndClickAndWait(Locator.linkWithText(ASSAY_NAME));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(Locator.name("name"), ASSAY_RUN_SINGLE_COLUMN);
-        click(Locator.xpath("//input[@value='textAreaDataProvider']"));
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, ASSAY_RUN_SINGLE_COLUMN);
+        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
 
         setFormElement(Locator.name("TextAreaDataCollector.textArea"), TEST_DATA_SINGLE_COLUMN_ASSAY_BAD);
         clickButton("Save and Finish");
         assertLabKeyErrorPresent();
 
-        click(Locator.xpath("//input[@value='textAreaDataProvider']"));
+        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
         setFormElement(Locator.name("TextAreaDataCollector.textArea"), TEST_DATA_SINGLE_COLUMN_ASSAY);
         clickButton("Save and Finish");
         assertNoLabKeyErrors();
@@ -122,15 +127,15 @@ public class AssayMissingValuesTest extends MissingValueIndicatorsTest
         clickAndWait(Locator.linkWithText(ASSAY_NAME));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(Locator.name("name"), ASSAY_RUN_TWO_COLUMN);
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, ASSAY_RUN_TWO_COLUMN);
 
-        click(Locator.xpath("//input[@value='textAreaDataProvider']"));
-        setFormElement(Locator.name("TextAreaDataCollector.textArea"), TEST_DATA_TWO_COLUMN_ASSAY_BAD);
+        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_DATA_TWO_COLUMN_ASSAY_BAD);
         clickButton("Save and Finish");
         assertLabKeyErrorPresent();
 
-        click(Locator.xpath("//input[@value='textAreaDataProvider']"));
-        setFormElement(Locator.name("TextAreaDataCollector.textArea"), TEST_DATA_TWO_COLUMN_ASSAY);
+        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_DATA_TWO_COLUMN_ASSAY);
         clickButton("Save and Finish");
         assertNoLabKeyErrors();
         clickAndWait(Locator.linkWithText(ASSAY_RUN_TWO_COLUMN));
@@ -158,7 +163,7 @@ public class AssayMissingValuesTest extends MissingValueIndicatorsTest
         clickAndWait(Locator.linkWithText(ASSAY_NAME));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(Locator.name("name"), ASSAY_EXCEL_RUN_SINGLE_COLUMN);
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, ASSAY_EXCEL_RUN_SINGLE_COLUMN);
         checkCheckbox(Locator.radioButtonByNameAndValue("dataCollectorName", "File upload"));
 
         setFormElement(Locator.name("__primaryFile__"), ASSAY_SINGLE_COLUMN_EXCEL_FILE_BAD);
@@ -183,7 +188,7 @@ public class AssayMissingValuesTest extends MissingValueIndicatorsTest
         clickAndWait(Locator.linkWithText(ASSAY_NAME));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(Locator.name("name"), ASSAY_EXCEL_RUN_TWO_COLUMN);
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, ASSAY_EXCEL_RUN_TWO_COLUMN);
         checkCheckbox(Locator.radioButtonByNameAndValue("dataCollectorName", "File upload"));
         setFormElement(Locator.name("__primaryFile__"), ASSAY_TWO_COLUMN_EXCEL_FILE_BAD);
         clickButton("Save and Finish");

--- a/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
+++ b/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
@@ -9,11 +9,11 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.pages.admin.ExportFolderPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.assay.GeneralAssayDesign;
 import org.labkey.test.tests.MissingValueIndicatorsTest;
-import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 
@@ -94,14 +94,14 @@ public class AssayMissingValuesTest extends MissingValueIndicatorsTest
         waitAndClickAndWait(Locator.linkWithText(ASSAY_NAME));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, ASSAY_RUN_SINGLE_COLUMN);
-        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, ASSAY_RUN_SINGLE_COLUMN);
+        click(AssayConstants.TEXT_AREA_DATA_PROVIDER_LOCATOR);
 
         setFormElement(Locator.name("TextAreaDataCollector.textArea"), TEST_DATA_SINGLE_COLUMN_ASSAY_BAD);
         clickButton("Save and Finish");
         assertLabKeyErrorPresent();
 
-        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        click(AssayConstants.TEXT_AREA_DATA_PROVIDER_LOCATOR);
         setFormElement(Locator.name("TextAreaDataCollector.textArea"), TEST_DATA_SINGLE_COLUMN_ASSAY);
         clickButton("Save and Finish");
         assertNoLabKeyErrors();
@@ -127,15 +127,15 @@ public class AssayMissingValuesTest extends MissingValueIndicatorsTest
         clickAndWait(Locator.linkWithText(ASSAY_NAME));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, ASSAY_RUN_TWO_COLUMN);
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, ASSAY_RUN_TWO_COLUMN);
 
-        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_DATA_TWO_COLUMN_ASSAY_BAD);
+        click(AssayConstants.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_DATA_TWO_COLUMN_ASSAY_BAD);
         clickButton("Save and Finish");
         assertLabKeyErrorPresent();
 
-        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
-        setFormElement(AssayTest.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_DATA_TWO_COLUMN_ASSAY);
+        click(AssayConstants.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayConstants.TEXT_AREA_DATA_COLLECTOR_LOCATOR, TEST_DATA_TWO_COLUMN_ASSAY);
         clickButton("Save and Finish");
         assertNoLabKeyErrors();
         clickAndWait(Locator.linkWithText(ASSAY_RUN_TWO_COLUMN));
@@ -163,7 +163,7 @@ public class AssayMissingValuesTest extends MissingValueIndicatorsTest
         clickAndWait(Locator.linkWithText(ASSAY_NAME));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, ASSAY_EXCEL_RUN_SINGLE_COLUMN);
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, ASSAY_EXCEL_RUN_SINGLE_COLUMN);
         checkCheckbox(Locator.radioButtonByNameAndValue("dataCollectorName", "File upload"));
 
         setFormElement(Locator.name("__primaryFile__"), ASSAY_SINGLE_COLUMN_EXCEL_FILE_BAD);
@@ -188,7 +188,7 @@ public class AssayMissingValuesTest extends MissingValueIndicatorsTest
         clickAndWait(Locator.linkWithText(ASSAY_NAME));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, ASSAY_EXCEL_RUN_TWO_COLUMN);
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, ASSAY_EXCEL_RUN_TWO_COLUMN);
         checkCheckbox(Locator.radioButtonByNameAndValue("dataCollectorName", "File upload"));
         setFormElement(Locator.name("__primaryFile__"), ASSAY_TWO_COLUMN_EXCEL_FILE_BAD);
         clickButton("Save and Finish");

--- a/src/org/labkey/test/tests/assay/AssayRenameExportImportTest.java
+++ b/src/org/labkey/test/tests/assay/AssayRenameExportImportTest.java
@@ -60,6 +60,9 @@ public class AssayRenameExportImportTest extends BaseWebDriverTest
             .setDate(2024, 1, 29)
             .setTimeOfDay(10, 45, 0)
             .build().getTime();
+    public static final String RUN_DATE_FIELD_NAME = "RunDate";
+    public static final String RUN_TIME_FIELD_NAME = "RunTime";
+    public static final String RUN_DATE_TIME_FIELD_NAME = "RunDateTime";
 
     private final SimpleDateFormat _defaultDateFormat = new SimpleDateFormat("yyyy-MM-dd");
     private final SimpleDateFormat _defaultTimeFormat = new SimpleDateFormat("HH:mm:ss");
@@ -289,9 +292,9 @@ public class AssayRenameExportImportTest extends BaseWebDriverTest
         domainFormPanel.getField("Time").setType(FieldDefinition.ColumnType.Time);
 
         domainFormPanel = assayDesignerPage.expandFieldsPanel("Run Fields");
-        domainFormPanel.addField(new FieldDefinition("RunDate", FieldDefinition.ColumnType.Date));
-        domainFormPanel.addField(new FieldDefinition("RunTime", FieldDefinition.ColumnType.Time));
-        domainFormPanel.addField(new FieldDefinition("RunDateTime", FieldDefinition.ColumnType.DateAndTime));
+        domainFormPanel.addField(new FieldDefinition(RUN_DATE_FIELD_NAME, FieldDefinition.ColumnType.Date));
+        domainFormPanel.addField(new FieldDefinition(RUN_TIME_FIELD_NAME, FieldDefinition.ColumnType.Time));
+        domainFormPanel.addField(new FieldDefinition(RUN_DATE_TIME_FIELD_NAME, FieldDefinition.ColumnType.DateAndTime));
 
         assayDesignerPage.clickFinish();
 
@@ -300,13 +303,13 @@ public class AssayRenameExportImportTest extends BaseWebDriverTest
         WebElement runPropertiesPanel = Locator.tagWithAttributeContaining("form", "data-region-form", "Runs")
                 .findElement(getDriver());
 
-        setFormElement(Locator.name("runDate").findElement(runPropertiesPanel),
+        setFormElement(Locator.name(RUN_DATE_FIELD_NAME).findElement(runPropertiesPanel),
                 _defaultDateFormat.format(runDateValue));
 
-        setFormElement(Locator.name("runTime").findElement(runPropertiesPanel),
+        setFormElement(Locator.name(RUN_TIME_FIELD_NAME).findElement(runPropertiesPanel),
                 _defaultTimeFormat.format(runDateValue));
 
-        setFormElement(Locator.name("runDateTime").findElement(runPropertiesPanel),
+        setFormElement(Locator.name(RUN_DATE_TIME_FIELD_NAME).findElement(runPropertiesPanel),
                 _defaultDateTimeFormat.format(runDateValue));
 
         waitAndClick(Locator.lkButton("Save and Finish"));

--- a/src/org/labkey/test/tests/assay/AssayTransformImportUpdateTest.java
+++ b/src/org/labkey/test/tests/assay/AssayTransformImportUpdateTest.java
@@ -281,7 +281,7 @@ public class AssayTransformImportUpdateTest extends BaseWebDriverTest
         new AssayRunsPage(getDriver()).getTable().clickHeaderButton("Import Data");
         clickButton("Next");
         var importPage = new AssayImportPage(getDriver());
-        importPage.setNamedInputText("name", "cancelTransformTestImport");
+        importPage.setNamedInputText("Name", "cancelTransformTestImport");
         importPage.setNamedTextAreaValue("TextAreaDataCollector.textArea", importDataBuilder.toString());
         Instant before = Instant.now();
         importPage.clickSaveAndFinish();

--- a/src/org/labkey/test/tests/assay/AssayTransformImportUpdateTest.java
+++ b/src/org/labkey/test/tests/assay/AssayTransformImportUpdateTest.java
@@ -132,7 +132,7 @@ public class AssayTransformImportUpdateTest extends BaseWebDriverTest
         new AssayRunsPage(getDriver()).getTable().clickHeaderButton("Import Data");
         clickButton("Next");
         var importPage = new AssayImportPage(getDriver());
-        importPage.setNamedInputText("name", "transformTestImport");
+        importPage.setNamedInputText("Name", "transformTestImport");
         importPage.setNamedTextAreaValue("TextAreaDataCollector.textArea", importData);
         importPage.clickSaveAndFinish();
 

--- a/src/org/labkey/test/tests/assay/AssayTransformImportUpdateTest.java
+++ b/src/org/labkey/test/tests/assay/AssayTransformImportUpdateTest.java
@@ -169,7 +169,7 @@ public class AssayTransformImportUpdateTest extends BaseWebDriverTest
         new AssayRunsPage(getDriver()).getTable().clickHeaderButton("Import Data");
         clickButton("Next");
         importPage = new AssayImportPage(getDriver());
-        importPage.setNamedInputText("name", "non_transform_import");
+        importPage.setNamedInputText("Name", "non_transform_import");
         importPage.setNamedTextAreaValue("TextAreaDataCollector.textArea", importData);
         importPage.clickSaveAndFinish();
 

--- a/src/org/labkey/test/tests/assay/AssayTransformWarningTest.java
+++ b/src/org/labkey/test/tests/assay/AssayTransformWarningTest.java
@@ -50,6 +50,7 @@ public class AssayTransformWarningTest extends BaseWebDriverTest
     public static final File R_TRANSFORM_SCRIPT = TestFileUtils.getSampleData("qc/assayTransformWarning.R");
     public static final File R_TRANSFORM_ERROR_SCRIPT = TestFileUtils.getSampleData("qc/assayTransformError.R");
     public static final File JAVA_INVALID_TRANSFORM_SCRIPT = TestFileUtils.getSampleData("qc/src/org/labkey/AssayTransformNoOp.java");
+    public static final Locator.XPathLocator ASSAY_NAME_FIELD_LOCATOR = Locator.name("Name");
 
     @Override
     public List<String> getAssociatedModules()
@@ -110,7 +111,7 @@ public class AssayTransformWarningTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(assayName));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(Locator.name("name"), runName);
+        setFormElement(ASSAY_NAME_FIELD_LOCATOR, runName);
         setFormElement(Locator.name("TextAreaDataCollector.textArea"), importData);
 
         clickButton("Save and Finish");
@@ -150,7 +151,7 @@ public class AssayTransformWarningTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(assayName));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(Locator.name("name"), runName);
+        setFormElement(ASSAY_NAME_FIELD_LOCATOR, runName);
 
         // Use this file as a sample upload file parameter
         setFormElement(Locator.name("myFile"), JAVA_TRANSFORM_SCRIPT);
@@ -213,7 +214,7 @@ public class AssayTransformWarningTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(assayName));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(Locator.name("name"), runName);
+        setFormElement(ASSAY_NAME_FIELD_LOCATOR, runName);
         setFormElement(Locator.name("TextAreaDataCollector.textArea"), importData);
         clickButton("Save and Finish");
 
@@ -247,7 +248,7 @@ public class AssayTransformWarningTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(assayName));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(Locator.name("name"), runName);
+        setFormElement(ASSAY_NAME_FIELD_LOCATOR, runName);
 
         setFormElement(Locator.name("TextAreaDataCollector.textArea"), importData);
 
@@ -284,7 +285,7 @@ public class AssayTransformWarningTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(assayName));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(Locator.name("name"), runName);
+        setFormElement(ASSAY_NAME_FIELD_LOCATOR, runName);
         setFormElement(Locator.name("TextAreaDataCollector.textArea"), importData);
 
         clickButton("Save and Finish");

--- a/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
+++ b/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
@@ -15,6 +15,7 @@ import org.labkey.test.pages.assay.AssayUploadJobsPage;
 import org.labkey.test.pages.query.SourceQueryPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.assay.GeneralAssayDesign;
+import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.AbstractDataRegionExportOrSignHelper;
 import org.labkey.test.util.TestDataGenerator;
 
@@ -95,7 +96,7 @@ public class UploadLargeExcelAssayTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(LARGE_ASSAY));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(Locator.input("name"), "200k");
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, "200k");
         checkRadioButton(Locator.inputById("Fileupload"));
         setFormElement(Locator.input("__primaryFile__"), largeExcelFile);
         clickButton("Save and Finish");

--- a/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
+++ b/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
@@ -10,12 +10,12 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.assay.AssayUploadJobsPage;
 import org.labkey.test.pages.query.SourceQueryPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.assay.GeneralAssayDesign;
-import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.AbstractDataRegionExportOrSignHelper;
 import org.labkey.test.util.TestDataGenerator;
 
@@ -96,7 +96,7 @@ public class UploadLargeExcelAssayTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(LARGE_ASSAY));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, "200k");
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, "200k");
         checkRadioButton(Locator.inputById("Fileupload"));
         setFormElement(Locator.input("__primaryFile__"), largeExcelFile);
         clickButton("Save and Finish");

--- a/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
+++ b/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
@@ -120,7 +120,7 @@ public class UploadLargeExcelAssayTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(LARGE_ASSAY_2));
         clickButton("Import Data");
         clickButton("Next");
-        setFormElement(Locator.input("name"), "200k take 2");
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, "200k take 2");
         checkRadioButton(Locator.inputById("Fileupload"));
         setFormElement(Locator.input("__primaryFile__"), largeExportExcelFile);
         clickButton("Save and Finish");

--- a/src/org/labkey/test/tests/elisa/ElisaAssayTest.java
+++ b/src/org/labkey/test/tests/elisa/ElisaAssayTest.java
@@ -151,7 +151,7 @@ public class ElisaAssayTest extends AbstractAssayTest
             setFormElement(specimenLocator, "specimen " + (i) + " " + uniqueifier);
             setFormElement(participantLocator, "ptid " + (i) + " " + uniqueifier);
 
-            setFormElement(Locator.name("specimen" + (i) + "_VisitID"), "" + (i));
+            setFormElement(Locator.name("Specimen " + (i) + "_VisitID"), "" + (i));
         }
 
         setFormElement(Locator.name("__primaryFile__"), file);

--- a/src/org/labkey/test/tests/elisa/ElisaAssayTest.java
+++ b/src/org/labkey/test/tests/elisa/ElisaAssayTest.java
@@ -155,7 +155,7 @@ public class ElisaAssayTest extends AbstractAssayTest
         }
 
         setFormElement(Locator.name("__primaryFile__"), file);
-        setFormElement(Locator.name("curveFitMethod"), "Linear");
+        setFormElement(Locator.name("CurveFitMethod"), "Linear");
 
         clickButton("Next");
 

--- a/src/org/labkey/test/tests/elisa/ElisaAssayTest.java
+++ b/src/org/labkey/test/tests/elisa/ElisaAssayTest.java
@@ -142,8 +142,8 @@ public class ElisaAssayTest extends AbstractAssayTest
     {
         for (int i = startSpecimen; i <= lastSpecimen; i++)
         {
-            Locator specimenLocator = Locator.name("specimen" + (i) + "_SpecimenID");
-            Locator participantLocator = Locator.name("specimen" + (i) + "_ParticipantID");
+            Locator specimenLocator = Locator.name("Specimen " + (i) + "_SpecimenID");
+            Locator participantLocator = Locator.name("Specimen " + (i) + "_ParticipantID");
 
             // test for prepopulation of specimen form element values
 //            if (testPrepopulation)

--- a/src/org/labkey/test/tests/elisa/ElisaAssayTest.java
+++ b/src/org/labkey/test/tests/elisa/ElisaAssayTest.java
@@ -173,7 +173,7 @@ public class ElisaAssayTest extends AbstractAssayTest
         String[] letters = {"A","B","C","D","E","F","G","H"};
         for (int i = 0; i <= 5; i++)
         {
-            setFormElement(Locator.name(letters[i].toLowerCase()+"1"+letters[i]+"2_Concentration"), "" + (i + 1));
+            setFormElement(Locator.name(letters[i]+"1-"+letters[i]+"2_Concentration"), "" + (i + 1));
 
             if (!testPrepopulation)
             {

--- a/src/org/labkey/test/tests/elisa/ElisaMultiPlateAssayTest.java
+++ b/src/org/labkey/test/tests/elisa/ElisaMultiPlateAssayTest.java
@@ -15,12 +15,12 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.pages.assay.AssayDataPage;
 import org.labkey.test.pages.assay.AssayRunsPage;
 import org.labkey.test.pages.assay.elisa.ElisaRunDetailsPage;
 import org.labkey.test.pages.assay.plate.PlateDesignerPage;
 import org.labkey.test.pages.assay.plate.PlateTemplateListPage;
-import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.PortalHelper;
 
 import java.io.File;
@@ -240,7 +240,7 @@ public class ElisaMultiPlateAssayTest extends BaseWebDriverTest
         clickButton("Import Data");
         clickButton("Next");
 
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, runName);
         setFormElement(Locator.name("CurveFitMethod"), curveFitMethod);
         setFormElement(Locator.name("__primaryFile__"), file);
         clickButton("Save and Finish", 180000); // 3 minutes wait if need
@@ -264,7 +264,7 @@ public class ElisaMultiPlateAssayTest extends BaseWebDriverTest
             setFormElement(Locator.name("specimen" + (i) + "_VisitID"), "" + (i));
         }
 
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, runName);
         setFormElement(Locator.name("CurveFitMethod"), curveFitMethod);
         setFormElement(Locator.name("__primaryFile__"), file);
         clickButton("Next");

--- a/src/org/labkey/test/tests/elisa/ElisaMultiPlateAssayTest.java
+++ b/src/org/labkey/test/tests/elisa/ElisaMultiPlateAssayTest.java
@@ -20,6 +20,7 @@ import org.labkey.test.pages.assay.AssayRunsPage;
 import org.labkey.test.pages.assay.elisa.ElisaRunDetailsPage;
 import org.labkey.test.pages.assay.plate.PlateDesignerPage;
 import org.labkey.test.pages.assay.plate.PlateTemplateListPage;
+import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.PortalHelper;
 
 import java.io.File;
@@ -239,8 +240,8 @@ public class ElisaMultiPlateAssayTest extends BaseWebDriverTest
         clickButton("Import Data");
         clickButton("Next");
 
-        setFormElement(Locator.name("name"), runName);
-        setFormElement(Locator.name("curveFitMethod"), curveFitMethod);
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
+        setFormElement(Locator.name("CurveFitMethod"), curveFitMethod);
         setFormElement(Locator.name("__primaryFile__"), file);
         clickButton("Save and Finish", 180000); // 3 minutes wait if need
         return new AssayRunsPage(getDriver());
@@ -263,15 +264,15 @@ public class ElisaMultiPlateAssayTest extends BaseWebDriverTest
             setFormElement(Locator.name("specimen" + (i) + "_VisitID"), "" + (i));
         }
 
-        setFormElement(Locator.name("name"), runName);
-        setFormElement(Locator.name("curveFitMethod"), curveFitMethod);
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
+        setFormElement(Locator.name("CurveFitMethod"), curveFitMethod);
         setFormElement(Locator.name("__primaryFile__"), file);
         clickButton("Next");
 
         String[] letters = {"A","B","C","D","E","F","G","H"};
         for (int i = 0; i <= 5; i++)
         {
-            setFormElement(Locator.name(letters[i].toLowerCase()+"1"+letters[i]+"2_Concentration"), "" + (i + 1));
+            setFormElement(Locator.name(letters[i]+"1"+letters[i]+"2_Concentration"), "" + (i + 1));
         }
 
         clickButton("Save and Finish");

--- a/src/org/labkey/test/tests/elisa/ElisaMultiPlateAssayTest.java
+++ b/src/org/labkey/test/tests/elisa/ElisaMultiPlateAssayTest.java
@@ -261,7 +261,7 @@ public class ElisaMultiPlateAssayTest extends BaseWebDriverTest
             setFormElement(specimenLocator, "specimen " + (i) + " " + uniqueifier);
             setFormElement(participantLocator, "ptid " + (i) + " " + uniqueifier);
 
-            setFormElement(Locator.name("specimen" + (i) + "_VisitID"), "" + (i));
+            setFormElement(Locator.name("Specimen " + (i) + "_VisitID"), "" + (i));
         }
 
         setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, runName);

--- a/src/org/labkey/test/tests/elisa/ElisaMultiPlateAssayTest.java
+++ b/src/org/labkey/test/tests/elisa/ElisaMultiPlateAssayTest.java
@@ -272,7 +272,7 @@ public class ElisaMultiPlateAssayTest extends BaseWebDriverTest
         String[] letters = {"A","B","C","D","E","F","G","H"};
         for (int i = 0; i <= 5; i++)
         {
-            setFormElement(Locator.name(letters[i]+"1"+letters[i]+"2_Concentration"), "" + (i + 1));
+            setFormElement(Locator.name(letters[i]+"1-"+letters[i]+"2_Concentration"), "" + (i + 1));
         }
 
         clickButton("Save and Finish");

--- a/src/org/labkey/test/tests/elisa/ElisaMultiPlateAssayTest.java
+++ b/src/org/labkey/test/tests/elisa/ElisaMultiPlateAssayTest.java
@@ -255,8 +255,8 @@ public class ElisaMultiPlateAssayTest extends BaseWebDriverTest
 
         for (int i = startSpecimen; i <= lastSpecimen; i++)
         {
-            Locator specimenLocator = Locator.name("specimen" + (i) + "_SpecimenID");
-            Locator participantLocator = Locator.name("specimen" + (i) + "_ParticipantID");
+            Locator specimenLocator = Locator.name("Specimen " + (i) + "_SpecimenID");
+            Locator participantLocator = Locator.name("Specimen " + (i) + "_ParticipantID");
 
             setFormElement(specimenLocator, "specimen " + (i) + " " + uniqueifier);
             setFormElement(participantLocator, "ptid " + (i) + " " + uniqueifier);

--- a/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
+++ b/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
@@ -83,7 +83,7 @@ public class ElispotAssayTest extends AbstractAssayTest
     private static final String FLUOROSPOT_DETECTION_METHOD = "fluorescent";
 
     public static final String FLUOROSPOT_FOLDER = "Fluorospot";
-    public static final Locator.XPathLocator PLATE_READER_LOCATOR = Locator.name("plateReader");
+    public static final Locator.XPathLocator PLATE_READER_LOCATOR = Locator.name("PlateReader");
 
     @Override
     public List<String> getAssociatedModules()

--- a/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
+++ b/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
@@ -30,10 +30,10 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.components.CrosstabDataRegion;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.components.PlateSummary;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.assay.plate.PlateDesignerPage;
 import org.labkey.test.tests.AbstractAssayTest;
-import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PipelineStatusTable;
@@ -508,7 +508,7 @@ public class ElispotAssayTest extends AbstractAssayTest
         clickButton("Import Data");
         clickButton("Next");
 
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, "transformed assayId");
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, "transformed assayId");
         selectOptionByText(PLATE_READER_LOCATOR, "AID");
         uploadFile(TEST_ASSAY_ELISPOT_FILE4, "D", "Save and Finish", false);
 

--- a/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
+++ b/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
@@ -295,7 +295,7 @@ public class ElispotAssayTest extends AbstractAssayTest
     protected void uploadFile(File file, String uniqueifier, String finalButton, boolean testPrepopulation, boolean subtractBackground, boolean fluorospot)
     {
         if (subtractBackground)
-            checkCheckbox(Locator.checkboxByName("subtractBackground"));
+            checkCheckbox(Locator.checkboxByName("SubtractBackground"));
         for (int i = 0; i < 4; i++)
         {
             Locator specimenLocator = Locator.name("Specimen " + (i + 1) + "_ParticipantID");
@@ -329,9 +329,9 @@ public class ElispotAssayTest extends AbstractAssayTest
         if (fluorospot)
         {
             clickButton("Next");
-            setFormElement(Locator.input("cy3_CytokineName"), "Cytokine 1");
+            setFormElement(Locator.input("Cy3_CytokineName"), "Cytokine 1");
             setFormElement(Locator.input("FITC_CytokineName"), "Cytokine 2");
-            setFormElement(Locator.input("FITCCy3_CytokineName"), "Cytokine 3");
+            setFormElement(Locator.input("FITC+Cy3_CytokineName"), "Cytokine 3");
         }
         clickButton(finalButton);
     }

--- a/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
+++ b/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
@@ -314,16 +314,16 @@ public class ElispotAssayTest extends AbstractAssayTest
 
         for (int i = 0; i < 6; i++)
         {
-            setFormElement(Locator.name("antigen" + (i + 1) + "_AntigenID"), "" + (i + 1));
+            setFormElement(Locator.name("Antigen " + (i + 1) + "_AntigenID"), "" + (i + 1));
 
-            Locator antigenLocator = Locator.name("antigen" + (i + 1) + "_AntigenName");
+            Locator antigenLocator = Locator.name("Antigen " + (i + 1) + "_AntigenName");
 
             // test for prepopulation of antigen element values
             if (testPrepopulation)
                 assertEquals("Antigen " + (i+1), getFormElement(antigenLocator));
 
             setFormElement(antigenLocator, "atg_" + (i + 1) + uniqueifier);
-            setFormElement(Locator.name("antigen" + (i + 1) + "_CellWell"), "150");
+            setFormElement(Locator.name("Antigen " + (i + 1) + "_CellWell"), "150");
         }
 
         if (fluorospot)

--- a/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
+++ b/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
@@ -298,15 +298,15 @@ public class ElispotAssayTest extends AbstractAssayTest
             checkCheckbox(Locator.checkboxByName("subtractBackground"));
         for (int i = 0; i < 4; i++)
         {
-            Locator specimenLocator = Locator.name("specimen" + (i + 1) + "_ParticipantID");
+            Locator specimenLocator = Locator.name("Specimen " + (i + 1) + "_ParticipantID");
 
             // test for prepopulation of specimen form element values
             if (testPrepopulation)
                 assertEquals("Specimen " + (i+1), getFormElement(specimenLocator));
             setFormElement(specimenLocator, "ptid " + (i + 1) + " " + uniqueifier);
 
-            setFormElement(Locator.name("specimen" + (i + 1) + "_VisitID"), "" + (i + 1));
-            setFormElement(Locator.name("specimen" + (i + 1) + "_SampleDescription"), "blood");
+            setFormElement(Locator.name("Specimen " + (i + 1) + "_VisitID"), "" + (i + 1));
+            setFormElement(Locator.name("Specimen " + (i + 1) + "_SampleDescription"), "blood");
         }
 
         setFormElement(Locator.name("__primaryFile__"), file);

--- a/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
+++ b/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
@@ -33,6 +33,7 @@ import org.labkey.test.components.PlateSummary;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.assay.plate.PlateDesignerPage;
 import org.labkey.test.tests.AbstractAssayTest;
+import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PipelineStatusTable;
@@ -82,6 +83,7 @@ public class ElispotAssayTest extends AbstractAssayTest
     private static final String FLUOROSPOT_DETECTION_METHOD = "fluorescent";
 
     public static final String FLUOROSPOT_FOLDER = "Fluorospot";
+    public static final Locator.XPathLocator PLATE_READER_LOCATOR = Locator.name("plateReader");
 
     @Override
     public List<String> getAssociatedModules()
@@ -136,15 +138,15 @@ public class ElispotAssayTest extends AbstractAssayTest
         clickButton("Import Data");
         clickButton("Next");
 
-        selectOptionByText(Locator.name("plateReader"), "Cellular Technology Ltd. (CTL)");
+        selectOptionByText(PLATE_READER_LOCATOR, "Cellular Technology Ltd. (CTL)");
         uploadFile(TEST_ASSAY_ELISPOT_FILE1, "A", "Save and Import Another Run", false);
         assertTextPresent("Upload successful.");
 
-        selectOptionByText(Locator.name("plateReader"), "AID");
+        selectOptionByText(PLATE_READER_LOCATOR, "AID");
         uploadFile(TEST_ASSAY_ELISPOT_FILE2, "B", "Save and Import Another Run", false);
         assertTextPresent("Upload successful.");
 
-        selectOptionByText(Locator.name("plateReader"), "Zeiss");
+        selectOptionByText(PLATE_READER_LOCATOR, "Zeiss");
         uploadFile(TEST_ASSAY_ELISPOT_FILE3, "C", "Save and Finish", false);
 
         assertElispotData();
@@ -176,11 +178,11 @@ public class ElispotAssayTest extends AbstractAssayTest
         log("Uploading Fluorospot Runs");
         clickButton("Import Data");
         clickButton("Next");
-        selectOptionByText(Locator.name("plateReader"), "AID");
+        selectOptionByText(PLATE_READER_LOCATOR, "AID");
         uploadFluorospotFile(TEST_ASSAY_FLUOROSPOT_FILE1, "F1", "Save and Import Another Run");
         assertTextPresent("Upload successful.");
 
-        selectOptionByText(Locator.name("plateReader"), "AID");
+        selectOptionByText(PLATE_READER_LOCATOR, "AID");
         uploadFluorospotFile(TEST_ASSAY_FLUOROSPOT_FILE2, "F2", "Save and Finish");
 
         clickAndWait(Locator.linkContainingText("AID_fluoro2"));
@@ -300,7 +302,7 @@ public class ElispotAssayTest extends AbstractAssayTest
 
             // test for prepopulation of specimen form element values
             if (testPrepopulation)
-                assertFormElementEquals(specimenLocator, "Specimen " + (i+1));
+                assertEquals("Specimen " + (i+1), getFormElement(specimenLocator));
             setFormElement(specimenLocator, "ptid " + (i + 1) + " " + uniqueifier);
 
             setFormElement(Locator.name("specimen" + (i + 1) + "_VisitID"), "" + (i + 1));
@@ -318,7 +320,7 @@ public class ElispotAssayTest extends AbstractAssayTest
 
             // test for prepopulation of antigen element values
             if (testPrepopulation)
-                assertFormElementEquals(antigenLocator, "Antigen " + (i+1));
+                assertEquals("Antigen " + (i+1), getFormElement(antigenLocator));
 
             setFormElement(antigenLocator, "atg_" + (i + 1) + uniqueifier);
             setFormElement(Locator.name("antigen" + (i + 1) + "_CellWell"), "150");
@@ -506,8 +508,8 @@ public class ElispotAssayTest extends AbstractAssayTest
         clickButton("Import Data");
         clickButton("Next");
 
-        setFormElement(Locator.name("name"), "transformed assayId");
-        selectOptionByText(Locator.name("plateReader"), "AID");
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, "transformed assayId");
+        selectOptionByText(PLATE_READER_LOCATOR, "AID");
         uploadFile(TEST_ASSAY_ELISPOT_FILE4, "D", "Save and Finish", false);
 
         // verify there is a spot count value of 747.747 and a custom column added by the transform
@@ -592,7 +594,7 @@ public class ElispotAssayTest extends AbstractAssayTest
         clickButton("Import Data");
         clickButton("Next");
 
-        selectOptionByText(Locator.name("plateReader"), "AID");
+        selectOptionByText(PLATE_READER_LOCATOR, "AID");
         uploadFile(TEST_ASSAY_ELISPOT_FILE5, "E", "Save and Finish", false, true);
         DataRegionTable runTable = new DataRegionTable("Runs", this);
         assertTextPresent("AID_0161456 W8");
@@ -632,7 +634,7 @@ public class ElispotAssayTest extends AbstractAssayTest
         clickButton("Import Data");
         clickButton("Next");
 
-        selectOptionByText(Locator.name("plateReader"), "AID");
+        selectOptionByText(PLATE_READER_LOCATOR, "AID");
         uploadFile(TEST_ASSAY_ELISPOT_FILE6, "F", "Save and Finish", false);
 
         testMeanAndMedian();

--- a/src/org/labkey/test/tests/flow/BaseFlowTest.java
+++ b/src/org/labkey/test/tests/flow/BaseFlowTest.java
@@ -279,12 +279,14 @@ abstract public class BaseFlowTest extends BaseWebDriverTest
         if (setBackground)
         {
             // specify forground-background match columns
-            assertFormElementEquals(Locator.name("ff_matchColumn").index(0), "Run");
+            Locator loc1 = Locator.name("ff_matchColumn").index(0);
+            assertEquals("Run", getFormElement(loc1));
             selectOptionByText(Locator.name("ff_matchColumn").index(1), "Sample Sample Order");
 
             // specify background values
             selectOptionByText(Locator.name("ff_backgroundFilterField").index(0), "Sample Stim");
-            assertFormElementEquals(Locator.name("ff_backgroundFilterOp").index(0), "eq");
+            Locator loc = Locator.name("ff_backgroundFilterOp").index(0);
+            assertEquals("eq", getFormElement(loc));
             setFormElement(Locator.name("ff_backgroundFilterValue").index(0), "Neg Cont");
         }
 
@@ -339,7 +341,8 @@ abstract public class BaseFlowTest extends BaseWebDriverTest
         if (!options.canAccelerateWizard())
         {
             importAnalysis_selectFCSFiles(options.getContainerPath(), options.getSelectFCSFilesOption(), options.getKeywordDirs());
-            assertFormElementEquals(Locator.name("selectFCSFilesOption"), options.getSelectFCSFilesOption().name());
+            Locator loc = Locator.name("selectFCSFilesOption");
+            assertEquals(options.getSelectFCSFilesOption().name(), getFormElement(loc));
 
             boolean resolving = options.getSelectFCSFilesOption() == SelectFCSFileOption.Previous;
             importAnalysis_reviewSamples(options.getContainerPath(), resolving, options.getSelectedGroupNames(), options.getSelectedSampleIds());

--- a/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
+++ b/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
@@ -23,6 +23,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Flow;
 import org.labkey.test.categories.Specimen;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PipelineStatusTable;
@@ -161,7 +162,7 @@ public class FlowSpecimenTest extends BaseFlowTest
         clickAndWait(Locator.linkWithText("Browse for more FCS files to be imported"));
         _fileBrowserHelper.selectFileBrowserItem("flowjoquery/microFCS");
         _fileBrowserHelper.selectImportDataAction("Import Directory of FCS Files");
-        selectOptionByText(Locator.id("targetStudy"), "/" + getProjectName() + "/" + STUDY_FOLDER + " (" + STUDY_FOLDER + " Study)");
+        selectOptionByText(AssayConstants.TARGET_STUDY_FIELD_LOCATOR, "/" + getProjectName() + "/" + STUDY_FOLDER + " (" + STUDY_FOLDER + " Study)");
         clickButton("Import Selected Runs");
         waitForPipelineComplete();
 
@@ -223,7 +224,7 @@ public class FlowSpecimenTest extends BaseFlowTest
         beginAt("/flow" + getContainerPath() + "/query.view?schemaName=flow&query.queryName=FCSAnalyses");
         click(Locator.checkboxByName(".toggle"));
         clickButton("Link to Study");
-        selectOptionByText(Locator.name("targetStudy"), "/" + getProjectName() + "/" + STUDY_FOLDER + " (" + STUDY_FOLDER + " Study)");
+        selectOptionByText(AssayConstants.TARGET_STUDY_FIELD_LOCATOR, "/" + getProjectName() + "/" + STUDY_FOLDER + " (" + STUDY_FOLDER + " Study)");
         clickButton("Next");
         assertTitleContains("Link to " + STUDY_FOLDER + " Study: Verify Results");
         // verify specimen information is filled in for '118795.fcs' FCS file

--- a/src/org/labkey/test/tests/issues/IssueDomainSharingTest.java
+++ b/src/org/labkey/test/tests/issues/IssueDomainSharingTest.java
@@ -126,7 +126,8 @@ public class IssueDomainSharingTest extends BaseWebDriverTest
         final String assignTo = _userHelper.getDisplayNameForEmail(USER);
         final String customValue = "Value for shared domain";
         final String listDef = SHARED_LIST_DEF;
-        final String inheritedField = "inheritedfield";
+        // Append ":" to field name: Issue 32057: Issues forms can't handle complex field names
+        final String inheritedField = "inheritedfield:";
 
         goToProjectHome("Shared");
         _containerHelper.enableModule("Issues");
@@ -144,8 +145,7 @@ public class IssueDomainSharingTest extends BaseWebDriverTest
         adminPage.clickSave();
 
         adminPage = IssuesAdminPage.beginAt(this, "Shared", listDef);
-        // Append ":" to field name: Issue 32057: Issues forms can't handle complex field names
-        adminPage.getFieldsPanel().addField(new FieldDefinition(inheritedField + ":", ColumnType.String).setLabel(inheritedField));
+        adminPage.getFieldsPanel().addField(new FieldDefinition(inheritedField, ColumnType.String).setLabel(inheritedField));
         adminPage.clickSave();
 
         ListPage issueList = ListPage.beginAt(this, getProjectName(), listDef);

--- a/src/org/labkey/test/tests/issues/IssuesAdminTest.java
+++ b/src/org/labkey/test/tests/issues/IssuesAdminTest.java
@@ -198,11 +198,11 @@ public class IssuesAdminTest extends BaseWebDriverTest
 
         DetailsPage detailsPage = _issuesHelper.addIssue(
                 Maps.of("title", mainTitle,
-                        "assignedTo", TEST_USER_DISPLAY_NAME,
+                        "AssignedTo", TEST_USER_DISPLAY_NAME,
                         "comment", "Main issue Comment"));
 
         Map<String, String> relatedIssueData = Maps.of("title", relatedIssueTitle,
-                "assignedTo", TEST_USER_DISPLAY_NAME,
+                "AssignedTo", TEST_USER_DISPLAY_NAME,
                 "comment", "Related issue Comment");
         InsertPage relatedIssuePage = detailsPage.clickCreateRelatedIssue(getProjectName(), ISSUE_LIST_NAME.toLowerCase());
         for (Map.Entry<String, String> field : relatedIssueData.entrySet())

--- a/src/org/labkey/test/tests/issues/IssuesAttachmentTest.java
+++ b/src/org/labkey/test/tests/issues/IssuesAttachmentTest.java
@@ -91,10 +91,10 @@ public class IssuesAttachmentTest extends BaseWebDriverTest implements NonWindow
     }
 
     @Test
-    public void testAttachmentInjection() throws Exception
+    public void testAttachmentInjection()
     {
         goToProjectHome();
-        Map<String, String> issue = Maps.of("assignedTo", getDisplayName(), "title", "Attempt Issue Attachment Injection");
+        Map<String, String> issue = Maps.of("AssignedTo", getDisplayName(), "title", "Attempt Issue Attachment Injection");
         final DetailsPage detailsPage = issuesHelper.addIssue(issue, ALERT_FILE, ESCAPE_FILE);
         final String issueId = detailsPage.getIssueId();
 

--- a/src/org/labkey/test/tests/issues/IssuesTest.java
+++ b/src/org/labkey/test/tests/issues/IssuesTest.java
@@ -279,7 +279,7 @@ public class IssuesTest extends BaseWebDriverTest
         adminPage.getFieldsPanel().getField("StringWithDefault")
                 .clickAdvancedSettings()
                 .clickDefaultValuesLink();  // should land us in
-        setFormElement(Locator.input("stringWithDefault"), "StringWithDefault (default value)");
+        setFormElement(Locator.input("StringWithDefault"), "StringWithDefault (default value)");
         clickButton("Save Defaults");
 
         clickProject(getProjectName());
@@ -290,23 +290,19 @@ public class IssuesTest extends BaseWebDriverTest
         setFormElement(Locator.name("title"), issueTitle);
         selectOptionByText(Locator.name("Type"), "UFO");
         selectOptionByText(Locator.name("Area"), "Area51");
-        selectOptionByText(Locator.name("module"), "Zvezda");
+        selectOptionByText(Locator.name("Module"), "Zvezda");
         selectOptionByText(Locator.name("Priority"), "2");
         setFormElement(Locator.name("comment"), ISSUE_0.get("comment"));
         selectOptionByText(Locator.name("AssignedTo"), NAME);
-        selectOptionByText(Locator.name("milestone"), "2012");
+        selectOptionByText(Locator.name("Milestone"), "2012");
 
-        Locator fouthStringLocator = Locator.name("myFourthString");
-        if (!isElementPresent(fouthStringLocator))
-            fouthStringLocator = Locator.name("myfourthstring");
-        setFormElement(fouthStringLocator, "http://www.issues.test");
+        Locator fourthStringLocator = Locator.name("MyFourthString");
+        setFormElement(fourthStringLocator, "http://www.issues.test");
 
-        Locator fifthStringLocator = Locator.name("myFifthString");
-        if (!isElementPresent(fifthStringLocator))
-            fifthStringLocator = Locator.name("myfifthstring");
+        Locator fifthStringLocator = Locator.name("MyFifthString");
         selectOptionByText(fifthStringLocator, "Polonium");
         // clear out the default value on insert
-        setFormElement(Locator.name("stringWithDefault"), "");
+        setFormElement(Locator.name("StringWithDefault"), "");
 
         clickButton("Save");
 
@@ -324,7 +320,7 @@ public class IssuesTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText("Issues List"));
 
         // Click the issue id based on the text issue title
-        clickAndWait(Locator.linkWithText("" + issueId));
+        clickAndWait(Locator.linkWithText(issueId));
 
         // UpdateAction
         updateIssue();
@@ -350,7 +346,7 @@ public class IssuesTest extends BaseWebDriverTest
         assertTextPresent("Issues List"); //we should be back at the issues list now
 
         // JumpToIssueAction
-        setFormElement(Locator.name("issueId"), "" + issueId);
+        setFormElement(Locator.name("issueId"), issueId);
         clickAndWait(Locator.tagWithAttribute("a", "data-original-title", "Search"));
         assertTextPresent(issueTitle);
         assertElementNotPresent(Locators.labkeyError);
@@ -443,7 +439,7 @@ public class IssuesTest extends BaseWebDriverTest
     {
         page.title().set(title);
         page.assignedTo().set(assignedTo);
-        page.selectWithName("type").set(type);
+        page.selectWithName("Type").set(type);
         page.priority().set(priority);
         page.related().set(related);
         page.notifyList().set(notify);
@@ -453,7 +449,7 @@ public class IssuesTest extends BaseWebDriverTest
     {
         assertEquals("title", title, page.title().get());
         assertEquals("assignedTo", assignedTo, page.assignedTo().get());
-        assertEquals("type", type, page.selectWithName("type").get());
+        assertEquals("type", type, page.selectWithName("Type").get());
         assertEquals("priority", priority, page.priority().get());
         assertEquals("related", related, page.related().get());
         Assertions.assertThat(page.notifyList().get()).as("notify").contains(_userHelper.getDisplayNameForEmail(notify));
@@ -799,10 +795,10 @@ public class IssuesTest extends BaseWebDriverTest
     {
         Locator relatedLocator = Locator.name("related");
 
-        String issueIdA = _issuesHelper.addIssue(Maps.of("AssignedTo", NAME, "title", "A is for Apple", "priority", "0")).getIssueId();
-        String issueIdB = _issuesHelper.addIssue(Maps.of("AssignedTo", NAME, "title", "B is for Baking", "priority", "0")).getIssueId();
+        String issueIdA = _issuesHelper.addIssue(Maps.of("AssignedTo", NAME, "title", "A is for Apple", "Priority", "0")).getIssueId();
+        String issueIdB = _issuesHelper.addIssue(Maps.of("AssignedTo", NAME, "title", "B is for Baking", "Priority", "0")).getIssueId();
         // related C to A
-        String issueIdC = _issuesHelper.addIssue(Maps.of("AssignedTo", NAME, "title", "C is for Cat", "priority", "0", "related", issueIdA)).getIssueId();
+        String issueIdC = _issuesHelper.addIssue(Maps.of("AssignedTo", NAME, "title", "C is for Cat", "Priority", "0", "related", issueIdA)).getIssueId();
 
         clickAndWait(Locator.linkWithText(issueIdA));
         assertElementPresent(Locator.linkWithText(issueIdC)); // Should link back to related issue

--- a/src/org/labkey/test/tests/issues/IssuesTest.java
+++ b/src/org/labkey/test/tests/issues/IssuesTest.java
@@ -162,8 +162,8 @@ public class IssuesTest extends BaseWebDriverTest
     public void doInit()
     {
         NAME = getDisplayName();
-        ISSUE_0.put("assignedTo", NAME);
-        ISSUE_1.put("assignedTo", NAME);
+        ISSUE_0.put("AssignedTo", NAME);
+        ISSUE_1.put("AssignedTo", NAME);
         _containerHelper.createProject(getProjectName(), null);
         _permissionsHelper.createPermissionsGroup(TEST_GROUP);
         _permissionsHelper.assertPermissionSetting(TEST_GROUP, "No Permissions");
@@ -278,12 +278,12 @@ public class IssuesTest extends BaseWebDriverTest
         // InsertAction
         clickButton("New Issue");
         setFormElement(Locator.name("title"), issueTitle);
-        selectOptionByText(Locator.name("type"), "UFO");
-        selectOptionByText(Locator.name("area"), "Area51");
+        selectOptionByText(Locator.name("Type"), "UFO");
+        selectOptionByText(Locator.name("Area"), "Area51");
         selectOptionByText(Locator.name("module"), "Zvezda");
-        selectOptionByText(Locator.name("priority"), "2");
+        selectOptionByText(Locator.name("Priority"), "2");
         setFormElement(Locator.name("comment"), ISSUE_0.get("comment"));
-        selectOptionByText(Locator.name("assignedTo"), NAME);
+        selectOptionByText(Locator.name("AssignedTo"), NAME);
         selectOptionByText(Locator.name("milestone"), "2012");
 
         Locator fouthStringLocator = Locator.name("myFourthString");
@@ -477,7 +477,7 @@ public class IssuesTest extends BaseWebDriverTest
     @Test
     public void emailTest()
     {
-        Map<String, String> ISSUE = Maps.of("assignedTo", _userHelper.getDisplayNameForEmail(USER1), "title", "A not so serious issue", "priority", "4", "comment", "No big whup", "notifyList", USER2);
+        Map<String, String> ISSUE = Maps.of("AssignedTo", _userHelper.getDisplayNameForEmail(USER1), "title", "A not so serious issue", "Priority", "4", "comment", "No big whup", "notifyList", USER2);
 
         _issuesHelper.goToAdmin();
         _issuesHelper.setIssueAssignmentList(null);
@@ -669,7 +669,7 @@ public class IssuesTest extends BaseWebDriverTest
     {
         final Map<String, String> issue0 = new HashMap<>(ISSUE_0);
         issue0.put("title", "This is for the subfolder test");
-        final Map<String, String> issue1 = Maps.of("assignedTo", NAME, "title", "A sub-folder issue", "priority", "2", "comment", "We are in a sub-folder");
+        final Map<String, String> issue1 = Maps.of("AssignedTo", NAME, "title", "A sub-folder issue", "Priority", "2", "comment", "We are in a sub-folder");
         final String subFolder = "SubFolder";
 
         // NOTE: be afraid -- very afraid. this data is used other places and could lead to false+ or false-
@@ -700,14 +700,14 @@ public class IssuesTest extends BaseWebDriverTest
     @Test
     public void duplicatesTest()
     {
-        _issuesHelper.addIssue(Maps.of("assignedTo", NAME, "title", "This Is some Issue -- let's say A"));
+        _issuesHelper.addIssue(Maps.of("AssignedTo", NAME, "title", "This Is some Issue -- let's say A"));
         String issueIdA = getIssueId();
 
-        _issuesHelper.addIssue(Maps.of("assignedTo", NAME, "title", "This is another issue -- let's say B"));
+        _issuesHelper.addIssue(Maps.of("AssignedTo", NAME, "title", "This is another issue -- let's say B"));
         String issueIdB = getIssueId();
 
         clickButton("Resolve");
-        selectOptionByText(Locator.name("resolution"), "Duplicate");
+        selectOptionByText(Locator.name("Resolution"), "Duplicate");
         setFormElement(Locator.name("duplicate"), issueIdA);
         clickButton("Save");
 
@@ -735,7 +735,7 @@ public class IssuesTest extends BaseWebDriverTest
         goToModule("Issues");
 
         // create a new issue to be moved
-        _issuesHelper.addIssue(Maps.of("assignedTo", displayName, "title", issueTitle));
+        _issuesHelper.addIssue(Maps.of("AssignedTo", displayName, "title", issueTitle));
 
         // move the created issue
         goToModule("Issues");
@@ -756,11 +756,11 @@ public class IssuesTest extends BaseWebDriverTest
         goToModule("Issues");
 
         String issueTitleA = "Multi-Issue Move A";
-        _issuesHelper.addIssue(Maps.of("assignedTo", displayName, "title", issueTitleA));
+        _issuesHelper.addIssue(Maps.of("AssignedTo", displayName, "title", issueTitleA));
         String issueIdA = getIssueId();
 
         String issueTitleB = "Multi-Issue Move B";
-        _issuesHelper.addIssue(Maps.of("assignedTo", displayName, "title", issueTitleB));
+        _issuesHelper.addIssue(Maps.of("AssignedTo", displayName, "title", issueTitleB));
         String issueIdB = getIssueId();
 
         goToModule("Issues");
@@ -783,10 +783,10 @@ public class IssuesTest extends BaseWebDriverTest
     {
         Locator relatedLocator = Locator.name("related");
 
-        String issueIdA = _issuesHelper.addIssue(Maps.of("assignedTo", NAME, "title", "A is for Apple", "priority", "0")).getIssueId();
-        String issueIdB = _issuesHelper.addIssue(Maps.of("assignedTo", NAME, "title", "B is for Baking", "priority", "0")).getIssueId();
+        String issueIdA = _issuesHelper.addIssue(Maps.of("AssignedTo", NAME, "title", "A is for Apple", "priority", "0")).getIssueId();
+        String issueIdB = _issuesHelper.addIssue(Maps.of("AssignedTo", NAME, "title", "B is for Baking", "priority", "0")).getIssueId();
         // related C to A
-        String issueIdC = _issuesHelper.addIssue(Maps.of("assignedTo", NAME, "title", "C is for Cat", "priority", "0", "related", issueIdA)).getIssueId();
+        String issueIdC = _issuesHelper.addIssue(Maps.of("AssignedTo", NAME, "title", "C is for Cat", "priority", "0", "related", issueIdA)).getIssueId();
 
         clickAndWait(Locator.linkWithText(issueIdA));
         assertElementPresent(Locator.linkWithText(issueIdC)); // Should link back to related issue
@@ -839,7 +839,7 @@ public class IssuesTest extends BaseWebDriverTest
 
         // check for no default
         clickButton("New Issue");
-        assertEquals("", getSelectedOptionText(Locator.name("assignedTo")));
+        assertEquals("", getSelectedOptionText(Locator.name("AssignedTo")));
         clickButton("Cancel");
 
         /// check reader cannot be set as default user (issue 20598)
@@ -853,7 +853,7 @@ public class IssuesTest extends BaseWebDriverTest
 
         // verify
         clickButton("New Issue");
-        assertEquals(getSelectedOptionText(Locator.name("assignedTo")), user1DisplayName);
+        assertEquals(getSelectedOptionText(Locator.name("AssignedTo")), user1DisplayName);
         clickButton("Cancel");
 
         // set default group and user
@@ -864,7 +864,7 @@ public class IssuesTest extends BaseWebDriverTest
 
         // verify
         clickButton("New Issue");
-        assertEquals(getSelectedOptionText(Locator.name("assignedTo")), NAME);
+        assertEquals(getSelectedOptionText(Locator.name("AssignedTo")), NAME);
         clickButton("Cancel");
 
         // set no default user and return to project users assign list
@@ -875,7 +875,7 @@ public class IssuesTest extends BaseWebDriverTest
 
         // check for no default
         clickButton("New Issue");
-        assertEquals("", getSelectedOptionText(Locator.name("assignedTo")));
+        assertEquals("", getSelectedOptionText(Locator.name("AssignedTo")));
         clickButton("Cancel");
 
         // issue 20699 - NPE b/c default assign to user deleted!
@@ -901,7 +901,7 @@ public class IssuesTest extends BaseWebDriverTest
         goToProjectHome();
         waitAndClickAndWait(Locator.linkContainingText(ISSUE_SUMMARY_WEBPART_NAME));
         clickButton("New Issue");
-        List<WebElement> assignedToUserOptionWebElement = new Select(Locator.name("assignedTo").findElement(getDriver())).getOptions();
+        List<WebElement> assignedToUserOptionWebElement = new Select(Locator.name("AssignedTo").findElement(getDriver())).getOptions();
         List<String> assignedToUserOptions = new ArrayList<>();
         for (WebElement e : assignedToUserOptionWebElement)
             if (!e.getText().isBlank())

--- a/src/org/labkey/test/tests/issues/IssuesTest.java
+++ b/src/org/labkey/test/tests/issues/IssuesTest.java
@@ -84,8 +84,8 @@ public class IssuesTest extends BaseWebDriverTest
     private static final String USER2 = "user2_issuetest@issues.test";
     private static final String USER3 = "user3_issuetest@issues.test";
     private static final String user = "reader@issues.test";
-    private static final Map<String, String> ISSUE_0 = new HashMap<>(Maps.of("title", ISSUE_TITLE_0, "priority", "2", "comment", "a bright flash of light"));
-    private static final Map<String, String> ISSUE_1 = new HashMap<>(Maps.of("title", ISSUE_TITLE_1, "priority", "1", "comment", "alien autopsy"));
+    private static final Map<String, String> ISSUE_0 = new HashMap<>(Maps.of("title", ISSUE_TITLE_0, "Priority", "2", "comment", "a bright flash of light"));
+    private static final Map<String, String> ISSUE_1 = new HashMap<>(Maps.of("title", ISSUE_TITLE_1, "Priority", "1", "comment", "alien autopsy"));
     private static final String ISSUE_SUMMARY_WEBPART_NAME = "Issues Summary";
     private static final String ISSUE_LIST_REGION_NAME = "issues-issues";
     private static final String TEST_GROUP = "testers";

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -541,7 +541,7 @@ public class NabAssayTest extends AbstractAssayTest
         clickFolder(TEST_ASSAY_FLDR_NAB);
         clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));
         clickButton("Import Data");
-        checkRadioButton(Locator.radioButtonByNameAndValue("participantVisitResolver", "ParticipantVisitDate"));
+        checkRadioButton(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", "ParticipantVisitDate"));
         clickButton("Next");
 
         // verify that 'Participant ID', 'Visit ID', and 'Date' fields are included

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -542,7 +542,7 @@ public class NabAssayTest extends AbstractAssayTest
         clickFolder(TEST_ASSAY_FLDR_NAB);
         clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));
         clickButton("Import Data");
-        checkRadioButton(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", "ParticipantVisitDate"));
+        checkRadioButton(Locator.radioButtonByNameAndValue(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME, "ParticipantVisitDate"));
         clickButton("Next");
 
         // verify that 'Participant ID', 'Visit ID', and 'Date' fields are included

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -29,6 +29,7 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.PlateGrid;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.components.labkey.LabKeyAlert;
 import org.labkey.test.pages.admin.PermissionsPage;
 import org.labkey.test.pages.assay.RunQCPage;
@@ -419,7 +420,7 @@ public class NabAssayTest extends AbstractAssayTest
             region.checkAllOnPage();
             region.clickHeaderButtonAndWait("Link to Study");
 
-            selectOptionByText(Locator.name("targetStudy"), "/" + TEST_ASSAY_PRJ_NAB + "/" + TEST_ASSAY_FLDR_STUDY1 + " (" + TEST_ASSAY_FLDR_STUDY1 + " Study)");
+            selectOptionByText(AssayConstants.TARGET_STUDY_FIELD_LOCATOR, "/" + TEST_ASSAY_PRJ_NAB + "/" + TEST_ASSAY_FLDR_STUDY1 + " (" + TEST_ASSAY_FLDR_STUDY1 + " Study)");
             clickButton("Next", 300_000); // Triggers a query that is, sometimes, very slow on SQL Server
 
             region = new DataRegionTable("Data", this);
@@ -549,8 +550,8 @@ public class NabAssayTest extends AbstractAssayTest
         assertTextPresent("Participant id, visit id, and date.");
         // assert that both the visit id and date are present.  In other resolver types only one
         // or the other is present
-        assertElementPresent(Locator.checkboxById("Specimen 1_VisitIDCheckBox"));
-        assertElementPresent(Locator.checkboxById("Specimen 1_DateCheckBox"));
+        assertElementPresent(Locator.checkboxById("specimen1_VisitIDCheckBox"));
+        assertElementPresent(Locator.checkboxById("specimen1_DateCheckBox"));
         clickButton("Cancel");
     }
 

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -549,8 +549,8 @@ public class NabAssayTest extends AbstractAssayTest
         assertTextPresent("Participant id, visit id, and date.");
         // assert that both the visit id and date are present.  In other resolver types only one
         // or the other is present
-        assertElementPresent(Locator.checkboxById("specimen1_VisitIDCheckBox"));
-        assertElementPresent(Locator.checkboxById("specimen1_DateCheckBox"));
+        assertElementPresent(Locator.checkboxById("Specimen 1_VisitIDCheckBox"));
+        assertElementPresent(Locator.checkboxById("Specimen 1_DateCheckBox"));
         clickButton("Cancel");
     }
 

--- a/src/org/labkey/test/tests/nab/NabAssayThawListTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayThawListTest.java
@@ -25,6 +25,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.tests.AbstractAssayTest;
 import org.labkey.test.util.AbstractAssayHelper;
 import org.labkey.test.util.AssayImportOptions;
@@ -123,7 +124,7 @@ public class NabAssayThawListTest extends AbstractAssayTest
         // We'll override it later at the folder level.
         clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));
         _assayHelper.setDefaultValues(TEST_ASSAY_NAB, AbstractAssayHelper.AssayDefaultAreas.BATCH_FIELDS);
-        click(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", AssayImportOptions.VisitResolverType.ParticipantVisitDate.name()));
+        click(Locator.radioButtonByNameAndValue(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME, AssayImportOptions.VisitResolverType.ParticipantVisitDate.name()));
         clickButton("Save Defaults");
 
         // Add the list we'll use for the thaw list lookup
@@ -141,13 +142,13 @@ public class NabAssayThawListTest extends AbstractAssayTest
         // Are we seeing the default set in the parent project?
         Assert.assertEquals("Default participant visit resolver not inherited from project",
                 AssayImportOptions.VisitResolverType.ParticipantVisitDate.name(),
-                Locator.checkedRadioInGroup("ParticipantVisitResolver").findElement(getDriver()).getAttribute("value"));
+                Locator.checkedRadioInGroup(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME).findElement(getDriver()).getAttribute("value"));
 
         // Now override
-        click(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", "Lookup"));
+        click(Locator.radioButtonByNameAndValue(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME, "Lookup"));
 
         // 20583 We now hide the option to paste in a tsv for the default value
-        assertElementNotPresent(Locator.radioButtonByNameAndValue("ThawListType", "Text"));
+        assertElementNotPresent(Locator.radioButtonByNameAndValue(AssayConstants.THAW_LIST_TYPE_FIELD_NAME, "Text"));
 
         // 20998 as part of that fix, the List option should already be checked
         waitForElement(Locator.css(".schema-loaded-marker"));
@@ -190,16 +191,16 @@ public class NabAssayThawListTest extends AbstractAssayTest
         // As long as we're here, make sure inheritance is still being acknowledged.
         Assert.assertEquals("Default participant visit resolver not inherited from project",
                             AssayImportOptions.VisitResolverType.ParticipantVisitDate.name(),
-                            Locator.checkedRadioInGroup("ParticipantVisitResolver").findElement(getDriver()).getAttribute("value"));
+                            Locator.checkedRadioInGroup(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME).findElement(getDriver()).getAttribute("value"));
         assertTextPresent("These values are overridden by defaults");
 
         log("Verify Delete and Re-import doesn't autofill SpecimenId");
         navToRunDetails();
         clickAndWait(Locator.linkWithText("Delete and Re-import"));
         Assert.assertEquals("Wrong participant visit resolver selected",
-                "Lookup", Locator.checkedRadioInGroup("ParticipantVisitResolver").findElement(getDriver()).getAttribute("value"));
+                "Lookup", Locator.checkedRadioInGroup(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME).findElement(getDriver()).getAttribute("value"));
         Assert.assertEquals("Wrong participant visit resolver selected",
-                "List", Locator.checkedRadioInGroup("ThawListType").findElement(getDriver()).getAttribute("value"));
+                "List", Locator.checkedRadioInGroup(AssayConstants.THAW_LIST_TYPE_FIELD_NAME).findElement(getDriver()).getAttribute("value"));
         waitForFormElementToEqual(Locator.tagWithName("input", "ThawListList-QueryName"), "NabThawList");
         clickButton("Next");
         assertElementPresent(Locator.input("Specimen 1_SpecimenID").withoutAttribute("value", ""));

--- a/src/org/labkey/test/tests/nab/NabAssayThawListTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayThawListTest.java
@@ -88,7 +88,7 @@ public class NabAssayThawListTest extends AbstractAssayTest
         init.doSetup();
     }
 
-    private void doSetup() throws Exception
+    private void doSetup()
     {
         // default project
         _containerHelper.createProject(getProjectName(), null);

--- a/src/org/labkey/test/tests/nab/NabAssayThawListTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayThawListTest.java
@@ -123,7 +123,7 @@ public class NabAssayThawListTest extends AbstractAssayTest
         // We'll override it later at the folder level.
         clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));
         _assayHelper.setDefaultValues(TEST_ASSAY_NAB, AbstractAssayHelper.AssayDefaultAreas.BATCH_FIELDS);
-        click(Locator.radioButtonByNameAndValue("participantVisitResolver", AssayImportOptions.VisitResolverType.ParticipantVisitDate.name()));
+        click(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", AssayImportOptions.VisitResolverType.ParticipantVisitDate.name()));
         clickButton("Save Defaults");
 
         // Add the list we'll use for the thaw list lookup
@@ -141,10 +141,10 @@ public class NabAssayThawListTest extends AbstractAssayTest
         // Are we seeing the default set in the parent project?
         Assert.assertEquals("Default participant visit resolver not inherited from project",
                 AssayImportOptions.VisitResolverType.ParticipantVisitDate.name(),
-                Locator.checkedRadioInGroup("participantVisitResolver").findElement(getDriver()).getAttribute("value"));
+                Locator.checkedRadioInGroup("ParticipantVisitResolver").findElement(getDriver()).getAttribute("value"));
 
         // Now override
-        click(Locator.radioButtonByNameAndValue("participantVisitResolver", "Lookup"));
+        click(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", "Lookup"));
 
         // 20583 We now hide the option to paste in a tsv for the default value
         assertElementNotPresent(Locator.radioButtonByNameAndValue("ThawListType", "Text"));
@@ -190,21 +190,21 @@ public class NabAssayThawListTest extends AbstractAssayTest
         // As long as we're here, make sure inheritance is still being acknowledged.
         Assert.assertEquals("Default participant visit resolver not inherited from project",
                             AssayImportOptions.VisitResolverType.ParticipantVisitDate.name(),
-                            Locator.checkedRadioInGroup("participantVisitResolver").findElement(getDriver()).getAttribute("value"));
+                            Locator.checkedRadioInGroup("ParticipantVisitResolver").findElement(getDriver()).getAttribute("value"));
         assertTextPresent("These values are overridden by defaults");
 
         log("Verify Delete and Re-import doesn't autofill SpecimenId");
         navToRunDetails();
         clickAndWait(Locator.linkWithText("Delete and Re-import"));
         Assert.assertEquals("Wrong participant visit resolver selected",
-                "Lookup", Locator.checkedRadioInGroup("participantVisitResolver").findElement(getDriver()).getAttribute("value"));
+                "Lookup", Locator.checkedRadioInGroup("ParticipantVisitResolver").findElement(getDriver()).getAttribute("value"));
         Assert.assertEquals("Wrong participant visit resolver selected",
                 "List", Locator.checkedRadioInGroup("ThawListType").findElement(getDriver()).getAttribute("value"));
         waitForFormElementToEqual(Locator.tagWithName("input", "ThawListList-QueryName"), "NabThawList");
         clickButton("Next");
-        assertElementPresent(Locator.input("specimen1_SpecimenID").withoutAttribute("value", ""));
+        assertElementPresent(Locator.input("Specimen 1_SpecimenID").withoutAttribute("value", ""));
         // Let's make sure *some* of the last entered values did get auto-filled.
-        assertElementPresent(Locator.input("specimen1_InitialDilution").withAttribute("value", "20.0"));
+        assertElementPresent(Locator.input("Specimen 1_InitialDilution").withAttribute("value", "20.0"));
 
         verifyValidation(iob);
     }

--- a/src/org/labkey/test/tests/nab/NabHighThroughputAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabHighThroughputAssayTest.java
@@ -199,7 +199,7 @@ public class NabHighThroughputAssayTest extends BaseWebDriverTest
 
         setFormElement(Locator.name("cutoff1"), "50");
         setFormElement(Locator.name("cutoff2"), "70");
-        selectOptionByText(Locator.name("curveFitMethod"), "Polynomial");
+        selectOptionByText(Locator.name("CurveFitMethod"), "Polynomial");
 
         if (metadataFile != null)
         {
@@ -322,7 +322,7 @@ public class NabHighThroughputAssayTest extends BaseWebDriverTest
     {
         // high throughput Nab assays should not contain the Participant, Visit, Date resolver type
         clickAndWait(Locator.linkWithText("Import Data"));
-        assertElementNotPresent(Locator.radioButtonByNameAndValue("participantVisitResolver", "ParticipantVisitDate"));
+        assertElementNotPresent(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", "ParticipantVisitDate"));
         clickButton("Cancel");
     }
 

--- a/src/org/labkey/test/tests/nab/NabHighThroughputAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabHighThroughputAssayTest.java
@@ -197,8 +197,8 @@ public class NabHighThroughputAssayTest extends BaseWebDriverTest
         clickButton("Import Data");
         clickButton("Next");
 
-        setFormElement(Locator.name("cutoff1"), "50");
-        setFormElement(Locator.name("cutoff2"), "70");
+        setFormElement(Locator.name("Cutoff1"), "50");
+        setFormElement(Locator.name("Cutoff2"), "70");
         selectOptionByText(Locator.name("CurveFitMethod"), "Polynomial");
 
         if (metadataFile != null)

--- a/src/org/labkey/test/tests/nab/NabHighThroughputAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabHighThroughputAssayTest.java
@@ -25,6 +25,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.assay.plate.PlateDesignerPage;
 import org.labkey.test.pages.assay.plate.PlateTemplateListPage;
@@ -322,7 +323,7 @@ public class NabHighThroughputAssayTest extends BaseWebDriverTest
     {
         // high throughput Nab assays should not contain the Participant, Visit, Date resolver type
         clickAndWait(Locator.linkWithText("Import Data"));
-        assertElementNotPresent(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", "ParticipantVisitDate"));
+        assertElementNotPresent(Locator.radioButtonByNameAndValue(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME, "ParticipantVisitDate"));
         clickButton("Cancel");
     }
 

--- a/src/org/labkey/test/tests/nab/NabMultiVirusPlateTest.java
+++ b/src/org/labkey/test/tests/nab/NabMultiVirusPlateTest.java
@@ -239,9 +239,9 @@ public class NabMultiVirusPlateTest extends BaseWebDriverTest
         setFormElement(Locator.name("Specimen 01_InitialDilution"), "5");
         setFormElement(Locator.name("Specimen 01_Factor"), "42");
         selectOptionByText(Locator.name("Specimen 01_Method"), "Dilution");
-        checkCheckbox(Locator.name("Specimen 01_InitialDilutionCheckBox"));
-        checkCheckbox(Locator.name("Specimen 01_FactorCheckBox"));
-        checkCheckbox(Locator.name("Specimen 01_MethodCheckBox"));
+        checkCheckbox(Locator.name("specimen01_InitialDilutionCheckBox"));
+        checkCheckbox(Locator.name("specimen01_FactorCheckBox"));
+        checkCheckbox(Locator.name("specimen01_MethodCheckBox"));
 
         setFormElement(Locator.xpath("//input[@type='file' and @name='__primaryFile__']"), dataFile);
 

--- a/src/org/labkey/test/tests/nab/NabMultiVirusPlateTest.java
+++ b/src/org/labkey/test/tests/nab/NabMultiVirusPlateTest.java
@@ -236,12 +236,12 @@ public class NabMultiVirusPlateTest extends BaseWebDriverTest
         setFormElement(Locator.name("Cutoff1"), "50");
         setFormElement(Locator.name("Cutoff2"), "70");
         selectOptionByText(Locator.name("CurveFitMethod"), curveFitMethod);
-        setFormElement(Locator.name("specimen01_InitialDilution"), "5");
-        setFormElement(Locator.name("specimen01_Factor"), "42");
-        selectOptionByText(Locator.name("specimen01_Method"), "Dilution");
-        checkCheckbox(Locator.name("specimen01_InitialDilutionCheckBox"));
-        checkCheckbox(Locator.name("specimen01_FactorCheckBox"));
-        checkCheckbox(Locator.name("specimen01_MethodCheckBox"));
+        setFormElement(Locator.name("Specimen 01_InitialDilution"), "5");
+        setFormElement(Locator.name("Specimen 01_Factor"), "42");
+        selectOptionByText(Locator.name("Specimen 01_Method"), "Dilution");
+        checkCheckbox(Locator.name("Specimen 01_InitialDilutionCheckBox"));
+        checkCheckbox(Locator.name("Specimen 01_FactorCheckBox"));
+        checkCheckbox(Locator.name("Specimen 01_MethodCheckBox"));
 
         setFormElement(Locator.xpath("//input[@type='file' and @name='__primaryFile__']"), dataFile);
 

--- a/src/org/labkey/test/tests/nab/NabMultiVirusPlateTest.java
+++ b/src/org/labkey/test/tests/nab/NabMultiVirusPlateTest.java
@@ -235,7 +235,7 @@ public class NabMultiVirusPlateTest extends BaseWebDriverTest
 
         setFormElement(Locator.name("cutoff1"), "50");
         setFormElement(Locator.name("cutoff2"), "70");
-        selectOptionByText(Locator.name("curveFitMethod"), curveFitMethod);
+        selectOptionByText(Locator.name("CurveFitMethod"), curveFitMethod);
         setFormElement(Locator.name("specimen01_InitialDilution"), "5");
         setFormElement(Locator.name("specimen01_Factor"), "42");
         selectOptionByText(Locator.name("specimen01_Method"), "Dilution");

--- a/src/org/labkey/test/tests/nab/NabMultiVirusPlateTest.java
+++ b/src/org/labkey/test/tests/nab/NabMultiVirusPlateTest.java
@@ -233,8 +233,8 @@ public class NabMultiVirusPlateTest extends BaseWebDriverTest
         clickButton("Import Data");
         clickButton("Next");
 
-        setFormElement(Locator.name("cutoff1"), "50");
-        setFormElement(Locator.name("cutoff2"), "70");
+        setFormElement(Locator.name("Cutoff1"), "50");
+        setFormElement(Locator.name("Cutoff2"), "70");
         selectOptionByText(Locator.name("CurveFitMethod"), curveFitMethod);
         setFormElement(Locator.name("specimen01_InitialDilution"), "5");
         setFormElement(Locator.name("specimen01_Factor"), "42");

--- a/src/org/labkey/test/tests/study/StudyMissingValuesTest.java
+++ b/src/org/labkey/test/tests/study/StudyMissingValuesTest.java
@@ -202,7 +202,7 @@ public class StudyMissingValuesTest extends MissingValueIndicatorsTest
         waitAndClickAndWait(Locator.linkWithText(ASSAY_NAME));
         clickButton("Import Data");
         String targetStudyValue = "/" + getProjectName() + " (" + getProjectName() + " Study)";
-        selectOptionByText(Locator.xpath("//select[@name='targetStudy']"), targetStudyValue);
+        selectOptionByText(AssayConstants.TARGET_STUDY_FIELD_LOCATOR, targetStudyValue);
 
         clickButton("Next");
         setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, ASSAY_RUN_SINGLE_COLUMN);

--- a/src/org/labkey/test/tests/study/StudyMissingValuesTest.java
+++ b/src/org/labkey/test/tests/study/StudyMissingValuesTest.java
@@ -9,6 +9,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.pages.DatasetPropertiesPage;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.tests.MissingValueIndicatorsTest;
@@ -204,8 +205,8 @@ public class StudyMissingValuesTest extends MissingValueIndicatorsTest
         selectOptionByText(Locator.xpath("//select[@name='targetStudy']"), targetStudyValue);
 
         clickButton("Next");
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, ASSAY_RUN_SINGLE_COLUMN);
-        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, ASSAY_RUN_SINGLE_COLUMN);
+        click(AssayConstants.TEXT_AREA_DATA_PROVIDER_LOCATOR);
         setFormElement(Locator.name("TextAreaDataCollector.textArea"), TEST_DATA_SINGLE_COLUMN_ASSAY);
         clickButton("Save and Finish");
         assertNoLabKeyErrors();

--- a/src/org/labkey/test/tests/study/StudyMissingValuesTest.java
+++ b/src/org/labkey/test/tests/study/StudyMissingValuesTest.java
@@ -204,8 +204,8 @@ public class StudyMissingValuesTest extends MissingValueIndicatorsTest
         selectOptionByText(Locator.xpath("//select[@name='targetStudy']"), targetStudyValue);
 
         clickButton("Next");
-        setFormElement(Locator.name("name"), ASSAY_RUN_SINGLE_COLUMN);
-        click(Locator.xpath("//input[@value='textAreaDataProvider']"));
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, ASSAY_RUN_SINGLE_COLUMN);
+        click(AssayTest.TEXT_AREA_DATA_PROVIDER_LOCATOR);
         setFormElement(Locator.name("TextAreaDataCollector.textArea"), TEST_DATA_SINGLE_COLUMN_ASSAY);
         clickButton("Save and Finish");
         assertNoLabKeyErrors();

--- a/src/org/labkey/test/tests/viability/AbstractViabilityTest.java
+++ b/src/org/labkey/test/tests/viability/AbstractViabilityTest.java
@@ -19,11 +19,11 @@ package org.labkey.test.tests.viability;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.tests.AbstractAssayTest;
-import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.PostgresOnlyTest;
 import org.labkey.test.util.QCAssayScriptHelper;
@@ -136,7 +136,7 @@ public abstract class AbstractViabilityTest extends AbstractAssayTest implements
         clickButton("Next");
 
         if (runName != null)
-            setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
+            setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, runName);
 
         uploadAssayFile(file);
     }
@@ -151,7 +151,7 @@ public abstract class AbstractViabilityTest extends AbstractAssayTest implements
         clickButton("Next");
 
         if (runName != null)
-            setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
+            setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, runName);
 
         uploadAssayFile(file);
     }

--- a/src/org/labkey/test/tests/viability/AbstractViabilityTest.java
+++ b/src/org/labkey/test/tests/viability/AbstractViabilityTest.java
@@ -23,6 +23,7 @@ import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.tests.AbstractAssayTest;
+import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.PostgresOnlyTest;
 import org.labkey.test.util.QCAssayScriptHelper;
@@ -135,7 +136,7 @@ public abstract class AbstractViabilityTest extends AbstractAssayTest implements
         clickButton("Next");
 
         if (runName != null)
-            setFormElement(Locator.name("name"), runName);
+            setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
 
         uploadAssayFile(file);
     }
@@ -150,7 +151,7 @@ public abstract class AbstractViabilityTest extends AbstractAssayTest implements
         clickButton("Next");
 
         if (runName != null)
-            setFormElement(Locator.name("name"), runName);
+            setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, runName);
 
         uploadAssayFile(file);
     }

--- a/src/org/labkey/test/tests/viability/AbstractViabilityTest.java
+++ b/src/org/labkey/test/tests/viability/AbstractViabilityTest.java
@@ -132,7 +132,7 @@ public abstract class AbstractViabilityTest extends AbstractAssayTest implements
         clickAndWait(Locator.linkWithText(getAssayName()));
         clickButton("Import Data");
         if (setBatchTargetStudy)
-            selectOptionByText(Locator.name("targetStudy"), "/" + getProjectName() + "/" + getFolderName() + " (" + getFolderName() + " Study)");
+            selectOptionByText(AssayConstants.TARGET_STUDY_FIELD_LOCATOR, "/" + getProjectName() + "/" + getFolderName() + " (" + getFolderName() + " Study)");
         clickButton("Next");
 
         if (runName != null)

--- a/src/org/labkey/test/tests/viability/ViabilityTest.java
+++ b/src/org/labkey/test/tests/viability/ViabilityTest.java
@@ -262,8 +262,8 @@ public class ViabilityTest extends AbstractViabilityTest
         log("** Insert specimen IDs");
         addSpecimenIds("_pool_160450533-5_0_SpecimenIDs", "vial2", "vial3", "vial1", "foobar");
         addSpecimenIds("_pool_159402032-5_1_SpecimenIDs", "vial1");
-        addSpecimenIds("_pool_16140000610-5_2_SpecimenIDs", "vial2");
-        addSpecimenIds("_pool_16140000611-5_3_SpecimenIDs", "vial3");
+        addSpecimenIds("_pool_161400006.10-5_2_SpecimenIDs", "vial2");
+        addSpecimenIds("_pool_161400006.11-5_3_SpecimenIDs", "vial3");
         addSpecimenIds("_pool_161401643-5_4_SpecimenIDs", "xyzzy");
 
         doAndWaitForPageToLoad(() ->
@@ -323,19 +323,19 @@ public class ViabilityTest extends AbstractViabilityTest
                 getSelectedOptionValue(Locator.name("_pool_159402032-5_1_TargetStudy")));
         assertEquals("Target study didn't propagate with 'Same' checkbox.",
                 getSelectedOptionValue(Locator.name("_pool_160450533-5_0_TargetStudy")),
-                getSelectedOptionValue(Locator.name("_pool_16140000611-5_3_TargetStudy")));
+                getSelectedOptionValue(Locator.name("_pool_161400006.11-5_3_TargetStudy")));
         uncheckCheckbox(Locator.checkboxById("_pool_1604505335_0_TargetStudyCheckBox"));
 
         // clear TargetStudy for 'vial2' and set the TargetStudy for 'vial3' and 'xyzzy'
-        selectOptionByText(Locator.name("_pool_16140000610-5_2_TargetStudy"), "[None]");
-        selectOptionByText(Locator.name("_pool_16140000611-5_3_TargetStudy"), "/" + getProjectName() + "/" + STUDY2_NAME + " (" + STUDY2_NAME + " Study)");
+        selectOptionByText(Locator.name("_pool_161400006.10-5_2_TargetStudy"), "[None]");
+        selectOptionByText(Locator.name("_pool_161400006.11-5_3_TargetStudy"), "/" + getProjectName() + "/" + STUDY2_NAME + " (" + STUDY2_NAME + " Study)");
         selectOptionByText(Locator.name("_pool_161401643-5_4_TargetStudy"), "/" + getProjectName() + "/" + STUDY2_NAME + " (" + STUDY2_NAME + " Study)");
 
         log("** Insert specimen IDs");
         addSpecimenIds("_pool_160450533-5_0_SpecimenIDs", "vial2", "vial3", "vial1", "foobar");
         addSpecimenIds("_pool_159402032-5_1_SpecimenIDs", "vial1");
-        addSpecimenIds("_pool_16140000610-5_2_SpecimenIDs", "vial2");
-        addSpecimenIds("_pool_16140000611-5_3_SpecimenIDs", "vial3");
+        addSpecimenIds("_pool_161400006.10-5_2_SpecimenIDs", "vial2");
+        addSpecimenIds("_pool_161400006.11-5_3_SpecimenIDs", "vial3");
         addSpecimenIds("_pool_161401643-5_4_SpecimenIDs", "xyzzy");
 
         doAndWaitForPageToLoad(() ->

--- a/src/org/labkey/test/tests/viability/ViabilityTest.java
+++ b/src/org/labkey/test/tests/viability/ViabilityTest.java
@@ -85,13 +85,13 @@ public class ViabilityTest extends AbstractViabilityTest
         uploadViabilityRun(TestFileUtils.getSampleData("viability/small.VIA.csv"), true);
 
         log("** Check form field values");
-        assertEquals("160450533", getFormElement(Locator.name("_pool_1604505335_0_ParticipantID")));
-        assertEquals("5.0", getFormElement(Locator.name("_pool_1604505335_0_VisitID")));
-        assertEquals("3.700E7", getFormElement(Locator.name("_pool_1604505335_0_TotalCells")));
-        assertEquals("3.127E7", getFormElement(Locator.name("_pool_1604505335_0_ViableCells")));
+        assertEquals("160450533", getFormElement(Locator.name("_pool_160450533-5_0_ParticipantID")));
+        assertEquals("5.0", getFormElement(Locator.name("_pool_160450533-5_0_VisitID")));
+        assertEquals("3.700E7", getFormElement(Locator.name("_pool_160450533-5_0_TotalCells")));
+        assertEquals("3.127E7", getFormElement(Locator.name("_pool_160450533-5_0_ViableCells")));
         assertEquals("84.5%", getFormElement(Locator.name("_pool_1604505335_0_Viability")));
-        assertNotChecked(Locator.checkboxByName("_pool_1604505335_0_Unreliable"));
-        assertEquals("", getFormElement(Locator.name("_pool_1604505335_0_IntValue")));
+        assertNotChecked(Locator.checkboxByName("_pool_160450533-5_0_Unreliable"));
+        assertEquals("", getFormElement(Locator.name("_pool_160450533-5_0_IntValue")));
 
         sleep(500);
         clickButton(SAVE_AND_FINISH, 0);
@@ -105,15 +105,15 @@ public class ViabilityTest extends AbstractViabilityTest
         assertElementNotPresent(Locator.lkButtonDisabled(SAVE_AND_IMPORT));
 
         log("** Insert specimen IDs");
-        addSpecimenIds("_pool_1604505335_0_SpecimenIDs", "vial2", "vial3", "vial1", "foobar");
-        addSpecimenIds("_pool_1594020325_1_SpecimenIDs", "vial1");
-        addSpecimenIds("_pool_161400006105_2_SpecimenIDs", "vial2");
-        addSpecimenIds("_pool_161400006115_3_SpecimenIDs", "vial3");
-        addSpecimenIds("_pool_1614016435_4_SpecimenIDs", "xyzzy");
+        addSpecimenIds("_pool_160450533-5_0_SpecimenIDs", "vial2", "vial3", "vial1", "foobar");
+        addSpecimenIds("_pool_159402032-5_1_SpecimenIDs", "vial1");
+        addSpecimenIds("_pool_16140000610-5_2_SpecimenIDs", "vial2");
+        addSpecimenIds("_pool_16140000611-5_3_SpecimenIDs", "vial3");
+        addSpecimenIds("_pool_161401643-5_4_SpecimenIDs", "xyzzy");
 
         log("** Set Unreliable flag and IntValue");
-        checkCheckbox(Locator.checkboxByName("_pool_1604505335_0_Unreliable"));
-        setFormElement(Locator.xpath("//input[@name='_pool_1604505335_0_IntValue'][1]"), "300");
+        checkCheckbox(Locator.checkboxByName("_pool_160450533-5_0_Unreliable"));
+        setFormElement(Locator.xpath("//input[@name='_pool_160450533-5_0_IntValue'][1]"), "300");
 
         doAndWaitForPageToLoad(() ->
         {
@@ -184,11 +184,11 @@ public class ViabilityTest extends AbstractViabilityTest
 
         // Check the 'SpecimenIDs' and 'IntValue' field is copied on re-run
         assertEquals("Specimen IDs for 160450533-5", List.of("foobar", "vial1", "vial2", "vial3"),
-                getValues("_pool_1604505335_0_SpecimenIDs"));
+                getValues("_pool_160450533-5_0_SpecimenIDs"));
         assertEquals("Specimen IDs for 161401643-5", List.of("xyzzy"),
-                getValues("_pool_1614016435_4_SpecimenIDs"));
+                getValues("_pool_161401643-5_4_SpecimenIDs"));
         assertEquals("IntValue for 160450533-5", List.of("300"),
-                getValues("_pool_1604505335_0_IntValue"));
+                getValues("_pool_160450533-5_0_IntValue"));
 
         // Check the 'Unreliable' field isn't copied on re-run
         assertNotChecked(Locator.checkboxByName("_pool_1604505335_0_Unreliable"));
@@ -253,18 +253,18 @@ public class ViabilityTest extends AbstractViabilityTest
         uploadViabilityRun(TestFileUtils.getSampleData("viability/small.VIA.csv"), runName, false);
 
         log("** Check form field values");
-        assertEquals("160450533", getFormElement(Locator.name("_pool_1604505335_0_ParticipantID")));
-        assertEquals("5.0", getFormElement(Locator.name("_pool_1604505335_0_VisitID")));
-        assertEquals("3.700E7", getFormElement(Locator.name("_pool_1604505335_0_TotalCells")));
-        assertEquals("3.127E7", getFormElement(Locator.name("_pool_1604505335_0_ViableCells")));
-        assertEquals("84.5%", getFormElement(Locator.name("_pool_1604505335_0_Viability")));
+        assertEquals("160450533", getFormElement(Locator.name("_pool_160450533-5_0_ParticipantID")));
+        assertEquals("5.0", getFormElement(Locator.name("_pool_160450533-5_0_VisitID")));
+        assertEquals("3.700E7", getFormElement(Locator.name("_pool_160450533-5_0_TotalCells")));
+        assertEquals("3.127E7", getFormElement(Locator.name("_pool_160450533-5_0_ViableCells")));
+        assertEquals("84.5%", getFormElement(Locator.name("_pool_160450533-5_0_Viability")));
 
         log("** Insert specimen IDs");
-        addSpecimenIds("_pool_1604505335_0_SpecimenIDs", "vial2", "vial3", "vial1", "foobar");
-        addSpecimenIds("_pool_1594020325_1_SpecimenIDs", "vial1");
-        addSpecimenIds("_pool_161400006105_2_SpecimenIDs", "vial2");
-        addSpecimenIds("_pool_161400006115_3_SpecimenIDs", "vial3");
-        addSpecimenIds("_pool_1614016435_4_SpecimenIDs", "xyzzy");
+        addSpecimenIds("_pool_160450533-5_0_SpecimenIDs", "vial2", "vial3", "vial1", "foobar");
+        addSpecimenIds("_pool_159402032-5_1_SpecimenIDs", "vial1");
+        addSpecimenIds("_pool_16140000610-5_2_SpecimenIDs", "vial2");
+        addSpecimenIds("_pool_16140000611-5_3_SpecimenIDs", "vial3");
+        addSpecimenIds("_pool_161401643-5_4_SpecimenIDs", "xyzzy");
 
         doAndWaitForPageToLoad(() ->
         {
@@ -315,28 +315,28 @@ public class ViabilityTest extends AbstractViabilityTest
 
         log("** Test 'same' checkbox for TargetStudy");
         String targetStudyOptionText = "/" + getProjectName() + "/" + getFolderName() + " (" + getFolderName() + " Study)";
-        selectOptionByText(Locator.name("_pool_1604505335_0_TargetStudy"), targetStudyOptionText);
-        assertEquals("[None]", getSelectedOptionText(Locator.name("_pool_1594020325_1_TargetStudy")));
-        checkCheckbox(Locator.checkboxById("_pool_1604505335_0_TargetStudyCheckBox"));
+        selectOptionByText(Locator.name("_pool_160450533-5_0_TargetStudy"), targetStudyOptionText);
+        assertEquals("[None]", getSelectedOptionText(Locator.name("_pool_159402032-5_1_TargetStudy")));
+        checkCheckbox(Locator.checkboxById("_pool_160450533-5_0_TargetStudyCheckBox"));
         assertEquals("Target study didn't propagate with 'Same' checkbox.",
-                getSelectedOptionValue(Locator.name("_pool_1604505335_0_TargetStudy")),
-                getSelectedOptionValue(Locator.name("_pool_1594020325_1_TargetStudy")));
+                getSelectedOptionValue(Locator.name("_pool_160450533-5_0_TargetStudy")),
+                getSelectedOptionValue(Locator.name("_pool_159402032-5_1_TargetStudy")));
         assertEquals("Target study didn't propagate with 'Same' checkbox.",
-                getSelectedOptionValue(Locator.name("_pool_1604505335_0_TargetStudy")),
-                getSelectedOptionValue(Locator.name("_pool_161400006115_3_TargetStudy")));
-        uncheckCheckbox(Locator.checkboxById("_pool_1604505335_0_TargetStudyCheckBox"));
+                getSelectedOptionValue(Locator.name("_pool_160450533-5_0_TargetStudy")),
+                getSelectedOptionValue(Locator.name("_pool_16140000611-5_3_TargetStudy")));
+        uncheckCheckbox(Locator.checkboxById("_pool_160450533-5_0_TargetStudyCheckBox"));
 
         // clear TargetStudy for 'vial2' and set the TargetStudy for 'vial3' and 'xyzzy'
-        selectOptionByText(Locator.name("_pool_161400006105_2_TargetStudy"), "[None]");
-        selectOptionByText(Locator.name("_pool_161400006115_3_TargetStudy"), "/" + getProjectName() + "/" + STUDY2_NAME + " (" + STUDY2_NAME + " Study)");
-        selectOptionByText(Locator.name("_pool_1614016435_4_TargetStudy"), "/" + getProjectName() + "/" + STUDY2_NAME + " (" + STUDY2_NAME + " Study)");
+        selectOptionByText(Locator.name("_pool_16140000610-5_2_TargetStudy"), "[None]");
+        selectOptionByText(Locator.name("_pool_16140000611-5_3_TargetStudy"), "/" + getProjectName() + "/" + STUDY2_NAME + " (" + STUDY2_NAME + " Study)");
+        selectOptionByText(Locator.name("_pool_161401643-5_4_TargetStudy"), "/" + getProjectName() + "/" + STUDY2_NAME + " (" + STUDY2_NAME + " Study)");
 
         log("** Insert specimen IDs");
-        addSpecimenIds("_pool_1604505335_0_SpecimenIDs", "vial2", "vial3", "vial1", "foobar");
-        addSpecimenIds("_pool_1594020325_1_SpecimenIDs", "vial1");
-        addSpecimenIds("_pool_161400006105_2_SpecimenIDs", "vial2");
-        addSpecimenIds("_pool_161400006115_3_SpecimenIDs", "vial3");
-        addSpecimenIds("_pool_1614016435_4_SpecimenIDs", "xyzzy");
+        addSpecimenIds("_pool_160450533-5_0_SpecimenIDs", "vial2", "vial3", "vial1", "foobar");
+        addSpecimenIds("_pool_159402032-5_1_SpecimenIDs", "vial1");
+        addSpecimenIds("_pool_16140000610-5_2_SpecimenIDs", "vial2");
+        addSpecimenIds("_pool_16140000611-5_3_SpecimenIDs", "vial3");
+        addSpecimenIds("_pool_161401643-5_4_SpecimenIDs", "xyzzy");
 
         doAndWaitForPageToLoad(() ->
         {

--- a/src/org/labkey/test/tests/viability/ViabilityTest.java
+++ b/src/org/labkey/test/tests/viability/ViabilityTest.java
@@ -317,14 +317,14 @@ public class ViabilityTest extends AbstractViabilityTest
         String targetStudyOptionText = "/" + getProjectName() + "/" + getFolderName() + " (" + getFolderName() + " Study)";
         selectOptionByText(Locator.name("_pool_160450533-5_0_TargetStudy"), targetStudyOptionText);
         assertEquals("[None]", getSelectedOptionText(Locator.name("_pool_159402032-5_1_TargetStudy")));
-        checkCheckbox(Locator.checkboxById("_pool_160450533-5_0_TargetStudyCheckBox"));
+        checkCheckbox(Locator.checkboxById("_pool_1604505335_0_TargetStudyCheckBox"));
         assertEquals("Target study didn't propagate with 'Same' checkbox.",
                 getSelectedOptionValue(Locator.name("_pool_160450533-5_0_TargetStudy")),
                 getSelectedOptionValue(Locator.name("_pool_159402032-5_1_TargetStudy")));
         assertEquals("Target study didn't propagate with 'Same' checkbox.",
                 getSelectedOptionValue(Locator.name("_pool_160450533-5_0_TargetStudy")),
                 getSelectedOptionValue(Locator.name("_pool_16140000611-5_3_TargetStudy")));
-        uncheckCheckbox(Locator.checkboxById("_pool_160450533-5_0_TargetStudyCheckBox"));
+        uncheckCheckbox(Locator.checkboxById("_pool_1604505335_0_TargetStudyCheckBox"));
 
         // clear TargetStudy for 'vial2' and set the TargetStudy for 'vial3' and 'xyzzy'
         selectOptionByText(Locator.name("_pool_16140000610-5_2_TargetStudy"), "[None]");

--- a/src/org/labkey/test/tests/viability/ViabilityTest.java
+++ b/src/org/labkey/test/tests/viability/ViabilityTest.java
@@ -191,7 +191,7 @@ public class ViabilityTest extends AbstractViabilityTest
                 getValues("_pool_160450533-5_0_IntValue"));
 
         // Check the 'Unreliable' field isn't copied on re-run
-        assertNotChecked(Locator.checkboxByName("_pool_1604505335_0_Unreliable"));
+        assertNotChecked(Locator.checkboxByName("_pool_160450533-5_0_Unreliable"));
 
         doAndWaitForPageToLoad(() ->
         {

--- a/src/org/labkey/test/tests/viability/ViabilityTest.java
+++ b/src/org/labkey/test/tests/viability/ViabilityTest.java
@@ -89,7 +89,7 @@ public class ViabilityTest extends AbstractViabilityTest
         assertEquals("5.0", getFormElement(Locator.name("_pool_160450533-5_0_VisitID")));
         assertEquals("3.700E7", getFormElement(Locator.name("_pool_160450533-5_0_TotalCells")));
         assertEquals("3.127E7", getFormElement(Locator.name("_pool_160450533-5_0_ViableCells")));
-        assertEquals("84.5%", getFormElement(Locator.name("_pool_1604505335_0_Viability")));
+        assertEquals("84.5%", getFormElement(Locator.name("_pool_160450533-5_0_Viability")));
         assertNotChecked(Locator.checkboxByName("_pool_160450533-5_0_Unreliable"));
         assertEquals("", getFormElement(Locator.name("_pool_160450533-5_0_IntValue")));
 

--- a/src/org/labkey/test/tests/viability/ViabilityTest.java
+++ b/src/org/labkey/test/tests/viability/ViabilityTest.java
@@ -107,8 +107,8 @@ public class ViabilityTest extends AbstractViabilityTest
         log("** Insert specimen IDs");
         addSpecimenIds("_pool_160450533-5_0_SpecimenIDs", "vial2", "vial3", "vial1", "foobar");
         addSpecimenIds("_pool_159402032-5_1_SpecimenIDs", "vial1");
-        addSpecimenIds("_pool_16140000610-5_2_SpecimenIDs", "vial2");
-        addSpecimenIds("_pool_16140000611-5_3_SpecimenIDs", "vial3");
+        addSpecimenIds("_pool_161400006.10-5_2_SpecimenIDs", "vial2");
+        addSpecimenIds("_pool_161400006.11-5_3_SpecimenIDs", "vial3");
         addSpecimenIds("_pool_161401643-5_4_SpecimenIDs", "xyzzy");
 
         log("** Set Unreliable flag and IntValue");

--- a/src/org/labkey/test/tests/viability/ViabilityTest.java
+++ b/src/org/labkey/test/tests/viability/ViabilityTest.java
@@ -23,6 +23,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
@@ -302,8 +303,8 @@ public class ViabilityTest extends AbstractViabilityTest
         ReactAssayDesignerPage assayDesignerPage = _assayHelper.clickEditAssayDesign(true);
 
         // remove TargetStudy field from the Batch domain and add it to the Result domain.
-        assayDesignerPage.expandFieldsPanel("Batch").removeField("TargetStudy", true);
-        assayDesignerPage.expandFieldsPanel("Result").addField(new FieldDefinition("TargetStudy", FieldDefinition.ColumnType.String).setLabel("Target Study"));
+        assayDesignerPage.expandFieldsPanel("Batch").removeField(AssayConstants.TARGET_STUDY_FIELD_NAME, true);
+        assayDesignerPage.expandFieldsPanel("Result").addField(new FieldDefinition(AssayConstants.TARGET_STUDY_FIELD_NAME, FieldDefinition.ColumnType.String).setLabel("Target Study"));
         assayDesignerPage.clickFinish();
 
         navigateToFolder(getProjectName(), getFolderName());
@@ -348,7 +349,7 @@ public class ViabilityTest extends AbstractViabilityTest
         clickAndWait(Locator.linkWithText(runName));
 
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn("TargetStudy");
+        _customizeViewsHelper.addColumn(AssayConstants.TARGET_STUDY_FIELD_NAME);
         _customizeViewsHelper.saveDefaultView();
 
         DataRegionTable table = new DataRegionTable("Data", this);
@@ -356,25 +357,25 @@ public class ViabilityTest extends AbstractViabilityTest
         assertEquals("4", table.getDataAsText(0, "SpecimenCount"));
         assertEquals("3", table.getDataAsText(0, "SpecimenMatchCount"));
         assertEquals("52.11%", table.getDataAsText(0, "Recovery"));
-        assertEquals(getFolderName() + " Study", table.getDataAsText(0, "TargetStudy"));
+        assertEquals(getFolderName() + " Study", table.getDataAsText(0, AssayConstants.TARGET_STUDY_FIELD_NAME));
 
         assertEquals("vial2", table.getDataAsText(2, "Specimen IDs"));
         assertEquals("1", table.getDataAsText(2, "SpecimenCount"));
         assertEquals("0", table.getDataAsText(2, "SpecimenMatchCount"));
         assertEquals(" ", table.getDataAsText(2, "Recovery"));
-        assertEquals(" ", table.getDataAsText(2, "TargetStudy"));
+        assertEquals(" ", table.getDataAsText(2, AssayConstants.TARGET_STUDY_FIELD_NAME));
 
         assertEquals("vial3", table.getDataAsText(3, "Specimen IDs"));
         assertEquals("1", table.getDataAsText(3, "SpecimenCount"));
         assertEquals("0", table.getDataAsText(3, "SpecimenMatchCount"));
         assertEquals(" ", table.getDataAsText(3, "Recovery"));
-        assertEquals(STUDY2_NAME + " Study", table.getDataAsText(3, "TargetStudy"));
+        assertEquals(STUDY2_NAME + " Study", table.getDataAsText(3, AssayConstants.TARGET_STUDY_FIELD_NAME));
 
         assertEquals("xyzzy", table.getDataAsText(4, "Specimen IDs"));
         assertEquals("1", table.getDataAsText(4, "SpecimenCount"));
         assertEquals("1", table.getDataAsText(4, "SpecimenMatchCount"));
         assertEquals("88.88%", table.getDataAsText(4, "Recovery"));
-        assertEquals(STUDY2_NAME + " Study", table.getDataAsText(4, "TargetStudy"));
+        assertEquals(STUDY2_NAME + " Study", table.getDataAsText(4, AssayConstants.TARGET_STUDY_FIELD_NAME));
 
         // UNDONE: participant/visit resolver test
         // UNDONE: link to study

--- a/src/org/labkey/test/util/APIAssayHelper.java
+++ b/src/org/labkey/test/util/APIAssayHelper.java
@@ -38,6 +38,7 @@ import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.WebTestHelper;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.assay.AssayDesign;
 import org.openqa.selenium.NotFoundException;
@@ -132,7 +133,7 @@ public class APIAssayHelper extends AbstractAssayHelper
     @Override
     public void importAssay(String assayName, File file, String projectPath) throws CommandException, IOException
     {
-        importAssay(assayName, file, projectPath, Collections.singletonMap("ParticipantVisitResolver", "SampleInfo"));
+        importAssay(assayName, file, projectPath, Collections.singletonMap(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME, "SampleInfo"));
     }
 
     @Override

--- a/src/org/labkey/test/util/APIAssayHelper.java
+++ b/src/org/labkey/test/util/APIAssayHelper.java
@@ -113,10 +113,10 @@ public class APIAssayHelper extends AbstractAssayHelper
                 irc.setComment(runProperties.get("Comment").toString());
                 runProperties.remove("Comment");
             }
-            if (runProperties.containsKey("name") && StringUtils.isBlank(runName))
+            if (runProperties.containsKey("Name") && StringUtils.isBlank(runName))
             {
-                irc.setName(runProperties.get("name").toString());
-                runProperties.remove("name");
+                irc.setName(runProperties.get("Name").toString());
+                runProperties.remove("Name");
             }
 
             irc.setProperties(runProperties);

--- a/src/org/labkey/test/util/AssayImporter.java
+++ b/src/org/labkey/test/util/AssayImporter.java
@@ -42,30 +42,30 @@ public class AssayImporter
         {
             if (options.getVisitResolver() == AssayImportOptions.VisitResolverType.SpecimenIDParticipantVisit)
             {
-                test.checkRadioButton(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", AssayImportOptions.VisitResolverType.SpecimenID.name()));
+                test.checkRadioButton(Locator.radioButtonByNameAndValue(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME, AssayImportOptions.VisitResolverType.SpecimenID.name()));
                 Locator checkBox = Locator.checkboxByName("includeParticipantAndVisit");
                 test.waitForElement(checkBox);
                 test.checkCheckbox(checkBox);
             }
             else
-                test.checkRadioButton(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", options.getVisitResolver().name()));
+                test.checkRadioButton(Locator.radioButtonByNameAndValue(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME, options.getVisitResolver().name()));
         }
         else
         {
             switch (options.getVisitResolver())
             {
                 case LookupList:
-                    test.assertChecked(Locator.radioButtonByNameAndValue("ThawListType", "List"));
+                    test.assertChecked(Locator.radioButtonByNameAndValue(AssayConstants.THAW_LIST_TYPE_FIELD_NAME, "List"));
                     test.waitForFormElementToNotEqual(Locator.name("ThawListList-QueryName"), "");
                     break;
                 case LookupText:
-                    test.assertChecked(Locator.radioButtonByNameAndValue("ThawListType", "Text"));
+                    test.assertChecked(Locator.radioButtonByNameAndValue(AssayConstants.THAW_LIST_TYPE_FIELD_NAME, "Text"));
                     break;
                 case SpecimenIDParticipantVisit:
-                    test.assertChecked(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", AssayImportOptions.VisitResolverType.SpecimenID.name()));
+                    test.assertChecked(Locator.radioButtonByNameAndValue(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME, AssayImportOptions.VisitResolverType.SpecimenID.name()));
                     break;
                 default:
-                    test.assertChecked(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", options.getVisitResolver().name()));
+                    test.assertChecked(Locator.radioButtonByNameAndValue(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME, options.getVisitResolver().name()));
             }
         }
 

--- a/src/org/labkey/test/util/AssayImporter.java
+++ b/src/org/labkey/test/util/AssayImporter.java
@@ -17,6 +17,7 @@ package org.labkey.test.util;
 
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.tests.study.AssayTest;
 
 public class AssayImporter
 {
@@ -41,13 +42,13 @@ public class AssayImporter
         {
             if (options.getVisitResolver() == AssayImportOptions.VisitResolverType.SpecimenIDParticipantVisit)
             {
-                test.checkRadioButton(Locator.radioButtonByNameAndValue("participantVisitResolver", AssayImportOptions.VisitResolverType.SpecimenID.name()));
+                test.checkRadioButton(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", AssayImportOptions.VisitResolverType.SpecimenID.name()));
                 Locator checkBox = Locator.checkboxByName("includeParticipantAndVisit");
                 test.waitForElement(checkBox);
                 test.checkCheckbox(checkBox);
             }
             else
-                test.checkRadioButton(Locator.radioButtonByNameAndValue("participantVisitResolver", options.getVisitResolver().name()));
+                test.checkRadioButton(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", options.getVisitResolver().name()));
         }
         else
         {
@@ -61,10 +62,10 @@ public class AssayImporter
                     test.assertChecked(Locator.radioButtonByNameAndValue("ThawListType", "Text"));
                     break;
                 case SpecimenIDParticipantVisit:
-                    test.assertChecked(Locator.radioButtonByNameAndValue("participantVisitResolver", AssayImportOptions.VisitResolverType.SpecimenID.name()));
+                    test.assertChecked(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", AssayImportOptions.VisitResolverType.SpecimenID.name()));
                     break;
                 default:
-                    test.assertChecked(Locator.radioButtonByNameAndValue("participantVisitResolver", options.getVisitResolver().name()));
+                    test.assertChecked(Locator.radioButtonByNameAndValue("ParticipantVisitResolver", options.getVisitResolver().name()));
             }
         }
 
@@ -77,20 +78,20 @@ public class AssayImporter
         test.clickButton("Next");
 
         if (options.getAssayId() != null)
-            test.setFormElement(Locator.name("name"), options.getAssayId());
+            test.setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, options.getAssayId());
 
-        test.setFormElement(Locator.name("cutoff1"), options.getCutoff1());
+        test.setFormElement(Locator.name("Cutoff1"), options.getCutoff1());
         if (options.getCutoff2() != null)
-            test.setFormElement(Locator.name("cutoff2"), options.getCutoff2());
+            test.setFormElement(Locator.name("Cutoff2"), options.getCutoff2());
         if (options.getCutoff3() != null)
-            test.setFormElement(Locator.name("cutoff3"), options.getCutoff3());
+            test.setFormElement(Locator.name("Cutoff3"), options.getCutoff3());
 
         if (options.getVirusName() != null)
-            test.setFormElement(Locator.name("virusName"), options.getVirusName());
+            test.setFormElement(Locator.name("VirusName"), options.getVirusName());
         if (options.getVirusId() != null)
-            test.setFormElement(Locator.name("virusID"), options.getVirusId());
+            test.setFormElement(Locator.name("VirusID"), options.getVirusId());
 
-        test.selectOptionByText(Locator.name("curveFitMethod"), options.getCurveFitMethod());
+        test.selectOptionByText(Locator.name("CurveFitMethod"), options.getCurveFitMethod());
 
         if (options.getMetadataFile() == null)
         {

--- a/src/org/labkey/test/util/AssayImporter.java
+++ b/src/org/labkey/test/util/AssayImporter.java
@@ -17,7 +17,7 @@ package org.labkey.test.util;
 
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
-import org.labkey.test.tests.study.AssayTest;
+import org.labkey.test.components.assay.AssayConstants;
 
 public class AssayImporter
 {
@@ -78,7 +78,7 @@ public class AssayImporter
         test.clickButton("Next");
 
         if (options.getAssayId() != null)
-            test.setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, options.getAssayId());
+            test.setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, options.getAssayId());
 
         test.setFormElement(Locator.name("Cutoff1"), options.getCutoff1());
         if (options.getCutoff2() != null)

--- a/src/org/labkey/test/util/AssayImporter.java
+++ b/src/org/labkey/test/util/AssayImporter.java
@@ -98,37 +98,37 @@ public class AssayImporter
             // populate the sample well group information
             for (int i = 0; i < options.getPtids().length; i++)
             {
-                test.setFormElement(Locator.name("specimen" + (i + 1) + "_ParticipantID"), options.getPtids()[i]);
+                test.setFormElement(Locator.name("Specimen " + (i + 1) + "_ParticipantID"), options.getPtids()[i]);
             }
 
             for (int i = 0; i < options.getVisits().length; i++)
             {
-                test.setFormElement(Locator.name("specimen" + (i + 1) + "_VisitID"), options.getVisits()[i]);
+                test.setFormElement(Locator.name("Specimen " + (i + 1) + "_VisitID"), options.getVisits()[i]);
             }
 
             for (int i = 0; i < options.getInitialDilutions().length; i++)
             {
-                test.setFormElement(Locator.name("specimen" + (i + 1) + "_InitialDilution"), options.getInitialDilutions()[i]);
+                test.setFormElement(Locator.name("Specimen " + (i + 1) + "_InitialDilution"), options.getInitialDilutions()[i]);
             }
 
             for (int i = 0; i < options.getDilutionFactors().length; i++)
             {
-                test.setFormElement(Locator.name("specimen" + (i + 1) + "_Factor"), options.getDilutionFactors()[i]);
+                test.setFormElement(Locator.name("Specimen " + (i + 1) + "_Factor"), options.getDilutionFactors()[i]);
             }
 
             for (int i = 0; i < options.getMethods().length; i++)
             {
-                test.selectOptionByText(Locator.name("specimen" + (i + 1) + "_Method"), options.getMethods()[i]);
+                test.selectOptionByText(Locator.name("Specimen " + (i + 1) + "_Method"), options.getMethods()[i]);
             }
 
             for (int i = 0; i < options.getDates().length; i++)
             {
-                test.setFormElement(Locator.name("specimen" + (i + 1) + "_Date"), options.getDates()[i]);
+                test.setFormElement(Locator.name("Specimen " + (i + 1) + "_Date"), options.getDates()[i]);
             }
 
             for (int i = 0; i < options.getSampleIds().length; i++)
             {
-                test.setFormElement(Locator.name("specimen" + (i + 1) + "_SpecimenID"), options.getSampleIds()[i]);
+                test.setFormElement(Locator.name("Specimen " + (i + 1) + "_SpecimenID"), options.getSampleIds()[i]);
             }
         }
         else

--- a/src/org/labkey/test/util/IssuesApiHelper.java
+++ b/src/org/labkey/test/util/IssuesApiHelper.java
@@ -34,9 +34,9 @@ public class IssuesApiHelper extends IssuesHelper
         issue.setAction(IssueModel.IssueAction.insert);
 
         // translate display name to userId
-        if (props.containsKey("assignedTo"))
+        if (props.containsKey("AssignedTo"))
         {
-            String displayName = props.get("assignedTo");
+            String displayName = props.get("AssignedTo");
             List<GetUsersResponse.UserInfo> user = _userHelper.getUsers().getUsersInfo().stream()
                     .filter(ui -> ui.getDisplayName().equals(displayName)).toList();
 
@@ -45,7 +45,7 @@ public class IssuesApiHelper extends IssuesHelper
                 issue.setAssignedTo(user.get(0).getUserId());
         }
 
-        if (!props.containsKey("priority"))
+        if (!props.containsKey("Priority"))
             issue.setPriority(_defaultPriority);
 
         try

--- a/src/org/labkey/test/util/IssuesHelper.java
+++ b/src/org/labkey/test/util/IssuesHelper.java
@@ -188,7 +188,7 @@ public class IssuesHelper extends WebDriverWrapper
     {
         Map<String, String> fields = new TreeMap<>();
         fields.put("title", title);
-        fields.put("assignedTo", assignedTo);
+        fields.put("AssignedTo", assignedTo);
         fields.putAll(extraFields);
         return addIssue(fields, attachments);
     }

--- a/src/org/labkey/test/util/PortalHelper.java
+++ b/src/org/labkey/test/util/PortalHelper.java
@@ -34,6 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * TODO: Move appropriate functionality into {@link org.labkey.test.pages.PortalBodyPanel} and {@link org.labkey.test.components.WebPart}
  */
@@ -463,15 +465,18 @@ public class PortalHelper extends WebDriverWrapper
         doInAdminMode(() -> {
             openWebpartPermissionWindow(webpart);
 
-            assertFormElementEquals(Locator.name("permission"), expectedPermission);
+            Locator loc1 = Locator.name("permission");
+            assertEquals(expectedPermission, getFormElement(loc1));
 
             if (expectedFolder == null)
             {
-                assertFormElementEquals(Locator.name("permissionContainer"), "");
+                Locator loc = Locator.name("permissionContainer");
+                assertEquals("", getFormElement(loc));
             }
             else
             {
-                assertFormElementEquals(Locator.name("permissionContainer"), expectedFolder);
+                Locator loc = Locator.name("permissionContainer");
+                assertEquals(expectedFolder, getFormElement(loc));
             }
 
             click(Locator.tagWithText("span", "Cancel"));

--- a/src/org/labkey/test/util/SampleTypeHelper.java
+++ b/src/org/labkey/test/util/SampleTypeHelper.java
@@ -23,6 +23,7 @@ import org.labkey.remoteapi.query.InsertRowsCommand;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.experiment.CreateSampleTypePage;
@@ -378,7 +379,7 @@ public class SampleTypeHelper extends WebDriverWrapper
         samplesTable.clickHeaderButtonAndWait("Link to Study");
 
         log("Link to study: Choose target");
-        selectOptionByText(Locator.id("targetStudy"), "/" + targetStudy + " (" + targetStudy + " Study)");
+        selectOptionByText(AssayConstants.TARGET_STUDY_FIELD_LOCATOR, "/" + targetStudy + " (" + targetStudy + " Study)");
         if (categoryName != null)
             setFormElement(Locator.name("autoLinkCategory"), categoryName);
         clickButton("Next");


### PR DESCRIPTION
#### Rationale
Some `<input>` fields are using `name` attributes that don't differentiate from similarly named fields.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6804

#### Changes
- Test coverage for original repro scenario - deriving samples with fields that differ only by special characters