### PR TITLE
Ignore whitespace difference when comparing tooltips

### DIFF
--- a/src/org/labkey/test/tests/component/EditableGridTest.java
+++ b/src/org/labkey/test/tests/component/EditableGridTest.java
@@ -1496,7 +1496,7 @@ public class EditableGridTest extends BaseWebDriverTest
 
             checker().verifyEquals("Cell warning status not as expected at row " + rowId + " for col " + field.getLabel(), !StringUtils.isEmpty(expectedWarning), testGrid.hasCellError(rowId, field));
             if (!StringUtils.isEmpty(expectedWarning))
-                checker().verifyEquals("Cell warning msg not as expected at row " + rowId + " for col " + field.getLabel(), expectedWarning, testGrid.getCellPopoverText(rowId, field));
+                checker().verifyEqualsIgnoreWhiteSpaces("Cell warning msg not as expected at row " + rowId + " for col " + field.getLabel(), expectedWarning, testGrid.getCellPopoverText(rowId, field));
         }
     }
 


### PR DESCRIPTION
#### Rationale
[EditableGridTest.testFillCellValidation](https://teamcity.labkey.org/viewLog.html?buildId=3585139&buildTypeId=LabkeyTrunk_DailyPostgres_2&fromSakuraUI=true#testNameId-902226239894477351), [EditableGridTest.testInputCellValidation](https://teamcity.labkey.org/viewLog.html?buildId=3585139&buildTypeId=LabkeyTrunk_DailyPostgres_2&fromSakuraUI=true#testNameId-4294666059547290705)
Tooltip warnings differ from expectation with columns that contains more than one whitespaces

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
