### PR TITLE
Test updates after change to input names to fix issue 53306

### DIFF
--- a/src/org/labkey/test/pages/issues/ResolvePage.java
+++ b/src/org/labkey/test/pages/issues/ResolvePage.java
@@ -74,7 +74,7 @@ public class ResolvePage extends BaseUpdatePage<ResolvePage.ElementCache>
     {
         protected ElementCache()
         {
-            resolution = getSelect("resolution");
+            resolution = getSelect("Resolution");
             duplicate = getSelect("duplicate");
         }
     }


### PR DESCRIPTION
#### Rationale
A few more tests need updates related to the improved naming for `<form>` `<input>` elements

#### Changes
- Use the right casing