### PR TITLE
Make LinkedReportTest more robust

### DIFF
--- a/src/org/labkey/test/tests/LinkedReportTest.java
+++ b/src/org/labkey/test/tests/LinkedReportTest.java
@@ -40,13 +40,13 @@ public class LinkedReportTest extends BaseWebDriverTest
     /* Regression coverage : Issue 47004: Add Test Automation for LinkedReports  */
 
     @Test
-    public void testLinkedReportToExternalURL() throws InterruptedException
+    public void testLinkedReportToExternalURL()
     {
         goToProjectHome();
         goToManageViews().clickAddReport("Link Report");
         setFormElement(Locator.name("viewName"), REPORT_NAME);
         setFormElement(Locator.name("linkUrl"), LINK_REPORT_URL);
-        Thread.sleep(1000);  // Hack to prevent saving before the form is ready to submit, lacking a way to check before clicking
+        sleep(1000);  // Hack to prevent saving before the form is ready to submit, lacking a way to check before clicking
         clickButton("Save");
         waitForText("Manage Views");
 

--- a/src/org/labkey/test/tests/LinkedReportTest.java
+++ b/src/org/labkey/test/tests/LinkedReportTest.java
@@ -40,12 +40,13 @@ public class LinkedReportTest extends BaseWebDriverTest
     /* Regression coverage : Issue 47004: Add Test Automation for LinkedReports  */
 
     @Test
-    public void testLinkedReportToExternalURL()
+    public void testLinkedReportToExternalURL() throws InterruptedException
     {
         goToProjectHome();
         goToManageViews().clickAddReport("Link Report");
         setFormElement(Locator.name("viewName"), REPORT_NAME);
         setFormElement(Locator.name("linkUrl"), LINK_REPORT_URL);
+        Thread.sleep(1000);  // Hack to prevent saving before the form is ready to submit, lacking a way to check before clicking
         clickButton("Save");
         waitForText("Manage Views");
 


### PR DESCRIPTION
#### Rationale
LinkedReportTest can be flaky, especially when run solo, because it clicks on Save before the form is ready to process it.

#### Changes
- A yucky `Thread.sleep()` since we lack a way to ask the form if it's ready