### PR TITLE
Regression for manage views exception

### DIFF
--- a/src/org/labkey/test/tests/DataViewsReportOrderingTest.java
+++ b/src/org/labkey/test/tests/DataViewsReportOrderingTest.java
@@ -25,6 +25,8 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.ext4.Window;
+import org.labkey.test.pages.reports.ManageViewsPage;
+import org.labkey.test.pages.user.ShowUsersPage;
 import org.labkey.test.util.PortalHelper;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
@@ -131,6 +133,15 @@ public class DataViewsReportOrderingTest extends BaseWebDriverTest
             reverseReports[x] = reportsOriginalOrder.get(reportsOriginalOrder.size() - x -1);
         }
         return reverseReports;
+    }
+
+    @Test
+    public void testRootFolderAccess()
+    {
+        // Regression for issue 53630
+        ShowUsersPage showUsersPage = goToSiteUsers();
+        ManageViewsPage mvp = showUsersPage.getUsersTable().openManageViews();
+        mvp.clickAddReport("R Report");
     }
 
     @Override

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -169,10 +169,7 @@ public class DataRegionTable extends DataRegion
 
     public ManageViewsPage openManageViews()
     {
-        if (!getCustomizeView().isPanelExpanded())
-        {
-            getViewsMenu().clickSubMenu(false, "Manage Views");
-        }
+        getViewsMenu().clickSubMenu(false, "Manage Views");
         return new ManageViewsPage(getDriver());
     }
 

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -40,6 +40,7 @@ import org.labkey.test.components.ui.grids.FieldReferenceManager.FieldReference;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.TimeChartWizard;
 import org.labkey.test.pages.query.UpdateQueryRowPage;
+import org.labkey.test.pages.reports.ManageViewsPage;
 import org.labkey.test.params.FieldKey;
 import org.labkey.test.selenium.LazyWebElement;
 import org.labkey.test.selenium.RefindingWebElement;
@@ -164,6 +165,15 @@ public class DataRegionTable extends DataRegion
                     DataRegion.PANEL_SHOW_SIGNAL);
         }
         return getCustomizeView();
+    }
+
+    public ManageViewsPage openManageViews()
+    {
+        if (!getCustomizeView().isPanelExpanded())
+        {
+            getViewsMenu().clickSubMenu(false, "Manage Views");
+        }
+        return new ManageViewsPage(getDriver());
     }
 
     protected DataRegionExportHelper getExportPanel()


### PR DESCRIPTION
#### Rationale
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53630)

This adds a simple regression test for 53630 by going to the site users table and opening the manage views page. I'm open to moving this test to a more appropriate class, it is independent of study. I could move it to the `DataViewsTest` but that is also study-based and one of those old style monolithic tests.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6971
- https://github.com/LabKey/testAutomation/pull/2657
