### PR TITLE
ListLookupTest failure fix related to randomFieldName for list key

### DIFF
--- a/src/org/labkey/test/tests/list/ListLookupTest.java
+++ b/src/org/labkey/test/tests/list/ListLookupTest.java
@@ -27,19 +27,21 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.labkey.test.util.TestDataGenerator.ALL_CHARS_PLACEHOLDER;
+import static org.labkey.test.util.TestDataGenerator.REPEAT_PLACEHOLDER;
 
 // Issue 52098, Issue 49422
 @Category({Daily.class, Data.class, Hosting.class})
 public class ListLookupTest extends BaseWebDriverTest
 {
     private static final String lookToListName = TestDataGenerator.randomDomainName("lookToList", DomainUtils.DomainKind.IntList);
-    private static final String lookToKeyFieldName = TestDataGenerator.randomFieldName("lookToKeyField", null, DomainUtils.DomainKind.IntList);
+    private static final String lookToKeyFieldName = TestDataGenerator.randomFieldName("lookToKeyField", 5, 5, "" + REPEAT_PLACEHOLDER + ALL_CHARS_PLACEHOLDER, DomainUtils.DomainKind.IntList);
     private static final String lookToFieldName = TestDataGenerator.randomFieldName("lookToField", null, DomainUtils.DomainKind.IntList);
     private static List<Map<String, String>> lookToListValues;
     private static String lookupKeyAsNameNumber;
     private static String lookupKeyAsNameFieldValue;
     private static final String lookFromListName = TestDataGenerator.randomDomainName("lookFromList", DomainUtils.DomainKind.IntList);
-    private static final String lookFromKeyFieldName = TestDataGenerator.randomFieldName("Look From Key Field", null, DomainUtils.DomainKind.IntList);
+    private static final String lookFromKeyFieldName = TestDataGenerator.randomFieldName("Look From Key Field", 5, 5, "" + REPEAT_PLACEHOLDER + ALL_CHARS_PLACEHOLDER, DomainUtils.DomainKind.IntList);
     private static final String lookFromLookupFieldName = TestDataGenerator.randomFieldName("Look From Lookup Field", null, DomainUtils.DomainKind.IntList);
     private static final String lookFromLookupFieldKey = EscapeUtil.fieldKeyEncodePart(lookFromLookupFieldName);
 


### PR DESCRIPTION
#### Rationale
List key field name can only be 64 chars. This isn't checked via the randomFieldName validation API so restrict it in the params.

#### Changes
- set num start and end chars in list key random name gen and exclusion repeat / all
