### PR TITLE
Optional features ui coverage

### DIFF
--- a/src/org/labkey/test/pages/core/admin/OptionalFeaturesPage.java
+++ b/src/org/labkey/test/pages/core/admin/OptionalFeaturesPage.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Set;
 
 /*
-    Wraps Optional Features, Experimental Featueres, Deprecated Features pages linked
+    Wraps Optional Features, Experimental Features, Deprecated Features pages linked
     from Admin Console
  */
 public class OptionalFeaturesPage extends LabKeyPage<OptionalFeaturesPage.ElementCache>

--- a/src/org/labkey/test/pages/core/admin/OptionalFeaturesPage.java
+++ b/src/org/labkey/test/pages/core/admin/OptionalFeaturesPage.java
@@ -1,0 +1,106 @@
+package org.labkey.test.pages.core.admin;
+
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.components.html.Checkbox;
+import org.labkey.test.pages.LabKeyPage;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/*
+    Wraps Optional Features, Experimental Featueres, Deprecated Features pages linked
+    from Admin Console
+ */
+public class OptionalFeaturesPage extends LabKeyPage<OptionalFeaturesPage.ElementCache>
+{
+    public OptionalFeaturesPage(WebDriver driver)
+    {
+        super(driver);
+    }
+
+    public static OptionalFeaturesPage beginAt(WebDriverWrapper webDriverWrapper, OptionalFeatureType featureType)
+    {
+        webDriverWrapper.beginAt(WebTestHelper.buildURL("admin", "/", "optionalFeatures", Map.of("Type", featureType.toString())));
+        return new OptionalFeaturesPage(webDriverWrapper.getDriver());
+    }
+
+    @Override
+    protected void waitForPage()
+    {
+        waitFor(()-> elementCache().listGroupLoc.findWhenNeeded(getDriver()).isDisplayed(),
+                "The page did not render in time", WAIT_FOR_JAVASCRIPT);
+    }
+
+    public ShowAdminPage goToAdminConsole()
+    {
+        clickAndWait(Locator.linkWithText("Admin Console"));
+        return new ShowAdminPage(getDriver());
+    }
+
+    public Map<String, String> getFeatureMap()
+    {
+        return elementCache().getListItems();
+    }
+
+    public Set<String> getFeatureIds()
+    {
+        return getFeatureMap().keySet();
+    }
+
+    public boolean getFeatureStatus(String id)
+    {
+        return elementCache().getCheckboxById(id).get();
+    }
+
+    public OptionalFeaturesPage setFeatureStatus(String id, boolean status)
+    {
+        elementCache().getCheckboxById(id).set(status);
+        return this;
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends LabKeyPage<ElementCache>.ElementCache
+    {
+        public final Locator.XPathLocator listGroupLoc = Locator.tagWithClass("div", "list-group");
+        public final WebElement listGroupElement = listGroupLoc.waitForElement(getDriver(), 1500);
+        public final Locator listItemLabelLoc = Locator.tagWithClass("div", "list-group-item")
+                .child(Locator.tag("Label"));
+        private Map<String, String> _listItems;
+
+        public Map<String, String> getListItems()
+        {
+            if (_listItems == null) {
+                _listItems = new HashMap<String, String>();
+                for (WebElement el : listItemLabelLoc.findElements(listGroupElement)) {
+                    WebElement idEl = Locator.tagWithAttribute("type", "checkbox")
+                            .findElement(el);
+                    WebElement labelEl = Locator.tagWithClass("span", "toggle-label-text")
+                            .findElement(el);
+                    _listItems.put(idEl.getText(), labelEl.getText());
+                }
+            }
+            return _listItems;
+        }
+
+        public Checkbox getCheckboxById(String id)
+        {
+            return Checkbox.Checkbox(Locator.id(id)).waitFor(listGroupElement);
+        }
+    }
+
+    public enum OptionalFeatureType{
+        Experimental,
+        Optional,
+        Deprecated
+    }
+}

--- a/src/org/labkey/test/pages/core/admin/OptionalFeaturesPage.java
+++ b/src/org/labkey/test/pages/core/admin/OptionalFeaturesPage.java
@@ -42,16 +42,6 @@ public class OptionalFeaturesPage extends LabKeyPage<OptionalFeaturesPage.Elemen
         return new ShowAdminPage(getDriver());
     }
 
-    public Map<String, String> getFeatureMap()
-    {
-        return elementCache().getListItems();
-    }
-
-    public Set<String> getFeatureIds()
-    {
-        return getFeatureMap().keySet();
-    }
-
     public boolean getFeatureStatus(String id)
     {
         return elementCache().getCheckboxById(id).get();
@@ -75,22 +65,6 @@ public class OptionalFeaturesPage extends LabKeyPage<OptionalFeaturesPage.Elemen
         public final WebElement listGroupElement = listGroupLoc.waitForElement(getDriver(), 1500);
         public final Locator listItemLabelLoc = Locator.tagWithClass("div", "list-group-item")
                 .child(Locator.tag("Label"));
-        private Map<String, String> _listItems;
-
-        public Map<String, String> getListItems()
-        {
-            if (_listItems == null) {
-                _listItems = new HashMap<String, String>();
-                for (WebElement el : listItemLabelLoc.findElements(listGroupElement)) {
-                    WebElement idEl = Locator.tagWithAttribute("type", "checkbox")
-                            .findElement(el);
-                    WebElement labelEl = Locator.tagWithClass("span", "toggle-label-text")
-                            .findElement(el);
-                    _listItems.put(idEl.getText(), labelEl.getText());
-                }
-            }
-            return _listItems;
-        }
 
         public Checkbox getCheckboxById(String id)
         {

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.tests;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
@@ -25,13 +26,16 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
+import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.core.admin.CustomizeSitePage;
+import org.labkey.test.pages.core.admin.OptionalFeaturesPage;
 import org.labkey.test.pages.core.login.LoginConfigRow;
 import org.labkey.test.pages.core.login.LoginConfigurePage;
 import org.labkey.test.util.LogMethod;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -224,6 +228,88 @@ public class AdminConsoleTest extends AbstractAdminConsoleTest
         refresh();
         checker().withScreenshot("banner is shown when not expected")
                 .verifyFalse("expect banner not to be shown", bannerLoc.isDisplayed(getDriver()));
+    }
+
+    @Test
+    public void testUIOptionalFeatures()
+    {
+        goToAdminConsole();
+        waitAndClickAndWait(Locator.linkWithText("optional features"));
+        var optionalFeaturesPage = new OptionalFeaturesPage(getDriver());
+        var featureIds = List.of("extendedMetrics", "StageFileUploads");
+        var cn = createDefaultConnection();
+
+        for (String testId : featureIds) {
+            // capture initial state
+            boolean initialState = OptionalFeatureHelper.isOptionalFeatureEnabled(cn, testId);
+
+            // ensure the UI reflects the same state
+            boolean initialUIState = optionalFeaturesPage.getFeatureStatus(testId);
+            checker().withScreenshot("initial state not as expected")
+                    .wrapAssertion(()-> Assertions.assertThat(initialUIState)
+                            .as("expect ui to align with API initial state")
+                            .isEqualTo(initialState));
+
+            // toggle it the other way
+            optionalFeaturesPage.setFeatureStatus(testId, !initialState);
+            checker().withScreenshot("toggled state not as expected")
+                    .awaiting(Duration.ofMillis(500), ()-> Assertions.assertThat(OptionalFeatureHelper.isOptionalFeatureEnabled(cn, testId))
+                            .as("expect toggling the UI to update the server status for the feature")
+                            .isEqualTo(!initialState));
+
+            // use the API to restore the initial state
+            OptionalFeatureHelper.setOptionalFeature(cn, testId, initialState);
+            optionalFeaturesPage.goToAdminConsole();
+
+            optionalFeaturesPage = OptionalFeaturesPage.beginAt(this,
+                    OptionalFeaturesPage.OptionalFeatureType.Optional);
+
+            // verify the page state reflects the API change after a reload
+            checker().withScreenshot("state not as expected after api set and refresh")
+                    .verifyEquals("expect page to reflect state after api config",
+                            initialState, optionalFeaturesPage.getFeatureStatus(testId));
+        }
+    }
+
+    @Test
+    public void testUIExperimentalFeatures()
+    {
+        goToAdminConsole();
+        waitAndClickAndWait(Locator.linkWithText("experimental features"));
+        var experimentalFeaturesPage = new OptionalFeaturesPage(getDriver());
+        var featureIds = List.of("queryBasedDatasets", "LinkedDatasetCheck", "blockMaliciousClients");
+        var cn = createDefaultConnection();
+
+        for (String testId : featureIds) {
+            // capture initial state
+            boolean initialState = OptionalFeatureHelper.isOptionalFeatureEnabled(cn, testId);
+
+            // ensure the UI reflects the same state
+            boolean initialUIState = experimentalFeaturesPage.getFeatureStatus(testId);
+            checker().withScreenshot("initial state not as expected")
+                    .wrapAssertion(()-> Assertions.assertThat(initialUIState)
+                            .as("expect ui to align with API initial state")
+                            .isEqualTo(initialState));
+
+            // toggle it the other way
+            experimentalFeaturesPage.setFeatureStatus(testId, !initialState);
+            checker().withScreenshot("toggled state not as expected")
+                    .awaiting(Duration.ofMillis(500), ()-> Assertions.assertThat(OptionalFeatureHelper.isOptionalFeatureEnabled(cn, testId))
+                            .as("expect toggling the UI to update the server status for the feature")
+                            .isEqualTo(!initialState));
+
+            // use the API to restore the initial state
+            OptionalFeatureHelper.setOptionalFeature(cn, testId, initialState);
+            experimentalFeaturesPage.goToAdminConsole();
+
+            experimentalFeaturesPage = OptionalFeaturesPage.beginAt(this,
+                    OptionalFeaturesPage.OptionalFeatureType.Experimental);
+
+            // verify the page state reflects the API change after a reload
+            checker().withScreenshot("state not as expected after api set and refresh")
+                    .verifyEquals("expect page to reflect state after api config",
+                            initialState, experimentalFeaturesPage.getFeatureStatus(testId));
+        }
     }
 
     @Test

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -244,7 +244,7 @@ public class AdminConsoleTest extends AbstractAdminConsoleTest
     public void testUIExperimentalFeatures()
     {
         goToAdminConsole();
-        waitAndClickAndWait(Locator.linkWithText("experimental features"));
+
         var featureIds = List.of("queryBasedDatasets", "LinkedDatasetCheck", "blockMaliciousClients");
 
         verifyOptionalFeatures("experimental features", featureIds, OptionalFeaturesPage.OptionalFeatureType.Experimental);

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -235,40 +235,9 @@ public class AdminConsoleTest extends AbstractAdminConsoleTest
     {
         goToAdminConsole();
         waitAndClickAndWait(Locator.linkWithText("optional features"));
-        var optionalFeaturesPage = new OptionalFeaturesPage(getDriver());
         var featureIds = List.of("extendedMetrics", "StageFileUploads");
-        var cn = createDefaultConnection();
 
-        for (String testId : featureIds) {
-            // capture initial state
-            boolean initialState = OptionalFeatureHelper.isOptionalFeatureEnabled(cn, testId);
-
-            // ensure the UI reflects the same state
-            boolean initialUIState = optionalFeaturesPage.getFeatureStatus(testId);
-            checker().withScreenshot("initial state not as expected")
-                    .wrapAssertion(()-> Assertions.assertThat(initialUIState)
-                            .as("expect ui to align with API initial state")
-                            .isEqualTo(initialState));
-
-            // toggle it the other way
-            optionalFeaturesPage.setFeatureStatus(testId, !initialState);
-            checker().withScreenshot("toggled state not as expected")
-                    .awaiting(Duration.ofMillis(500), ()-> Assertions.assertThat(OptionalFeatureHelper.isOptionalFeatureEnabled(cn, testId))
-                            .as("expect toggling the UI to update the server status for the feature")
-                            .isEqualTo(!initialState));
-
-            // use the API to restore the initial state
-            OptionalFeatureHelper.setOptionalFeature(cn, testId, initialState);
-            optionalFeaturesPage.goToAdminConsole();
-
-            optionalFeaturesPage = OptionalFeaturesPage.beginAt(this,
-                    OptionalFeaturesPage.OptionalFeatureType.Optional);
-
-            // verify the page state reflects the API change after a reload
-            checker().withScreenshot("state not as expected after api set and refresh")
-                    .verifyEquals("expect page to reflect state after api config",
-                            initialState, optionalFeaturesPage.getFeatureStatus(testId));
-        }
+        verifyOptionalFeatures(featureIds, OptionalFeaturesPage.OptionalFeatureType.Optional);
     }
 
     @Test
@@ -276,40 +245,9 @@ public class AdminConsoleTest extends AbstractAdminConsoleTest
     {
         goToAdminConsole();
         waitAndClickAndWait(Locator.linkWithText("experimental features"));
-        var experimentalFeaturesPage = new OptionalFeaturesPage(getDriver());
         var featureIds = List.of("queryBasedDatasets", "LinkedDatasetCheck", "blockMaliciousClients");
-        var cn = createDefaultConnection();
 
-        for (String testId : featureIds) {
-            // capture initial state
-            boolean initialState = OptionalFeatureHelper.isOptionalFeatureEnabled(cn, testId);
-
-            // ensure the UI reflects the same state
-            boolean initialUIState = experimentalFeaturesPage.getFeatureStatus(testId);
-            checker().withScreenshot("initial state not as expected")
-                    .wrapAssertion(()-> Assertions.assertThat(initialUIState)
-                            .as("expect ui to align with API initial state")
-                            .isEqualTo(initialState));
-
-            // toggle it the other way
-            experimentalFeaturesPage.setFeatureStatus(testId, !initialState);
-            checker().withScreenshot("toggled state not as expected")
-                    .awaiting(Duration.ofMillis(500), ()-> Assertions.assertThat(OptionalFeatureHelper.isOptionalFeatureEnabled(cn, testId))
-                            .as("expect toggling the UI to update the server status for the feature")
-                            .isEqualTo(!initialState));
-
-            // use the API to restore the initial state
-            OptionalFeatureHelper.setOptionalFeature(cn, testId, initialState);
-            experimentalFeaturesPage.goToAdminConsole();
-
-            experimentalFeaturesPage = OptionalFeaturesPage.beginAt(this,
-                    OptionalFeaturesPage.OptionalFeatureType.Experimental);
-
-            // verify the page state reflects the API change after a reload
-            checker().withScreenshot("state not as expected after api set and refresh")
-                    .verifyEquals("expect page to reflect state after api config",
-                            initialState, experimentalFeaturesPage.getFeatureStatus(testId));
-        }
+        verifyOptionalFeatures(featureIds, OptionalFeaturesPage.OptionalFeatureType.Experimental);
     }
 
     @Test
@@ -442,5 +380,41 @@ public class AdminConsoleTest extends AbstractAdminConsoleTest
         goToAdminConsole().clickCredits();
         log("Verifying the page is properly loaded");
         assertTextPresent("JAR Files Distributed with the API Module");
+    }
+
+    private void verifyOptionalFeatures(List<String> featureIds, OptionalFeaturesPage.OptionalFeatureType optionalFeatureType)
+    {
+        var optionalFeaturesPage = new OptionalFeaturesPage(getDriver());
+        var cn = createDefaultConnection();
+
+        for (String testId : featureIds) {
+            // capture initial state
+            boolean initialState = OptionalFeatureHelper.isOptionalFeatureEnabled(cn, testId);
+
+            // ensure the UI reflects the same state
+            boolean initialUIState = optionalFeaturesPage.getFeatureStatus(testId);
+            checker().withScreenshot("initial state not as expected")
+                    .wrapAssertion(()-> Assertions.assertThat(initialUIState)
+                            .as("expect ui to align with API initial state")
+                            .isEqualTo(initialState));
+
+            // toggle it the other way
+            optionalFeaturesPage.setFeatureStatus(testId, !initialState);
+            checker().withScreenshot("toggled state not as expected")
+                    .awaiting(Duration.ofMillis(500), ()-> Assertions.assertThat(OptionalFeatureHelper.isOptionalFeatureEnabled(cn, testId))
+                            .as("expect toggling the UI to update the server status for the feature")
+                            .isEqualTo(!initialState));
+
+            // use the API to restore the initial state
+            OptionalFeatureHelper.setOptionalFeature(cn, testId, initialState);
+            optionalFeaturesPage.goToAdminConsole();
+
+            optionalFeaturesPage = OptionalFeaturesPage.beginAt(this, optionalFeatureType);
+
+            // verify the page state reflects the API change after a reload
+            checker().withScreenshot("state not as expected after api set and refresh")
+                    .verifyEquals("expect page to reflect state after api config",
+                            initialState, optionalFeaturesPage.getFeatureStatus(testId));
+        }
     }
 }

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -234,10 +234,10 @@ public class AdminConsoleTest extends AbstractAdminConsoleTest
     public void testUIOptionalFeatures()
     {
         goToAdminConsole();
-        waitAndClickAndWait(Locator.linkWithText("optional features"));
+
         var featureIds = List.of("extendedMetrics", "StageFileUploads");
 
-        verifyOptionalFeatures(featureIds, OptionalFeaturesPage.OptionalFeatureType.Optional);
+        verifyOptionalFeatures("optional features", featureIds, OptionalFeaturesPage.OptionalFeatureType.Optional);
     }
 
     @Test
@@ -247,7 +247,7 @@ public class AdminConsoleTest extends AbstractAdminConsoleTest
         waitAndClickAndWait(Locator.linkWithText("experimental features"));
         var featureIds = List.of("queryBasedDatasets", "LinkedDatasetCheck", "blockMaliciousClients");
 
-        verifyOptionalFeatures(featureIds, OptionalFeaturesPage.OptionalFeatureType.Experimental);
+        verifyOptionalFeatures("experimental features", featureIds, OptionalFeaturesPage.OptionalFeatureType.Experimental);
     }
 
     @Test
@@ -382,8 +382,9 @@ public class AdminConsoleTest extends AbstractAdminConsoleTest
         assertTextPresent("JAR Files Distributed with the API Module");
     }
 
-    private void verifyOptionalFeatures(List<String> featureIds, OptionalFeaturesPage.OptionalFeatureType optionalFeatureType)
+    private void verifyOptionalFeatures(String linkText, List<String> featureIds, OptionalFeaturesPage.OptionalFeatureType optionalFeatureType)
     {
+        waitAndClickAndWait(Locator.linkWithText(linkText));
         var optionalFeaturesPage = new OptionalFeaturesPage(getDriver());
         var cn = createDefaultConnection();
 


### PR DESCRIPTION
#### Rationale
This change adds UI coverage for optional features and experimental features.
Recent changes have refactored the implementation for exp features, optional features, and deprecated features under the singular optionalFeaturesService implementation.  This coverage seeks to validate the UI continues to work as expected.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/6828

#### Changes
New page class to wrap all three of the optional features pages
