### PR TITLE
Fix WebDriverWrapper.isTextPresent usages

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -431,7 +431,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
             errorText = getText(Locator.tagWithClass("div", "auth-form-body").childTag("p"));
         }
 
-        List<String> missingErrors = getMissingTexts(new TextSearcher(errorText), expectedMessages);
+        List<String> missingErrors = new TextSearcher(errorText).getMissingTexts(expectedMessages);
         assertTrue(String.format("Wrong errors.\nExpected: ['%s']\nActual: '%s'", String.join("',\n'", expectedMessages), errorText), missingErrors.isEmpty());
     }
 

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1615,6 +1615,16 @@ public abstract class WebDriverWrapper implements WrapsDriver
     }
 
     /**
+     * Check whether all the specified text is present on the page
+     * @param texts un-encoded text to search for
+     * @return true if all the specified texts are present on the page
+     */
+    public boolean isTextPresent(String... texts)
+    {
+        return new TextSearcher(this).areAllTextsPresent(texts);
+    }
+
+    /**
      * Check whether the HTML-encoded text is in the page source
      * @param htmlFragments encoded html fragments to search for
      * @return true if all the specified texts are present on the page
@@ -1625,16 +1635,6 @@ public abstract class WebDriverWrapper implements WrapsDriver
         searcher.setSearchTransformer(TextTransformers.IDENTITY);
 
         return searcher.areAllTextsPresent(htmlFragments);
-    }
-
-    /**
-     * Check whether all the specified text is present on the page
-     * @param texts un-encoded text to search for
-     * @return true if all the specified texts are present on the page
-     */
-    public boolean isTextPresent(String... texts)
-    {
-        return new TextSearcher(this).areAllTextsPresent(texts);
     }
 
     public List<String> getTextOrder(TextSearcher searcher, String... texts)

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -61,6 +61,7 @@ import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.RelativeUrl;
 import org.labkey.test.util.TestLogger;
 import org.labkey.test.util.TextSearcher;
+import org.labkey.test.util.TextSearcher.TextTransformers;
 import org.labkey.test.util.Timer;
 import org.labkey.test.util.selenium.ScrollUtils;
 import org.labkey.test.util.selenium.WebDriverUtils;
@@ -1614,15 +1615,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
         fail("No errors found");
     }
 
-    public static String encodeText(String unencodedText)
-    {
-        return unencodedText
-                .replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;");
-    }
-
-    public boolean isTextPresent(String... texts)
+    public boolean isHtmlPresent(String... texts)
     {
         final MutableBoolean present = new MutableBoolean(true);
 
@@ -1634,9 +1627,15 @@ public abstract class WebDriverWrapper implements WrapsDriver
             return present.get();
         };
         TextSearcher searcher = new TextSearcher(this);
+        searcher.setSearchTransformer(TextTransformers.IDENTITY);
         searcher.searchForTexts(handler, Arrays.asList(texts));
 
         return present.get();
+    }
+
+    public boolean isTextPresent(String... texts)
+    {
+        return isHtmlPresent(Arrays.stream(texts).map(TextTransformers.ENCODE_HTML).toArray(String[]::new));
     }
 
     public List<String> getTextOrder(TextSearcher searcher, String... texts)
@@ -1709,7 +1708,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
     {
         TextSearcher searcher = new TextSearcher(this);
 
-        searcher.setSearchTransformer((text) -> encodeText(text).toLowerCase());
+        searcher.setSearchTransformer(TextTransformers.ENCODE_HTML.andThen(String::toLowerCase));
 
         searcher.setSourceTransformer(String::toLowerCase);
 
@@ -1892,7 +1891,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
     public void assertTextNotPresent(String... texts)
     {
         TextSearcher searcher = new TextSearcher(this);
-        searcher.setSearchTransformer((text) -> encodeText(text).replace("&nbsp;", " "));
+        searcher.setSearchTransformer(TextTransformers.ENCODE_HTML.andThen(t -> t.replace("&nbsp;", " ")));
 
         assertTextNotPresent(searcher, texts);
     }

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -18,7 +18,6 @@ package org.labkey.test;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -1615,27 +1614,27 @@ public abstract class WebDriverWrapper implements WrapsDriver
         fail("No errors found");
     }
 
-    public boolean isHtmlPresent(String... texts)
+    /**
+     * Check whether the HTML-encoded text is in the page source
+     * @param htmlFragments encoded html fragments to search for
+     * @return true if all the specified texts are present on the page
+     */
+    public boolean isHtmlPresent(String... htmlFragments)
     {
-        final MutableBoolean present = new MutableBoolean(true);
-
-        TextSearcher.TextHandler handler = (htmlSource, text) -> {
-            // Not found... stop enumerating and return false
-            if (htmlSource == null || !htmlSource.contains(text))
-                present.setFalse();
-
-            return present.get();
-        };
         TextSearcher searcher = new TextSearcher(this);
         searcher.setSearchTransformer(TextTransformers.IDENTITY);
-        searcher.searchForTexts(handler, Arrays.asList(texts));
 
-        return present.get();
+        return searcher.areAllTextsPresent(htmlFragments);
     }
 
+    /**
+     * Check whether all the specified text is present on the page
+     * @param texts un-encoded text to search for
+     * @return true if all the specified texts are present on the page
+     */
     public boolean isTextPresent(String... texts)
     {
-        return isHtmlPresent(Arrays.stream(texts).map(TextTransformers.ENCODE_HTML).toArray(String[]::new));
+        return new TextSearcher(this).areAllTextsPresent(texts);
     }
 
     public List<String> getTextOrder(TextSearcher searcher, String... texts)
@@ -1656,11 +1655,6 @@ public abstract class WebDriverWrapper implements WrapsDriver
                 .forEachOrdered((pair) -> orderedTexts.add(pair.getKey()));
 
         return orderedTexts;
-    }
-
-    public List<String> getMissingTexts(TextSearcher searcher, String... texts)
-    {
-        return searcher.getMissingTexts(Arrays.asList(texts));
     }
 
     public String getText(Locator elementLocator)
@@ -1691,7 +1685,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
     public void assertTextPresent(TextSearcher searcher, String... texts)
     {
-        List<String> missingTexts = getMissingTexts(searcher, texts);
+        List<String> missingTexts = searcher.getMissingTexts(texts);
 
         if (!missingTexts.isEmpty())
         {
@@ -1720,18 +1714,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
      */
     public boolean isAnyTextPresent(String... texts)
     {
-        final MutableBoolean found = new MutableBoolean(false);
-
-        TextSearcher.TextHandler handler = (htmlSource, text) -> {
-            if (htmlSource.contains(text))
-                found.setTrue();
-
-            return !found.get(); // stop searching if any value is found
-        };
-        TextSearcher searcher = new TextSearcher(this);
-        searcher.searchForTexts(handler, Arrays.asList(texts));
-
-        return found.get();
+        return new TextSearcher(this).isAnyTextPresent(texts);
     }
 
     /**

--- a/src/org/labkey/test/tests/announcements/ModeratorReviewTest.java
+++ b/src/org/labkey/test/tests/announcements/ModeratorReviewTest.java
@@ -163,7 +163,7 @@ public class ModeratorReviewTest extends BaseWebDriverTest
 
         // commonmark-java auto-linking turns all email addresses into mailto: links
         String formattedResponse = replaceEmailAddressesWithMailToLinks(response);
-        boolean responseAdded = isTextPresent(formattedResponse);
+        boolean responseAdded = isHtmlPresent(formattedResponse);
         if (expectAutoApproved && !responseAdded)
         {
             checker().fatal().error(String.format("Expected response '%s' was not present on the thread page.", formattedResponse));

--- a/src/org/labkey/test/util/EscapeUtil.java
+++ b/src/org/labkey/test/util/EscapeUtil.java
@@ -150,4 +150,5 @@ public class EscapeUtil
     {
         return nameExpressionNeedsEscaping.matcher(name).replaceAll("\\\\$1");
     }
+
 }

--- a/src/org/labkey/test/util/TextSearcher.java
+++ b/src/org/labkey/test/util/TextSearcher.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.test.util;
 
-import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebDriverWrapper;
 
@@ -129,7 +128,10 @@ public class TextSearcher
 
     public static abstract class TextTransformers
     {
-        public static final Function<String, String> ENCODE_HTML = BaseWebDriverTest::encodeText;
+        public static final Function<String, String> ENCODE_HTML = t -> t
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;");
         public static final Function<String, String> IDENTITY = text -> text;
 
         //Inserts spaces between camel-cased words

--- a/src/org/labkey/test/util/TextSearcher.java
+++ b/src/org/labkey/test/util/TextSearcher.java
@@ -15,11 +15,13 @@
  */
 package org.labkey.test.util;
 
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebDriverWrapper;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -97,6 +99,11 @@ public class TextSearcher
         }
     }
 
+    public List<String> getMissingTexts(String... texts)
+    {
+        return getMissingTexts(Arrays.asList(texts));
+    }
+
     public List<String> getMissingTexts(List<String> texts)
     {
         final List<String> missingTexts = new ArrayList<>();
@@ -110,6 +117,46 @@ public class TextSearcher
         searchForTexts(handler, texts);
 
         return missingTexts;
+    }
+
+    /**
+     * Checks whether any of the texts are present
+     * @return true if any of the specified text is found
+     */
+    public boolean isAnyTextPresent(String... texts)
+    {
+        final MutableBoolean found = new MutableBoolean(false);
+
+        TextSearcher.TextHandler handler = (htmlSource, text) -> {
+            if (htmlSource.contains(text))
+                found.setTrue();
+
+            return !found.get(); // stop searching if any value is found
+        };
+        searchForTexts(handler, Arrays.asList(texts));
+
+        return found.get();
+    }
+
+    /**
+     * Checks whether all the specified texts are present
+     * @return true if all the specified texts are present on the page
+     */
+    public boolean areAllTextsPresent(String... texts)
+    {
+        final MutableBoolean present = new MutableBoolean(true);
+
+        TextSearcher.TextHandler handler = (htmlSource, text) -> {
+            // Not found... stop enumerating and return false
+            if (htmlSource == null || !htmlSource.contains(text))
+                present.setFalse();
+
+            return present.get();
+        };
+
+        searchForTexts(handler, Arrays.asList(texts));
+
+        return present.get();
     }
 
     /**


### PR DESCRIPTION
#### Rationale
`WebDriverWrapper.isTextPresent` no longer html encodes the text that is being searched for.
```
java.lang.AssertionError: Expected response 'This is a response to This is a real message 1754798280718 by user <a href="mailto:moderatorreviewapprovedauthor@messages.test" rel="nofollow">moderatorreviewapprovedauthor@messages.test</a>' was not present on the thread page.
  at org.junit.Assert.fail(Assert.java:89)
  at org.labkey.test.util.DeferredErrorCollector.lambda$13(DeferredErrorCollector.java:354)
  at org.labkey.test.util.DeferredErrorCollector.wrapAssertion(DeferredErrorCollector.java:187)
  at org.labkey.test.util.DeferredErrorCollector.error(DeferredErrorCollector.java:354)
  at org.labkey.test.tests.announcements.ModeratorReviewTest.addResponse(ModeratorReviewTest.java:169)
  at org.labkey.test.tests.announcements.ModeratorReviewTest.testNewThread(ModeratorReviewTest.java:134)
```
Introducing a separate `isHtmlPresent` method for cases that do want to search for HTML.

#### Related Pull Requests
- #2612

#### Changes
- Introduce `WebDriverWrapper.isHtmlPresent`
- Move some basic search functionality into `TextSearcher`
