### PR TITLE
Issue 53586: Domain field with long name can result in "PropertyURI cannot exceed 300 characters, but was 302 characters long."

### DIFF
--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -331,7 +331,8 @@ public class ListTest extends BaseWebDriverTest
         DomainFormPanel fieldsPanel = listDefinitionPage.getFieldsPanel();
         fieldsPanel.getField(_listColFake.getName())
             .setName(_listColDesc.getName())
-            .setLabel(_listColDesc.getLabel());
+            .setLabel(_listColDesc.getLabel())
+            .setImportAliases(_listColFake.getName());
         fieldsPanel.addField(_listColGood);
 
         // Create "Hidden Field" and remove from all views.


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53586
see related PR for rationale

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6939

#### Changes
- test fix to set field import alias on rename instead of relying on the parsing of the PropertyURI in createTableMap()

