### PR TITLE
Issue 53408: Encode field names in attachment download links

### DIFF
--- a/src/org/labkey/test/tests/AttachmentFieldTest.java
+++ b/src/org/labkey/test/tests/AttachmentFieldTest.java
@@ -19,6 +19,7 @@ import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
+import org.labkey.test.util.TestDataGenerator;
 
 import java.io.File;
 import java.util.List;
@@ -96,8 +97,8 @@ public class AttachmentFieldTest extends BaseWebDriverTest
     @Test
     public void testAttachmentFieldInLists()
     {
-        String listName = "List with attachment field";
-        String fieldName = "testFile";
+        String listName = TestDataGenerator.randomDomainName("List with attachment field");
+        String fieldName = TestDataGenerator.randomFieldName("Test File");
         goToProjectHome();
         log("Creating the list");
         _listHelper.createList(getProjectName(), listName, "id");

--- a/src/org/labkey/test/tests/FileAttachmentColumnTest.java
+++ b/src/org/labkey/test/tests/FileAttachmentColumnTest.java
@@ -35,6 +35,7 @@ import org.labkey.test.pages.files.FileContentPage;
 import org.labkey.test.pages.study.CreateStudyPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
+import org.labkey.test.params.FieldInfo;
 import org.labkey.test.params.assay.GeneralAssayDesign;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DataRegionTable;
@@ -42,6 +43,7 @@ import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
 import org.labkey.test.util.StudyHelper;
+import org.labkey.test.util.TestDataGenerator;
 import org.labkey.test.util.core.webdav.WebDavUploadHelper;
 import org.labkey.test.util.exp.SampleTypeAPIHelper;
 import org.openqa.selenium.By;
@@ -90,6 +92,7 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
     private final String RESULT_FILE_COL = "resultFile";
     private final String OTHER_RESULT_FILE_COL = "otherResultFile";
     private final String STUDY_DATASET_NAME = "ogreSpiteLevels";
+    private static final FieldInfo LIST_ATTACHMENT_FIELD = new FieldInfo(TestDataGenerator.randomFieldName("File / Attachment"), ColumnType.Attachment);
 
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
@@ -180,8 +183,8 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
         for (File testFile : downloadTestFiles)
         {
             int rowIndex = testListRegion.getRowIndex("Name", testFile.getName());
-            var downloadLink = testListRegion.link(rowIndex, "File");
-            doAndWaitForDownload(()-> downloadLink.click());
+            var downloadLink = testListRegion.link(rowIndex, LIST_ATTACHMENT_FIELD.getName());
+            doAndWaitForDownload(downloadLink::click);
         }
 
         // verify popup/sprite for jpeg
@@ -428,13 +431,13 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
         String LIST_KEY = "TestListId";
         listHelper.createList(getProjectName() + "/" + EXPORT_FOLDER_NAME, LIST_NAME, LIST_KEY,
                 new FieldDefinition("Name", ColumnType.String),
-                new FieldDefinition("File", ColumnType.Attachment));
+                LIST_ATTACHMENT_FIELD.getFieldDefinition());
         goToManageLists();
         listHelper.click(Locator.linkContainingText(LIST_NAME));
 
         for (File file : SAMPLE_FILES)
         {
-            Map<String, String> fileRow = Map.of("Name", file.getName(), "File", file.getAbsolutePath());
+            Map<String, String> fileRow = Map.of("Name", file.getName(), LIST_ATTACHMENT_FIELD.getName(), file.getAbsolutePath());
             listHelper.insertNewRow(fileRow, false);
         }
     }
@@ -448,7 +451,7 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
         for (File file : files)
         {
             sampleFileData.add(Map.of("Name", file.getName(), "Color", "green",
-                    "File", file.getName()));
+                    LIST_ATTACHMENT_FIELD.getName(), file.getName()));
         }
         helper.bulkImport(sampleFileData);
     }
@@ -513,7 +516,7 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
             else
             {
                 int rowIndex = testListRegion.getRowIndex("Name", testFile.getName());
-                var downloadLink = testListRegion.link(rowIndex, "File");
+                var downloadLink = testListRegion.link(rowIndex, LIST_ATTACHMENT_FIELD.getName());
                 doAndWaitForDownload(() -> downloadLink.click());
             }
         }
@@ -539,7 +542,7 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
             }
             else
             {
-                WebElement fileLinkCell = samplesRegion.findCell(rowIndex, "file");
+                WebElement fileLinkCell = samplesRegion.findCell(rowIndex, LIST_ATTACHMENT_FIELD.getName());
                 Optional<WebElement> optionalFileLink = Locator.tag("a").findOptionalElement(fileLinkCell);
                 checker().withScreenshot("unexpected_file_state")
                         .awaiting(Duration.ofSeconds(2),

--- a/src/org/labkey/test/tests/InlineImagesListTest.java
+++ b/src/org/labkey/test/tests/InlineImagesListTest.java
@@ -34,6 +34,7 @@ import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ExcelHelper;
+import org.labkey.test.util.TestDataGenerator;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
@@ -51,16 +52,16 @@ import static org.junit.Assert.assertTrue;
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class InlineImagesListTest extends BaseWebDriverTest
 {
-    protected final static String LIST_NAME = "InlineImagesList";
-    protected final static String LIST_KEY_NAME = "Key";
+    protected final static String LIST_NAME = TestDataGenerator.randomDomainName("InlineImagesList");
+    protected final static String LIST_KEY_NAME = TestDataGenerator.randomFieldName("Key");
     protected final static ColumnType LIST_KEY_TYPE = ColumnType.Integer;
 
-    protected final static String LIST_ATTACHMENT01_NAME = "Attachment01";
-    protected final static String LIST_ATTACHMENT01_LABEL = "Attachment Column 01";
+    protected final static String LIST_ATTACHMENT01_NAME = TestDataGenerator.randomFieldName("Attachment01");
+    protected final static String LIST_ATTACHMENT01_LABEL = TestDataGenerator.randomFieldName("Attachment Column 01");
     protected final static String LIST_ATTACHMENT01_DESC = "An 1st attachment column.";
 
-    protected final static String LIST_ATTACHMENT02_NAME = "Attachment02";
-    protected final static String LIST_ATTACHMENT02_LABEL = "Attachment Column 02";
+    protected final static String LIST_ATTACHMENT02_NAME = TestDataGenerator.randomFieldName("Attachment02");
+    protected final static String LIST_ATTACHMENT02_LABEL = TestDataGenerator.randomFieldName("Attachment Column 02");
     protected final static String LIST_ATTACHMENT02_DESC = "An 2nd attachment column.";
 
     protected final static ColumnType LIST_ATTACHMENT_TYPE = ColumnType.Attachment;
@@ -132,7 +133,7 @@ public class InlineImagesListTest extends BaseWebDriverTest
     }
 
     @Test
-    public final void ListTest() throws Exception
+    public final void testList() throws Exception
     {
         DataRegionTable list;
         DataRegionExportHelper exportHelper;


### PR DESCRIPTION
#### Rationale
Issue [53408](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53408): When a field name for an Attachment field contains a character that should be URL encoded, we need to be sure to do that encoding for download links.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6827
- https://github.com/LabKey/limsModules/pull/1512

#### Changes
- Update various tests that test attachments to use random names
