### PR TITLE
Switch back to main window after system maintenance

### DIFF
--- a/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
@@ -353,7 +353,11 @@ public class FileContentUploadTest extends BaseWebDriverTest
     {
         String calculateFileRootSizeTask = "Calculate file root sizes";
         goToAdminConsole().clickSystemMaintenance().runMaintenanceTask(calculateFileRootSizeTask);
+
         Integer initialFileRootSize = getFileRootSize();
+
+        getDriver().close();
+        switchToMainWindow();
 
         goToProjectHome();
         File testFile = TestFileUtils.getSampleData("fileTypes/tsv_sample.tsv");
@@ -363,6 +367,9 @@ public class FileContentUploadTest extends BaseWebDriverTest
 
         goToAdminConsole().clickSystemMaintenance().runMaintenanceTask(calculateFileRootSizeTask);
         Integer finalFileRootSize = getFileRootSize();
+
+        switchToMainWindow();
+
         if (!checker().wrapAssertion(() -> Assertions.assertThat(finalFileRootSize)
                 .as("Crawled file root size").isGreaterThan(initialFileRootSize)))
         {

--- a/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
@@ -356,7 +356,6 @@ public class FileContentUploadTest extends BaseWebDriverTest
 
         Integer initialFileRootSize = getFileRootSize();
 
-        getDriver().close();
         switchToMainWindow();
 
         goToProjectHome();


### PR DESCRIPTION
#### Rationale
Window name doesn't seem consistent on Windows. Need to switch back to the primary window after running system maintenance.
```
org.openqa.selenium.NoSuchWindowException: Unable to locate window: systemMaintenance
[...]
  at app//org.labkey.test.pages.admin.ConfigureSystemMaintenancePage.runMaintenanceTask(ConfigureSystemMaintenancePage.java:31)
  at app//org.labkey.test.tests.filecontent.FileContentUploadTest.testCalculateFileRootSize(FileContentUploadTest.java:364)
```

#### Related Pull Requests
- #2579 

#### Changes
- Switch back to main window after system maintenance