### PR TITLE
Avoid generating fields names with reserved substitution format patterns

### DIFF
--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -580,6 +580,17 @@ public class TestDataGenerator
         String chars = ALL_ILLEGAL_QUERY_KEY_CHARACTERS + " %()=+-[]_|*`'\":;<>?!@#^" + NON_LATIN_STRING;// + WIDE_PLACEHOLDER ;
 
         String randomFieldName = randomName(part, numStartChars, numEndChars, chars, exclusion);
+
+        // Avoid generating fields names with reserved substitution format patterns. e.g. ":Date" or ":First"
+        if (numStartChars > 0 && randomFieldName.charAt(numStartChars - 1) == ':' &&
+                StringUtils.isAlpha(part.substring(0, 4))) // The shortest pattern is four characters (see org.labkey.api.util.SubstitutionFormat.getFormatNames)
+        {
+            String regenExclusion = Objects.requireNonNullElse(exclusion, "") + ":";
+            randomFieldName = randomFieldName.substring(0, numStartChars - 1) +
+                    randomString(1, regenExclusion, chars) +
+                    randomFieldName.substring(numStartChars + 1);
+        }
+
         TestLogger.log("Generated random field name: " + randomFieldName);
         return randomFieldName;
     }


### PR DESCRIPTION
#### Rationale
As more tests are being converted to use random field names, they are failing periodically because we generate random field names that conflict with reserved formats. The reserved formats are colons followed by strings that tests often use for field names (e.g. ":Date" or ":First"). This change replaces the ':' with another random character if it generates something that might cause trouble.

#### Related Pull Requests
- N/A

#### Changes
- Avoid generating fields names with reserved substitution format patterns
