### PR TITLE
Issue 53796: DataRegion.getChecked() incorrectly HTML encodes

### DIFF
--- a/src/org/labkey/test/tests/DataRegionTest.java
+++ b/src/org/labkey/test/tests/DataRegionTest.java
@@ -39,6 +39,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.labkey.test.params.FieldDefinition.DOMAIN_TRICKY_CHARACTERS;
 
 @Category({Daily.class, Data.class})
@@ -199,13 +201,13 @@ public class DataRegionTest extends AbstractQWPTest
         assertEquals(TOTAL_ROWS, table.getDataRowCount());
         assertEquals("aqua", table.getDataAsText(0, "Name"));
         assertEquals("#FFFF00", table.getDataAsText(15, "Hex"));
-        assertEquals(false, table.getPagingWidget().hasPagingButton(true));
-        assertEquals(false, table.getPagingWidget().hasPagingButton(false));
+        assertFalse(table.getPagingWidget().hasPagingButton(true));
+        assertFalse(table.getPagingWidget().hasPagingButton(false));
 
         log("Test 3 per page");
         table.setMaxRows(3);
-        assertEquals(true, table.getPagingWidget().hasPagingButton(true));
-        assertEquals(true, table.getPagingWidget().hasPagingButton(false));
+        assertTrue(table.getPagingWidget().hasPagingButton(true));
+        assertTrue(table.getPagingWidget().hasPagingButton(false));
         table.getPagingWidget().viewPagingOptions();
         assertElementPresent(Locator.linkWithText("3 per page").notHidden().append(Locator.tagWithClass("i", "fa-check-square-o")));
         assertElementPresent(Locator.linkWithText("20 per page").notHidden());
@@ -221,40 +223,40 @@ public class DataRegionTest extends AbstractQWPTest
         table.assertPaginationText(1, 5, 16);
         assertEquals(5, table.getDataRowCount());
         assertEquals("aqua", table.getDataAsText(0, "Name"));
-        assertEquals(false, table.getPagingWidget().menuOptionEnabled("Show first", "Show first"));
-        assertEquals(true, table.getPagingWidget().menuOptionEnabled("Show last", "Show last"));
-        assertEquals(false, table.getPagingWidget().pagingButtonEnabled(true));
-        assertEquals(true, table.getPagingWidget().pagingButtonEnabled(false));
+        assertFalse(table.getPagingWidget().menuOptionEnabled("Show first", "Show first"));
+        assertTrue(table.getPagingWidget().menuOptionEnabled("Show last", "Show last"));
+        assertFalse(table.getPagingWidget().pagingButtonEnabled(true));
+        assertTrue(table.getPagingWidget().pagingButtonEnabled(false));
 
         log("Next Page");
         table.pageNext();
         table.assertPaginationText(6, 10, 16);
         assertEquals(5, table.getDataRowCount());
         assertEquals("grey", table.getDataAsText(0, "Name"));
-        assertEquals(true, table.getPagingWidget().menuOptionEnabled("Show first", "Show first"));
-        assertEquals(true, table.getPagingWidget().menuOptionEnabled("Show last", "Show last"));
-        assertEquals(true, table.getPagingWidget().pagingButtonEnabled(true));
-        assertEquals(true, table.getPagingWidget().pagingButtonEnabled(false));
+        assertTrue(table.getPagingWidget().menuOptionEnabled("Show first", "Show first"));
+        assertTrue(table.getPagingWidget().menuOptionEnabled("Show last", "Show last"));
+        assertTrue(table.getPagingWidget().pagingButtonEnabled(true));
+        assertTrue(table.getPagingWidget().pagingButtonEnabled(false));
 
         log("Last Page");
         table.pageLast();
         table.assertPaginationText(16, 16, 16);
         assertEquals(1, table.getDataRowCount());
         assertEquals("yellow", table.getDataAsText(0, "Name"));
-        assertEquals(true, table.getPagingWidget().menuOptionEnabled("Show first", "Show first"));
-        assertEquals(false, table.getPagingWidget().menuOptionEnabled("Show last", "Show last"));
-        assertEquals(true, table.getPagingWidget().pagingButtonEnabled(true));
-        assertEquals(false, table.getPagingWidget().pagingButtonEnabled(false));
+        assertTrue(table.getPagingWidget().menuOptionEnabled("Show first", "Show first"));
+        assertFalse(table.getPagingWidget().menuOptionEnabled("Show last", "Show last"));
+        assertTrue(table.getPagingWidget().pagingButtonEnabled(true));
+        assertFalse(table.getPagingWidget().pagingButtonEnabled(false));
 
         log("Previous Page");
         table.pagePrev();
         table.assertPaginationText(11, 15, 16);
         assertEquals(5, table.getDataRowCount());
         assertEquals("purple", table.getDataAsText(0, "Name"));
-        assertEquals(true, table.getPagingWidget().menuOptionEnabled("Show first", "Show first"));
-        assertEquals(true, table.getPagingWidget().menuOptionEnabled("Show last", "Show last"));
-        assertEquals(true, table.getPagingWidget().pagingButtonEnabled(true));
-        assertEquals(true, table.getPagingWidget().pagingButtonEnabled(false));
+        assertTrue(table.getPagingWidget().menuOptionEnabled("Show first", "Show first"));
+        assertTrue(table.getPagingWidget().menuOptionEnabled("Show last", "Show last"));
+        assertTrue(table.getPagingWidget().pagingButtonEnabled(true));
+        assertTrue(table.getPagingWidget().pagingButtonEnabled(false));
 
         log("Setting a filter should go back to first page");
         table.setFilter(NAME_COLUMN.getName(), "Does Not Equal", "aqua");
@@ -266,7 +268,7 @@ public class DataRegionTest extends AbstractQWPTest
         Locator.XPathLocator selectionPart = Locator.tagWithAttribute("div", "data-msgpart", "selection");
         waitForElement(selectionPart);
         WebElement msgDiv = selectionPart.findElement(getDriver());
-        assertEquals(true, msgDiv.getText().contains("Selected 5 of 15 rows."));
+        assertTrue(msgDiv.getText().contains("Selected 5 of 15 rows."));
 
         assertElementPresent(selectionPart.append(Locator.tagWithClass("span", "select-all")));
         assertElementPresent(selectionPart.append(Locator.tagWithClass("span", "select-none")));
@@ -284,7 +286,7 @@ public class DataRegionTest extends AbstractQWPTest
     private void enableComplianceIfInstalled()
     {
         // Make sure it works with Compliance on (which enables Elec Sign control)
-        // Have to do what enableModule does in order to check if it's installed
+        // Have to do what enableModule does to check if it's installed
         goToFolderManagement();
         clickAndWait(Locator.linkWithText("Folder Type"));
 

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -53,6 +53,7 @@ import org.labkey.test.pages.query.UpdateQueryRowPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.StringLookup;
 import org.labkey.test.params.FieldKey;
+import org.labkey.test.params.list.IntListDefinition;
 import org.labkey.test.params.list.VarListDefinition;
 import org.labkey.test.tests.AuditLogTest;
 import org.labkey.test.util.AbstractDataRegionExportOrSignHelper.ColumnHeaderType;
@@ -97,6 +98,7 @@ public class ListTest extends BaseWebDriverTest
     protected final static String PROJECT_VERIFY = "ListVerifyProject" ;//+ TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
     private final static String PROJECT_OTHER = "OtherListVerifyProject";
     protected final static String LIST_NAME_COLORS = "A_Colors_" + DOMAIN_TRICKY_CHARACTERS;
+    protected final static String LIST_NAME_HTML_KEY = "A_HtmlKey_" + DOMAIN_TRICKY_CHARACTERS;
     protected final static ColumnType LIST_KEY_TYPE = ColumnType.String;
     protected final static String LIST_KEY_NAME = "Key";
 
@@ -260,15 +262,33 @@ public class ListTest extends BaseWebDriverTest
                 .submit();
     }
 
+    /** Issue 53796: 25.3 -> 25.7: DataRegion.getChecked() incorrectly HTML encodes the results */
+    @Test
+    public void testKeyWithHtmlCharacters()
+    {
+        _listHelper.createList(getProjectName(), LIST_NAME_HTML_KEY, new FieldDefinition(LIST_KEY_NAME2, LIST_KEY_TYPE));
+        ImportDataPage importDataPage = _listHelper.clickImportData();
+        String value = "<>ThisIsTheKeyValueWithHtmlCharacters</>";
+        importDataPage.setText(LIST_KEY_NAME2_BULK + "\n" + value);
+        importDataPage.submit();
+        assertTextPresent(value);
+        final DataRegionTable dt = DataRegion(getDriver()).withName("query").find();
+        dt.checkAllOnPage();
+        @SuppressWarnings("unchecked") List<String> checked = (List<String>)executeScript("return LABKEY.DataRegions.query.getChecked()");
+        assertEquals(Arrays.asList(value), checked);
+        dt.deleteSelectedRows();
+        assertTextNotPresent(value);
+    }
+
     @LogMethod
-    protected void setUpList(String projectName)
+    protected void setUpList()
     {
         // TODO: Break this up into explicit test cases and remove redundant test coverage.
         // But at least now it's only called from the one test case that relies on this list, testCustomViews().
         // Previously it was called from the @BeforeClass method, even though none of the other test cases use this list.
 
         log("Add list -- " + LIST_NAME_COLORS);
-        _listHelper.createList(projectName, LIST_NAME_COLORS, new FieldDefinition(LIST_KEY_NAME2, LIST_KEY_TYPE), _listColFake,
+        _listHelper.createList(getProjectName(), LIST_NAME_COLORS, new FieldDefinition(LIST_KEY_NAME2, LIST_KEY_TYPE), _listColFake,
         _listColMonth, _listColTone);
 
         log("Add description and test edit");
@@ -307,13 +327,13 @@ public class ListTest extends BaseWebDriverTest
         log("Test check/uncheck of checkboxes");
         // Second row (Green)
         assertEquals(1, table.getRowIndex(TEST_DATA[TD_COLOR][1]));
-        clickAndWait(table.updateLink(1));
+        table.clickEditRow(1);
         setFormElement(Locator.name("quf_" + _listColMonth.getName()), VALID_MONTHS[1]);  // Has a funny format -- need to post converted date
         checkCheckbox(Locator.checkboxByName("quf_JewelTone"));
         clickButton("Submit");
         // Third row (Red)
         assertEquals(2, table.getRowIndex(TEST_DATA[TD_COLOR][2]));
-        clickAndWait(table.updateLink(2));
+        table.clickEditRow(2);
         setFormElement(Locator.name("quf_" + _listColMonth.getName()), VALID_MONTHS[2]);  // Has a funny format -- need to post converted date
         uncheckCheckbox(Locator.checkboxByName("quf_JewelTone"));
         clickButton("Submit");
@@ -578,7 +598,7 @@ public class ListTest extends BaseWebDriverTest
     public void testCustomViews()
     {
         goToProjectHome();
-        setUpList(getProjectName());
+        setUpList();
 
         goToProjectHome();
         waitAndClickAndWait(Locator.linkWithText(LIST_NAME_COLORS));
@@ -1062,7 +1082,7 @@ public class ListTest extends BaseWebDriverTest
         clickButton("Edit");
         assertTextPresent("dummy one");
         clickButton("Cancel");
-        clickAndWait(regionTable.updateLink(0));
+        regionTable.clickEditRow(0);
         assertTextPresent("dummy one");
         clickButton("Cancel");
     }


### PR DESCRIPTION
#### Rationale
We're double-encoding the value for record selectors in standard LKS grid views.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6970

#### Changes
- Ensure the JS API returns the correct value
- Ensure that we can delete the row based on the selection