### PR TITLE
Fix random failures in the ListTest and SampleTypeFolderExportImportTest

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
@@ -43,6 +43,7 @@ import org.labkey.test.pages.admin.FolderManagementPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.DataClassDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
+import org.labkey.test.util.ArtifactCollector;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PortalHelper;
@@ -546,7 +547,7 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
     {
         String subfolder = "samplesWithAssayRunsFolder";
         String subfolderPath = getProjectName() + "/" + subfolder;
-        String testSamples = "testSamples";
+        String testSamples = "testSamplesWithFiles";
         String assayName = "testAssay";
         String importFolder = "assaySamplesImportFolder";
 
@@ -572,7 +573,7 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         portalHelper.addWebPart("Experiment Runs");
         portalHelper.addWebPart("Assay List");
 
-        // upload a file for a sample's file field
+        log(String.format("Upload a file '%s' to a sample's file field.", SAMPLE_TXT_FILE.getName()));
         clickAndWait(Locator.linkWithText(testSamples));
         DataRegionTable sourceSamplesTable = new SampleTypeHelper(this).getSamplesDataRegionTable();
         sourceSamplesTable.clickEditRow(1);
@@ -586,6 +587,8 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         clickAndWait(Locator.lkButton("Submit"));
 
         waitForElementToBeVisible(Locator.linkContainingText(SAMPLE_TXT_FILE.getName()));
+
+        new ArtifactCollector(this).dumpPageSnapshot("File_Attached_Proof");
 
         goToProjectFolder(getProjectName(), subfolder);
 
@@ -651,14 +654,26 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
             exportData.add(dataTable.getRowDataAsMap(i));
         }
 
-        // now export the current folder and import it to importProject
+        log("Now export the current folder and import it to importProject.");
         goToFolderManagement()
                 .goToExportTab();
 
-        Checkbox checkbox = new Checkbox(Locator.tagWithText("label", ExportFolderPage.EXPERIMENTS_AND_RUNS)
-                .precedingSibling("input").waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT));
-        new Checkbox(Locator.tagWithText("label", "Files").precedingSibling("input").findElement(getDriver())).check();
-        checkbox.check();
+        new Checkbox(Locator.tagWithText("label", ExportFolderPage.EXPERIMENTS_AND_RUNS)
+                .precedingSibling("input").waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT)).check();
+
+        new Checkbox(Locator.tagWithText("label", "Files")
+                .precedingSibling("input").waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT)).check();
+
+        Assert.assertTrue("Experiment and Runs not checked for export.",
+                new Checkbox(Locator.tagWithText("label", ExportFolderPage.EXPERIMENTS_AND_RUNS)
+                        .precedingSibling("input").waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT)).isChecked());
+
+        Assert.assertTrue("Files not checked for export.",
+                new Checkbox(Locator.tagWithText("label", "Files").precedingSibling("input").findElement(getDriver()))
+                        .isChecked());
+
+        log("'Experiment and Runs' & 'Files' are selected for export.");
+
         File exportedFolderFile = doAndWaitForDownload(()->findButton("Export").click());
 
         goToProjectFolder(IMPORT_PROJECT_NAME, importFolder);

--- a/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
@@ -557,7 +557,7 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         // create a test sampleType
         List<FieldDefinition> testFields = SampleTypeAPIHelper.sampleTypeTestFields(true);
         SampleTypeDefinition testSampleType = new SampleTypeDefinition(testSamples).setFields(testFields)
-                .addParentAlias("SelfParent"); // to derive from samles in the current type
+                .addParentAlias("SelfParent"); // to derive from samples in the current type
 
         TestDataGenerator parentDgen = SampleTypeAPIHelper.createEmptySampleType(subfolderPath, testSampleType);
         parentDgen.addCustomRow(Map.of("Name", "sample1", "intColumn", 1, "decimalColumn", 1.1, "stringColumn", "one"));
@@ -578,6 +578,11 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         sourceSamplesTable.clickEditRow(1);
         waitForElementToBeVisible(Locator.tagWithAttribute("input", "type", "file"));
         setFormElement(Locator.tagWithAttribute("input", "type", "file"), SAMPLE_TXT_FILE);
+        // setFormElement doesn't check that the form element is set.
+        // Because this test uses random field names, we should validate that the file was actually uploaded. If the
+        // file is missing later in the test, we can be sure it was present at this point.
+        Assert.assertFalse("File not uploaded.",
+                getFormElement(Locator.tagWithAttribute("input", "type", "file")).isEmpty());
         clickAndWait(Locator.lkButton("Submit"));
 
         goToProjectFolder(getProjectName(), subfolder);

--- a/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
@@ -581,9 +581,11 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         // setFormElement doesn't check that the form element is set.
         // Because this test uses random field names, we should validate that the file was actually uploaded. If the
         // file is missing later in the test, we can be sure it was present at this point.
-        Assert.assertFalse("File not uploaded.",
-                getFormElement(Locator.tagWithAttribute("input", "type", "file")).isEmpty());
+        Assert.assertTrue("File not uploaded to 'add new' form.",
+                waitFor(()->!getFormElement(Locator.tagWithAttribute("input", "type", "file")).isEmpty(), 1_500));
         clickAndWait(Locator.lkButton("Submit"));
+
+        waitForElementToBeVisible(Locator.linkContainingText(SAMPLE_TXT_FILE.getName()));
 
         goToProjectFolder(getProjectName(), subfolder);
 

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -660,10 +660,15 @@ public class ListTest extends BaseWebDriverTest
 
         log("Test list history");
         clickAndWait(Locator.linkWithText("manage lists"));
-        clickAndWait(Locator.linkWithText("view history"));
-        checker().wrapAssertion(()->assertTextPresent(":History"));
-        checker().wrapAssertion(()->assertTextPresent("record was modified", 2));    // An existing list record was modified
+        waitAndClickAndWait(Locator.linkWithText("view history"));
 
+        // Wait for the header to load on the page.
+        waitForElementToBeVisible(Locator.tagContainingText("h3", ":History"));
+
+        checker().verifyTrue("DataRegions didn't load.",
+                waitFor(()->new DataRegionTable.DataRegionFinder(getDriver()).findAll().size() == 2, 3_000));
+
+        checker().wrapAssertion(()->assertTextPresent("record was modified", 2));    // An existing list record was modified
         checker().wrapAssertion(()->assertTextPresent(" was created. The column(s) of domain ", 1));// Create domain and update columns combined into a single event
         checker().wrapAssertion(()->assertTextPresent(" were modified.", 7));          // The column(s) of LIST_NAME_COLORS domain were modified
         checker().wrapAssertion(()->assertTextPresent("The descriptor of domain", 1));          // The description LIST_NAME_COLORS domain were modified
@@ -674,13 +679,16 @@ public class ListTest extends BaseWebDriverTest
         checker().wrapAssertion(()->assertEquals("details Links", 6/*List Events*/ + 8/*Domain Audit*/, DataRegionTable.detailsLinkLocator().findElements(getDriver()).size()));
         checker().wrapAssertion(()->assertEquals("Project Links", 17, DataRegionTable.Locators.table().append(Locator.linkWithText(PROJECT_VERIFY)).findElements(getDriver()).size()));
         checker().wrapAssertion(()->assertEquals("List Links", 17, DataRegionTable.Locators.table().append(Locator.linkWithText(LIST_NAME_COLORS)).findElements(getDriver()).size()));
+        checker().screenShotIfNewError("List_History_Error");
+
         DataRegionTable dataRegionTable = new DataRegionTable("query", getDriver());
         dataRegionTable.clickRowDetails(0);
         checker().wrapAssertion(()->assertTextPresent("List Item Details"));
         checker().wrapAssertion(()->assertTextNotPresent("No details available for this event.", "Unable to find the audit history detail for this event"));
+        checker().screenShotIfNewError("History_Detail_Error");
 
         clickButton("Done");
-        clickAndWait(Locator.linkWithText(PROJECT_VERIFY).index(3));
+        waitAndClickAndWait(Locator.linkWithText(PROJECT_VERIFY).index(3));
 
         log("Test single list web part");
         new PortalHelper(this).addWebPart("List - Single");

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -535,6 +535,7 @@ public class ListTest extends BaseWebDriverTest
         checker().verifyEquals("Default value not as expected ", "42", updatePage.getTextInputValue(fieldWithDefault));
         updatePage.submit();
     }
+
     /* Issue 51572: Bug with creating a new list by uploading a csv file in "UTF-8 with BOM" format
      */
     @Test
@@ -580,7 +581,7 @@ public class ListTest extends BaseWebDriverTest
         setUpList(getProjectName());
 
         goToProjectHome();
-        clickAndWait(Locator.linkWithText(LIST_NAME_COLORS));
+        waitAndClickAndWait(Locator.linkWithText(LIST_NAME_COLORS));
 
         log("Test Sort and Filter in Data View");
         DataRegionTable region = new DataRegionTable("query", getDriver());
@@ -595,7 +596,7 @@ public class ListTest extends BaseWebDriverTest
         log("Test Customize View");
         // Re-navigate to the list to clear filters and sorts
         clickTab("List");
-        clickAndWait(Locator.linkWithText(LIST_NAME_COLORS));
+        waitAndClickAndWait(Locator.linkWithText(LIST_NAME_COLORS));
         _customizeViewsHelper.openCustomizeViewPanel();
         _customizeViewsHelper.removeColumn(_listColGood.getName());
         _customizeViewsHelper.addFilter(_listColGood.getName(), "Is Less Than", "10");
@@ -660,6 +661,10 @@ public class ListTest extends BaseWebDriverTest
 
         log("Test list history");
         clickAndWait(Locator.linkWithText("manage lists"));
+        DataRegionTable drt = new DataRegionTable.DataRegionFinder(getDriver()).find();
+        drt.setFilter("Name", "Equals", LIST_NAME_COLORS);
+        waitFor(()->drt.getDataRowCount()==1,
+                String.format("DataRegion table did not filter to list %s", LIST_NAME_COLORS), 2_500);
         waitAndClickAndWait(Locator.linkWithText("view history"));
 
         // Wait for the header to load on the page.


### PR DESCRIPTION
#### Rationale
Fixing two test issues. The failure in SampleTypeFolderExportImportTest appears to be random, and may not really need this change, but I think checking is still a good thing to do.

#### Related Pull Requests
- None.

#### Changes
- In ListTest, wait for the DataRegions that contain the list history.
- For SampleTypeFolderExportImportTest.testExportImportSampleTypesWithAssayRuns validate that file has been uploaded.
