### PR TITLE
Increase timeout for getting updated password score

### DIFF
--- a/src/org/labkey/test/components/core/login/SetPasswordForm.java
+++ b/src/org/labkey/test/components/core/login/SetPasswordForm.java
@@ -113,7 +113,9 @@ public class SetPasswordForm extends WebDriverComponent<SetPasswordForm.ElementC
 
     private void assertGuidanceMessage(String expectedGuidance)
     {
-        Awaitility.await().atMost(Duration.ofSeconds(2)).untilAsserted(() ->
+        // Though it's usually quite fast, sometimes the password scoring API takes ~4 sec on TeamCity, so give it
+        // enough time to refresh
+        Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() ->
                 assertEquals("Strength guidance for password", expectedGuidance, elementCache().strengthGuidance.getText()));
     }
 


### PR DESCRIPTION
#### Rationale
We continue to see some intermittent failures testing out the password scoring. Looking at the HTTP access logs, in rare cases, the API takes > 2 seconds to process the request.

https://teamcity.labkey.org/viewLog.html?buildId=3576471&buildTypeId=LabKey_257Release_Premium_CommunitySqlserver_CustomModulesSqlserver&tab=buildLog&_focus=1311

#### Changes
- Wait 10 seconds instead of 2