### PR TITLE
Misc test updates related to recent fuzz testing changes

### DIFF
--- a/src/org/labkey/test/tests/FileAttachmentColumnTest.java
+++ b/src/org/labkey/test/tests/FileAttachmentColumnTest.java
@@ -93,7 +93,9 @@ public class FileAttachmentColumnTest extends BaseWebDriverTest
     private final String RESULT_FILE_COL = "resultFile";
     private final String OTHER_RESULT_FILE_COL = "otherResultFile";
     private final String STUDY_DATASET_NAME = "ogreSpiteLevels";
-    private static final FieldInfo LIST_ATTACHMENT_FIELD = new FieldInfo(TestDataGenerator.randomFieldName("File / Attachment"), ColumnType.Attachment);
+    // Issue 53505: enable use of randomFieldName when issue is fixed
+    //private static final FieldInfo LIST_ATTACHMENT_FIELD = new FieldInfo(TestDataGenerator.randomFieldName("File / Attachment"), ColumnType.Attachment);
+    private static final FieldInfo LIST_ATTACHMENT_FIELD = new FieldInfo("File / Attachment", ColumnType.Attachment);
 
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException

--- a/src/org/labkey/test/tests/InlineImagesListTest.java
+++ b/src/org/labkey/test/tests/InlineImagesListTest.java
@@ -33,6 +33,7 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.DomainUtils;
 import org.labkey.test.util.ExcelHelper;
 import org.labkey.test.util.TestDataGenerator;
 import org.openqa.selenium.By;
@@ -47,21 +48,24 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.TestDataGenerator.ALL_CHARS_PLACEHOLDER;
+import static org.labkey.test.util.TestDataGenerator.REPEAT_PLACEHOLDER;
 
 @Category(Daily.class)
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class InlineImagesListTest extends BaseWebDriverTest
 {
-    protected final static String LIST_NAME = TestDataGenerator.randomDomainName("InlineImagesList");
-    protected final static String LIST_KEY_NAME = TestDataGenerator.randomFieldName("Key");
+    protected final static String LIST_NAME = TestDataGenerator.randomDomainName("InlineImagesList", DomainUtils.DomainKind.IntList);
+    // list key name has a smaller max length than other field names, so we use a constant numEndChars and exclude the repeat and all chars placeholders
+    protected final static String LIST_KEY_NAME = TestDataGenerator.randomFieldName("Key" + ALL_CHARS_PLACEHOLDER, 0, 5, "" + ALL_CHARS_PLACEHOLDER + REPEAT_PLACEHOLDER, DomainUtils.DomainKind.IntList);
     protected final static ColumnType LIST_KEY_TYPE = ColumnType.Integer;
 
-    protected final static String LIST_ATTACHMENT01_NAME = TestDataGenerator.randomFieldName("Attachment01");
-    protected final static String LIST_ATTACHMENT01_LABEL = TestDataGenerator.randomFieldName("Attachment Column 01");
+    protected final static String LIST_ATTACHMENT01_NAME = TestDataGenerator.randomFieldName("Attachment01", null, DomainUtils.DomainKind.IntList);
+    protected final static String LIST_ATTACHMENT01_LABEL = "Attachment Column 01";
     protected final static String LIST_ATTACHMENT01_DESC = "An 1st attachment column.";
 
-    protected final static String LIST_ATTACHMENT02_NAME = TestDataGenerator.randomFieldName("Attachment02");
-    protected final static String LIST_ATTACHMENT02_LABEL = TestDataGenerator.randomFieldName("Attachment Column 02");
+    protected final static String LIST_ATTACHMENT02_NAME = TestDataGenerator.randomFieldName("Attachment02", null, DomainUtils.DomainKind.IntList);
+    protected final static String LIST_ATTACHMENT02_LABEL = "Attachment Column 02";
     protected final static String LIST_ATTACHMENT02_DESC = "An 2nd attachment column.";
 
     protected final static ColumnType LIST_ATTACHMENT_TYPE = ColumnType.Attachment;

--- a/src/org/labkey/test/tests/TextChoiceSampleTypeTest.java
+++ b/src/org/labkey/test/tests/TextChoiceSampleTypeTest.java
@@ -110,7 +110,7 @@ public class TextChoiceSampleTypeTest extends BaseWebDriverTest
         expectedValues.add("A");
         expectedValues.add("\u00DC");
         expectedValues.add("|X|Y|Z|withPipeChars");
-        expectedValues.add("A string with spaces and backslash at end.\\");
+        expectedValues.add("A string with \"spaces\" and backslash at end.\\");
         expectedValues.add("B");
 
         // Identify a couple of TextChoice values that will be used in samples.
@@ -173,8 +173,8 @@ public class TextChoiceSampleTypeTest extends BaseWebDriverTest
 
         samples.add(Map.of(textChoiceFieldName, valuesUsed.get(0), textField, ""));
         samples.add(Map.of(textChoiceFieldName, "", textField, expectedConvertedValues.get(0)));
-        samples.add(Map.of(textChoiceFieldName, "\"" + valuesUsed.get(1)+ "\"", textField, ""));
-        samples.add(Map.of(textChoiceFieldName, "\"" + valuesUsed.get(1) + "\"", textField, ""));
+        samples.add(Map.of(textChoiceFieldName, valuesUsed.get(1), textField, ""));
+        samples.add(Map.of(textChoiceFieldName, valuesUsed.get(1), textField, ""));
         samples.add(Map.of(textChoiceFieldName, "", textField, expectedConvertedValues.get(1)));
 
         sampleTypeHelper.bulkImport(samples);


### PR DESCRIPTION
#### Rationale

- FileAttachmentColumnTest update to comment out randomFieldName usage 
  - until [53505](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53505) is fixed
- InlineImagesListTest update to not use randomFieldName for list field labels
  - the test is checking for column width in the exported Excel file so fuzzing the label isn't helpful here
- TextChoiceSampleTypeTest update for how tsv import values are quoted in bulk import
  - remove surrounding quotes added by the test case and instead include a double quote in the value
