### PR TITLE
Prevent `StringIndexOutOfBoundsException` when generating field names

### DIFF
--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -582,7 +582,7 @@ public class TestDataGenerator
         String randomFieldName = randomName(part, numStartChars, numEndChars, chars, exclusion);
 
         // Avoid generating fields names with reserved substitution format patterns. e.g. ":Date" or ":First"
-        if (numStartChars > 0 && randomFieldName.charAt(numStartChars - 1) == ':' &&
+        if (numStartChars > 0 && part.length() >= 4 && randomFieldName.charAt(numStartChars - 1) == ':' &&
                 StringUtils.isAlpha(part.substring(0, 4))) // The shortest pattern is four characters (see org.labkey.api.util.SubstitutionFormat.getFormatNames)
         {
             String regenExclusion = Objects.requireNonNullElse(exclusion, "") + ":";


### PR DESCRIPTION
#### Rationale
```
java.lang.StringIndexOutOfBoundsException: begin 0, end 4, length 1
  at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4602)
  at java.base/java.lang.String.substring(String.java:2705)
  at org.labkey.test.util.TestDataGenerator.randomFieldName(TestDataGenerator.java:586)
  at org.labkey.test.util.TestDataGenerator.randomFieldName(TestDataGenerator.java:568)
  at org.labkey.test.util.TestDataGenerator.randomFieldName(TestDataGenerator.java:563)
  at org.labkey.test.params.FieldInfo.random(FieldInfo.java:57)
  at org.labkey.test.params.FieldInfo.random(FieldInfo.java:65)
  at org.labkey.test.tests.SampleTypeNameExpressionTest.testSimpleNameExpression(SampleTypeNameExpressionTest.java:176)
```

#### Related Pull Requests
- #2537 

#### Changes
- Prevent `StringIndexOutOfBoundsException` when generating field names