### PR TITLE
Issue 53562: Cap max blob size in database configuration option

### DIFF
--- a/src/org/labkey/test/pages/core/admin/CustomizeSitePage.java
+++ b/src/org/labkey/test/pages/core/admin/CustomizeSitePage.java
@@ -111,6 +111,12 @@ public class CustomizeSitePage extends LabKeyPage<CustomizeSitePage.ElementCache
         return this;
     }
 
+    public CustomizeSitePage setReadOnlyHttpRequestTimeout(String value)
+    {
+        elementCache().readOnlyHttpRequestTimeout.set(value);
+        return this;
+    }
+
     public CustomizeSitePage setExt3Required(boolean enable)
     {
         elementCache().ext3Required.set(enable);
@@ -247,6 +253,7 @@ public class CustomizeSitePage extends LabKeyPage<CustomizeSitePage.ElementCache
         // System Properties
         protected final Input memoryUsageDumpInterval = Input(Locator.id("memoryUsageDumpInterval"), getDriver()).findWhenNeeded(this);
         protected final Input maxBLOBSize = Input(Locator.id("maxBLOBSize"), getDriver()).findWhenNeeded(this);
+        protected final Input readOnlyHttpRequestTimeout = Input(Locator.id("readOnlyHttpRequestTimeout"), getDriver()).findWhenNeeded(this);
         protected final Checkbox ext3Required = Checkbox(Locator.id("ext3Required")).findWhenNeeded(this);
         protected final Checkbox ext3APIRequired = Checkbox(Locator.id("ext3APIRequired")).findWhenNeeded(this);
 

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -121,10 +121,24 @@ public class AdminConsoleTest extends AbstractAdminConsoleTest
         CustomizeSitePage customizeSitePage = goToAdminConsole().clickSiteSettings();
         customizeSitePage.setMaxBLOBSize(Integer.toString(200 * 1024 * 1024 + 1));
         customizeSitePage.setSslPort("-4");
+        customizeSitePage.setMemoryUsageDumpInterval("-3");
+        customizeSitePage.setReadOnlyHttpRequestTimeout("-1");
         customizeSitePage.save();
-        assertTextPresent("Maximum BLOB size cannot be set higher than 209715200 bytes");
-        assertTextPresent("HTTPS port must be between 1 and 65,535");
+        assertTextPresent(
+            "Maximum BLOB size cannot be set higher than 209715200 bytes",
+            "HTTPS port must be between 1 and 65,535",
+            "Memory logging frequency must be non-negative",
+            "HTTP timeout must be non-negative"
+        );
 
+        customizeSitePage = new CustomizeSitePage(getDriver());
+        customizeSitePage.setMaxBLOBSize("-10");
+        customizeSitePage.setSslPort(Integer.toString(256 * 256)); // 2^16
+        customizeSitePage.save();
+        assertTextPresent(
+            "Maximum BLOB size cannot be negative",
+            "HTTPS port must be between 1 and 65,535"
+        );
     }
     
     @Test

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -113,6 +113,19 @@ public class AdminConsoleTest extends AbstractAdminConsoleTest
             throw new RuntimeException("Failed to get Server HTTP response header", e);
         }
     }
+
+    @Test
+    public void testBogusSiteSettings()
+    {
+        // Issue 53562: Cap max BLOB size
+        CustomizeSitePage customizeSitePage = goToAdminConsole().clickSiteSettings();
+        customizeSitePage.setMaxBLOBSize(Integer.toString(200 * 1024 * 1024 + 1));
+        customizeSitePage.setSslPort("-4");
+        customizeSitePage.save();
+        assertTextPresent("Maximum BLOB size cannot be set higher than 209715200 bytes");
+        assertTextPresent("HTTPS port must be between 1 and 65,535");
+
+    }
     
     @Test
     public void testRibbonBar()


### PR DESCRIPTION
#### Rationale
We don't want admins to sign up for BLOB sizes that are likely to yield OutOfMemoryErrors. We can do better at validating other site settings too.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6956

#### Changes
- Try setting some bogus site setting values, ensure they're rejected
