### PR TITLE
Add selenium test for importing attachment as string values

### DIFF
--- a/src/org/labkey/test/tests/InlineImagesListTest.java
+++ b/src/org/labkey/test/tests/InlineImagesListTest.java
@@ -57,8 +57,8 @@ import static org.junit.Assert.assertTrue;
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class InlineImagesListTest extends BaseWebDriverTest
 {
-    private final static String PROJECT_NAME = "InlineImagesListTestProject";
-    private final static String IMPORT_PROJECT_NAME = "InlineImagesListImportTestProject";
+    private final static String PROJECT_NAME = "Inline Images List Test Project";
+    private final static String IMPORT_PROJECT_NAME = "Inline Images List Import Test Project";
 
     protected final static String LIST_NAME = TestDataGenerator.randomDomainName("InlineImagesList");
     protected final static String LIST_KEY_NAME = TestDataGenerator.randomFieldName("Key");
@@ -376,11 +376,11 @@ public class InlineImagesListTest extends BaseWebDriverTest
         try
         {
             String expectedError = "Row 1: Can't upload '" + attachmentValue + "' to field " + LIST_ATTACHMENT01_NAME + " with type Attachment.";
-            isElementPresent(Locator.tagWithClass("div", "labkey-error").withText(expectedError));
+            checker().withScreenshot("import_error").verifyTrue("Invalid attachment error not as expected", isElementPresent(Locator.tagWithClass("div", "labkey-error").withText(expectedError)));
         }
         catch(NoSuchElementException nse)
         {
-            checker().fatal().error("Invalid attachment error not present.");
+            checker().error("Invalid attachment error not present.");
         }
     }
 }

--- a/src/org/labkey/test/tests/InlineImagesListTest.java
+++ b/src/org/labkey/test/tests/InlineImagesListTest.java
@@ -28,6 +28,9 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.list.ManageListsGrid;
+import org.labkey.test.pages.ImportDataPage;
+import org.labkey.test.pages.list.BeginPage;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
@@ -35,6 +38,7 @@ import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ExcelHelper;
 import org.labkey.test.util.TestDataGenerator;
+import org.labkey.test.util.data.TestDataUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
@@ -44,6 +48,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -52,6 +57,9 @@ import static org.junit.Assert.assertTrue;
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class InlineImagesListTest extends BaseWebDriverTest
 {
+    private final static String PROJECT_NAME = "InlineImagesListTestProject";
+    private final static String IMPORT_PROJECT_NAME = "InlineImagesListImportTestProject";
+
     protected final static String LIST_NAME = TestDataGenerator.randomDomainName("InlineImagesList");
     protected final static String LIST_KEY_NAME = TestDataGenerator.randomFieldName("Key");
     protected final static ColumnType LIST_KEY_TYPE = ColumnType.Integer;
@@ -99,7 +107,7 @@ public class InlineImagesListTest extends BaseWebDriverTest
     @Override
     protected String getProjectName()
     {
-        return "InlineImagesListTestProject";
+        return PROJECT_NAME;
     }
 
     @Override
@@ -111,7 +119,8 @@ public class InlineImagesListTest extends BaseWebDriverTest
     @Override
     public void doCleanup(boolean afterTest) throws TestTimeoutException
     {
-        _containerHelper.deleteProject(getProjectName(), afterTest);
+        _containerHelper.deleteProject(PROJECT_NAME, afterTest);
+        _containerHelper.deleteProject(IMPORT_PROJECT_NAME, afterTest);
     }
 
     @Before
@@ -326,6 +335,52 @@ public class InlineImagesListTest extends BaseWebDriverTest
             assertTrue("Height of row 1 not in expected range (" + ROW_HEIGHT_LARGE_LBOUND + " to " + ROW_HEIGHT_LARGE_UBOUND + "). Actual height: " + sheet.getRow(1).getHeight(), (sheet.getRow(1).getHeight() > ROW_HEIGHT_LARGE_LBOUND) && (sheet.getRow(1).getHeight() < ROW_HEIGHT_LARGE_UBOUND));
             assertTrue("Height of row 2 not in expected range (" + ROW_HEIGHT_SMALL_LBOUND + " to " + ROW_HEIGHT_SMALL_UBOUND + "). Actual height: " + sheet.getRow(2).getHeight(), (sheet.getRow(2).getHeight() > ROW_HEIGHT_SMALL_LBOUND) && (sheet.getRow(2).getHeight() < ROW_HEIGHT_SMALL_UBOUND));
             assertTrue("Height of row 3 not in expected range (" + ROW_HEIGHT_TEXT_LBOUND + " to " + ROW_HEIGHT_TEXT_UBOUND + "). Actual height: " + sheet.getRow(3).getHeight(), (sheet.getRow(3).getHeight() > ROW_HEIGHT_TEXT_LBOUND) && (sheet.getRow(3).getHeight() < ROW_HEIGHT_TEXT_UBOUND));
+        }
+
+        log("Verify list archive export/import can round trip attachment successfully");
+        ManageListsGrid listsGrid = BeginPage.beginAt(this, getProjectName()).getGrid();
+        listsGrid.checkAllOnPage();
+        File listArchive = listsGrid.exportSelectedLists();
+
+        _containerHelper.createProject(IMPORT_PROJECT_NAME);
+
+        BeginPage.beginAt(this, IMPORT_PROJECT_NAME).importListArchive(listArchive);
+        _listHelper.goToList(LIST_NAME);
+
+        // Validate that list is imported as expected with attachments
+        assertElementPresent("Did not find the expected number of icons for images for " + LRG_PNG_FILE.getName(), Locator.xpath("//img[contains(@title, '" + LRG_PNG_FILE.getName() + "')]"), 1);
+        assertElementPresent("Did not find the expected number of icons for images for " + JPG01_FILE.getName(), Locator.xpath("//img[contains(@title, '" + JPG01_FILE.getName() + "')]"), 1);
+        assertElementPresent("Did not find the expected number of icons for images for " + PDF_FILE.getName(), Locator.xpath("//img[contains(@src, 'pdf.gif')]"), 1);
+        assertElementPresent("Did not find the expected text for " + PDF_FILE.getName(), Locator.xpath("//a[contains(text(), '" + PDF_FILE.getName() + "')]"), 1);
+
+        // Issue 53498: reject string attachment values for import
+        ImportDataPage listImportPage = _listHelper.clickImportData();
+        importFilePathError(listImportPage, "5", "absent.txt");
+        importFilePathError(listImportPage, "5", PDF_FILE.getName());
+        listImportPage.setCopyPasteMerge(false, true);
+        importFilePathError(listImportPage, "1", "absent.txt");
+        importFilePathError(listImportPage, "1", PDF_FILE.getName());
+        listImportPage.setCopyPasteMerge(true, true);
+        importFilePathError(listImportPage, "1", "absent.txt");
+        importFilePathError(listImportPage, "1", PDF_FILE.getName());
+        importFilePathError(listImportPage, "5", PDF_FILE.getName());
+    }
+
+    private void importFilePathError(ImportDataPage listImportPage, String key, String attachmentValue)
+    {
+        String pasteData = TestDataUtils.tsvStringFromRowMaps(List.of(Map.of(LIST_KEY_NAME, key, LIST_ATTACHMENT01_NAME, attachmentValue)),
+                List.of(LIST_KEY_NAME, LIST_ATTACHMENT01_NAME), true);
+        log(pasteData);
+        listImportPage.setText(pasteData);
+        listImportPage.submitExpectingError();
+        try
+        {
+            String expectedError = "Row 1: Can't upload '" + attachmentValue + "' to field " + LIST_ATTACHMENT01_NAME + " with type Attachment.";
+            isElementPresent(Locator.tagWithClass("div", "labkey-error").withText(expectedError));
+        }
+        catch(NoSuchElementException nse)
+        {
+            checker().fatal().error("Invalid attachment error not present.");
         }
     }
 }


### PR DESCRIPTION
#### Rationale
Selenium test for Issue 53498: Sample Manager: Attachment field is lost after export/import round trip. We are no longer accepting string values for attachment fields for import. The exception is list archive import, which we do still allow attachment name being provided.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6894
- https://github.com/LabKey/limsModules/pull/1563
- https://github.com/LabKey/testAutomation/pull/2597

#### Changes
- add test for importing attachment as string from tsv file - should fail
- add test for importing list archive with attachment - should be successful
