### PR TITLE
AuditLogHelper.checkAuditEventDiffCountForLastTransaction debugging for unexpected number of events case

### DIFF
--- a/src/org/labkey/test/util/AuditLogHelper.java
+++ b/src/org/labkey/test/util/AuditLogHelper.java
@@ -248,10 +248,14 @@ public class AuditLogHelper
     {
         Integer transactionId = getLastTransactionId(containerPath, auditEventName);
         List<Filter> transactionFilter = List.of(new Filter("TransactionId", transactionId, Filter.Operator.EQUAL));
-        int eventCount = getAuditLogsFromLKS(containerPath, auditEventName, List.of("NewRecordMap"), transactionFilter, null, ContainerFilter.CurrentAndSubfolders).getRows().size();
+        List<Map<String, Object>> events = getAuditLogsFromLKS(containerPath, auditEventName, List.of("Comment", "UserComment", "NewRecordMap"), transactionFilter, null, ContainerFilter.CurrentAndSubfolders).getRows();
         if (expectedEventCount != null)
-            assertEquals("Unexpected number of events for transactionId " + transactionId, expectedEventCount.intValue(), eventCount);
-        List<Integer> expectedChangeCounts = Collections.nCopies(eventCount, expectedDiffCount);
+        {
+            if (expectedEventCount.intValue() != events.size())
+                TestLogger.log("Last audit event info: " + events.get(0));
+            assertEquals("Unexpected number of events for transactionId " + transactionId, expectedEventCount.intValue(), events.size());
+        }
+        List<Integer> expectedChangeCounts = Collections.nCopies(events.size(), expectedDiffCount);
         checkAuditEventDiffCount(containerPath, auditEventName, transactionFilter, expectedChangeCounts);
         return transactionId;
     }


### PR DESCRIPTION
#### Rationale
The SMProMoveAliquotTest.testMoveAliquotToParentProject test intermittent failure indicates that it is getting 3 audit events for the last transactionId when it only expects 2. I have a hunch that it is looking at the wrong transaction events. This PR adds some logging in this failure case.

#### Changes
- AuditLogHelper.checkAuditEventDiffCountForLastTransaction debugging for unexpected number of events case
