### PR TITLE
Use `WebElement.getDomProperty` for element `src`

### DIFF
--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -850,7 +850,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
             Locator popup = Locator.tag("div").withAttribute("id", "helpDiv").descendant("img").withAttributeContaining("src", popupImage).
                     withAttributeContaining("style", popupWidth != null ? "width:" + popupWidth : "max-width:300px");
             shortWait().until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("#helpDiv")));
-            String src = StringUtils.trimToEmpty(popup.findElement(getDriver()).getDomAttribute("src"));
+            String src = StringUtils.trimToEmpty(popup.findElement(getDriver()).getDomProperty("src"));
 
             fireEvent(thumbnail, SeleniumEvent.mouseout);
             Locator.tagWithClass("th", "labkey-selectors").findElement(getDriver()).click(); // safe out-click in the first header cell
@@ -1230,7 +1230,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
         WebElement reportLink = waitForElement(Locator.xpath("//a[text()='" + reportTitle + "']"));
         mouseOver(reportLink);
         WebElement thumbnail = waitForElement(Locator.xpath("//div[@class='thumbnail']/img").notHidden());
-        String thumbnailData = WebTestHelper.getHttpResponse(thumbnail.getDomAttribute("src")).getResponseBody();
+        String thumbnailData = WebTestHelper.getHttpResponse(thumbnail.getDomProperty("src")).getResponseBody();
 
         int lengthToCompare = 5000;
         int diff = LevenshteinDistance.getDefaultInstance().apply(expectedThumbnail.substring(0, lengthToCompare), thumbnailData.substring(0, lengthToCompare));


### PR DESCRIPTION
#### Rationale
When converting this to not use the deprecated `WebElement.getAttribute`, I mistakenly picked `getDomAttribute` to get the src attribute for some thumbnails.  Running this test on a server with a contextPath configured revealed this error. The `src` attribute includes the server's contextPath but our test helpers generally do not expect relative URLs to include the contextPath (e.g. `/labkey/_webdav/SimpleModuleTest%20Project/%40files/focusPopup.jpg`). `getDomProperty` gets the absolute URL as interpreted by the browser (e.g. `http:localhost:8080/labkey/_webdav/SimpleModuleTest%20Project/%40files/focusPopup.jpg`).

`WebElement.getDomAttribute` gets the literal attribute (`el.attributes['src']` in JavaScript) but `WebElement.getDomProperty` gets the attribute as interpreted by the browser (`el.src` in JavaScript)

#### Related Pull Requests
- #2495 

#### Changes
- Use `WebElement.getDomProperty` for element `src`
