### PR TITLE
Fix blocked clicks for editable grid operations

### DIFF
--- a/src/org/labkey/test/components/ui/Pager.java
+++ b/src/org/labkey/test/components/ui/Pager.java
@@ -63,28 +63,41 @@ public class Pager extends WebDriverComponent<Pager.ElementCache>
 
     public Pager selectPageSize(String pageSize)    // only works on GridPanel
     {
-        int currentPageSize = getPageSize();
-        if(currentPageSize != Integer.parseInt(pageSize))
-        {
-            _pagedComponent.doAndWaitForUpdate(() -> elementCache().jumpToDropdown.clickSubMenu(false, pageSize));
-        }
+        pageSize(pageSize);
         return this;
     }
 
     public int getPageSize()                // only works on GridPanel
     {
-        // Changing the jumpToDropdown button from the deprecated DropdownButtonGroup class to a MultiMenu type has changed
-        // the way that various text from the control is gathered. Getting the current page size now requires that the dropdown
+        return pageSize(null);
+    }
+
+    /**
+     * Sets the page size if required (pageSize is specified and doesn't match the current page size)
+     * @return returns the initial page size
+     */
+    private int pageSize(String pageSize) // only works on GridPanel
+    {
+        // Getting the current page size requires that the dropdown
         // be expanded and the selected page size found in the list.
         elementCache().jumpToDropdown.expand();
 
         // Find the selected li element in the page size list
         WebElement activeLi = Locator.byClass("active").findElement(elementCache().jumpToDropdown);
 
-        int size = Integer.parseInt(activeLi.getText());
-        elementCache().jumpToDropdown.collapse();
+        int initialSize = Integer.parseInt(activeLi.getText());
 
-        return size;
+        if (pageSize != null && initialSize != Integer.parseInt(pageSize))
+        {
+            _pagedComponent.doAndWaitForUpdate(() -> elementCache().jumpToDropdown.clickSubMenu(false, pageSize));
+        }
+        else
+        {
+            // Tooltip sometimes blocks button. Click active option to dismiss menu.
+            activeLi.click();
+        }
+
+        return initialSize;
     }
 
     /**

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -192,8 +192,9 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         var checkBoxes = Locator.tag("tr").child("td")
                 .child(Locator.tagWithAttribute("input", "type", "checkbox"))
                 .findElements(elementCache().table);
+        getWrapper().scrollIntoView(checkBoxes.get(start)); // Make sure the header isn't in the way
         checkBoxes.get(start).click();
-        getWrapper().scrollIntoView(checkBoxes.get(end), true); // Actions.click() doesn't scroll
+        getWrapper().scrollIntoView(checkBoxes.get(end)); // Actions.click() doesn't scroll
         new Actions(getDriver())
                 .keyDown(Keys.SHIFT)
                 .click(checkBoxes.get(end))


### PR DESCRIPTION
#### Rationale
Long field names are still causing test problems.

Grid headers block some checkboxes.
```
org.openqa.selenium.ElementClickInterceptedException: Element <input class="grid-panel__checkbox" type="checkbox"> is not clickable at point (52,273) because another element <th id="__selection__" class="grid-header-cell"> obscures it
  [...]
  at app//org.labkey.test.selenium.WebElementWrapper.click(WebElementWrapper.java:37)
  at app//org.labkey.test.selenium.ReclickingWebElement.click(ReclickingWebElement.java:74)
  at app//org.labkey.test.components.ui.grids.EditableGrid.shiftSelectRange(EditableGrid.java:195)
  at app//org.labkey.test.tests.component.EditableGridTest.testShiftClick(EditableGridTest.java:413)
```
The pager tooltip gets in the way when the pager component is at the edge of the window.
```
org.openqa.selenium.ElementClickInterceptedException: Element <button id="dropdown-button-4" class="btn btn-default dropdown-toggle current-page-dropdown" type="button"> is not clickable at point (1247,393) because another element <div id="view-menu-tooltip" class="lk-tooltip in tooltip top"> obscures it
  [...]
  at app//org.labkey.test.selenium.WebElementWrapper.click(WebElementWrapper.java:37)
  at app//org.labkey.test.selenium.ReclickingWebElement.click(ReclickingWebElement.java:74)
  at app//org.labkey.test.selenium.WebElementWrapper.click(WebElementWrapper.java:37)
  at app//org.labkey.test.components.react.BaseBootstrapMenu.collapse(BaseBootstrapMenu.java:85)
  at app//org.labkey.test.components.ui.Pager.getPageSize(Pager.java:85)
  at app//org.labkey.test.components.ui.Pager.selectPageSize(Pager.java:66)
  at app//org.labkey.test.tests.component.GridPanelTest.testSearchAcrossColumns(GridPanelTest.java:1446)
```

#### Related Pull Requests
- N/A

#### Changes
- Scroll to avoid header when shift-selecting editable grid rows
- Click no-op option to close page size menu