### PR TITLE
Issue 53394: FileInput revert removal of the "-fileUpload" suffix from inputId

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -253,9 +253,9 @@ public class EntityBulkUpdateDialog extends ModalDialog
      * @param fieldIdentifier Identifier for the field; name ({@link String}) or fieldKey ({@link FieldKey})
      * @return file attachment component
      */
-    public FileAttachmentContainer getFileField(CharSequence fieldIdentifier)
+    private FileAttachmentContainer getFileField(CharSequence fieldIdentifier)
     {
-        String identifier = FileAttachmentContainer.fileUploadIdentifier(fieldIdentifier.toString());
+        FieldKey identifier = FileAttachmentContainer.fileUploadFieldKey(fieldIdentifier);
         return enableAndWait(identifier, elementCache().fileUploadField(identifier));
     }
 
@@ -280,9 +280,9 @@ public class EntityBulkUpdateDialog extends ModalDialog
         return this;
     }
 
-    public FileUploadField getExistingFileField(String fieldIdentifier)
+    public FileUploadField getExistingFileCard(CharSequence fieldIdentifier)
     {
-        String identifier = FileAttachmentContainer.fileUploadIdentifier(fieldIdentifier.toString());
+        FieldKey identifier = FileAttachmentContainer.fileUploadFieldKey(fieldIdentifier);
         return enableAndWait(identifier, elementCache().fileField(identifier));
     }
 

--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -245,7 +245,8 @@ public class EntityBulkUpdateDialog extends ModalDialog
      */
     public FileAttachmentContainer getFileField(CharSequence fieldIdentifier)
     {
-        return enableAndWait(fieldIdentifier, elementCache().fileUploadField(fieldIdentifier));
+        String identifier = FileAttachmentContainer.fileUploadIdentifier(fieldIdentifier.toString());
+        return enableAndWait(identifier, elementCache().fileUploadField(identifier));
     }
 
     /**
@@ -271,7 +272,8 @@ public class EntityBulkUpdateDialog extends ModalDialog
 
     public FileUploadField getExistingFileField(String fieldIdentifier)
     {
-        return enableAndWait(fieldIdentifier, elementCache().fileField(fieldIdentifier));
+        String identifier = FileAttachmentContainer.fileUploadIdentifier(fieldIdentifier.toString());
+        return enableAndWait(identifier, elementCache().fileField(identifier));
     }
 
     /**

--- a/src/org/labkey/test/components/ui/files/FileAttachmentContainer.java
+++ b/src/org/labkey/test/components/ui/files/FileAttachmentContainer.java
@@ -195,6 +195,10 @@ public class FileAttachmentContainer extends WebDriverComponent<FileAttachmentCo
         public Locator fileUploadScrollFooterLoc = Locator.tagWithClass("div", "file-upload__scroll-footer");
     }
 
+    public static String fileUploadIdentifier(String fieldIdentifier)
+    {
+        return fieldIdentifier + "-fileUpload"; // Issue 53394
+    }
 
     public static class FileAttachmentContainerFinder extends WebDriverComponentFinder<FileAttachmentContainer, FileAttachmentContainerFinder>
     {

--- a/src/org/labkey/test/components/ui/files/FileAttachmentContainer.java
+++ b/src/org/labkey/test/components/ui/files/FileAttachmentContainer.java
@@ -6,6 +6,7 @@ import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.html.FileInput;
 import org.labkey.test.components.html.Input;
+import org.labkey.test.params.FieldKey;
 import org.openqa.selenium.ElementNotInteractableException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -195,9 +196,14 @@ public class FileAttachmentContainer extends WebDriverComponent<FileAttachmentCo
         public Locator fileUploadScrollFooterLoc = Locator.tagWithClass("div", "file-upload__scroll-footer");
     }
 
-    public static String fileUploadIdentifier(String fieldIdentifier)
+    /**
+     * File upload fields append "-fileUpload" to the field's fieldKey
+     * @param fieldIdentifier Identifier for the field; name ({@link String}) or fieldKey ({@link FieldKey})
+     * @return FieldKey with expected suffix
+     */
+    public static FieldKey fileUploadFieldKey(CharSequence fieldIdentifier)
     {
-        return fieldIdentifier + "-fileUpload"; // Issue 53394
+        return FieldKey.fromFieldKey(FieldKey.fromName(fieldIdentifier) + "-fileUpload"); // Issue 53394
     }
 
     public static class FileAttachmentContainerFinder extends WebDriverComponentFinder<FileAttachmentContainer, FileAttachmentContainerFinder>


### PR DESCRIPTION
#### Rationale
Issue [53394](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53394): LKSM: Selection of file doesn't work on develop

Revert changes from https://github.com/LabKey/labkey-ui-components/pull/1800 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1825
- https://github.com/LabKey/testAutomation/pull/2532
- https://github.com/LabKey/limsModules/pull/1506

#### Changes
- Test identifier updates for -fileUpload suffix revert
