### PR TITLE
Improve synchronization of ParentEntityEditPanel

### DIFF
--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -19,6 +19,7 @@ package org.labkey.test;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.intellij.lang.annotations.Language;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.test.selenium.LazyWebElement;
@@ -373,11 +374,13 @@ public abstract class Locator extends By
         return wrappedContext.getValue();
     }
 
+    @Contract(pure = true)
     public LazyWebElement<?> findWhenNeeded(SearchContext context)
     {
         return new LazyWebElement<>(this, context);
     }
 
+    @Contract(pure = true)
     public RefindingWebElement refindWhenNeeded(SearchContext context)
     {
         return new RefindingWebElement(this, context);
@@ -391,11 +394,13 @@ public abstract class Locator extends By
                 new NoSuchElementException("Unable to find element: " + getFindDescription(context)));
     }
 
+    @Contract(pure = true)
     public WebElement findElementOrNull(SearchContext context)
     {
         return findOptionalElement(context).orElse(null);
     }
 
+    @Contract(pure = true)
     public Optional<WebElement> findOptionalElement(SearchContext context)
     {
         List<WebElement> elements = findElements(context);
@@ -404,6 +409,7 @@ public abstract class Locator extends By
         return Optional.of(elements.get(0));
     }
 
+    @Contract(pure = true)
     @Override
     public List<WebElement> findElements(SearchContext context)
     {
@@ -454,11 +460,13 @@ public abstract class Locator extends By
         }
     }
 
+    @Contract(pure = true)
     public boolean existsIn(SearchContext context)
     {
         return findElementOrNull(context) != null;
     }
 
+    @Contract(pure = true)
     public boolean isDisplayed(SearchContext context)
     {
         WebElement element = findElementOrNull(context);
@@ -471,6 +479,7 @@ public abstract class Locator extends By
      * @param context Search context.
      * @return True if there are any elements visible, false otherwise.
      */
+    @Contract(pure = true)
     public boolean areAnyVisible(SearchContext context)
     {
         List<WebElement> elements = findElements(context);

--- a/src/org/labkey/test/components/bootstrap/Panel.java
+++ b/src/org/labkey/test/components/bootstrap/Panel.java
@@ -71,26 +71,20 @@ public abstract class Panel<EC extends ElementCache> extends WebDriverComponent<
         protected final WebElement panelBody = Locator.byClass("panel-body").findWhenNeeded(this);
     }
 
-    public static class PanelFinder extends WebDriverComponentFinder<Panel<?>, PanelFinder>
+    protected static abstract class AbstractPanelFinder<C extends Panel<?>, F extends AbstractPanelFinder<C, F>> extends WebDriverComponentFinder<C, F>
     {
-        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "panel-default");
+        private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "panel");
         private String _title = null;
 
-        public PanelFinder(WebDriver driver)
+        public AbstractPanelFinder(WebDriver driver)
         {
             super(driver);
         }
 
-        public PanelFinder withTitle(String title)
+        public F withTitle(String title)
         {
             _title = title;
-            return this;
-        }
-
-        @Override
-        protected Panel<?> construct(WebElement el, WebDriver driver)
-        {
-            return new PanelImpl(el, driver);
+            return getThis();
         }
 
         @Override
@@ -101,6 +95,26 @@ public abstract class Panel<EC extends ElementCache> extends WebDriverComponent<
                 return _baseLocator.withChild(Locator.byClass("panel-heading").containing(_title));
             else
                 return _baseLocator;
+        }
+    }
+
+    public static class PanelFinder extends AbstractPanelFinder<Panel<?>, PanelFinder>
+    {
+        public PanelFinder(WebDriver driver)
+        {
+            super(driver);
+        }
+
+        @Override
+        protected PanelFinder getThis()
+        {
+            return this;
+        }
+
+        @Override
+        protected Panel<?> construct(WebElement el, WebDriver driver)
+        {
+            return new PanelImpl(el, driver);
         }
     }
 }

--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -4,8 +4,7 @@ import org.junit.Assert;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
-import org.labkey.test.components.Component;
-import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.components.bootstrap.Panel;
 import org.labkey.test.components.react.BaseReactSelect;
 import org.labkey.test.components.react.FilteringReactSelect;
 import org.labkey.test.components.react.ReactSelect;
@@ -13,9 +12,12 @@ import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * <p>
@@ -25,11 +27,8 @@ import java.util.List;
  * </p>
  * @see <a href="https://github.com/LabKey/labkey-ui-components/blob/master/packages/components/src/components/entities/ParentEntityEditPanel.tsx">ParentEntityEditPanel.tsx</a>
  */
-public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPanel.ElementCache>
+public class ParentEntityEditPanel extends Panel<ParentEntityEditPanel.ElementCache>
 {
-    private final WebDriver driver;
-    private final WebElement editingDiv;
-
     /**
      * Constructor for the panel.
      *
@@ -38,20 +37,7 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
      */
     public ParentEntityEditPanel(WebElement element, WebDriver driver)
     {
-        this.driver = driver;
-        editingDiv = element;
-    }
-
-    @Override
-    public WebElement getComponentElement()
-    {
-        return editingDiv;
-    }
-
-    @Override
-    protected WebDriver getDriver()
-    {
-        return driver;
+        super(element, driver);
     }
 
     @Override
@@ -184,6 +170,10 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
         WebDriverWrapper.waitFor(()->elementCache().saveButton.isEnabled(),
                 "Save button is not enabled.", 2_500);
 
+        String parentType = getTitle().split(" ", 2)[1].trim(); // Trim "Editing" from the title
+        Set<String> selections = new HashSet<>();
+        getAllParents().stream().map(BaseReactSelect::getSelections).forEach(selections::addAll);
+
         // The wait time is used here to validate the panel exits edit mode.
         clickButtonWaitForPanel(elementCache().saveButton, waitTime);
 
@@ -192,6 +182,20 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
         WebDriverWrapper.waitFor(()->!progressbar.isDisplayed(),
                 "It looks like an update took too long.", waitTime);
 
+        Panel<?> detailsPanel = new Panel.PanelFinder(getDriver()).withTitle(parentType).waitFor(getDriver());
+        if (!selections.isEmpty())
+        {
+            for (String selection : selections)
+            {
+                getWrapper().quickWait().until(ExpectedConditions.visibilityOf(
+                    Locator.linkWithText(selection).findWhenNeeded(detailsPanel)));
+            }
+        }
+        else
+        {
+            getWrapper().quickWait().until(ExpectedConditions.visibilityOf(
+                Locator.tag("td").containing("has been set for this sample.").findWhenNeeded(detailsPanel)));
+        }
     }
 
     /**
@@ -467,27 +471,18 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
     /**
      * Simple finder for this panel.
      */
-    public static class ParentEntityEditPanelFinder extends WebDriverComponentFinder<ParentEntityEditPanel, ParentEntityEditPanelFinder>
+    public static class ParentEntityEditPanelFinder extends AbstractPanelFinder<ParentEntityEditPanel, ParentEntityEditPanelFinder>
     {
         public ParentEntityEditPanelFinder(WebDriver driver)
         {
             super(driver);
+            withTitle("Editing");
         }
 
         @Override
         protected ParentEntityEditPanel construct(WebElement element, WebDriver driver)
         {
             return new ParentEntityEditPanel(element, driver);
-        }
-
-        @Override
-        protected Locator locator()
-        {
-            return Locator
-                    .tagContainingText("div", "Editing")
-                    .withClass("panel-heading")
-                    .parent()
-                    .child(Locator.tagWithClass("div", "panel-body"));
         }
     }
 
@@ -517,7 +512,7 @@ public class ParentEntityEditPanel extends WebDriverComponent<ParentEntityEditPa
         return new ElementCache();
     }
 
-    protected class ElementCache extends Component<?>.ElementCache
+    protected class ElementCache extends Panel<?>.ElementCache
     {
         final WebElement saveButton = Locator.byClass("btn-success").withText("Save").findWhenNeeded(this);
         final WebElement cancelButton = Locator.byClass("btn-default").withText("Cancel").refindWhenNeeded(this);


### PR DESCRIPTION
#### Rationale
`SMProLimitedReadTest.testTimelineView` has been failing intermittently with audit log mismatches. Presumably, the problem is that the test is failing to actually make the expected changes. Adding some extra synchronization to ensure that the expected audit events have actually happened.

```
org.junit.ComparisonFailure: New value for second parent change not as expected expected:<[TS_1, TS_2]> but was:<[NA]>
  at org.junit.Assert.assertEquals(Assert.java:117) ~[junit-4.13.2.jar:4.13.2]
  at org.labkey.test.util.DeferredErrorCollector.lambda$5(DeferredErrorCollector.java:248) [uiTest/:?]
  at org.labkey.test.util.DeferredErrorCollector.wrapAssertion(DeferredErrorCollector.java:188) [uiTest/:?]
  at org.labkey.test.util.DeferredErrorCollector.verifyEquals(DeferredErrorCollector.java:248) [uiTest/:?]
  at org.labkey.test.tests.samplemanagement.userAndPermissions.SMProLimitedReadTest.testTimelineView(SMProLimitedReadTest.java:178) [uiTest/:?]
```

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1634

#### Changes
- Improve synchronization of ParentEntityEditPanel