### PR TITLE
Add withTextIgnoreCase, use it to verify file root message

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1902,7 +1902,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         {
             _setPipelineRoot(rootPath, inherit);
 
-            waitForElement(Locators.labkeyMessage.withText("The pipeline root was set to '" + Paths.get(rootPath).normalize() + "'"));
+            waitForElement(Locators.labkeyMessage.withTextIgnoreCase("The pipeline root was set to '" + Paths.get(rootPath).normalize() + "'"));
 
             getArtifactCollector().addArtifactLocation(new File(rootPath));
 

--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -1247,6 +1247,11 @@ public abstract class Locator extends By
             return this.withPredicate("normalize-space()="+xq(ns(text)));
         }
 
+        public XPathLocator withTextIgnoreCase(String text)
+        {
+            return this.withPredicate("contains(" + toLowerCase("normalize-space()", text) + ", "+xq(ns(text.toLowerCase()))+")");
+        }
+
         public XPathLocator withText()
         {
             return this.withPredicate("string-length() > 0");

--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -1249,7 +1249,7 @@ public abstract class Locator extends By
 
         public XPathLocator withTextIgnoreCase(String text)
         {
-            return this.withPredicate("contains(" + toLowerCase("normalize-space()", text) + ", "+xq(ns(text.toLowerCase()))+")");
+            return this.withPredicate(toLowerCase("normalize-space()", text) + "= "+xq(ns(text.toLowerCase())));
         }
 
         public XPathLocator withText()


### PR DESCRIPTION
#### Rationale
Locally I've experienced issues setting a pipeline file root, the problem is that the test waits for a labkeyMessage with case-sensitive text notifying the user that the pipeline root was set to a particular path- this adds a `withTextIgnoreCase `overload to `Locators `to accompany existing `startsWithIgnoreCase `and `containsIgnoreCase`, and uses it to verify in a case-insensitive way that the specified path was set.

#### Related Pull Requests
n/a

#### Changes

- add `Locator.withTextIgnoreCase`
- use it to verify `setPipelineRoot`
