### PR TITLE
Use OS-specific file separator for expected file paths

### DIFF
--- a/src/org/labkey/test/tests/core/admin/AllowedFileExtensionTest.java
+++ b/src/org/labkey/test/tests/core/admin/AllowedFileExtensionTest.java
@@ -381,7 +381,7 @@ public class AllowedFileExtensionTest extends AllowedFileExtensionBaseTest
         {
             fieldMap = Map.of("Name", String.format("S-%d", i), stFileField, fileMap.get(allowedType).getAbsolutePath());
             sampleTypeHelper.insertRow(fieldMap);
-            expectedValues.add(String.format(" sampletype/%s", fileMap.get(allowedType).getName()));
+            expectedValues.add(" sampletype" + File.separator + fileMap.get(allowedType).getName());
             i++;
         }
 

--- a/src/org/labkey/test/tests/core/admin/AllowedFileExtensionTest.java
+++ b/src/org/labkey/test/tests/core/admin/AllowedFileExtensionTest.java
@@ -381,7 +381,7 @@ public class AllowedFileExtensionTest extends AllowedFileExtensionBaseTest
         {
             fieldMap = Map.of("Name", String.format("S-%d", i), stFileField, fileMap.get(allowedType).getAbsolutePath());
             sampleTypeHelper.insertRow(fieldMap);
-            expectedValues.add(" sampletype" + File.separator + fileMap.get(allowedType).getName());
+            expectedValues.add(String.format(" sampletype%s%s", File.separator, fileMap.get(allowedType).getName()));
             i++;
         }
 


### PR DESCRIPTION
#### Rationale
The files in this grid use OS file separators. First time running this test on Windows revealed the test needs to account for that.
```
Values in the 'File Upload Test' column not as expected. expected:<[ sampletype/csv_sample.csv,  sampletype/sample.txt,  sampletype/xls_sample.xls,  sampletype/tsv_sample.tsv,  sampletype/targz_sample.tar.gz]> but was:<[ sampletype\csv_sample.csv,  sampletype\sample.txt,  sampletype\xls_sample.xls,  sampletype\tsv_sample.tsv,  sampletype\targz_sample.tar.gz]>
```

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2428

#### Changes
- Use OS-specific file separator for expected file paths
