### PR TITLE
BiologicsReportTest fix for export PDF title replacement of WIDE_CHAR with ## in labels

### DIFF
--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -70,7 +70,7 @@ import static org.labkey.test.util.data.TestDataUtils.REALISTIC_SOURCE_FIELDS;
  */
 public class TestDataGenerator
 {
-    private static final String WIDE_CHAR = "\uD83D\uDC7E"; // 👾
+    public static final String WIDE_CHAR = "\uD83D\uDC7E"; // 👾
     private static final char WIDE_PLACEHOLDER = '\u03A0'; // 'Π' - Wide character can't be picked from the string with 'charAt'
     private static final String NON_LATIN_STRING = "\u0438\uC548\u306F"; // "и안は"
     // chose a Character random from this String


### PR DESCRIPTION
#### Rationale
Exporting a chart in the app to PDF will convert non-ASCII chars to # in the labels. The regex we are using on the test side converts the WIDE_CHAR to a single # but we need it to be ##.

#### Related Pull Requests
https://github.com/LabKey/limsModules/pull/1526
https://github.com/LabKey/testAutomation/pull/2564

#### Changes
- make WIDE_CHAR public
