### PR TITLE
Issue 53243: add "includeEmptyPermGroups" to security-getGroupPerms.api

### DIFF
--- a/data/api/security-api.xml
+++ b/data/api/security-api.xml
@@ -1,7 +1,7 @@
 <ApiTests xmlns="http://labkey.org/query/xml">
 
     <test name="get group permissions" type="get">
-        <url>Security%20API%20Test%20Project/security-getGroupPerms.view?</url>
+        <url>Security%20API%20Test%20Project/security-getGroupPerms.api</url>
         <response>
             {"container":
                 {
@@ -93,8 +93,71 @@
         </response>
     </test>
 
+    <test name="get group permissions excluding groups without effective permissions" type="get">
+        <url>Security%20API%20Test%20Project/security-getGroupPerms.api?includeEmptyPermGroups=false</url>
+        <response>
+            {"container":
+                {
+                    "id": "THIS CONTAINER GUID FIELD IS IGNORED IN JSON CHECK",
+                    "name": "Security API Test Project",
+                    "path": "/Security API Test Project",
+                    "isInheritingPerms": false,
+                    "groups": [
+                        {
+                            "id": 1672,
+                            "name": "testgroup1",
+                            "roles": ["org.labkey.api.security.roles.EditorRole"],
+                            "isSystemGroup": false,
+                            "isProjectGroup": true,
+                            "type": "g",
+                            "effectivePermissions": [
+                                "org.labkey.api.security.permissions.InsertPermission",
+                                "org.labkey.api.security.permissions.DeletePermission",
+                                "org.labkey.api.security.permissions.EditSharedViewPermission",
+                                "org.labkey.api.reports.permissions.EditSharedReportPermission",
+                                "org.labkey.api.security.permissions.ReadPermission",
+                                "org.labkey.api.reports.permissions.ShareReportPermission",
+                                "org.labkey.api.study.permissions.SharedParticipantGroupPermission",
+                                "org.labkey.announcements.model.SecureMessageBoardRespondPermission",
+                                "org.labkey.api.security.permissions.ReadSomePermission",
+                                "org.labkey.api.lists.permissions.ManagePicklistsPermission",
+                                "org.labkey.api.security.permissions.UpdatePermission",
+                                "org.labkey.announcements.model.SecureMessageBoardReadPermission",
+                                "org.labkey.api.security.permissions.SampleWorkflowDeletePermission",
+                                "org.labkey.api.security.permissions.SampleWorkflowJobPermission",
+                                "org.labkey.api.security.permissions.AssayReadPermission",
+                                "org.labkey.api.security.permissions.NotebookReadPermission",
+                                "org.labkey.api.security.permissions.DataClassReadPermission",
+                                "org.labkey.api.security.permissions.MediaReadPermission",
+                                "org.labkey.api.security.permissions.MoveEntitiesPermission",
+                            ],
+                            "groups": []
+                        },
+                        {
+                            "id": 1673,
+                            "name": "testgroup2",
+                            "roles": ["org.labkey.api.security.roles.ReaderRole"],
+                            "isSystemGroup": false,
+                            "isProjectGroup": true,
+                            "type": "g",
+                            "effectivePermissions": [
+                                "org.labkey.api.security.permissions.ReadPermission",
+                                "org.labkey.api.security.permissions.ReadSomePermission",
+                                "org.labkey.api.security.permissions.AssayReadPermission",
+                                "org.labkey.api.security.permissions.DataClassReadPermission",
+                                "org.labkey.api.security.permissions.NotebookReadPermission",
+                                "org.labkey.api.security.permissions.MediaReadPermission"
+                            ],
+                            "groups": []
+                        }
+                    ]
+                }
+            }
+        </response>
+    </test>
+
     <test name="groups for current user" type="get">
-        <url>Security%20Api%20Test%20Project/security-getGroupsForCurrentUser.view?</url>
+        <url>Security%20Api%20Test%20Project/security-getGroupsForCurrentUser.api</url>
         <response>
             {"groups": [
                     {
@@ -115,7 +178,7 @@
     </test>
 
     <test name="ensure login" type="get">
-        <url>Security%20Api%20Test%20Project/security-ensureLogin.view?</url>
+        <url>Security%20Api%20Test%20Project/security-ensureLogin.api</url>
         <response>
             {"currentUser":
                 {


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/platform/pull/6853 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6853

#### Changes
- Verify new parameter `includeEmptyPermGroups` is respected by the `security-getGroupPerms.api` endpoint
