### PR TITLE
Add more informative errors for null ElementCache

### DIFF
--- a/src/org/labkey/test/components/Component.java
+++ b/src/org/labkey/test/components/Component.java
@@ -27,6 +27,7 @@ import org.openqa.selenium.WebElement;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -69,8 +70,9 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
                 // Pass if element doesn't exist. Might be checking if component is visible.
             }
 
-            _elementCache = newElementCache();
+            _elementCache = Objects.requireNonNull(newElementCache());
             waitForReady();
+            Objects.requireNonNull(_elementCache, "waitForReady() cleared the element cache");
         }
         return _elementCache;
     }

--- a/src/org/labkey/test/components/Component.java
+++ b/src/org/labkey/test/components/Component.java
@@ -16,6 +16,7 @@
 package org.labkey.test.components;
 
 import org.apache.commons.lang3.NotImplementedException;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.test.Locator;
 import org.labkey.test.selenium.RefindingWebElement;
 import org.labkey.test.util.TestLogger;
@@ -44,13 +45,13 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
     }
 
     @Override
-    public WebElement findElement(By by)
+    public @NotNull WebElement findElement(@NotNull By by)
     {
         return getComponentElement().findElement(by);
     }
 
     @Override
-    public List<WebElement> findElements(By by)
+    public @NotNull List<WebElement> findElements(@NotNull By by)
     {
         return getComponentElement().findElements(by);
     }
@@ -105,13 +106,13 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
         }
 
         @Override
-        public List<WebElement> findElements(By by)
+        public @NotNull List<WebElement> findElements(@NotNull By by)
         {
             return getComponentElement().findElements(by);
         }
 
         @Override
-        public WebElement findElement(By by)
+        public @NotNull WebElement findElement(@NotNull By by)
         {
             return getComponentElement().findElement(by);
         }


### PR DESCRIPTION
#### Rationale
Some components are able to end up with a `null` element cache. Hopefully, adding some null checks to `Component.elementCache` will help narrow down what is happening.
```
java.lang.NullPointerException: Cannot read field "editableGrid" because the return value of "org.labkey.test.components.biologics.PlateEditor.elementCache()" is null
	at org.labkey.test.components.biologics.PlateEditor.getEditableGrid(PlateEditor.java:240)
	at org.labkey.test.components.biologics.PlateEditor.lambda$4(PlateEditor.java:251)
	at org.labkey.test.util.Timer.waitFor(Timer.java:91)
	at org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2315)
	at org.labkey.test.components.biologics.PlateEditor.doAndWaitForGridColumnUpdate(PlateEditor.java:247)
	at org.labkey.test.pages.biologics.plates.BasePlateSetPage.doAndWaitForGridColumnUpdate(BasePlateSetPage.java:279)
	at org.labkey.test.components.biologics.CustomizePlateViewDialog.clickUpdateGrid(CustomizePlateViewDialog.java:29)
	at org.labkey.test.tests.biologics.plates.PlateSamplesTest.testAssayImportWithTransformScript(PlateSamplesTest.java:938)
```

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1558

#### Changes
- Add null checks to `Component.elementCache`
- Add `@NotNull` annotations to overridden `SearchContext` methods
