### PR TITLE
MoveToContainerDialog verifyAuditEvents to use Runnable to wait for next transactionId before doing audit diff checks

### DIFF
--- a/src/org/labkey/test/util/AuditLogHelper.java
+++ b/src/org/labkey/test/util/AuditLogHelper.java
@@ -33,6 +33,8 @@ import java.util.stream.Stream;
 import static java.lang.Integer.parseInt;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.labkey.test.WebDriverWrapper.WAIT_FOR_JAVASCRIPT;
+import static org.labkey.test.WebDriverWrapper.waitFor;
 
 public class AuditLogHelper
 {
@@ -241,9 +243,30 @@ public class AuditLogHelper
         }
         catch (Exception e)
         {
-            // don't fail here, just return null if we can't get the last transactionId
-            return null;
+            throw new RuntimeException(e);
         }
+    }
+
+    public Integer doAndWaitForTransaction(Runnable action, String containerPath, AuditEvent auditEventName)
+    {
+        int prevTransactionId;
+        if (action != null)
+        {
+            prevTransactionId = Objects.requireNonNullElse(getLastTransactionId(containerPath, auditEventName), -1);
+            action.run();
+        }
+        else
+        {
+            prevTransactionId = -1;
+        }
+
+        return waitFor(() -> {
+            Integer transactionId = getLastTransactionId(containerPath, auditEventName);
+            if (transactionId != null && transactionId > prevTransactionId)
+                return transactionId;
+            else
+                return null;
+        }, "Error waiting for next transactionId in " + auditEventName, WAIT_FOR_JAVASCRIPT);
     }
 
     /**

--- a/src/org/labkey/test/util/AuditLogHelper.java
+++ b/src/org/labkey/test/util/AuditLogHelper.java
@@ -232,10 +232,18 @@ public class AuditLogHelper
         }
     }
 
-    public Integer getLastTransactionId(String containerPath, AuditEvent auditEventName) throws IOException, CommandException
+    public Integer getLastTransactionId(String containerPath, AuditEvent auditEventName)
     {
-        List<Map<String, Object>> events = getAuditLogsFromLKS(containerPath, auditEventName, List.of("TransactionId"), Collections.emptyList(), 1, ContainerFilter.CurrentAndSubfolders).getRows();
-        return events.size() == 1 ? (Integer) events.get(0).get("TransactionId") : null;
+        try
+        {
+            List<Map<String, Object>> events = getAuditLogsFromLKS(containerPath, auditEventName, List.of("TransactionId"), Collections.emptyList(), 1, ContainerFilter.CurrentAndSubfolders).getRows();
+            return events.size() == 1 ? (Integer) events.get(0).get("TransactionId") : null;
+        }
+        catch (Exception e)
+        {
+            // don't fail here, just return null if we can't get the last transactionId
+            return null;
+        }
     }
 
     /**

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -77,7 +77,7 @@ public class TestDataGenerator
     public static final char WIDE_PLACEHOLDER = '\u03A0'; // 'Π' - Wide character can't be picked from the string with 'charAt'
     public static final char REPEAT_PLACEHOLDER = '\u22EF'; // '⋯' - Used to indicate that the char will be repeated
     public static final char ALL_CHARS_PLACEHOLDER = '\u2211'; // '∑' - Used to indicate that all characters from the charset should be used
-    public static final String NON_LATIN_STRING = "\u0438\uC548\u306F"; // "и안は"
+    public static final String NON_LATIN_STRING = "\u0438\u0418\uC548\u306F"; // "иИ안は"
     // chose a Character random from this String
     public static final String CHARSET_STRING = "ABCDEFG01234abcdefvxyz~!@#$%^&*()-+=_{}[]|:;\"',.<>" + NON_LATIN_STRING + WIDE_PLACEHOLDER;
     public static final String ALPHANUMERIC_STRING = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvxyz";


### PR DESCRIPTION
#### Rationale
See related PR for rationale. 

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1578

#### Changes
- AuditLogHelper.getLastTransactionId try/catch
- Add capital to NON_LATIN_STRING (for BiologicsReportTest export chart pdf scenario)
