### PR TITLE
Create `TestFileUtils.getMD5Hash` to compare binary files

### DIFF
--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -64,6 +64,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.Security;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -105,6 +107,9 @@ public abstract class TestFileUtils
         return getFileContents(path);
     }
 
+    /**
+     * Get text content of a file. Will throw an error for non-text files (e.g. PDF).
+     */
     public static String getFileContents(Path path)
     {
         try
@@ -112,6 +117,21 @@ public abstract class TestFileUtils
             return Files.readString(path);
         }
         catch (IOException fail)
+        {
+            throw new RuntimeException(fail);
+        }
+    }
+
+    /**
+     * Compute MD5 hash for the given file. Useful checking file equivalence.
+     */
+    public static String getMD5Hash(Path path)
+    {
+        try
+        {
+            return new String(MessageDigest.getInstance("MD5").digest(Files.readAllBytes(path)), StandardCharsets.UTF_8);
+        }
+        catch (IOException | NoSuchAlgorithmException fail)
         {
             throw new RuntimeException(fail);
         }

--- a/src/org/labkey/test/tests/FileAttachmentColumnTest.java
+++ b/src/org/labkey/test/tests/FileAttachmentColumnTest.java
@@ -550,9 +550,9 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
                  {
                      // verify fie download behavior
                      File downloadedFile = doAndWaitForDownload(() -> optionalFileLink.get().click());
-                     checker().wrapAssertion(() -> Assertions.assertThat(TestFileUtils.getFileContents(downloadedFile))
+                     checker().wrapAssertion(() -> Assertions.assertThat(TestFileUtils.getMD5Hash(downloadedFile.toPath()))
                              .as("expect the downloaded file to be the expected file")
-                             .isEqualTo(TestFileUtils.getFileContents(file)));   // guard against renames like file2.xyz
+                             .isEqualTo(TestFileUtils.getMD5Hash(file.toPath())));   // guard against renames like file2.xyz
                  }
             }
         }
@@ -576,9 +576,9 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
         if (optionalFileLink.isPresent())
         {
             var file = doAndWaitForDownload(()-> optionalFileLink.get().click());
-            checker().wrapAssertion(()-> Assertions.assertThat(TestFileUtils.getFileContents(file))
+            checker().wrapAssertion(()-> Assertions.assertThat(TestFileUtils.getMD5Hash(file.toPath()))
                     .as("expect the downloaded file to have equivalent content")
-                    .isEqualTo(TestFileUtils.getFileContents(runFile)));
+                    .isEqualTo(TestFileUtils.getMD5Hash(runFile.toPath())));
         }
 
         var resultsPage = runsPage.clickAssayIdLink(runName);
@@ -644,9 +644,9 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
                 {
                     // verify fie download behavior
                     File downloadedFile = doAndWaitForDownload(() -> optionalFileLink.get().click());
-                    checker().wrapAssertion(() -> Assertions.assertThat(TestFileUtils.getFileContents(downloadedFile))
+                    checker().wrapAssertion(() -> Assertions.assertThat(TestFileUtils.getMD5Hash(downloadedFile.toPath()))
                             .as("expect the downloaded file to be the expected file")
-                            .isEqualTo(TestFileUtils.getFileContents(file)));   // guard against renames like file2.xyz
+                            .isEqualTo(TestFileUtils.getMD5Hash(file.toPath())));   // guard against renames like file2.xyz
                 }
             }
         }


### PR DESCRIPTION
#### Rationale
IntelliJ recommended using `Files.readString` instead of `Files.readAllBytes`. However, `Files.readString` is more strict about the file structure. `FileAttachmentColumnTest` is failing because it is using `TestFileUtils.getFileContents` for various non-text files (e.g. zip and pdf). This strictness is useful for most scenarios, so I've created a new method to compare whether two files are equal (`TestFileUtils.getMD5Hash`).

```
java.lang.RuntimeException: java.nio.charset.MalformedInputException: Input length = 1
  at org.labkey.test.TestFileUtils.getFileContents(TestFileUtils.java:116)
  at org.labkey.test.TestFileUtils.getFileContents(TestFileUtils.java:105)
  at org.labkey.test.tests.FileAttachmentColumnTest.lambda$7(FileAttachmentColumnTest.java:553)
  at org.labkey.test.util.DeferredErrorCollector.wrapAssertion(DeferredErrorCollector.java:187)
  at org.labkey.test.tests.FileAttachmentColumnTest.validateSampleData(FileAttachmentColumnTest.java:553)
  at org.labkey.test.tests.FileAttachmentColumnTest.testSampleFileFields(FileAttachmentColumnTest.java:217)
```

#### Related Pull Requests
- #2530 

#### Changes
- `TestFileUtils.getMD5Hash`
