### PR TITLE
Fix tab management and random data generation

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -148,6 +148,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -2118,25 +2119,29 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
     public long doAndWaitForWindow(Runnable action, String windowName)
     {
+        String initialWindow = getDriver().getWindowHandle();
+        AtomicBoolean targetWindowExists = new AtomicBoolean(false);
+        try
+        {
+            getDriver().switchTo().window(windowName);
+            targetWindowExists.set(true);
+        }
+        catch (NoSuchWindowException e)
+        {
+            targetWindowExists.set(false);
+        }
+
+        // Call doAndMaybeWaitForPageToLoad with target window in focus (if present)
+        // Then it will correctly detect the page load in that window
         return doAndMaybeWaitForPageToLoad(10_000, () -> {
-            String initialWindow = getDriver().getWindowHandle();
-            boolean targetWindowExists;
-            try
-            {
-                getDriver().switchTo().window(windowName);
+            if (targetWindowExists.get())
                 getDriver().switchTo().window(initialWindow);
-                targetWindowExists = true;
-            }
-            catch (NoSuchWindowException e)
-            {
-                targetWindowExists = false;
-            }
 
             action.run();
 
             new WebDriverWait(getDriver(), Duration.ofSeconds(5)).until(windowIsPresent(windowName));
 
-            return targetWindowExists;
+            return targetWindowExists.get();
         });
     }
 

--- a/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
@@ -356,7 +356,7 @@ public class FileContentUploadTest extends BaseWebDriverTest
 
         Integer initialFileRootSize = getFileRootSize();
 
-        switchToMainWindow();
+        closeExtraWindows();
 
         goToProjectHome();
         File testFile = TestFileUtils.getSampleData("fileTypes/tsv_sample.tsv");

--- a/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
@@ -356,7 +356,7 @@ public class FileContentUploadTest extends BaseWebDriverTest
 
         Integer initialFileRootSize = getFileRootSize();
 
-        closeExtraWindows();
+        switchToMainWindow();
 
         goToProjectHome();
         File testFile = TestFileUtils.getSampleData("fileTypes/tsv_sample.tsv");

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -429,7 +429,7 @@ public class TestDataGenerator
     private Supplier<Object> getDefaultDataSupplier(PropertyDescriptor propertyDescriptor)
     {
         Map<String, Object> allProperties = Objects.requireNonNullElse(propertyDescriptor.getAllProperties(), Collections.emptyMap());
-        Function<String, String> getType = s -> s == null ? null : s.substring(s.indexOf('#') + 1).toLowerCase();
+        Function<String, String> getType = s -> s == null ? "" : s.substring(s.indexOf('#') + 1).toLowerCase().trim();
         String conceptUriName = getType.apply((String) allProperties.get("conceptURI"));
         String rangeUriName = getType.apply(propertyDescriptor.getRangeURI());
 

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -429,7 +429,7 @@ public class TestDataGenerator
     private Supplier<Object> getDefaultDataSupplier(PropertyDescriptor propertyDescriptor)
     {
         Map<String, Object> allProperties = Objects.requireNonNullElse(propertyDescriptor.getAllProperties(), Collections.emptyMap());
-        Function<String, String> getType = s -> s.substring(s.indexOf('#') + 1).toLowerCase();
+        Function<String, String> getType = s -> s == null ? null : s.substring(s.indexOf('#') + 1).toLowerCase();
         String conceptUriName = getType.apply((String) allProperties.get("conceptURI"));
         String rangeUriName = getType.apply(propertyDescriptor.getRangeURI());
 

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -56,6 +56,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
@@ -428,46 +429,51 @@ public class TestDataGenerator
     private Supplier<Object> getDefaultDataSupplier(PropertyDescriptor propertyDescriptor)
     {
         Map<String, Object> allProperties = Objects.requireNonNullElse(propertyDescriptor.getAllProperties(), Collections.emptyMap());
-        String columnType = (String) allProperties.get("conceptURI");
-        if (columnType == null) columnType = propertyDescriptor.getRangeURI();
+        Function<String, String> getType = s -> s.substring(s.indexOf('#') + 1).toLowerCase();
+        String conceptUriName = getType.apply((String) allProperties.get("conceptURI"));
+        String rangeUriName = getType.apply(propertyDescriptor.getRangeURI());
 
-        switch (columnType.substring(columnType.indexOf('#') + 1).toLowerCase())
+        switch (conceptUriName)
         {
-            case "string":
-                return () -> randomString(20, _excludedChars, _alphaNumericStr ? ALPHANUMERIC_STRING : CHARSET_STRING);
-            case "int":
-                return () -> randomInt(0, 20);
-            case "float":
-                return () -> randomFloat(0, 20);
-            case "double":
-                return () -> randomDouble(0, 20);
-            case "boolean":
-                return this::randomBoolean;
-            case "date":
-            case "datetime":
-                return () -> randomDateString(DateUtils.addWeeks(new Date(), -39), new Date());
-            case "time":
-                return () ->
-                    randomInt(0, 23) + ":" + // hour
-                        StringUtils.leftPad(String.valueOf(randomInt(0, 59)), 2, "0") + ":" + // minute
-                        StringUtils.leftPad(String.valueOf(randomInt(0, 59)), 2, "0") + "." + // second
-                        StringUtils.leftPad(String.valueOf(randomInt(0, 999)), 3, "0"); // millisecond
             case "textchoice":
                 List<String> textChoices = ((FieldDefinition) propertyDescriptor)
-                    .getValidators().stream()
-                    .map(v -> {
-                        if (v instanceof FieldDefinition.TextChoiceValidator tcv && !tcv.getValues().isEmpty())
-                            return tcv.getValues();
-                        else
-                            return null;
-                    })
-                    .filter(Objects::nonNull)
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalStateException("No choices defined for textChoice field : " + propertyDescriptor.getName()));
+                        .getValidators().stream()
+                        .map(v -> {
+                            if (v instanceof FieldDefinition.TextChoiceValidator tcv && !tcv.getValues().isEmpty())
+                                return tcv.getValues();
+                            else
+                                return null;
+                        })
+                        .filter(Objects::nonNull)
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalStateException("No choices defined for textChoice field : " + propertyDescriptor.getName()));
 
                 return () -> randomChoice(textChoices);
             default:
-                throw new IllegalArgumentException("ColumnType " + columnType + " isn't implemented yet");
+                switch (rangeUriName)
+                {
+                    case "string":
+                        return () -> randomString(20, _excludedChars, _alphaNumericStr ? ALPHANUMERIC_STRING : CHARSET_STRING);
+                    case "int":
+                        return () -> randomInt(0, 20);
+                    case "float":
+                        return () -> randomFloat(0, 20);
+                    case "double":
+                        return () -> randomDouble(0, 20);
+                    case "boolean":
+                        return this::randomBoolean;
+                    case "date":
+                    case "datetime":
+                        return () -> randomDateString(DateUtils.addWeeks(new Date(), -39), new Date());
+                    case "time":
+                        return () ->
+                                randomInt(0, 23) + ":" + // hour
+                                        StringUtils.leftPad(String.valueOf(randomInt(0, 59)), 2, "0") + ":" + // minute
+                                        StringUtils.leftPad(String.valueOf(randomInt(0, 59)), 2, "0") + "." + // second
+                                        StringUtils.leftPad(String.valueOf(randomInt(0, 999)), 3, "0"); // millisecond
+                    default:
+                        throw new IllegalArgumentException("ColumnType " + conceptUriName + " isn't implemented yet");
+                }
         }
     }
 


### PR DESCRIPTION
#### Rationale
1. `doAndWaitForWindow` was implemented incorrectly. It needs to switch to the named window before calling `doAndMaybeWaitForPageToLoad` so that the page load is correctly detected.
2. When updating `TestDataGenerator.getDefaultDataSupplier` to generate random data for textChoice fields, I assumed that we weren't generating random data for other field types with a `conceptURI`. We are generating random values for some `Sample` columns so I've restored the old behavior for other column types.

#### Related Pull Requests
- #2616 
- #2615

#### Changes
- Switch to target window before waiting for page load
- Fix random data generation for sample fields
