### PR TITLE
Don't disable CSP enforcement for knitr tests

### DIFF
--- a/src/org/labkey/test/tests/AbstractKnitrReportTest.java
+++ b/src/org/labkey/test/tests/AbstractKnitrReportTest.java
@@ -245,7 +245,6 @@ public abstract class AbstractKnitrReportTest extends BaseWebDriverTest
     public void testEmbeddedReportNonce()
     {
         CspConfigHelper.debugCspWarnings();
-        new CspConfigHelper(this).setEnforceCsp(false);
 
         String name = "rhtml nonce check";
         Locator[] reportContains = {nonceCheckSuccessLoc};

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -582,7 +582,7 @@ public class TestDataGenerator
         String randomFieldName = randomName(part, numStartChars, numEndChars, chars, exclusion);
 
         // Avoid generating fields names with reserved substitution format patterns. e.g. ":Date" or ":First"
-        if (numStartChars > 0 && randomFieldName.charAt(numStartChars - 1) == ':' &&
+        if (numStartChars > 0 && part.length() >= 4 && randomFieldName.charAt(numStartChars - 1) == ':' &&
                 StringUtils.isAlpha(part.substring(0, 4))) // The shortest pattern is four characters (see org.labkey.api.util.SubstitutionFormat.getFormatNames)
         {
             String regenExclusion = Objects.requireNonNullElse(exclusion, "") + ":";


### PR DESCRIPTION
#### Rationale
1. `AbstractKnitrReportTest`
`new CspConfigHelper(this).setEnforceCsp(false)` doesn't work on trial instances. It isn't really necessary for this test though.
```
java.lang.NullPointerException: Unable to configure enforce CSP.
  at java.base/java.util.Objects.requireNonNull(Objects.java:336)
  at org.labkey.test.util.core.admin.CspConfigHelper.setEnforceCsp(CspConfigHelper.java:70)
  at org.labkey.test.tests.AbstractKnitrReportTest.testEmbeddedReportNonce(AbstractKnitrReportTest.java:248)
```

#### Related Pull Requests
- #2530 

#### Changes
- Don't disable CSP enforcement for knitr tests
