### PR TITLE
GridPanelTest fix - grid filter pills use field label

### DIFF
--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -1786,7 +1786,7 @@ public class GridPanelTest extends GridPanelBaseTest
         grid.selectView(VIEW_EXTRA_COLUMNS);
 
         List<FilterStatusValue> filterPills = grid.getFilterStatusValues();
-        String expectedValue = String.format("%s = true", FILTER_BOOL_COL.getName());
+        String expectedValue = String.format("%s = true", FILTER_BOOL_COL.getLabel());
         checker().withScreenshot("View_Filter_Pill_Error").verifyTrue(String.format("Filter pills not as expected. There should only be one with value of '%s'", expectedValue),
                 filterPills.size() == 1 && filterPills.get(0).getText().equals(expectedValue));
 


### PR DESCRIPTION
#### Rationale
The GridPanelTest was recently updated to use fuzz testing for field names. This PR fixes the test case that checks the grid filter pill text.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2540

#### Changes
- use getLabel() for field filter panel text check
