### PR TITLE
Allow `ScriptReportPage.saveReport` to return `null`

### DIFF
--- a/src/org/labkey/test/pages/reports/ScriptReportPage.java
+++ b/src/org/labkey/test/pages/reports/ScriptReportPage.java
@@ -17,8 +17,9 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import static org.labkey.test.components.ext4.Checkbox.Ext4Checkbox;
@@ -89,12 +90,25 @@ public class ScriptReportPage extends LabKeyPage<ScriptReportPage.ElementCache>
         {
             saveReportWithName(name, isSaveAs);
         }
-        return Objects.requireNonNullElse(getReportId(), reportIdBeforeSave);
+        String reportIdAfterSave = getReportId();
+        return reportIdAfterSave == null ? reportIdBeforeSave : reportIdAfterSave;
     }
 
     public String getReportId()
     {
-        return getUrlParam("reportId", true);
+        String paramName = "reportId";
+
+        Map<String, String> params = WebTestHelper.parseUrlQuery(getURL());
+        String paramValue = params.get(paramName);
+
+        if (paramValue == null)
+        {
+            paramValue = params.entrySet().stream()
+                    .filter(entry -> entry.getKey().endsWith("." + paramName))
+                    .map(Map.Entry::getValue).findFirst().orElse(null);
+        }
+
+        return paramValue == null ? null : URLDecoder.decode(paramValue, StandardCharsets.UTF_8);
     }
 
     /**


### PR DESCRIPTION
#### Rationale
Sometimes the reportId parameter for a script report is prefixed with a data region name. `getReportId` needs to iterate through the parameters to find the right one.

```
java.lang.NullPointerException: defaultObj
  at java.base/java.util.Objects.requireNonNull(Objects.java:235)
  at java.base/java.util.Objects.requireNonNullElse(Objects.java:290)
  at org.labkey.test.pages.reports.ScriptReportPage.saveReport(ScriptReportPage.java:92)
  at org.labkey.test.pages.reports.ScriptReportPage.saveReport(ScriptReportPage.java:132)
  at org.labkey.test.util.RReportHelper.saveReport(RReportHelper.java:454)
```

#### Related Pull Requests
- #2530 

#### Changes
- Allow `ScriptReportPage.saveReport` to return `null`
