### PR TITLE
Fix data region column name references

### DIFF
--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -29,7 +29,6 @@ import org.labkey.test.components.ext4.ComboBox;
 import org.labkey.test.components.ext4.RadioButton;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.params.FieldKey;
-import org.labkey.test.selenium.LazyWebElement;
 import org.labkey.test.selenium.RefindingWebElement;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
@@ -233,14 +232,14 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         saveWindow.save();
     }
 
-    public static class SaveWindow extends Window
+    public static class SaveWindow extends Window<Window<?>.ElementCache>
     {
         public final Checkbox shareCheckbox = Ext4Checkbox().withLabel("Make this grid view available to all users").findWhenNeeded(this);
         public final Checkbox inheritCheckbox = Ext4Checkbox().withLabel("Make this grid view available in child folders").findWhenNeeded(this);
         public final RadioButton defaultViewRadio = RadioButton().withLabelContaining("Default").findWhenNeeded(this);
         public final RadioButton namedViewRadio = RadioButton().withLabelContaining("Named").findWhenNeeded(this);
-        private final WebElement viewNameInput = new LazyWebElement(Locator.xpath("//input[@name='saveCustomView_name']"), this);
-        private final WebElement targetContainerInput = new LazyWebElement(Locator.xpath("//input[@name='saveCustomView_targetContainer']"), this);
+        private final WebElement viewNameInput = Locator.input("saveCustomView_name").findWhenNeeded(this);
+        private final WebElement targetContainerInput = Locator.input("saveCustomView_targetContainer").findWhenNeeded(this);
 
         protected SaveWindow(WebDriver driver)
         {
@@ -353,7 +352,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
             WebElement fieldRow = Locator.tag("tr").withClass("x4-grid-data-row").withAttribute("data-recordid", dataRecordId).waitForElement(getComponentElement(), 10000);
 
             _driver.scrollIntoView(fieldRow, false);
-            if (!fieldRow.getAttribute("class").contains("expanded"))
+            if (!StringUtils.trimToEmpty(fieldRow.getAttribute("class")).contains("expanded"))
             {
                 Locator.css(".x4-tree-expander").findElement(fieldRow).click();
             }
@@ -733,7 +732,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
             super(ViewItemType.Columns, fieldkey);
         }
 
-        public Window clickEdit()
+        public Window<?> clickEdit()
         {
             WebElement gear = Locator.css("div.labkey-tool-gear").findElement(getComponentElement());
             _driver.scrollIntoView(gear, true);

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -46,6 +46,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import static org.labkey.test.components.ext4.Checkbox.Ext4Checkbox;
 import static org.labkey.test.components.ext4.RadioButton.RadioButton;
@@ -307,10 +308,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
     /**
      * add a column to an already open customize view grid
      *
-     * @param fieldKey Name of the column.  If your column is nested, should be of the form
-     *          "nodename/nodename/lastnodename", where nodename is not the displayed text of a node
-     *          but the name included in the span containing the checkbox.  It will often be the same name,
-     *          but with less whitespace
+     * @param fieldKey fieldKey of the column
      */
     public void addColumn(CharSequence fieldKey)
     {
@@ -338,14 +336,14 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
     }
 
     /**
-     * expand customize view menu to all but the last of fieldKeyParts
-     * @return The data-recordid property of the &lt;tr&gt; element for the specified field in the "Available Fields" column tree.
+     * expand customize view fields tree to expose the specified column
+     * @return The row element for the specified column
      */
-    private WebElement expandPivots(CharSequence fieldIdentifier)
+    private WebElement expandPivots(CharSequence fieldKey)
     {
-        Iterator<FieldKey> fieldKeyIterator = FieldKey.fromFieldKey(fieldIdentifier).getIterator();
-        FieldKey fieldKey = fieldKeyIterator.next();
-        String dataRecordId = fieldKey.toString().toUpperCase();
+        Iterator<FieldKey> fieldKeyIterator = Objects.requireNonNull(FieldKey.fromFieldKey(fieldKey), "Invalid fieldKey: " + fieldKey).getIterator();
+        FieldKey currentFieldKey = fieldKeyIterator.next();
+        String dataRecordId = currentFieldKey.toString().toUpperCase();
 
         while (fieldKeyIterator.hasNext())
         {
@@ -359,8 +357,8 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
             Locator.tag("tr").withClass("x4-grid-tree-node-expanded").withAttribute("data-recordid", dataRecordId).waitForElement(getComponentElement(), 10000);
             WebDriverWrapper.waitFor(() -> Locator.css("tr[data-recordid] + tr:not(.x4-grid-row)").findElements(getComponentElement()).isEmpty(), 2000); // Spacer row appears during expansion animation
 
-            fieldKey = fieldKeyIterator.next();
-            dataRecordId = fieldKey.toString().toUpperCase();
+            currentFieldKey = fieldKeyIterator.next();
+            dataRecordId = currentFieldKey.toString().toUpperCase();
         }
 
         return Locator.tag("tr").withClass("x4-grid-data-row").withAttribute("data-recordid", dataRecordId).findElement(getComponentElement());

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -45,8 +45,6 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -320,11 +318,6 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         addItem(fieldKey, ViewItemType.Columns);
     }
 
-    public void addColumn(String[] fieldKeyParts)
-    {
-        addColumn(StringUtils.join(fieldKeyParts, "/"));
-    }
-
     public void changeTab(ViewItemType tab)
     {
         Locator.tag("ul").child(Locator.tag("li").withClass("labkey-customview-tab").containing(tab.toString())).findElement(this).click();
@@ -393,11 +386,6 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
     public void addFilter(CharSequence fieldKey, String filter_type)
     {
         addFilter(fieldKey, filter_type, "");
-    }
-
-    public void addFilter(String[] fieldKeyParts, String filter_type, String filter)
-    {
-        addFilter(String.join("/", fieldKeyParts), filter_type, filter);
     }
 
     public void addFilter(CharSequence fieldKey, String filter_type, String filter)
@@ -513,11 +501,6 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
 
         _driver._ext4Helper.selectComboBoxItem(itemXPath, order.toString());
         itemXPath.append("//tr").findElement(this).click(); // Sort direction doesn't stick without this
-    }
-
-    public void addSort(String[] fieldKeyParts, SortDirection order)
-    {
-        addSort(String.join("/", fieldKeyParts), order);
     }
 
     public void removeColumn(CharSequence fieldKey)

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -28,6 +28,7 @@ import org.labkey.test.components.ext4.Checkbox;
 import org.labkey.test.components.ext4.ComboBox;
 import org.labkey.test.components.ext4.RadioButton;
 import org.labkey.test.components.ext4.Window;
+import org.labkey.test.params.FieldKey;
 import org.labkey.test.selenium.LazyWebElement;
 import org.labkey.test.selenium.RefindingWebElement;
 import org.labkey.test.util.DataRegionTable;
@@ -46,6 +47,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 
 import static org.labkey.test.components.ext4.Checkbox.Ext4Checkbox;
@@ -258,10 +260,10 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
             getWrapper().setFormElement(targetContainerInput, container);
         }
 
-        public Window saveError()
+        public Window<?> saveError()
         {
             clickButton("Save", 0);
-            return new Window("Error saving grid view", getWrapper().getDriver());
+            return new Window<>("Error saving grid view", getWrapper().getDriver());
         }
 
         public void save()
@@ -279,7 +281,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
     public void deleteView()
     {
         elements().deleteButton.click();
-        Window confirm = Window(getDriver()).withTitleContaining("Delete").find();
+        Window<?> confirm = Window(getDriver()).withTitleContaining("Delete").find();
         confirm.clickButton("Yes");
     }
 
@@ -308,19 +310,19 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
     /**
      * add a column to an already open customize view grid
      *
-     * @param column_name Name of the column.  If your column is nested, should be of the form
+     * @param fieldKey Name of the column.  If your column is nested, should be of the form
      *          "nodename/nodename/lastnodename", where nodename is not the displayed text of a node
      *          but the name included in the span containing the checkbox.  It will often be the same name,
      *          but with less whitespace
      */
-    public void addColumn(String column_name)
+    public void addColumn(CharSequence fieldKey)
     {
-        addColumn(column_name, column_name);
+        addItem(fieldKey, ViewItemType.Columns);
     }
 
     public void addColumn(String[] fieldKeyParts)
     {
-        addColumn(fieldKeyParts, StringUtils.join(fieldKeyParts, "/"));
+        addColumn(StringUtils.join(fieldKeyParts, "/"));
     }
 
     public void changeTab(ViewItemType tab)
@@ -347,84 +349,71 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
      * expand customize view menu to all but the last of fieldKeyParts
      * @return The data-recordid property of the &lt;tr&gt; element for the specified field in the "Available Fields" column tree.
      */
-    private WebElement expandPivots(String[] fieldKeyParts)
+    private WebElement expandPivots(CharSequence fieldIdentifier)
     {
-        String nodePath = "";
-        String fieldKey = StringUtils.join(fieldKeyParts, "/").toUpperCase();
+        Iterator<FieldKey> fieldKeyIterator = FieldKey.fromFieldKey(fieldIdentifier).getIterator();
+        FieldKey fieldKey = fieldKeyIterator.next();
+        String dataRecordId = fieldKey.toString().toUpperCase();
 
-        for (int i = 0; i < fieldKeyParts.length - 1; i ++ )
+        while (fieldKeyIterator.hasNext())
         {
-            nodePath += fieldKeyParts[i].toUpperCase();
-            WebElement fieldRow = Locator.tag("tr").withClass("x4-grid-data-row").withAttribute("data-recordid", nodePath).waitForElement(getComponentElement(), 10000);
+            WebElement fieldRow = Locator.tag("tr").withClass("x4-grid-data-row").withAttribute("data-recordid", dataRecordId).waitForElement(getComponentElement(), 10000);
 
             _driver.scrollIntoView(fieldRow, false);
             if (!fieldRow.getAttribute("class").contains("expanded"))
             {
                 Locator.css(".x4-tree-expander").findElement(fieldRow).click();
             }
-            Locator.tag("tr").withClass("x4-grid-tree-node-expanded").withAttribute("data-recordid", nodePath).waitForElement(getComponentElement(), 10000);
+            Locator.tag("tr").withClass("x4-grid-tree-node-expanded").withAttribute("data-recordid", dataRecordId).waitForElement(getComponentElement(), 10000);
             WebDriverWrapper.waitFor(() -> Locator.css("tr[data-recordid] + tr:not(.x4-grid-row)").findElements(getComponentElement()).isEmpty(), 2000); // Spacer row appears during expansion animation
-            nodePath += "/";
+
+            fieldKey = fieldKeyIterator.next();
+            dataRecordId = fieldKey.toString().toUpperCase();
         }
 
-        return Locator.tag("tr").withClass("x4-grid-data-row").withAttribute("data-recordid", fieldKey).findElement(getComponentElement());
+        return Locator.tag("tr").withClass("x4-grid-data-row").withAttribute("data-recordid", dataRecordId).findElement(getComponentElement());
     }
 
-    private void addItem(String[] fieldKeyParts, String columnName, ViewItemType type)
+    private void addItem(CharSequence fieldKey, ViewItemType type)
     {
         // fieldKey is the value contained in @fieldkey
-        _driver.log("Adding " + columnName + " " + type.toString());
+        _driver.log("Adding " + fieldKey + " " + type);
 
         changeTab(type);
 
         // Expand all nodes necessary to reveal the desired node.
-        WebElement fieldRow = expandPivots(fieldKeyParts);
+        WebElement fieldRow = expandPivots(fieldKey);
         WebElement checkbox = Locator.css("input[type=button]").findElement(fieldRow);
         WebElement rowLabel = Locator.byClass("x4-tree-node-text").findElement(fieldRow);
         rowLabel.click();
         new Checkbox(checkbox).check();
-        itemXPath(type, fieldKeyParts).waitForElement(this, 2_000);
+        itemXPath(type, fieldKey).waitForElement(this, 2_000);
     }
 
-    public void addColumn(String[] fieldKeyParts, String label)
+    public void addFilter(CharSequence fieldKey, String filter_type)
     {
-        addItem(fieldKeyParts, label, ViewItemType.Columns);
+        addFilter(fieldKey, filter_type, "");
     }
 
-    public void addColumn(String fieldKey, String column_name)
+    public void addFilter(String[] fieldKeyParts, String filter_type, String filter)
     {
-        addItem(fieldKey.split("/"), column_name, ViewItemType.Columns);
+        addFilter(String.join("/", fieldKeyParts), filter_type, filter);
     }
 
-    public void addFilter(String fieldKey, String filter_type)
-    {
-        addFilter(fieldKey, fieldKey, filter_type, "");
-    }
-
-    public void addFilter(String fieldKey, String filter_type, String filter)
-    {
-        addFilter(fieldKey, fieldKey, filter_type, filter);
-    }
-
-    public void addFilter(String fieldKey, String column_name, String filter_type, String filter)
-    {
-        addFilter(fieldKey.split("/"), column_name, filter_type, filter);
-    }
-
-    public void addFilter(String[] fieldKeyParts, String column_name, String filter_type, String filter)
+    public void addFilter(CharSequence fieldKey, String filter_type, String filter)
     {
         if (filter.isEmpty())
-            _driver.log("Adding " + column_name + " filter of " + filter_type);
+            _driver.log("Adding " + fieldKey + " filter of " + filter_type);
         else
-            _driver.log("Adding " + column_name + " filter of " + filter_type + " " + filter);
+            _driver.log("Adding " + fieldKey + " filter of " + filter_type + " " + filter);
 
         changeTab(ViewItemType.Filter);
-        Locator.XPathLocator itemXPath = itemXPath(ViewItemType.Filter, fieldKeyParts);
+        Locator.XPathLocator itemXPath = itemXPath(ViewItemType.Filter, fieldKey);
 
         if (!_driver.isElementPresent(itemXPath))
         {
             // Add filter if it doesn't exist
-            addItem(fieldKeyParts, column_name, ViewItemType.Filter);
+            addItem(fieldKey, ViewItemType.Filter);
             _driver.assertElementPresent(itemXPath);
         }
         else
@@ -459,15 +448,9 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         return Locator.tagWithClass("div", "test-" + type.toString().toLowerCase() + "-tab");
     }
 
-    private Locator.XPathLocator itemXPath(ViewItemType type, String[] fieldKeyParts)
+    private Locator.XPathLocator itemXPath(ViewItemType type, CharSequence fieldKey)
     {
-        return itemXPath(type, StringUtils.join(fieldKeyParts, "/"));
-    }
-
-    private Locator.XPathLocator itemXPath(ViewItemType type, String fieldKey)
-    {
-        FieldKey parsedFieldKey = new FieldKey(fieldKey);
-        return itemXPath(type).withPredicate("@fieldkey=" + Locator.xq(fieldKey) + " or @fieldkey=" + Locator.xq(parsedFieldKey.toString()));
+        return itemXPath(type).withAttribute("fieldkey", fieldKey.toString());
     }
 
     private Locator.XPathLocator itemXPath(ViewItemType type, int item_index)
@@ -510,43 +493,6 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         }
     }
 
-    public static class FieldKey
-    {
-        public static final String SEPARATOR = "/";
-        private final String fieldName;
-        private final String fieldKey;
-        private final List<String> lookupParts;
-
-        public FieldKey(String fieldKey)
-        {
-            List<String> allParts = Arrays.asList(fieldKey.split(SEPARATOR));
-            lookupParts = allParts.subList(0, allParts.size() - 1);
-            for (int i = 0; i < lookupParts.size(); i++)
-            {
-                lookupParts.set(i, lookupParts.get(i));//.toUpperCase());
-            }
-            fieldName = allParts.get(allParts.size() - 1);
-            allParts = new ArrayList<>(lookupParts);
-            allParts.add(fieldName);
-            this.fieldKey = String.join(SEPARATOR, allParts);
-        }
-
-        public String getFieldName()
-        {
-            return fieldName;
-        }
-
-        public List<String> getLookupParts()
-        {
-            return lookupParts;
-        }
-
-        public String toString()
-        {
-            return fieldKey;
-        }
-    }
-
     //enable customize view grid to show hidden fields
     public void showHiddenItems()
     {
@@ -558,25 +504,20 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         BaseWebDriverTest.sleep(250); // wait for columns to display
     }
 
-    public void addSort(String column_name, SortDirection order)
+    public void addSort(CharSequence fieldKey, SortDirection order)
     {
-        addSort(column_name, column_name, order);
-    }
-
-    public void addSort(String fieldKey, String column_name, SortDirection order)
-    {
-        addSort(fieldKey.split("/"), column_name, order);
-    }
-
-    public void addSort(String[] fieldKeyParts, String column_name, SortDirection order)
-    {
-        Locator.XPathLocator itemXPath = itemXPath(ViewItemType.Sort, fieldKeyParts);
+        Locator.XPathLocator itemXPath = itemXPath(ViewItemType.Sort, fieldKey);
 
         _driver.assertElementNotPresent(itemXPath);
-        addItem(fieldKeyParts, column_name, ViewItemType.Sort);
+        addItem(fieldKey, ViewItemType.Sort);
 
         _driver._ext4Helper.selectComboBoxItem(itemXPath, order.toString());
         itemXPath.append("//tr").findElement(this).click(); // Sort direction doesn't stick without this
+    }
+
+    public void addSort(String[] fieldKeyParts, SortDirection order)
+    {
+        addSort(String.join("/", fieldKeyParts), order);
     }
 
     public void removeColumn(String fieldKey)
@@ -714,11 +655,11 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
     }
 
     /** Check that a column is present. */
-    public boolean isColumnPresent(String fieldKey)
+    public boolean isColumnPresent(CharSequence fieldKey)
     {
         try
         {
-            expandPivots(fieldKey.split("/"));
+            expandPivots(fieldKey);
             return true;
         }
         catch (NoSuchElementException no)
@@ -728,23 +669,23 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
     }
 
     /** Check that a column is present and is not selectable. */
-    public boolean isColumnUnselectable(String fieldKey)
+    public boolean isColumnUnselectable(CharSequence fieldKey)
     {
-        WebElement fieldRow = expandPivots(fieldKey.split("/"));
+        WebElement fieldRow = expandPivots(fieldKey);
         return "on".equals(fieldRow.getAttribute("unselectable"));
     }
 
-    public WebElement getColumn(String fieldKey)
+    public WebElement getColumn(CharSequence fieldKey)
     {
-        return expandPivots(fieldKey.split("/"));
+        return expandPivots(fieldKey);
     }
 
     /** Check that a column is present and not hidden. Assumes that the 'show hidden columns' is unchecked. */
-    public boolean isColumnVisible(String fieldKey)
+    public boolean isColumnVisible(CharSequence fieldKey)
     {
         try
         {
-            WebElement fieldRow = expandPivots(fieldKey.split("/"));
+            WebElement fieldRow = expandPivots(fieldKey);
             return fieldRow.isDisplayed();
         }
         catch (NoSuchElementException no)
@@ -754,9 +695,9 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
     }
 
     /** Check that a column is present and is a lookup column. */
-    public boolean isLookupColumn(String fieldKey)
+    public boolean isLookupColumn(CharSequence fieldKey)
     {
-        WebElement fieldRow = expandPivots(fieldKey.split("/"));
+        WebElement fieldRow = expandPivots(fieldKey);
         return !Locator.css("img.x4-tree-expander").findElements(fieldRow).isEmpty();
     }
 
@@ -766,7 +707,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         return new Elements();
     }
 
-    protected class Elements extends Component.ElementCache
+    protected class Elements extends Component<?>.ElementCache
     {
         protected final WebElement deleteButton = new RefindingWebElement(Ext4Helper.Locators.ext4Button("Delete"), this);
         protected final WebElement revertButton = new RefindingWebElement(Ext4Helper.Locators.ext4Button("Revert"), this);
@@ -774,7 +715,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         protected final WebElement saveButton = new RefindingWebElement(Ext4Helper.Locators.ext4Button("Save"), this);
     }
 
-    private class SelectedItemRow extends Component
+    private class SelectedItemRow extends Component<Component<?>.ElementCache>
     {
         private final WebElement _element;
         private final String _fieldKey;

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -463,7 +463,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         return Locator.tagWithClass("table", "labkey-customview-" + type.toString().toLowerCase() + "-item");
     }
 
-    private void removeItem(String fieldKey, ViewItemType type)
+    private void removeItem(CharSequence fieldKey, ViewItemType type)
     {
         changeTab(type);
 
@@ -520,19 +520,19 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         addSort(String.join("/", fieldKeyParts), order);
     }
 
-    public void removeColumn(String fieldKey)
+    public void removeColumn(CharSequence fieldKey)
     {
         _driver.log("Removing " + fieldKey + " column");
         removeItem(fieldKey, ViewItemType.Columns);
     }
 
-    public void removeFilter(String fieldKey)
+    public void removeFilter(CharSequence fieldKey)
     {
         _driver.log("Removing " + fieldKey + " filter");
         removeItem(fieldKey, ViewItemType.Filter);
     }
 
-    public void removeSort(String fieldKey)
+    public void removeSort(CharSequence fieldKey)
     {
         _driver.log("Removing " + fieldKey + " sort");
         removeItem(fieldKey, ViewItemType.Sort);
@@ -584,25 +584,25 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         _driver._ext4Helper.selectComboBoxItem("Folder Filter:", folderFilter);
     }
 
-    public void moveColumn(String fieldKey, boolean moveUp)
+    public void moveColumn(CharSequence fieldKey, boolean moveUp)
     {
         _driver.log("Moving filter, " + fieldKey + " " + (moveUp ? "up." : "down."));
         moveItem(fieldKey, moveUp, ViewItemType.Columns);
     }
 
-    public void moveFilter(String fieldKey, boolean moveUp)
+    public void moveFilter(CharSequence fieldKey, boolean moveUp)
     {
         _driver.log("Moving filter, " + fieldKey + " " + (moveUp ? "up." : "down."));
         moveItem(fieldKey, moveUp, ViewItemType.Filter);
     }
 
-    public void moveSort(String fieldKey, boolean moveUp)
+    public void moveSort(CharSequence fieldKey, boolean moveUp)
     {
         _driver.log("Moving sort, " + fieldKey + " " + (moveUp ? "up." : "down."));
         moveItem(fieldKey, moveUp, ViewItemType.Sort);
     }
 
-    private void moveItem(String fieldKey, boolean moveUp, ViewItemType type)
+    private void moveItem(CharSequence fieldKey, boolean moveUp, ViewItemType type)
     {
         changeTab(type);
         final int itemIndex = _driver.getElementIndex(itemXPath(type, fieldKey).findElement(this));
@@ -624,7 +624,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         builder.dragAndDrop(fromItem, toItem).build().perform();
     }
 
-    public void removeColumnTitle(String fieldKey)
+    public void removeColumnTitle(CharSequence fieldKey)
     {
         setColumnTitle(fieldKey, null);
     }
@@ -634,7 +634,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
      * @param fieldKey The field key of the column to change.  Note that the column should already be in the selected column list.
      * @param caption The caption value or null to unset the column caption.
      */
-    public void setColumnTitle(String fieldKey, String caption)
+    public void setColumnTitle(CharSequence fieldKey, String caption)
     {
         String msg = "Setting column " + fieldKey;
         if (caption != null)
@@ -643,15 +643,14 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
 
         changeTab(ViewItemType.Columns);
 
-        Window window = new SelectedColumnRow(fieldKey).clickEdit();
+        Window<?> window = new SelectedColumnRow(fieldKey).clickEdit();
 
         if (caption == null)
             caption = "";
         _driver.setFormElement(Locator.name("title").findElement(window), caption);
         Locator.xpath("//label").findElement(window).click();
 
-        window.clickButton("OK", 0);
-        window.waitForClose();
+        window.clickButton("OK", true);
     }
 
     /** Check that a column is present. */
@@ -718,11 +717,11 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
     private class SelectedItemRow extends Component<Component<?>.ElementCache>
     {
         private final WebElement _element;
-        private final String _fieldKey;
+        private final FieldKey _fieldKey;
 
-        protected SelectedItemRow(ViewItemType itemType, String fieldkey)
+        protected SelectedItemRow(ViewItemType itemType, CharSequence fieldkey)
         {
-            _fieldKey = fieldkey;
+            _fieldKey = FieldKey.fromFieldKey(fieldkey);
             _element = itemXPath(itemType, fieldkey).findElement(CustomizeView.this);
         }
 
@@ -732,7 +731,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
             return _element;
         }
 
-        protected String getFieldKey()
+        protected FieldKey getFieldKey()
         {
             return _fieldKey;
         }
@@ -746,7 +745,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
 
     private class SelectedColumnRow extends SelectedItemRow
     {
-        public SelectedColumnRow(String fieldkey)
+        public SelectedColumnRow(CharSequence fieldkey)
         {
             super(ViewItemType.Columns, fieldkey);
         }
@@ -762,7 +761,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
 
     private class SelectedFilterRow extends SelectedItemRow
     {
-        public SelectedFilterRow(String fieldkey)
+        public SelectedFilterRow(CharSequence fieldkey)
         {
             super(ViewItemType.Filter, fieldkey);
         }
@@ -775,7 +774,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
 
     private class SelectedSortRow extends SelectedItemRow
     {
-        public SelectedSortRow(String fieldkey)
+        public SelectedSortRow(CharSequence fieldkey)
         {
             super(ViewItemType.Sort, fieldkey);
         }

--- a/src/org/labkey/test/params/FieldKey.java
+++ b/src/org/labkey/test/params/FieldKey.java
@@ -27,9 +27,18 @@ public final class FieldKey implements CharSequence, WrapsFieldKey
 
     private FieldKey(FieldKey parent, String child)
     {
-        _parent = parent;
-        _name = (parent != null && !parent.getName().isBlank() ? parent.getName() + SEPARATOR : "") + child;
-        _fieldKey = (parent != null && !parent.getName().isBlank() ? parent + SEPARATOR : "") + encodePart(child);
+        if (parent != null && !parent.isEmpty())
+        {
+            _parent = parent;
+            _name = parent.getName() + SEPARATOR + child;
+            _fieldKey = parent + SEPARATOR + encodePart(child);
+        }
+        else
+        {
+            _parent = null;
+            _name = child;
+            _fieldKey = encodePart(child);
+        }
     }
 
     public static List<String> getIllegalChars()

--- a/src/org/labkey/test/params/FieldKey.java
+++ b/src/org/labkey/test/params/FieldKey.java
@@ -15,9 +15,9 @@ public final class FieldKey implements CharSequence, WrapsFieldKey
     private static final String[] ILLEGAL = {"$", "/", "&", "}", "~", ",", "."};
     private static final String[] REPLACEMENT = {"$D", "$S", "$A", "$B", "$T", "$C", "$P"};
 
-    public static final FieldKey EMPTY = new FieldKey(""); // Useful as a sort of FieldKey builder starting point
-    public static final FieldKey SOURCES_FK = new FieldKey("DataInputs");
-    public static final FieldKey PARENTS_FK = new FieldKey("MaterialInputs");
+    public static final FieldKey EMPTY = new FieldKey(null, ""); // Useful as a sort of FieldKey builder starting point
+    public static final FieldKey SOURCES_FK = FieldKey.fromParts("DataInputs");
+    public static final FieldKey PARENTS_FK = FieldKey.fromParts("MaterialInputs");
 
     private static final String SEPARATOR = "/";
 
@@ -25,18 +25,11 @@ public final class FieldKey implements CharSequence, WrapsFieldKey
     private final String _name;
     private final String _fieldKey;
 
-    private FieldKey(String name)
-    {
-        _parent = null;
-        _name = name;
-        _fieldKey = encodePart(name);
-    }
-
     private FieldKey(FieldKey parent, String child)
     {
         _parent = parent;
-        _name = parent.getName() + SEPARATOR + child;
-        _fieldKey = parent + SEPARATOR + encodePart(child);
+        _name = (parent != null && !parent.getName().isBlank() ? parent.getName() + SEPARATOR : "") + child;
+        _fieldKey = (parent != null && !parent.getName().isBlank() ? parent + SEPARATOR : "") + encodePart(child);
     }
 
     public static List<String> getIllegalChars()
@@ -46,14 +39,7 @@ public final class FieldKey implements CharSequence, WrapsFieldKey
 
     public static FieldKey fromParts(List<String> parts)
     {
-        FieldKey fieldKey = EMPTY;
-
-        for (String part : parts)
-        {
-            fieldKey = fieldKey.child(part);
-        }
-
-        return fieldKey;
+        return EMPTY.child(parts);
     }
 
     public static FieldKey fromParts(String... parts)
@@ -113,19 +99,23 @@ public final class FieldKey implements CharSequence, WrapsFieldKey
         return _parent;
     }
 
-    public FieldKey child(String part)
+    public FieldKey child(String... parts)
     {
-        if (StringUtils.isBlank(part))
-            throw new IllegalArgumentException("FieldKey can't have blank part(s): " + this);
+        return child(Arrays.asList(parts));
+    }
 
-        if (StringUtils.isBlank(getName()))
+    public FieldKey child(List<String> parts)
+    {
+        FieldKey child = this;
+
+        for (String part : parts)
         {
-            return new FieldKey(part);
+            if (StringUtils.isBlank(part))
+                throw new IllegalArgumentException("FieldKey can't have blank part(s): " + parts);
+
+            child = new FieldKey(child, part);
         }
-        else
-        {
-            return new FieldKey(this, part);
-        }
+        return child;
     }
 
     public Iterator<FieldKey> getIterator()

--- a/src/org/labkey/test/tests/ButtonCustomizationTest.java
+++ b/src/org/labkey/test/tests/ButtonCustomizationTest.java
@@ -188,7 +188,7 @@ public class ButtonCustomizationTest extends BaseWebDriverTest
                 Locator.lkButton(METADATA_LINK_BUTTON).waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT)
                         .getAttribute("class").contains("labkey-disabled-button"));
 
-        buttonRegion.checkCheckbox(buttonRegion.getRowIndex("Portland", "Name"));
+        buttonRegion.checkCheckbox(buttonRegion.getRowIndex("Name", "Portland"));
         // wait for the button to enable:
         waitForElement(Locator.lkButton(METADATA_LINK_BUTTON), 10000);
 

--- a/src/org/labkey/test/tests/ContainerContextTest.java
+++ b/src/org/labkey/test/tests/ContainerContextTest.java
@@ -35,6 +35,7 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Data;
 import org.labkey.test.pages.reports.ScriptReportPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldKey;
 import org.labkey.test.params.list.IntListDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
@@ -177,7 +178,7 @@ public class ContainerContextTest extends BaseWebDriverTest
 
         log("** Adding in lookup list columns to grid");
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn(new String[] { "ListLookup", "LookupAge" });
+        _customizeViewsHelper.addColumn(FieldKey.fromParts("ListLookup", "LookupAge"));
         _customizeViewsHelper.saveCustomView();
 
         log("** Checking URLs go to correct container...");

--- a/src/org/labkey/test/tests/CustomizeViewTest.java
+++ b/src/org/labkey/test/tests/CustomizeViewTest.java
@@ -300,7 +300,7 @@ public class CustomizeViewTest extends BaseWebDriverTest
     @Test
     public void saveFilterTest()
     {
-        String fieldKey = FieldKey.fromParts(LAST_NAME_COLUMN).toString();
+        FieldKey fieldKey = FieldKey.fromParts(LAST_NAME_COLUMN);
         String op = "Starts With";
         String value = "J";
         String[] viewNames = {TRICKY_CHARACTERS + "view", "AAC", "aaa", "aad", "zzz"};
@@ -309,7 +309,7 @@ public class CustomizeViewTest extends BaseWebDriverTest
         for(String name : viewNames)
         {
             _customizeViewsHelper.openCustomizeViewPanel();
-            _customizeViewsHelper.addFilter(new String[]{fieldKey}, op, value);
+            _customizeViewsHelper.addFilter(fieldKey, op, value);
             _customizeViewsHelper.saveCustomView(name);
         }
 

--- a/src/org/labkey/test/tests/CustomizeViewTest.java
+++ b/src/org/labkey/test/tests/CustomizeViewTest.java
@@ -309,7 +309,7 @@ public class CustomizeViewTest extends BaseWebDriverTest
         for(String name : viewNames)
         {
             _customizeViewsHelper.openCustomizeViewPanel();
-            _customizeViewsHelper.addFilter(new String[]{fieldKey}, fieldKey, op, value);
+            _customizeViewsHelper.addFilter(new String[]{fieldKey}, op, value);
             _customizeViewsHelper.saveCustomView(name);
         }
 
@@ -350,7 +350,7 @@ public class CustomizeViewTest extends BaseWebDriverTest
     private void addFilter(String columnName, String op, String value)
     {
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addFilter(FieldKey.fromParts(columnName).toString(), columnName, op, value);
+        _customizeViewsHelper.addFilter(FieldKey.fromParts(columnName).toString(), op, value);
         _customizeViewsHelper.applyCustomView();
     }
 

--- a/src/org/labkey/test/tests/DataReportsTest.java
+++ b/src/org/labkey/test/tests/DataReportsTest.java
@@ -191,7 +191,7 @@ public class DataReportsTest extends ReportTest
         clickAndWait(Locator.linkWithText("AE-1:(VTN) AE Log"));
         DataRegionTable dataSetTable = new DataRegionTable("Dataset", getDriver());
         dataSetTable.openCustomizeGrid();
-        _customizeViewsHelper.addFilter("MouseId", "Mouse Id", "Equals One Of", String.join(";", PTIDS_FOR_CUSTOM_VIEW));
+        _customizeViewsHelper.addFilter("MouseId", "Equals One Of", String.join(";", PTIDS_FOR_CUSTOM_VIEW));
         _customizeViewsHelper.saveCustomView(QUERY_REPORT_VIEW_NAME_2);
 
         goToManageViews().clickAddReport("Query Report");
@@ -337,8 +337,8 @@ public class DataReportsTest extends ReportTest
         DataRegionTable dataSetTable = new DataRegionTable("Dataset", getDriver());
         dataSetTable.openCustomizeGrid();
         _customizeViewsHelper.removeColumn(R_REMCOL);
-        _customizeViewsHelper.addFilter("DEMhisp", "3.Latino\\a or Hispanic?", "Does Not Equal", "Yes");
-        _customizeViewsHelper.addSort(R_SORT, "2.What is your sex?", SortDirection.DESC);
+        _customizeViewsHelper.addFilter("DEMhisp", "Does Not Equal", "Yes");
+        _customizeViewsHelper.addSort(R_SORT, SortDirection.DESC);
         _customizeViewsHelper.saveCustomView("Custom Query View");
 
         log("Check that customize view worked");

--- a/src/org/labkey/test/tests/FlagColumnTest.java
+++ b/src/org/labkey/test/tests/FlagColumnTest.java
@@ -12,6 +12,7 @@ import org.labkey.test.SortDirection;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldKey;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.RelativeUrl;
 
@@ -116,9 +117,9 @@ public class FlagColumnTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText("view results"));
         var customizeView = _customizeViewsHelper.openCustomizeViewPanel();
         customizeView.showHiddenItems();
-        customizeView.addColumn(new String[] { "Run" });
-        customizeView.addColumn(new String[] { "Run", RUN_FLAG});
-        customizeView.addColumn(new String[] { "Run", "AnotherRunFlag" });
+        customizeView.addColumn(FieldKey.fromParts("Run"));
+        customizeView.addColumn(FieldKey.fromParts("Run", RUN_FLAG));
+        customizeView.addColumn(FieldKey.fromParts("Run", "AnotherRunFlag"));
         customizeView.addSort("RowId", SortDirection.ASC);
         customizeView.saveCustomView();
 

--- a/src/org/labkey/test/tests/InlineImagesAssayTest.java
+++ b/src/org/labkey/test/tests/InlineImagesAssayTest.java
@@ -30,6 +30,7 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldKey;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ExcelHelper;
@@ -177,8 +178,8 @@ public class InlineImagesAssayTest extends BaseWebDriverTest
         DataRegionTable list = new DataRegionTable("Data", getDriver());
         CustomizeView customizeView = list.openCustomizeGrid();
         customizeView.showHiddenItems();
-        customizeView.addColumn(new String[]{"Run", "RowId"});
-        customizeView.addColumn(new String[]{"Run", "Protocol", "RowId"});
+        customizeView.addColumn(FieldKey.fromParts("Run", "RowId"));
+        customizeView.addColumn(FieldKey.fromParts("Run", "Protocol", "RowId"));
         customizeView.applyCustomView();
         var protocolId = list.getDataAsText(0, "Run/Protocol/RowId");
         var runId = list.getDataAsText(0, "Run/RowId");

--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -383,7 +383,7 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
 
         log("Check that the imported data is as expected.");
         DataRegionTable dataRegionTable = new DataRegionTable("Material", this);
-        int row = dataRegionTable.getRowIndex(testSample, "Name");
+        int row = dataRegionTable.getRowIndex("Name", testSample);
         String data = dataRegionTable.getDataAsText(row, columnName);
         checker().verifyEquals("Something doesn't look right. Value for column not as expected.",
                 testData, data);
@@ -406,7 +406,7 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
 
         log("Check that the updated data is shown.");
         dataRegionTable = new DataRegionTable("Material", this);
-        row = dataRegionTable.getRowIndex(testSample, "Name");
+        row = dataRegionTable.getRowIndex("Name", testSample);
         data = dataRegionTable.getDataAsText(row, columnName);
         checker().verifyEquals("Value for column not updated as expected.",
                 updatedTestData, data);
@@ -652,7 +652,7 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
 
         for(String parent : parents)
         {
-            int index = drt.getRowIndex(parent, "Name");
+            int index = drt.getRowIndex("Name", parent);
             drt.checkCheckbox(index);
         }
 
@@ -1129,7 +1129,7 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         sampleHelper.createSampleType(new SampleTypeDefinition(SAMPLE_TYPE_NAME), sampleData);
         DataRegionTable drtSamples = sampleHelper.getSamplesDataRegionTable();
         log("Derive one sample from another");
-        drtSamples.checkCheckbox(drtSamples.getRowIndex(parentSampleNames.get(0), "Name"));
+        drtSamples.checkCheckbox(drtSamples.getRowIndex("Name", parentSampleNames.get(0)));
         clickButton("Derive Samples");
         waitAndClickAndWait(Locator.lkButton("Next"));
         String childName = parentSampleNames.get(0) + ".1";
@@ -1145,8 +1145,8 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
 
         log("Derive a sample with two parents");
         clickAndWait(Locator.linkContainingText(SAMPLE_TYPE_NAME));
-        drtSamples.checkCheckbox(drtSamples.getRowIndex(parentSampleNames.get(1), "Name"));
-        drtSamples.checkCheckbox(drtSamples.getRowIndex(childName, "Name"));
+        drtSamples.checkCheckbox(drtSamples.getRowIndex("Name", parentSampleNames.get(1)));
+        drtSamples.checkCheckbox(drtSamples.getRowIndex("Name", childName));
         clickButton("Derive Samples");
         waitAndClickAndWait(Locator.lkButton("Next"));
         String twoParentChildName = parentSampleNames.get(1) + "+" + childName + ".1";
@@ -1156,14 +1156,14 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         clickAndWait(Locator.linkContainingText(SAMPLE_TYPE_NAME));
 
         log("Try to delete parent sample");
-        drtSamples.checkCheckbox(drtSamples.getRowIndex(parentSampleNames.get(0), "Name"));
+        drtSamples.checkCheckbox(drtSamples.getRowIndex("Name", parentSampleNames.get(0)));
         drtSamples.clickHeaderButton("Delete");
         Window.Window(getDriver()).withTitle("No samples can be deleted").waitFor()
                 .clickButton("Dismiss", true);
 
         log("Try to delete multiple parent samples");
-        drtSamples.checkCheckbox(drtSamples.getRowIndex(parentSampleNames.get(1), "Name"));
-        drtSamples.checkCheckbox(drtSamples.getRowIndex(childName, "Name"));
+        drtSamples.checkCheckbox(drtSamples.getRowIndex("Name", parentSampleNames.get(1)));
+        drtSamples.checkCheckbox(drtSamples.getRowIndex("Name", childName));
         drtSamples.clickHeaderButton("Delete");
         Window.Window(getDriver()).withTitle("No samples can be deleted").waitFor()
                 .clickButton("Dismiss", true);
@@ -1172,21 +1172,21 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         assertEquals("No selection should remain", 0, drtSamples.getSelectedCount());
 
         log("Try to delete parent and child");
-        drtSamples.checkCheckbox(drtSamples.getRowIndex(parentSampleNames.get(1), "Name"));
-        drtSamples.checkCheckbox(drtSamples.getRowIndex(twoParentChildName, "Name"));
+        drtSamples.checkCheckbox(drtSamples.getRowIndex("Name", parentSampleNames.get(1)));
+        drtSamples.checkCheckbox(drtSamples.getRowIndex("Name", twoParentChildName));
         assertEquals("Parent and child should be checked", 2, drtSamples.getCheckedCount());
         assertEquals("Parent and child should be checked", 2, drtSamples.getSelectedCount());
 
         sampleHelper.deleteSamples(drtSamples, "Permanently delete 1 sample");
-        assertEquals("Deleted sample " + twoParentChildName + " still appears in grid", -1, drtSamples.getRowIndex(twoParentChildName, "Name"));
-        assertTrue("Parent sample " + parentSampleNames.get(1) + " does not appears in grid", drtSamples.getRowIndex(parentSampleNames.get(1), "Name") > -1);
+        assertEquals("Deleted sample " + twoParentChildName + " still appears in grid", -1, drtSamples.getRowIndex("Name", twoParentChildName));
+        assertTrue("Parent sample " + parentSampleNames.get(1) + " does not appears in grid", drtSamples.getRowIndex("Name", parentSampleNames.get(1)) > -1);
         assertEquals("Only parent sample should be checked", 1, drtSamples.getCheckedCount());
         assertEquals("Only parent sample should be checked", 1, drtSamples.getSelectedCount());
 
         log("Now that the child is gone, try to delete the parent");
         sampleHelper.deleteSamples(drtSamples, "Permanently delete 1 sample");
 
-        assertEquals("Deleted sample " + parentSampleNames.get(1) + " still appears in grid", -1, drtSamples.getRowIndex(parentSampleNames.get(1), "Name"));
+        assertEquals("Deleted sample " + parentSampleNames.get(1) + " still appears in grid", -1, drtSamples.getRowIndex("Name", parentSampleNames.get(1)));
         assertEquals("No selection should remain", 0, drtSamples.getCheckedCount());
 
         log("Now try to delete what's left, in several hitches");

--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -17,6 +17,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldKey;
 import org.labkey.test.params.experiment.DataClassDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DataRegionTable;
@@ -459,7 +460,7 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         DataRegionTable table = sampleHelper.getSamplesDataRegionTable();
         table.openCustomizeGrid();
         _customizeViewsHelper.showHiddenItems();
-        _customizeViewsHelper.addColumn(new String[]{"Inputs", "Materials", parentSampleType});
+        _customizeViewsHelper.addColumn(FieldKey.fromParts("Inputs", "Materials", parentSampleType));
         _customizeViewsHelper.applyCustomView();
         waitAndClickAndWait(Locator.linkWithText("SampleSetBVT4"));
 

--- a/src/org/labkey/test/tests/TimeChartAPITest.java
+++ b/src/org/labkey/test/tests/TimeChartAPITest.java
@@ -152,16 +152,16 @@ public class TimeChartAPITest extends TimeChartTest
 
         final List<Pair<String, List<Object>>> GETDATA_API_TEST_VISITLABEL = new ArrayList<>()
         {{
-            add(Pair.of("VisitLabel", Arrays.asList("Month 2", "Month 3", "Month 4", "Month 7", "Month 9", "Month 10", "Month 10", "Month 11", "Month 12", "Month 13")));
-            add(Pair.of("VisitLabel", Arrays.asList("Month 2", "Month 3", "Month 4", "Month 7", "Month 9", "Month 10", "Month 10", "Month 11", "Month 12", "Month 13")));
             add(Pair.of("study_Lab Results_ParticipantVisit_Visit_Label", Arrays.asList("Month 2", "Month 3", "Month 4", "Month 7", "Month 9", "Month 10", "Month 10", "Month 11", "Month 12", "Month 13")));
             add(Pair.of("study_Lab Results_ParticipantVisit_Visit_Label", Arrays.asList("Month 2", "Month 3", "Month 4", "Month 7", "Month 9", "Month 10", "Month 10", "Month 11", "Month 12", "Month 13")));
-            add(Pair.of("VisitLabel", Arrays.asList("Month 2", "Month 2", "Month 2", "Month 3", "Month 3", "Month 3", "Month 4", "Month 4", "Month 4", "Month 7", "Month 7", "Month 7", "Month 9", "Month 9", "Month 9")));
+            add(Pair.of("study_Lab Results_ParticipantVisit_Visit_Label", Arrays.asList("Month 2", "Month 3", "Month 4", "Month 7", "Month 9", "Month 10", "Month 10", "Month 11", "Month 12", "Month 13")));
+            add(Pair.of("study_Lab Results_ParticipantVisit_Visit_Label", Arrays.asList("Month 2", "Month 3", "Month 4", "Month 7", "Month 9", "Month 10", "Month 10", "Month 11", "Month 12", "Month 13")));
+            add(Pair.of("study_Lab Results_ParticipantVisit_Visit_Label", Arrays.asList("Month 2", "Month 2", "Month 2", "Month 3", "Month 3", "Month 3", "Month 4", "Month 4", "Month 4", "Month 7", "Month 7", "Month 7", "Month 9", "Month 9", "Month 9")));
             add(Pair.of("study_Lab Results_ParticipantVisit_Visit_Label", Arrays.asList("Month 2", "Month 2", "Month 2", "Month 3", "Month 3", "Month 3", "Month 4", "Month 4", "Month 4", "Month 7", "Month 7", "Month 7", "Month 9", "Month 9", "Month 9", "Month 10", "Month 10", "Month 11", "Month 12", "Month 13")));
-            add(Pair.of("VisitLabel", Arrays.asList("Month 2", "Month 3", "Month 4", "Month 7", "Month 9")));
+            add(Pair.of("study_Lab Results_ParticipantVisit_Visit_Label", Arrays.asList("Month 2", "Month 3", "Month 4", "Month 7", "Month 9")));
             add(Pair.of("study_Lab Results_ParticipantVisit_Visit_Label", Arrays.asList("Month 2", "Month 3", "Month 4", "Month 7", "Month 9", "Month 10", "Month 10", "Month 11", "Month 12", "Month 13")));
-            add(Pair.of("VisitLabel", Arrays.asList("Month 2", "Month 2", "Month 2", "Month 3", "Month 4", "Month 7", "Month 9", "Month 10", "Month 10", "Month 11", "Month 12", "Month 13")));
-            add(Pair.of("VisitLabel", Arrays.asList("Month 2", "Month 3", "Month 4", "Month 7", "Month 9", "Month 10", "Month 10", "Month 11", "Month 12", "Month 13")));
+            add(Pair.of("study_Lab Results_ParticipantVisit_Visit_Label", Arrays.asList("Month 2", "Month 2", "Month 2", "Month 3", "Month 4", "Month 7", "Month 9", "Month 10", "Month 10", "Month 11", "Month 12", "Month 13")));
+            add(Pair.of("study_Lab Results_ParticipantVisit_Visit_Label", Arrays.asList("Month 2", "Month 3", "Month 4", "Month 7", "Month 9", "Month 10", "Month 10", "Month 11", "Month 12", "Month 13")));
         }};
 
         testVisApi(TestFileUtils.getSampleData("api/getDataVisitTest.html"), GETDATA_API_TEST_TITLES, GETDATA_API_TEST_NUMROWS, GETDATA_API_VISITTEST_COLNAMES, null, GETDATA_API_TEST_VISITLABEL,

--- a/src/org/labkey/test/tests/TimeChartAPITest.java
+++ b/src/org/labkey/test/tests/TimeChartAPITest.java
@@ -82,7 +82,7 @@ public class TimeChartAPITest extends TimeChartTest
         add(Pair.of("study_LuminexAssay_ObsConc", Arrays.asList(35.87, 40.07, 52.74, 13.68, 28.35, 42.38, 2.82, 5.19, 7.99, 5.12, 6.69, 32.33, 3.09, 5.76, 12.49)));
         add(Pair.of("IL-10 (23)::study_LuminexAssay_ObsConc_MAX", Arrays.asList(40.07, 42.38, 7.99, 32.33, 12.49)));
         add(Pair.of("IL-10 (23)::study_LuminexAssay_ObsConc_MAX", Arrays.asList(40.07, 42.38, 7.99, 32.33, 12.49)));
-        add(Pair.of("M1", Arrays.asList(520.0, 543.0)));
+        add(Pair.of("study_GenericAssay_M1", Arrays.asList(520.0, 543.0)));
         add(Pair.of("IL-10 (23)::study_LuminexAssay_ObsConc_MAX", Arrays.asList(40.07, 42.38, 7.99, 32.33, 12.49)));
     }};
 
@@ -333,7 +333,7 @@ public class TimeChartAPITest extends TimeChartTest
             {
                 Pair<String, List<Object>> expectedColumn = expectedColForAllTests.get(testIndex);
                 String columnName = expectedColumn.getKey();
-                int columnIndex = table.getColumnIndex(columnName);
+                int columnIndex = table.getColumnIndexStrict(columnName);
                 List<Object> expectedValues = expectedColumn.getValue();
                 List<Object> actualValues = new ArrayList<>();
                 boolean isNumberCol = expectedValues.get(0) instanceof Number;

--- a/src/org/labkey/test/tests/UserDetailsPermissionTest.java
+++ b/src/org/labkey/test/tests/UserDetailsPermissionTest.java
@@ -256,12 +256,12 @@ public class UserDetailsPermissionTest extends BaseWebDriverTest
         selectOptionByText(Locator.name("quf_user"), _userHelper.getDisplayNameForEmail(ADMIN_USER));
         clickButton("Submit");
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn("user/Phone", "Phone");
-        _customizeViewsHelper.addColumn("user/" + CUSTOM_USER_COLUMN, CUSTOM_USER_COLUMN);
-        _customizeViewsHelper.addColumn("user/Email", "Email");
-        _customizeViewsHelper.addColumn("user/ModifiedBy/Email", "Email");
-        _customizeViewsHelper.addColumn("user/ModifiedBy/ModifiedBy/Email", "Email");
-        _customizeViewsHelper.addColumn("ModifiedBy/Email", "Email");
+        _customizeViewsHelper.addColumn("user/Phone");
+        _customizeViewsHelper.addColumn("user/" + CUSTOM_USER_COLUMN);
+        _customizeViewsHelper.addColumn("user/Email");
+        _customizeViewsHelper.addColumn("user/ModifiedBy/Email");
+        _customizeViewsHelper.addColumn("user/ModifiedBy/ModifiedBy/Email");
+        _customizeViewsHelper.addColumn("ModifiedBy/Email");
         _customizeViewsHelper.saveCustomView(HIDDEN_COL_VIEW, true);
 
         assertTextPresent(CHECKED_USER, ADMIN_USER, HIDDEN_STRING); // Ensure subsequent check is valid
@@ -273,7 +273,7 @@ public class UserDetailsPermissionTest extends BaseWebDriverTest
     {
         ExecuteQueryPage.beginAt(this, "core", "Users");
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn("ModifiedBy/Email", "Email");
+        _customizeViewsHelper.addColumn("ModifiedBy/Email");
         _customizeViewsHelper.saveCustomView(HIDDEN_COL_VIEW, true);
 
         assertTextPresent(CHECKED_USER, ADMIN_USER, HIDDEN_STRING); // Ensure subsequent check is valid

--- a/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
+++ b/src/org/labkey/test/tests/assay/AssayMissingValuesTest.java
@@ -272,8 +272,8 @@ public class AssayMissingValuesTest extends MissingValueIndicatorsTest
 
         // expect 3 rows in this assay, p2 and p3 should get mv indicators in the count column
         Map<String, List<String>> expectedData = new HashMap<>();
-        expectedData.put("Participant ID", List.of("p1", "p2", "p3"));
-        expectedData.put("Visit ID", List.of("1", "1", "1"));
+        expectedData.put("ParticipantID", List.of("p1", "p2", "p3"));
+        expectedData.put("VisitId", List.of("1", "1", "1"));
         expectedData.put("Count", List.of("4", "N", "Q"));
         checkDataregionData(dataRegion, expectedData);
 

--- a/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
+++ b/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
@@ -17,6 +17,7 @@
 package org.labkey.test.tests.elispotassay;
 
 import org.apache.commons.lang3.math.NumberUtils;
+import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -210,8 +211,8 @@ public class ElispotAssayTest extends AbstractAssayTest
         clickAndWait(Locator.linkWithText("view runs"));
         waitAndClick(Locator.linkWithText("view results"));
         DataRegionTable results = new DataRegionTable("Data", this);
-        assertEquals("Wrong columns", List.of("Wellgroup Name", "Antigen Wellgroup Name", "Antigen Name", "Cells per Well", "Wellgroup Location", "Spot Count", "Normalized Spot Count", "Spot Size", "Analyte", "Cytokine", "Activity", "Intensity", "Specimen ID", "Participant ID", "Visit ID", "Date", "Sample Description", "ProtocolName", "Plate Reader"), results.getColumnLabels());
-        assertEquals(Arrays.asList("Specimen 4", "Antigen 6", "atg_6F2", "150", "(7, 8)", "0.0", "0.0", " ", "FITC+Cy5", " ", " ", " ", " ", "ptid 4 F2", "4.0", " ", "blood", " ", "AID", " "), results.getRowDataAsText(0));
+        Assertions.assertThat(results.getColumnLabels()).as("Wrong columns").containsExactly("Wellgroup Name", "Antigen Wellgroup Name", "Antigen Name", "Cells per Well", "Wellgroup Location", "Spot Count", "Normalized Spot Count", "Spot Size", "Analyte", "Cytokine", "Activity", "Intensity", "Specimen ID", "Participant ID", "Visit ID", "Date", "Sample Description", "ProtocolName", "Plate Reader", "Target Study");
+        Assertions.assertThat(results.getRowDataAsText(0)).as("row data").containsExactly("Specimen 4", "Antigen 6", "atg_6F2", "150", "(7, 8)", "0.0", "0.0", " ", "FITC+Cy5", " ", " ", " ", " ", "ptid 4 F2", "4.0", " ", "blood", " ", "AID", " ");
     }
 
     private void verifyDataRegion(DataRegionTable table, SortDirection sortDir, List<String> expectedSpotCount, List<String> expectedActivity, List<String> expectedIntensity, List<String> expectedCytokine)

--- a/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
+++ b/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
@@ -210,7 +210,7 @@ public class ElispotAssayTest extends AbstractAssayTest
         clickAndWait(Locator.linkWithText("view runs"));
         waitAndClick(Locator.linkWithText("view results"));
         DataRegionTable results = new DataRegionTable("Data", this);
-        results.ensureColumnsPresent("Wellgroup Name", "Antigen Wellgroup Name", "Antigen Name", "Cells per Well", "Wellgroup Location", "Spot Count", "Normalized Spot Count", "Spot Size", "Analyte", "Cytokine", "Activity", "Intensity", "Specimen ID", "Participant ID", "Visit ID", "Date", "Sample Description", "ProtocolName", "Plate Reader");
+        assertEquals("Wrong columns", List.of("Wellgroup Name", "Antigen Wellgroup Name", "Antigen Name", "Cells per Well", "Wellgroup Location", "Spot Count", "Normalized Spot Count", "Spot Size", "Analyte", "Cytokine", "Activity", "Intensity", "Specimen ID", "Participant ID", "Visit ID", "Date", "Sample Description", "ProtocolName", "Plate Reader"), results.getColumnLabels());
         assertEquals(Arrays.asList("Specimen 4", "Antigen 6", "atg_6F2", "150", "(7, 8)", "0.0", "0.0", " ", "FITC+Cy5", " ", " ", " ", " ", "ptid 4 F2", "4.0", " ", "blood", " ", "AID", " "), results.getRowDataAsText(0));
     }
 
@@ -226,9 +226,9 @@ public class ElispotAssayTest extends AbstractAssayTest
         cvHelper.removeSort("Analyte");
         cvHelper.removeSort("WellgroupLocation");
 
-        cvHelper.addSort("AntigenLsid/AntigenName", "AntigenName", sortDir);
-        cvHelper.addSort("Analyte", "Analyte", sortDir);
-        cvHelper.addSort("WellgroupLocation", "WellgroupLocation", sortDir);
+        cvHelper.addSort("AntigenLsid/AntigenName", sortDir);
+        cvHelper.addSort("Analyte", sortDir);
+        cvHelper.addSort("WellgroupLocation", sortDir);
         cvHelper.applyCustomView();
 
         pushLocation();

--- a/src/org/labkey/test/tests/flow/FlowDuplicateSamplesTest.java
+++ b/src/org/labkey/test/tests/flow/FlowDuplicateSamplesTest.java
@@ -10,6 +10,7 @@ import org.labkey.test.SortDirection;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.FileBrowser;
 import org.labkey.test.categories.Flow;
+import org.labkey.test.params.FieldKey;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PipelineStatusTable;
 
@@ -53,16 +54,19 @@ public class FlowDuplicateSamplesTest extends BaseFlowTest
 
         importAnalysis(getContainerPath(), "/flowjoquery/Workspaces/duplicate-samples.xml", SelectFCSFileOption.Previous, null, "dupes", false, true);
 
+        FieldKey fcsFileFk = FieldKey.fromParts("FCSFile");
+        FieldKey DTOTfk = fcsFileFk.child("Keyword", "$TOT");
+        FieldKey filePathFk = fcsFileFk.child("FilePath");
         // verify both samples "118795.fcs" were imported and associated with the correct FCS file
         _customizeViewsHelper.openCustomizeViewPanel();
         _customizeViewsHelper.showHiddenItems();
-        _customizeViewsHelper.addColumn(new String[] { "FCSFile", "Keyword", "$DTOT"});
-        _customizeViewsHelper.addColumn(new String[] { "FCSFile", "FilePath"});
+        _customizeViewsHelper.addColumn(DTOTfk.toString());
+        _customizeViewsHelper.addColumn(filePathFk.toString());
         _customizeViewsHelper.addSort("Statistic/Count", SortDirection.ASC);
         _customizeViewsHelper.applyCustomView();
 
         var dr = new DataRegionTable("query", getDriver());
-        var rows = dr.getRows("Name", "Count", "$TOT", "FilePath");
+        var rows = dr.getRows("Name", "Count", DTOTfk, filePathFk);
         Assert.assertEquals(2, rows.size());
 
         var row0 = rows.get(0);

--- a/src/org/labkey/test/tests/flow/FlowJoQueryTest.java
+++ b/src/org/labkey/test/tests/flow/FlowJoQueryTest.java
@@ -71,12 +71,12 @@ public class FlowJoQueryTest extends BaseFlowTest
         _customizeViewsHelper.openCustomizeViewPanel();
         _customizeViewsHelper.clearColumns();
         _customizeViewsHelper.addColumn("Name");
-        _customizeViewsHelper.addColumn("AnalysisScript", "Analysis Script");
-        _customizeViewsHelper.addColumn("FCSFile/Keyword/Comp", "Comp");
-        _customizeViewsHelper.addColumn("FCSFile/Keyword/Stim", "Stim");
-        _customizeViewsHelper.addColumn("FCSFile/Keyword/Sample Order", "Sample Order");
-        _customizeViewsHelper.addColumn("Statistic/S$SLv$SL$S3+$S4+:Count", "4+:Count");
-        _customizeViewsHelper.addColumn("Statistic/S$SLv$SL$S3+$S8+:Count", "8+:Count");
+        _customizeViewsHelper.addColumn("AnalysisScript");
+        _customizeViewsHelper.addColumn("FCSFile/Keyword/Comp");
+        _customizeViewsHelper.addColumn("FCSFile/Keyword/Stim");
+        _customizeViewsHelper.addColumn("FCSFile/Keyword/Sample Order");
+        _customizeViewsHelper.addColumn("Statistic/S$SLv$SL$S3+$S4+:Count");
+        _customizeViewsHelper.addColumn("Statistic/S$SLv$SL$S3+$S8+:Count");
         _customizeViewsHelper.applyCustomView();
 
         clickProject(getProjectName());

--- a/src/org/labkey/test/tests/flow/FlowTest.java
+++ b/src/org/labkey/test/tests/flow/FlowTest.java
@@ -34,6 +34,7 @@ import org.labkey.test.pages.flow.reports.QCReportEditorPage;
 import org.labkey.test.pages.flow.reports.ReportEditorPage;
 import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldKey;
 import org.labkey.test.tests.AuditLogTest;
 import org.labkey.test.util.DataRegion;
 import org.labkey.test.util.DataRegionTable;
@@ -787,13 +788,13 @@ public class FlowTest extends BaseFlowTest
     {
         beginAt("/flow" + getContainerPath() + "/query.view?schemaName=flow&query.queryName=FCSAnalyses");
 
-        String reportNameEscaped = EscapeUtil.fieldKeyEncodePart(reportName);
+        FieldKey reportNameFk = FieldKey.fromParts(reportName);
 
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn(new String[] { reportNameEscaped, "Raw P" });
-        _customizeViewsHelper.addColumn(new String[] { reportNameEscaped, "Adjusted P"});
-        _customizeViewsHelper.addColumn(new String[] { reportNameEscaped, "Response"});
-        _customizeViewsHelper.addFilter(new String[] { reportNameEscaped, "Response"}, "Equals", "1");
+        _customizeViewsHelper.addColumn(reportNameFk.child("Raw P"));
+        _customizeViewsHelper.addColumn(reportNameFk.child("Adjusted P"));
+        _customizeViewsHelper.addColumn(reportNameFk.child("Response"));
+        _customizeViewsHelper.addFilter(reportNameFk.child("Response"), "Equals", "1");
         _customizeViewsHelper.addSort("Name", SortDirection.ASC);
         _customizeViewsHelper.saveCustomView();
 

--- a/src/org/labkey/test/tests/flow/FlowTest.java
+++ b/src/org/labkey/test/tests/flow/FlowTest.java
@@ -793,7 +793,7 @@ public class FlowTest extends BaseFlowTest
         _customizeViewsHelper.addColumn(new String[] { reportNameEscaped, "Raw P" });
         _customizeViewsHelper.addColumn(new String[] { reportNameEscaped, "Adjusted P"});
         _customizeViewsHelper.addColumn(new String[] { reportNameEscaped, "Response"});
-        _customizeViewsHelper.addFilter(new String[] { reportNameEscaped, "Response"}, "Response", "Equals", "1");
+        _customizeViewsHelper.addFilter(new String[] { reportNameEscaped, "Response"}, "Equals", "1");
         _customizeViewsHelper.addSort("Name", SortDirection.ASC);
         _customizeViewsHelper.saveCustomView();
 

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -51,6 +51,7 @@ import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.pages.list.GridPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.StringLookup;
+import org.labkey.test.params.FieldKey;
 import org.labkey.test.params.list.VarListDefinition;
 import org.labkey.test.tests.AuditLogTest;
 import org.labkey.test.util.AbstractDataRegionExportOrSignHelper.ColumnHeaderType;
@@ -570,10 +571,8 @@ public class ListTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(LIST_NAME_COLORS));
         _customizeViewsHelper.openCustomizeViewPanel();
         _customizeViewsHelper.removeColumn(_listColGood.getName());
-        String fieldKey6 = _listColGood.getName();
-        _customizeViewsHelper.addFilter(fieldKey6, "Is Less Than", "10");
-        String fieldKey8 = _listColMonth.getName();
-        _customizeViewsHelper.addSort(fieldKey8, SortDirection.ASC);
+        _customizeViewsHelper.addFilter(_listColGood.getName(), "Is Less Than", "10");
+        _customizeViewsHelper.addSort(_listColMonth.getName(), SortDirection.ASC);
         _customizeViewsHelper.saveCustomView(TEST_VIEW);
 
         log("Check Customize View worked");
@@ -692,20 +691,13 @@ public class ListTest extends BaseWebDriverTest
 
         log("Check that reference worked");
         _customizeViewsHelper.openCustomizeViewPanel();
-        String fieldKey4 = EscapeUtil.fieldKeyEncodePart(_list2Col1.getName()) + "/" + _listColDesc.getName();
-        _customizeViewsHelper.addColumn(fieldKey4);
-        String fieldKey3 = EscapeUtil.fieldKeyEncodePart(_list2Col1.getName()) + "/" + _listColMonth.getName();
-        _customizeViewsHelper.addColumn(fieldKey3);
-        String fieldKey2 = EscapeUtil.fieldKeyEncodePart(_list2Col1.getName()) + "/" + _listColGood.getName();
-        _customizeViewsHelper.addColumn(fieldKey2);
-        String fieldKey5 = EscapeUtil.fieldKeyEncodePart(_list2Col1.getName()) + "/" + _listColGood.getName();
-        _customizeViewsHelper.addFilter(fieldKey5, "Is Less Than", "10");
-        String fieldKey7 = EscapeUtil.fieldKeyEncodePart(_list2Col1.getName()) + "/" + _listColGood.getName();
-        _customizeViewsHelper.addSort(fieldKey7, SortDirection.ASC);
-        String fieldKey1 = _list3Col1.getName() + "/" + _list3Col1.getName();
-        _customizeViewsHelper.addColumn(fieldKey1);
-        String fieldKey = _list3Col1.getName() + "/" + _list3Col2.getName();
-        _customizeViewsHelper.addColumn(fieldKey);
+        _customizeViewsHelper.addColumn(FieldKey.fromParts(_list2Col1.getName(), _listColDesc.getName()));
+        _customizeViewsHelper.addColumn(FieldKey.fromParts(_list2Col1.getName(), _listColMonth.getName()));
+        _customizeViewsHelper.addColumn(FieldKey.fromParts(_list2Col1.getName(), _listColGood.getName()));
+        _customizeViewsHelper.addFilter(FieldKey.fromParts(_list2Col1.getName(), _listColGood.getName()), "Is Less Than", "10");
+        _customizeViewsHelper.addSort(FieldKey.fromParts(_list2Col1.getName(), _listColGood.getName()), SortDirection.ASC);
+        _customizeViewsHelper.addColumn(_list3Col1.getName() + "/" + _list3Col1.getName());
+        _customizeViewsHelper.addColumn(_list3Col1.getName() + "/" + _list3Col2.getName());
         _customizeViewsHelper.saveCustomView(TEST_VIEW);
 
         log("Check adding referenced fields worked");

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -51,7 +51,6 @@ import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.pages.list.GridPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.StringLookup;
-import org.labkey.test.params.FieldInfo;
 import org.labkey.test.params.list.VarListDefinition;
 import org.labkey.test.tests.AuditLogTest;
 import org.labkey.test.util.AbstractDataRegionExportOrSignHelper.ColumnHeaderType;
@@ -571,8 +570,10 @@ public class ListTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(LIST_NAME_COLORS));
         _customizeViewsHelper.openCustomizeViewPanel();
         _customizeViewsHelper.removeColumn(_listColGood.getName());
-        _customizeViewsHelper.addFilter(_listColGood.getName(), _listColGood.getLabel(), "Is Less Than", "10");
-        _customizeViewsHelper.addSort(_listColMonth.getName(), _listColMonth.getLabel(), SortDirection.ASC);
+        String fieldKey6 = _listColGood.getName();
+        _customizeViewsHelper.addFilter(fieldKey6, "Is Less Than", "10");
+        String fieldKey8 = _listColMonth.getName();
+        _customizeViewsHelper.addSort(fieldKey8, SortDirection.ASC);
         _customizeViewsHelper.saveCustomView(TEST_VIEW);
 
         log("Check Customize View worked");
@@ -691,13 +692,20 @@ public class ListTest extends BaseWebDriverTest
 
         log("Check that reference worked");
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn(EscapeUtil.fieldKeyEncodePart(_list2Col1.getName()) + "/" + _listColDesc.getName(), _list2Col1.getLabel() + " " + _listColDesc.getLabel());
-        _customizeViewsHelper.addColumn(EscapeUtil.fieldKeyEncodePart(_list2Col1.getName()) + "/" + _listColMonth.getName(), _list2Col1.getLabel() + " " + _listColMonth.getLabel());
-        _customizeViewsHelper.addColumn(EscapeUtil.fieldKeyEncodePart(_list2Col1.getName()) + "/" + _listColGood.getName(), _list2Col1.getLabel() + " " + _listColGood.getLabel());
-        _customizeViewsHelper.addFilter(EscapeUtil.fieldKeyEncodePart(_list2Col1.getName()) + "/" + _listColGood.getName(), _listColGood.getLabel(), "Is Less Than", "10");
-        _customizeViewsHelper.addSort(EscapeUtil.fieldKeyEncodePart(_list2Col1.getName()) + "/" + _listColGood.getName(), _listColGood.getLabel(), SortDirection.ASC);
-        _customizeViewsHelper.addColumn(_list3Col1.getName() + "/" + _list3Col1.getName(), _list3Col1.getLabel() + " " + _list3Col1.getLabel());
-        _customizeViewsHelper.addColumn(_list3Col1.getName() + "/" + _list3Col2.getName(), _list3Col1.getLabel() + " " + _list3Col2.getLabel());
+        String fieldKey4 = EscapeUtil.fieldKeyEncodePart(_list2Col1.getName()) + "/" + _listColDesc.getName();
+        _customizeViewsHelper.addColumn(fieldKey4);
+        String fieldKey3 = EscapeUtil.fieldKeyEncodePart(_list2Col1.getName()) + "/" + _listColMonth.getName();
+        _customizeViewsHelper.addColumn(fieldKey3);
+        String fieldKey2 = EscapeUtil.fieldKeyEncodePart(_list2Col1.getName()) + "/" + _listColGood.getName();
+        _customizeViewsHelper.addColumn(fieldKey2);
+        String fieldKey5 = EscapeUtil.fieldKeyEncodePart(_list2Col1.getName()) + "/" + _listColGood.getName();
+        _customizeViewsHelper.addFilter(fieldKey5, "Is Less Than", "10");
+        String fieldKey7 = EscapeUtil.fieldKeyEncodePart(_list2Col1.getName()) + "/" + _listColGood.getName();
+        _customizeViewsHelper.addSort(fieldKey7, SortDirection.ASC);
+        String fieldKey1 = _list3Col1.getName() + "/" + _list3Col1.getName();
+        _customizeViewsHelper.addColumn(fieldKey1);
+        String fieldKey = _list3Col1.getName() + "/" + _list3Col2.getName();
+        _customizeViewsHelper.addColumn(fieldKey);
         _customizeViewsHelper.saveCustomView(TEST_VIEW);
 
         log("Check adding referenced fields worked");
@@ -2052,11 +2060,11 @@ public class ListTest extends BaseWebDriverTest
 
             // show all columns
             _customizeViewsHelper.openCustomizeViewPanel();
-            _customizeViewsHelper.addColumn("Bfk/B", "Bfk B");
-            _customizeViewsHelper.addColumn("Bfk/title", "Bfk Title");
-            _customizeViewsHelper.addColumn("Bfk/Cfk", "Bfk Cfk");
-            _customizeViewsHelper.addColumn("Bfk/Cfk/C", "Bfk Cfk C");
-            _customizeViewsHelper.addColumn("Bfk/Cfk/title", "Bfk Cfk Title");
+            _customizeViewsHelper.addColumn("Bfk/B");
+            _customizeViewsHelper.addColumn("Bfk/title");
+            _customizeViewsHelper.addColumn("Bfk/Cfk");
+            _customizeViewsHelper.addColumn("Bfk/Cfk/C");
+            _customizeViewsHelper.addColumn("Bfk/Cfk/title");
             _customizeViewsHelper.saveCustomView("allColumns");
 
             clickAndWait(Locator.linkWithText("one C").index(1));

--- a/src/org/labkey/test/tests/nab/NAbResultCalcTest.java
+++ b/src/org/labkey/test/tests/nab/NAbResultCalcTest.java
@@ -72,8 +72,8 @@ public class NAbResultCalcTest extends BaseWebDriverTest
         waitAndClickAndWait(Locator.linkWithText("View Results"));
 
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn("PercentNeutralizationInitialDilution", "Percent Neutralization Initial Dilution");
-        _customizeViewsHelper.addColumn("PercentNeutralizationMax", "Percent Neutralization Max");
+        _customizeViewsHelper.addColumn("PercentNeutralizationInitialDilution");
+        _customizeViewsHelper.addColumn("PercentNeutralizationMax");
         _customizeViewsHelper.applyCustomView();
 
         DataRegionTable region = new DataRegionTable("Data", this);
@@ -103,8 +103,8 @@ public class NAbResultCalcTest extends BaseWebDriverTest
         waitAndClickAndWait(Locator.linkWithText("View Results"));
 
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn("PercentNeutralizationInitialDilution", "Percent Neutralization Initial Dilution");
-        _customizeViewsHelper.addColumn("PercentNeutralizationMax", "Percent Neutralization Max");
+        _customizeViewsHelper.addColumn("PercentNeutralizationInitialDilution");
+        _customizeViewsHelper.addColumn("PercentNeutralizationMax");
         _customizeViewsHelper.applyCustomView();
 
         DataRegionTable region = new DataRegionTable("Data", this);

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -621,18 +621,18 @@ public class NabAssayTest extends AbstractAssayTest
         log("Adding AUC columns to custom view");
         // add AUC columns. ORDER MATTERS!
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn("AUC_4pl", "AUC 4pl");
-        _customizeViewsHelper.addColumn("AUC_5pl", "AUC 5pl");
-        _customizeViewsHelper.addColumn("AUC_Poly", "AUC Poly");
-        _customizeViewsHelper.addColumn("Cutoff50/IC_4pl", "Curve IC50 4pl");
-        _customizeViewsHelper.addColumn("Cutoff50/IC_5pl", "Curve IC50 5pl");
-        _customizeViewsHelper.addColumn("Cutoff50/IC_Poly", "Curve IC50 Poly");
-        _customizeViewsHelper.addColumn("Cutoff70/IC_4pl", "Curve IC70 4pl");
-        _customizeViewsHelper.addColumn("Cutoff70/IC_5pl", "Curve IC70 5pl");
-        _customizeViewsHelper.addColumn("Cutoff70/IC_Poly", "Curve IC70 Poly");
-        _customizeViewsHelper.addColumn("Cutoff80/IC_4pl", "Curve IC80 4pl");
-        _customizeViewsHelper.addColumn("Cutoff80/IC_5pl", "Curve IC80 5pl");
-        _customizeViewsHelper.addColumn("Cutoff80/IC_Poly", "Curve IC80 Poly");
+        _customizeViewsHelper.addColumn("AUC_4pl");
+        _customizeViewsHelper.addColumn("AUC_5pl");
+        _customizeViewsHelper.addColumn("AUC_Poly");
+        _customizeViewsHelper.addColumn("Cutoff50/IC_4pl");
+        _customizeViewsHelper.addColumn("Cutoff50/IC_5pl");
+        _customizeViewsHelper.addColumn("Cutoff50/IC_Poly");
+        _customizeViewsHelper.addColumn("Cutoff70/IC_4pl");
+        _customizeViewsHelper.addColumn("Cutoff70/IC_5pl");
+        _customizeViewsHelper.addColumn("Cutoff70/IC_Poly");
+        _customizeViewsHelper.addColumn("Cutoff80/IC_4pl");
+        _customizeViewsHelper.addColumn("Cutoff80/IC_5pl");
+        _customizeViewsHelper.addColumn("Cutoff80/IC_Poly");
         _customizeViewsHelper.applyCustomView();
     }
 
@@ -672,13 +672,13 @@ public class NabAssayTest extends AbstractAssayTest
         DataRegionTable table = new DataRegionTable("Dataset", this);
         table.setSort("ParticipantId", SortDirection.ASC);
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn("AUC_Poly",        AUC_POLY_COL_TITLE);
-        _customizeViewsHelper.addColumn("AUC_4pl",         AUC_4PL_COL_TITLE);
-        _customizeViewsHelper.addColumn("AUC_5pl",         AUC_5PL_COL_TITLE);
-        _customizeViewsHelper.addColumn("Cutoff50/IC_Poly", CURVE_IC50_POLY_COL_TITLE);
-        _customizeViewsHelper.addColumn("Cutoff50/IC_4pl",  CURVE_IC50_4PL_COL_TITLE);
-        _customizeViewsHelper.addColumn("Cutoff70/IC_Poly", CURVE_IC70_POLY_COL_TITLE);
-        _customizeViewsHelper.addColumn("Cutoff80/IC_4pl",  CURVE_IC80_4PL_COL_TITLE);
+        _customizeViewsHelper.addColumn("AUC_Poly");
+        _customizeViewsHelper.addColumn("AUC_4pl");
+        _customizeViewsHelper.addColumn("AUC_5pl");
+        _customizeViewsHelper.addColumn("Cutoff50/IC_Poly");
+        _customizeViewsHelper.addColumn("Cutoff50/IC_4pl");
+        _customizeViewsHelper.addColumn("Cutoff70/IC_Poly");
+        _customizeViewsHelper.addColumn("Cutoff80/IC_4pl");
         _customizeViewsHelper.saveCustomView();
 
         table = new DataRegionTable("Dataset", this);

--- a/src/org/labkey/test/tests/viability/ViabilityTest.java
+++ b/src/org/labkey/test/tests/viability/ViabilityTest.java
@@ -348,7 +348,7 @@ public class ViabilityTest extends AbstractViabilityTest
         clickAndWait(Locator.linkWithText(runName));
 
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn("TargetStudy", "Target Study");
+        _customizeViewsHelper.addColumn("TargetStudy");
         _customizeViewsHelper.saveDefaultView();
 
         DataRegionTable table = new DataRegionTable("Data", this);

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -416,7 +416,7 @@ public class DataRegionTable extends DataRegion
         return link(row, getColumnIndexStrict(columnIdentifier));
     }
 
-    protected int getColumnIndexStrict(CharSequence columnIdentifier)
+    public int getColumnIndexStrict(CharSequence columnIdentifier)
     {
         return elementCache().getColumnIndex(columnIdentifier).getDomIndex();
     }
@@ -1536,7 +1536,7 @@ public class DataRegionTable extends DataRegion
                 String noSpaces = columnIdentifier.toString().replace(" ", "");
                 if (!noSpaces.equals(columnIdentifier.toString()))
                 {
-                    fieldReference = elementCache().getColumnHeaderManager().findFieldReferenceOrNull(columnIdentifier);
+                    fieldReference = elementCache().getColumnHeaderManager().findFieldReferenceOrNull(noSpaces);
                     if (fieldReference != null)
                     {
                         TestLogger.warn("Unnecessary space in requested column name. " +


### PR DESCRIPTION
#### Rationale
My previous DataRegionTable refactor attempted to recreate the previous behavior that would remove spaces when matching field labels. I covered the case where the test passed in an unnecessary space but not when they omitted a space. Rather that duplicating that particular behavior, this updates the handful of tests that are passing incorrect field labels.

I've also updated the `CustomizeView` helper to accept `FieldKey` objects instead of String arrays.

#### Related Pull Requests
- #2513 

#### Changes
- Remove unnecessary logging parameters from the CustomizeView helper
- Update CustomizeViewHelper to use FieldKey
- Fix problematic data region column name references