### PR TITLE
Update test for auditlog.audit table removal

### DIFF
--- a/modules/simpletest/resources/scripts/validationTest/simpleQueryTest.js
+++ b/modules/simpletest/resources/scripts/validationTest/simpleQueryTest.js
@@ -49,7 +49,7 @@ var testFunctions = [
 
     function() //testResults[3]
     {
-        testResults[testResults.length] = LABKEY.Query.executeSql({schemaName: schemaName, sort: "Date", sql: "select audit.Date from audit"});
+        testResults[testResults.length] = LABKEY.Query.executeSql({schemaName: schemaName, sort: "Date", sql: "select Date from UserAuditEvent"});
         executeNext();
     },
 
@@ -100,7 +100,7 @@ var testFunctions = [
         if (!testResults[0].rowsAffected || testResults[0].rowsAffected != 1)
             errors[errors.length] = new Error("Query.insertRows() = "+Ext.util.JSON.encode(testResults[0]));
 
-        if (!testResults[1].rows || testResults[1].rows.length  != 1)
+        if (!testResults[1].rows || testResults[1].rows.length != 1)
             errors[errors.length] = new Error("Query.selectRows() = "+Ext.util.JSON.encode(testResults[1]));
 
         if (!testResults[2].exception)


### PR DESCRIPTION
#### Rationale
Related PR puts the legacy "audit" query behind a deprecated feature flag with plans to remove it entirely. Need to update this test to select from a different table.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6892