### PR TITLE
Results domain may be different for module assays

### DIFF
--- a/src/org/labkey/test/pages/ReactAssayDesignerPage.java
+++ b/src/org/labkey/test/pages/ReactAssayDesignerPage.java
@@ -345,7 +345,7 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
 
     public DomainFormPanel goToResultsFields()
     {
-        return expandFieldsPanel("Results");
+        return expandFieldsPanel("Result");
     }
 
     protected void expandPropertiesPanel()


### PR DESCRIPTION
#### Rationale
Ran into an issue using the test helpers to update the `SignalDataRawTest`. It turns out that the built in assays and module assays have a slight difference in the name of the results domain when viewed in the domain editor. For the built in assays it is : "Results Fields" and a module assay it is : "Result Fields".