### PR TITLE
Add EntityBulkUpdateDialog.getSelectionFieldHelpBlockText()

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -1,6 +1,7 @@
 package org.labkey.test.components.ui.entities;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
@@ -130,6 +131,15 @@ public class EntityBulkUpdateDialog extends ModalDialog
     public EntityBulkUpdateDialog setSelectionField(CharSequence fieldIdentifier, String selectValue)
     {
         return setSelectionField(fieldIdentifier, List.of(selectValue));
+    }
+
+    /**
+     * @param fieldIdentifier Identifier for the field; name ({@link String}) or fieldKey ({@link FieldKey})
+     * @return text displayed in the help block, if any, for the selection field
+     */
+    public @Nullable String getSelectionFieldHelpBlockText(CharSequence fieldIdentifier)
+    {
+        return elementCache().getSelect(fieldIdentifier).getHelpBlockText();
     }
 
     /**


### PR DESCRIPTION
#### Rationale
Expose utility method on test dialog component.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1824
- https://github.com/LabKey/limsModules/pull/1505
- https://github.com/LabKey/testAutomation/pull/2531

#### Changes
- Add `EntityBulkUpdateDialog.getSelectionFieldHelpBlockText()`
