### PR TITLE
Test component audit event row count and diff count checks for Jobs and Picklists

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1358,6 +1358,11 @@ public abstract class WebDriverWrapper implements WrapsDriver
         return whoAmI().getDisplayName();
     }
 
+    public Number getUserId()
+    {
+        return whoAmI().getUserId();
+    }
+
     public String getCurrentDateTimeFormatString()
     {
         return (String)executeScript("return LABKEY.container.formats.dateTimeFormat");

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1358,9 +1358,9 @@ public abstract class WebDriverWrapper implements WrapsDriver
         return whoAmI().getDisplayName();
     }
 
-    public Number getUserId()
+    public int getCurrentUserId()
     {
-        return whoAmI().getUserId();
+        return whoAmI().getUserId().intValue();
     }
 
     public String getCurrentDateTimeFormatString()

--- a/src/org/labkey/test/util/AuditLogHelper.java
+++ b/src/org/labkey/test/util/AuditLogHelper.java
@@ -176,7 +176,7 @@ public class AuditLogHelper
 
     public void checkAuditEventDiffCount(String containerPath, AuditEvent auditEventName, String eventDiffFieldName, List<Filter> filters, List<Integer> expectedDiffCounts) throws IOException, CommandException
     {
-        Integer maxRows = expectedDiffCounts.size();
+        Integer maxRows = null;//expectedDiffCounts.size(); TODO decide on this up before merge
         List<Map<String, Object>> events = getAuditLogsFromLKS(containerPath, auditEventName, List.of("InventoryUpdateType", eventDiffFieldName), filters, maxRows, ContainerFilter.CurrentAndSubfolders).getRows();
         assertEquals("Unexpected number of events", expectedDiffCounts.size(), events.size());
         for (int i = 0; i < expectedDiffCounts.size(); i++)

--- a/src/org/labkey/test/util/AuditLogHelper.java
+++ b/src/org/labkey/test/util/AuditLogHelper.java
@@ -171,15 +171,20 @@ public class AuditLogHelper
     }
     public void checkAuditEventDiffCount(String containerPath, AuditEvent auditEventName, List<Filter> filters, List<Integer> expectedDiffCounts) throws IOException, CommandException
     {
+        checkAuditEventDiffCount(containerPath, auditEventName, "NewRecordMap", filters, expectedDiffCounts);
+    }
+
+    public void checkAuditEventDiffCount(String containerPath, AuditEvent auditEventName, String eventDiffFieldName, List<Filter> filters, List<Integer> expectedDiffCounts) throws IOException, CommandException
+    {
         Integer maxRows = expectedDiffCounts.size();
-        List<Map<String, Object>> events = getAuditLogsFromLKS(containerPath, auditEventName, List.of("InventoryUpdateType", "NewRecordMap"), filters, maxRows, ContainerFilter.CurrentAndSubfolders).getRows();
+        List<Map<String, Object>> events = getAuditLogsFromLKS(containerPath, auditEventName, List.of("InventoryUpdateType", eventDiffFieldName), filters, maxRows, ContainerFilter.CurrentAndSubfolders).getRows();
         assertEquals("Unexpected number of events", expectedDiffCounts.size(), events.size());
         for (int i = 0; i < expectedDiffCounts.size(); i++)
         {
             Map<String, Object> event = events.get(i);
             boolean isInventoryUpdateType = event.get("InventoryUpdateType") != null;
             int expectedDiffCount = isInventoryUpdateType ? 0 : expectedDiffCounts.get(i);
-            String dataChangesStr = (String) event.get("NewRecordMap");
+            String dataChangesStr = (String) event.get(eventDiffFieldName);
             String[] dataChanges = dataChangesStr != null ? dataChangesStr.split("&") : new String[0];
 
             // filter out SampleStateLabel as that is not a change, it is added for display purposes
@@ -187,8 +192,8 @@ public class AuditLogHelper
             // filter out RowId as that is not a change, it is added for display purposes
             dataChanges = Stream.of(dataChanges).filter(s -> !s.toLowerCase().startsWith("rowid=")).toArray(String[]::new);
 
-            TestLogger.log("Audit record data changes diff count check: " + dataChangesStr);
-            assertEquals("Audit record data changes did not include the expected number of diffs, expected " + expectedDiffCount + " but was " + dataChanges.length + ": " + dataChangesStr,
+            TestLogger.log("Audit record data changes diff count check (" + eventDiffFieldName + "): " + dataChangesStr);
+            assertEquals("Audit record data changes did not include the expected number of diffs in " + eventDiffFieldName + ", expected " + expectedDiffCount + " but was " + dataChanges.length + ": " + dataChangesStr,
                     expectedDiffCount, dataChanges.length);
         }
     }

--- a/src/org/labkey/test/util/AuditLogHelper.java
+++ b/src/org/labkey/test/util/AuditLogHelper.java
@@ -176,7 +176,7 @@ public class AuditLogHelper
 
     public void checkAuditEventDiffCount(String containerPath, AuditEvent auditEventName, String eventDiffFieldName, List<Filter> filters, List<Integer> expectedDiffCounts) throws IOException, CommandException
     {
-        Integer maxRows = null;//expectedDiffCounts.size(); TODO decide on this up before merge
+        Integer maxRows = filters == null || filters.isEmpty() ? expectedDiffCounts.size() : null;
         List<Map<String, Object>> events = getAuditLogsFromLKS(containerPath, auditEventName, List.of("InventoryUpdateType", eventDiffFieldName), filters, maxRows, ContainerFilter.CurrentAndSubfolders).getRows();
         assertEquals("Unexpected number of events", expectedDiffCounts.size(), events.size());
         for (int i = 0; i < expectedDiffCounts.size(); i++)


### PR DESCRIPTION
#### Rationale
Expanding on recent AuditLogHelper checks for audit event row/diff counts on actions like sample/source bulk update and details update, this PR adds similar checks within the test components for creating/adding/removing samples from Jobs and Picklists.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1507
- https://github.com/LabKey/testAutomation/pull/2533

#### Changes
- Add AuditLogHelper checkAuditEventDiffCount support for checking event "Metadata" in addition to "NewRecordMap"
- WebDriverWrapper helper for getUserId
- AuditLogHelper.checkAuditEventDiffCount should set maxRows when no filters provided
