### PR TITLE
Delete unused method

### DIFF
--- a/src/org/labkey/test/util/APIUserHelper.java
+++ b/src/org/labkey/test/util/APIUserHelper.java
@@ -31,7 +31,6 @@ import org.labkey.remoteapi.SimpleGetCommand;
 import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.security.CreateUserCommand;
 import org.labkey.remoteapi.security.CreateUserResponse;
-import org.labkey.remoteapi.security.DeleteUserCommand;
 import org.labkey.remoteapi.security.GetUsersCommand;
 import org.labkey.remoteapi.security.GetUsersResponse;
 import org.labkey.remoteapi.security.GetUsersResponse.UserInfo;
@@ -58,6 +57,7 @@ import static org.junit.Assert.assertNotNull;
 public class APIUserHelper extends AbstractUserHelper
 {
     private final Supplier<Connection> connectionSupplier;
+
     public APIUserHelper(Supplier<Connection> connectionSupplier)
     {
         super(null);
@@ -221,19 +221,6 @@ public class APIUserHelper extends AbstractUserHelper
     protected void _deleteUser(String userEmail)
     {
         deleteUsers(false, userEmail);
-    }
-
-    private void deleteUser(@NotNull Integer userId)
-    {
-        DeleteUserCommand command = new DeleteUserCommand(userId);
-        try
-        {
-            command.execute(connectionSupplier.get(), "/");
-        }
-        catch (IOException|CommandException e)
-        {
-            throw new RuntimeException(e);
-        }
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Method is redundant with new `deleteUsers(int...)` variant and unused

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2502

Just removing an unused method, so, IMO, no need for additional test automation or manual testing