### PR TITLE
Wait for system maintenance page to load when rerunning the task

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -75,6 +75,7 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoAlertPresentException;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.NoSuchWindowException;
 import org.openqa.selenium.ScriptTimeoutException;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.StaleElementReferenceException;
@@ -2130,6 +2131,29 @@ public abstract class WebDriverWrapper implements WrapsDriver
         }
 
         return loadTimer.elapsed().toMillis();
+    }
+
+    public long doAndWaitForWindow(Runnable action, String windowName)
+    {
+        return doAndMaybeWaitForPageToLoad(10_000, () -> {
+            String initialWindow = getDriver().getWindowHandle();
+            boolean targetWindowExists;
+            try
+            {
+                getDriver().switchTo().window(windowName);
+                getDriver().switchTo().window(initialWindow);
+                targetWindowExists = true;
+            }
+            catch (NoSuchWindowException e)
+            {
+                targetWindowExists = false;
+            }
+
+            action.run();
+
+            getDriver().switchTo().window(windowName);
+            return targetWindowExists;
+        });
     }
 
     public long doAndAcceptUnloadAlert(Runnable func, String partialAlertText)

--- a/src/org/labkey/test/pages/admin/ConfigureSystemMaintenancePage.java
+++ b/src/org/labkey/test/pages/admin/ConfigureSystemMaintenancePage.java
@@ -26,9 +26,8 @@ public class ConfigureSystemMaintenancePage extends LabKeyPage<ConfigureSystemMa
      */
     public PipelineStatusDetailsPage runMaintenanceTask(String description)
     {
-        click(Locator.tagWithAttribute("input", "type", "checkbox")
-            .followingSibling("a").withText(description));
-        getDriver().switchTo().window("systemMaintenance");
+        doAndWaitForWindow(() -> click(Locator.tagWithAttribute("input", "type", "checkbox")
+                .followingSibling("a").withText(description)), "systemMaintenance");
 
         PipelineStatusDetailsPage pipelineStatusDetailsPage = new PipelineStatusDetailsPage(getDriver());
         pipelineStatusDetailsPage.waitForComplete();


### PR DESCRIPTION
#### Rationale
`ConfigureSystemMaintenancePage.runMaintenanceTask` assumes that it has opened a new window when it waits for the pipeline job to complete. `FileContentUploadTest.testCalculateFileRootSize` actually triggers the system maintenance twice without closing the window. The causes the test to fail intermittently as failing to wait for page loads often does.
```
java.lang.AssertionError: Incorrect job status expected:<COMPLETE> but was:<null>
  at org.junit.Assert.fail(Assert.java:89)
  at org.junit.Assert.failNotEquals(Assert.java:835)
  at org.junit.Assert.assertEquals(Assert.java:120)
  at org.labkey.test.pages.pipeline.PipelineStatusDetailsPage.assertStatus(PipelineStatusDetailsPage.java:125)
  at org.labkey.test.pages.pipeline.PipelineStatusDetailsPage.waitForStatus(PipelineStatusDetailsPage.java:139)
  at org.labkey.test.pages.pipeline.PipelineStatusDetailsPage.waitForComplete(PipelineStatusDetailsPage.java:182)
  at org.labkey.test.pages.pipeline.PipelineStatusDetailsPage.waitForComplete(PipelineStatusDetailsPage.java:170)
  at org.labkey.test.pages.admin.ConfigureSystemMaintenancePage.runMaintenanceTask(ConfigureSystemMaintenancePage.java:34)
  at org.labkey.test.tests.filecontent.FileContentUploadTest.testCalculateFileRootSize(FileContentUploadTest.java:367)
```

Rather that updating the test to close the window, we can make the page more robust by waiting for a page load when necessary.

#### Related Pull Requests
- #2579 

#### Changes
- Wait for system maintenance page to load when rerunning the task
