### PR TITLE
BackPort sample type test fix

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
+++ b/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
@@ -71,7 +71,10 @@ import static org.labkey.test.util.EscapeUtil.escapeForNameExpression;
 public class SampleTypeNameExpressionTest extends BaseWebDriverTest
 {
     private static final String PROJECT_NAME = "SampleType_Name_Expression_Test";
-    private static final String DEFAULT_SAMPLE_PARENT_VALUE = "SS" + TestDataGenerator.randomString(3).replaceAll("[_)]", "."); // '_' is used as delimiter to get batchRandomId and ) is used to close the defaultValue()
+
+    // Issue 53548: Naming Pattern with a default value containing a () or {} cannot be saved.
+    private static final String DEFAULT_SAMPLE_PARENT_VALUE = "SS" +
+            EscapeUtil.escapeForNameExpression(TestDataGenerator.randomString(3, "{}()_"));
 
     private static final String PARENT_SAMPLE_TYPE = "PS" + DOMAIN_TRICKY_CHARACTERS;
     private static final String PARENT_SAMPLE_TYPE_INPUT = escapeForNameExpression(PARENT_SAMPLE_TYPE);

--- a/src/org/labkey/test/tests/SampleTypeRenameTest.java
+++ b/src/org/labkey/test/tests/SampleTypeRenameTest.java
@@ -102,6 +102,8 @@ public class SampleTypeRenameTest extends BaseWebDriverTest
             testDataGenerator.addCustomRow(Map.of(FIELD_INT, intVal++));
         testDataGenerator.insertRows();
 
+        SearchAdminAPIHelper.waitForIndexer();
+
         goToProjectHome();
         SampleTypeHelper sampleHelper = new SampleTypeHelper(this);
         UpdateSampleTypePage updatePage = sampleHelper.goToEditSampleType(sampleTypeName);


### PR DESCRIPTION
#### Rationale
Backport fix to SampleType test to exclude special characters from a name expression and a waitForIndexer.

Since 25.7 is an ESR release I wanted to backport these fixes to keep the noise down.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2634

#### Changes
- Exclude special characters from name expression.
- Added a waitForIndexer
