### PR TITLE
Make `FieldKey.fromFieldKey` return null for invalid input

### DIFF
--- a/src/org/labkey/test/params/FieldKey.java
+++ b/src/org/labkey/test/params/FieldKey.java
@@ -80,7 +80,7 @@ public final class FieldKey implements CharSequence, WrapsFieldKey
             }
             catch (IllegalArgumentException iae)
             {
-                return null; // FieldRefernceManager depends on this returning null.
+                return null; // FieldReferenceManager depends on this returning null.
             }
         }
     }

--- a/src/org/labkey/test/params/FieldKey.java
+++ b/src/org/labkey/test/params/FieldKey.java
@@ -2,6 +2,7 @@ package org.labkey.test.params;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -65,7 +66,7 @@ public final class FieldKey implements CharSequence, WrapsFieldKey
      * @param fieldKey String or FieldKey
      * @return FieldKey representation of the String, or the identity if a FieldKey was provided
      */
-    public static FieldKey fromFieldKey(CharSequence fieldKey)
+    public static @Nullable FieldKey fromFieldKey(CharSequence fieldKey)
     {
         if (fieldKey instanceof WrapsFieldKey fk)
         {
@@ -73,7 +74,14 @@ public final class FieldKey implements CharSequence, WrapsFieldKey
         }
         else
         {
-            return fromParts(Arrays.stream(fieldKey.toString().split(SEPARATOR)).map(FieldKey::decodePart).toList());
+            try
+            {
+                return fromParts(Arrays.stream(fieldKey.toString().split(SEPARATOR)).map(FieldKey::decodePart).toList());
+            }
+            catch (IllegalArgumentException iae)
+            {
+                return null;
+            }
         }
     }
 

--- a/src/org/labkey/test/params/FieldKey.java
+++ b/src/org/labkey/test/params/FieldKey.java
@@ -80,7 +80,7 @@ public final class FieldKey implements CharSequence, WrapsFieldKey
             }
             catch (IllegalArgumentException iae)
             {
-                return null;
+                return null; // FieldRefernceManager depends on this returning null.
             }
         }
     }


### PR DESCRIPTION
#### Rationale
I removed this try/catch, hoping this could be a bit more strict but it's causing errors.

```
java.lang.IllegalArgumentException: FieldKey can't have blank part(s):
        at org.labkey.test.params.FieldKey.child(FieldKey.java:111)
        at org.labkey.test.params.FieldKey.fromParts(FieldKey.java:52)
        at org.labkey.test.params.FieldKey.fromFieldKey(FieldKey.java:76)
        at org.labkey.test.components.ui.grids.FieldReferenceManager.lambda$2(FieldReferenceManager.java:63)
        [...]
        at org.labkey.test.components.ui.grids.FieldReferenceManager.findFieldReference(FieldReferenceManager.java:72)
        at org.labkey.test.components.ui.grids.FieldReferenceManager.findFieldReferenceOrNull(FieldReferenceManager.java:80)
        at org.labkey.test.util.DataRegionTable$Elements.getColumnIndex(DataRegionTable.java:1532)
        at org.labkey.test.util.DataRegionTable.getColumnIndexStrict(DataRegionTable.java:421)
        at org.labkey.test.util.DataRegionTable.getDataAsText(DataRegionTable.java:675)
```

#### Related Pull Requests
- #2513 

#### Changes
- Make `FieldKey.fromFieldKey` return null for invalid input
