### PR TITLE
Fix Locator.xq to handle trailing quotes

### DIFF
--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -985,10 +985,39 @@ public abstract class Locator extends By
      *     Direct port from attibuteValue function in selenium IDE locatorBuilders.js
      * @param value to be quoted
      * @return value with either ' or " around it or assembled from parts
+     * @implNote {@link Quotes#escape(String)} doesn't handle trailing quotes correctly
      */
     public static String xq(String value)
     {
-        return Quotes.escape(value);
+        if (!value.contains("'")) {
+            return "'" + value + "'";
+        } else if (!value.contains("\"")) {
+            return '"' + value + '"';
+        } else {
+            StringBuilder result = new StringBuilder("concat(");
+            while (true) {
+                int apos = value.indexOf("'");
+                int quot = value.indexOf('"');
+                if (apos < 0) {
+                    result.append("'").append(value).append("'");
+                    break;
+                } else if (quot < 0) {
+                    result.append('"').append(value).append('"');
+                    break;
+                } else if (quot < apos) {
+                    String part = value.substring(0, apos);
+                    result.append("'").append(part).append("'");
+                    value = value.substring(part.length());
+                } else {
+                    String part = value.substring(0, quot);
+                    result.append('"').append(part).append('"');
+                    value = value.substring(part.length());
+                }
+                result.append(',');
+            }
+            result.append(')');
+            return result.toString();
+        }
     }
 
     /**


### PR DESCRIPTION
#### Rationale
[Issue 53700: Fuzz-generated names or identifiers with consecutive "" quotes](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53700)

Selenium's `Quotes.escape` doesn't handle multiple trailing quotes. This change reverts back to our old method instead of delegating to the broken method.

#### Related Pull Requests
- N/A

#### Changes
- Fix Locator.xq to handle trailing quotes
