### PR TITLE
TestDataGenerator.isDomainAndFieldNameInvalid API call update for trial instance tests

### DIFF
--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -123,8 +123,7 @@ public class FieldDefinition extends PropertyDescriptor
             }
         }
 
-        // Multiple spaces in the UI are collapsed into a single space
-        return buf.toString().replaceAll("\\s+", " ");
+        return buf.toString();
     }
 
     public String getEffectiveLabel()

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -561,7 +561,7 @@ public class TestDataGenerator
         String charSet = ALPHANUMERIC_STRING + DOMAIN_SPECIAL_STRING;
         // TODO increase min to 5 and max to 50
         String domainName = randomName(_namePart, getNumChars(numStartChars, 0), getNumChars(numEndChars, 10), charSet, null);
-        while (isDomainAndFieldNameInvalid(WebTestHelper.getRemoteApiConnection(), _domainKind, domainName, null))
+        while (isDomainAndFieldNameInvalid(_domainKind, domainName, null))
             domainName = randomName(_namePart, getNumChars(numStartChars, 0), getNumChars(numEndChars, 10), charSet, null);
 
         // Multiple spaces in the UI are collapsed into a single space. If we need to test for handling of multiple spaces, we'll not use this generator
@@ -602,14 +602,14 @@ public class TestDataGenerator
 
         // TODO increase max to 50
         String randomFieldName = randomName(part, getNumChars(numStartChars, 5), getNumChars(numEndChars, 5), chars, exclusion);
-        while (isDomainAndFieldNameInvalid(WebTestHelper.getRemoteApiConnection(), _domainKind, null, randomFieldName))
+        while (isDomainAndFieldNameInvalid(_domainKind, null, randomFieldName))
             randomFieldName = randomName(part, getNumChars(numStartChars, 5), getNumChars(numEndChars, 5), chars, exclusion);
 
         TestLogger.log("Generated random field name for domainKind " + _domainKind + ": " + randomFieldName);
         return randomFieldName;
     }
 
-    private static boolean isDomainAndFieldNameInvalid(Connection connection, DomainUtils.DomainKind domainKind, @Nullable String domainName, @Nullable String fieldName)
+    private static boolean isDomainAndFieldNameInvalid(DomainUtils.DomainKind domainKind, @Nullable String domainName, @Nullable String fieldName)
     {
         SimplePostCommand command = new SimplePostCommand("property", "validateDomainAndFieldNames");
         JSONObject domainDesign = new JSONObject();
@@ -630,7 +630,7 @@ public class TestDataGenerator
 
         try
         {
-            CommandResponse response = command.execute(connection, "/");
+            CommandResponse response = command.execute(WebTestHelper.getRemoteApiConnection(), "/");
             return response.getParsedData().containsKey("errors");
         }
         catch (CommandException | IOException e)

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -561,7 +561,7 @@ public class TestDataGenerator
         String charSet = ALPHANUMERIC_STRING + DOMAIN_SPECIAL_STRING;
         // TODO increase min to 5 and max to 50
         String domainName = randomName(_namePart, getNumChars(numStartChars, 0), getNumChars(numEndChars, 10), charSet, null);
-        while (isDomainAndFieldNameInvalid(WebTestHelper.getRemoteApiConnection(false), _domainKind, domainName, null))
+        while (isDomainAndFieldNameInvalid(WebTestHelper.getRemoteApiConnection(), _domainKind, domainName, null))
             domainName = randomName(_namePart, getNumChars(numStartChars, 0), getNumChars(numEndChars, 10), charSet, null);
 
         // Multiple spaces in the UI are collapsed into a single space. If we need to test for handling of multiple spaces, we'll not use this generator
@@ -602,7 +602,7 @@ public class TestDataGenerator
 
         // TODO increase max to 50
         String randomFieldName = randomName(part, getNumChars(numStartChars, 5), getNumChars(numEndChars, 5), chars, exclusion);
-        while (isDomainAndFieldNameInvalid(WebTestHelper.getRemoteApiConnection(false), _domainKind, null, randomFieldName))
+        while (isDomainAndFieldNameInvalid(WebTestHelper.getRemoteApiConnection(), _domainKind, null, randomFieldName))
             randomFieldName = randomName(part, getNumChars(numStartChars, 5), getNumChars(numEndChars, 5), chars, exclusion);
 
         TestLogger.log("Generated random field name for domainKind " + _domainKind + ": " + randomFieldName);

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -630,7 +630,7 @@ public class TestDataGenerator
 
         try
         {
-            CommandResponse response = command.execute(WebTestHelper.getRemoteApiConnection(), "/");
+            CommandResponse response = command.execute(WebTestHelper.getRemoteApiConnection(), "/home");
             return response.getParsedData().containsKey("errors");
         }
         catch (CommandException | IOException e)


### PR DESCRIPTION
#### Rationale
TestDataGenerator.isDomainAndFieldNameInvalid API call is failing for test cases on trial instances because of auth issues with creating a new API connection and with always using the root container for the API call. This PR changes the API call to use the current connection and to use the /home dir.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1547

#### Changes
- don't create new remote API connection for API call
- use /home dir for API call
