### PR TITLE
Fix problems caused by random project name generation

### DIFF
--- a/src/org/labkey/test/params/ContainerInfo.java
+++ b/src/org/labkey/test/params/ContainerInfo.java
@@ -15,7 +15,8 @@ import static org.labkey.test.util.TextUtils.containerPath;
 
 public class ContainerInfo
 {
-    public static final String TRICKY_CHARACTERS = "\u2603~!@$&()_+{}-=[],.#\u00E4\u00F6\u00FC\u00C5" + WIDE_PLACEHOLDER + ALL_CHARS_PLACEHOLDER; // No slash or space
+    public static final String TRICKY_CHARACTERS = "\u2603~!@$&()_+{}-=[],.#\u00E4\u00F6\u00FC\u00C5"; // No slash or space. Don't change; hard-coded in some test data
+    public static final String RANDOM_CHARSET = TRICKY_CHARACTERS + WIDE_PLACEHOLDER + ALL_CHARS_PLACEHOLDER;
 
     private final @NotNull String _name;
     private final String _parentContainerPath;
@@ -35,8 +36,16 @@ public class ContainerInfo
     private static @NotNull String getRandomName(String folderName)
     {
         if (TestProperties.isTestRunningOnTeamCity())
-            return TestDataGenerator.randomName(folderName, TestDataGenerator.randomInt(0, 5), 5, TRICKY_CHARACTERS, null);
-        else
+        {
+            String name = TestDataGenerator.randomName(folderName, TestDataGenerator.randomInt(0, 5), 5, RANDOM_CHARSET, null);
+            if (name.startsWith("@"))
+            {
+                // Folder name may not begin with '@'
+                name = name.replaceFirst("@", TestDataGenerator.randomString(1, "@", RANDOM_CHARSET));
+            }
+            return name;
+        }
+        else // Don't clutter dev machines with random project names
             return folderName + TRICKY_CHARACTERS;
     }
 

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -641,7 +641,12 @@ public class TestDataGenerator
         {
             CommandResponse response = command.execute(WebTestHelper.getRemoteApiConnection(), "/home");
             if (response.getParsedData() == null)
-                throw new RuntimeException("Failed to parse response for command: " + response.getText());
+            {
+                if (response.getText().contains("Register First User"))
+                    throw new RuntimeException("Unable to validate domain/field name. Server not initialized.");
+                else
+                    throw new RuntimeException("Failed to parse response for command: " + response.getText());
+            }
             return response.getParsedData().containsKey("errors");
         }
         catch (CommandException | IOException e)


### PR DESCRIPTION
#### Rationale
Changing `TRICKY_CHARACTERS_FOR_PROJECT_NAMES` caused a test to fail because it had the original value hard-coded.
```
java.lang.AssertionError: FAILED: test timechart-api.xml failed with status code: 404
{  "exception" : "No such folder or workbook: \/TimeChartTest Project☃~!@$&()_+{}-=[],.#äöüÅ\/Demo Study",  "success" : false}
  at org.junit.Assert.fail(Assert.java:89)
  at org.labkey.test.util.APITestHelper.sendRequestDirect(APITestHelper.java:186)
  at org.labkey.test.util.APITestHelper.runApiTests(APITestHelper.java:93)
  at org.labkey.test.util.APITestHelper.runApiTests(APITestHelper.java:74)
  at org.labkey.test.util.APITestHelper.runApiTests(APITestHelper.java:69)
  at org.labkey.test.tests.StudyBaseTest.runApiTests(StudyBaseTest.java:354)
  at org.labkey.test.tests.StudyBaseTest.testSteps(StudyBaseTest.java:361)
```

Also, the project name randomizer can generate illegal folder names. Updating random name generator to prevent these.

#### Related Pull Requests
- #2596 

#### Changes
- Fix problems caused by random project name generation
