### PR TITLE
53361: 'list-details.view' doesn't work when list pk is named "name"

### DIFF
--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -2109,8 +2109,8 @@ public class ListTest extends BaseWebDriverTest
     }
 
     /**
-     * Issue 53361: 'list-details.view' doesn't work when list pk is named "name"
-     * Expect bad product behavior. Convert this to a regression test once the issue is fixed.
+     * Regression for issue 53361: 'list-details.view' doesn't work when list pk is named "name"
+     * Test for both name and listId key field names.
      */
     @Test
     public void testPkNameParameterCollision() throws IOException, CommandException

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -2102,23 +2102,27 @@ public class ListTest extends BaseWebDriverTest
     @Test
     public void testPkNameParameterCollision() throws IOException, CommandException
     {
-        String listName = TestDataGenerator.randomDomainName("list_key_check");
-        String pkCol = "Name";
+        // Create lists with PKs having the same name as detail URL list definition identifier
+        // params to ensure we can resolve detail pages correctly
+        validateDetailsView("list_name_key_check", "Name");
+        validateDetailsView("list_id_key_check", "ListId");
+    }
 
+    private void validateDetailsView(String listName, String pkCol) throws CommandException, IOException
+    {
+        listName = TestDataGenerator.randomDomainName(listName);
         var dgen = new VarListDefinition(listName)
-            .setFields(List.of(new FieldDefinition(pkCol)))
-            .create(createDefaultConnection(), getProjectName())
-            .withGeneratedRows(10);
+                .setFields(List.of(new FieldDefinition(pkCol)))
+                .create(createDefaultConnection(), getProjectName())
+                .withGeneratedRows(10);
         List<String> pks = dgen.getRows().stream().map(row -> (String) row.get(pkCol)).toList();
         dgen.insertRows();
 
         goToProjectHome();
-
         goToManageLists().getGrid().viewListData(listName);
 
         clickAndWait(Locator.linkWithText(pks.get(0)));
-        assertElementPresent(Locator.byClass("labkey-error-heading")
-            .withText("List item '%s' does not exist".formatted(listName)));
+        assertElementPresent(Locator.tagContainingText("td", pks.get(0)));
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
[issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53361)

Enable regression tests for the tracking issue, testing both `name` and `listId` key field names.