### PR TITLE
Inverse regression test for list details issue

### DIFF
--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.domain.Domain;
 import org.labkey.remoteapi.domain.DomainResponse;
 import org.labkey.remoteapi.domain.PropertyDescriptor;
@@ -50,6 +51,8 @@ import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.pages.list.GridPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.StringLookup;
+import org.labkey.test.params.FieldInfo;
+import org.labkey.test.params.list.VarListDefinition;
 import org.labkey.test.tests.AuditLogTest;
 import org.labkey.test.util.AbstractDataRegionExportOrSignHelper.ColumnHeaderType;
 import org.labkey.test.util.AuditLogHelper;
@@ -2063,6 +2066,32 @@ public class ListTest extends BaseWebDriverTest
             assertTrue(getCurrentRelativeURL().contains(WebTestHelper.buildRelativeUrl("junit", PROJECT_VERIFY, "echoForm")));
         }
         popLocation();
+    }
+
+    /**
+     * Issue 53361: 'list-details.view' doesn't work when list pk is named "name"
+     * Expect bad product behavior. Convert this to a regression test once the issue is fixed.
+     */
+    @Test
+    public void testPkNameParameterCollision() throws IOException, CommandException
+    {
+        String listName = TestDataGenerator.randomDomainName("list_key_check");
+        String pkCol = "Name";
+
+        var dgen = new VarListDefinition(listName)
+            .setFields(List.of(new FieldDefinition(pkCol)))
+            .create(createDefaultConnection(), getProjectName())
+            .withGeneratedRows(10);
+        List<String> pks = dgen.getRows().stream().map(row -> (String) row.get(pkCol)).toList();
+        dgen.insertRows();
+
+        goToProjectHome();
+
+        goToManageLists().getGrid().viewListData(listName);
+
+        clickAndWait(Locator.linkWithText(pks.get(0)));
+        assertElementPresent(Locator.byClass("labkey-error-heading")
+            .withText("List item '%s' does not exist".formatted(listName)));
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
[Issue 53361: 'list-details.view' doesn't work when list pk is named "name"](https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=42042)

This test will start failing once the underlying issue is fixed.

#### Related Pull Requests
- N/A

#### Changes
- Inverse regression test for list details issue
