### PR TITLE
Don't crawl actions again after being redirected to them

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -997,6 +997,13 @@ public class Crawler
                 actualUrl = _test.getURL();
                 if (!actualUrl.toString().endsWith(relativeURL))
                 {
+                    try
+                    {
+                        String actualRelativeUrl = WebTestHelper.makeRelativeUrl(actualUrl.toString());
+                        _actionsVisited.add(new ControllerActionId(actualRelativeUrl));
+                        _urlsVisited.add(actualRelativeUrl);
+                        _urlsChecked.add(EscapeUtil.decodeUriPath(stripQueryParams(actualRelativeUrl)));
+                    } catch (IllegalArgumentException ignored) {}
                     originMessage = originMessage + "\nRedirected to: " + actualUrl;
                 }
 


### PR DESCRIPTION
#### Rationale
`.lastFilter` parameter can apply injection parameters when the crawler doesn't expect them.
The crawler would navigate to `mothership-begin.view`, which redirects to `mothership-showExceptions.view`. Then it would throw a bunch of injection parameters at `mothership-showExceptions.view`. The injection checker expects to hit some non-fatal errors, and knows how to evaluate them.
Later, it would crawl `mothership-showExceptions.view?.lastFilter=true` which would apply the bad parameters to the view. The non-injection phase of the crawler is more strict about what sort of product behavior it expects and might error out when it hits something the injector was fine with.

```
java.lang.RuntimeException: Crawler threw IllegalArgumentException.
Target page: _mothership/mothership-showExceptions.view?.lastFilter=true
Originating page: http://localhost:8111/_mothership/mothership-showExceptions.view?.lastFilter=true
Target Page: _mothership/mothership-showExceptions.view?.lastFilter=true
Redirected to: http://localhost:8111/_mothership/mothership-showExceptions.view?query.sort=%22%3E%27%3E%27%22%3Cscript%3Ealert(%278(%27)%3C%2Fscript%3E&userId=&returnUrl=&query.name~contains=&rowid=&query.rowid~eq=&name=
  at org.labkey.test.util.Crawler.crawlLink(Crawler.java:1129)
  at org.labkey.test.util.Crawler.crawl(Crawler.java:838)
  at org.labkey.test.util.Crawler.crawlAllLinks(Crawler.java:801)
```

#### Related Pull Requests
- N/A

#### Changes
- Don't crawl actions again after being redirected to them
