### PR TITLE
Stop referencing removed setting

### DIFF
--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -262,6 +262,11 @@ public abstract class TestProperties
         return "true".equals(System.getProperty("webtest.checker.fatal"));
     }
 
+    public static boolean isControllerFirstUrlFatal()
+    {
+        return getBooleanProperty("webtest.fatalControllerFirstUrl", false);
+    }
+
     public static boolean isAssayProductFeatureAvailable()
     {
         return isProductFeatureAvailable("assay");

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1206,6 +1206,25 @@ public abstract class WebDriverWrapper implements WrapsDriver
                 logMessage = "Navigating to " + relativeURL;
             }
 
+            if (WebTestHelper.isUseContainerRelativeUrl())
+            {
+                try
+                {
+                    if (new Crawler.ControllerActionId(relativeURL).isControllerFirstUrl())
+                    {
+                        RuntimeException ex = new RuntimeException("Controller first url found in URL: " + relativeURL);
+                        if (TestProperties.isControllerFirstUrlFatal())
+                            throw ex;
+                        else
+                            TestLogger.log().warn(ex.getMessage(), ex);
+                    }
+                }
+                catch (IllegalArgumentException e)
+                {
+                    TestLogger.warn("Unable to parse URL: " + relativeURL, e);
+                }
+            }
+
             final String fullURL = WebTestHelper.getBaseURL() + relativeURL;
             final boolean expectPageLoad = expectPageLoad(fullURL);
 

--- a/src/org/labkey/test/pages/core/admin/CustomizeSitePage.java
+++ b/src/org/labkey/test/pages/core/admin/CustomizeSitePage.java
@@ -75,12 +75,6 @@ public class CustomizeSitePage extends LabKeyPage<CustomizeSitePage.ElementCache
         return elementCache().baseServerUrl.get();
     }
 
-    public CustomizeSitePage setContainerRelativeUrl(boolean enable)
-    {
-        elementCache().containerRelativeUrl.set(enable);
-        return this;
-    }
-
     public CustomizeSitePage setUsageReportingLevel(ReportingLevel level)
     {
         elementCache().usageReportingLevel(level).check();
@@ -233,7 +227,6 @@ public class CustomizeSitePage extends LabKeyPage<CustomizeSitePage.ElementCache
         // Site URLs
         protected final Input defaultDomain = Input(Locator.id("defaultDomain"), getDriver()).findWhenNeeded(this);
         protected final Input baseServerUrl = Input(Locator.id("baseServerURL"), getDriver()).findWhenNeeded(this);
-        protected final Checkbox containerRelativeUrl = Checkbox(Locator.id("useContainerRelativeURL")).findWhenNeeded(this);
 
         // Usage Reporting
         protected RadioButton usageReportingLevel(ReportingLevel level)

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -527,6 +527,8 @@ public class Crawler
                 p += (_prioritizeAdminPages ? -1 : 1);
             priority = p + random.nextFloat();
 
+            checkControllerRelativeUrl();
+
             try
             {
                 isVisitableURL();
@@ -605,6 +607,18 @@ public class Crawler
             return _projects.contains(currentProject);
         }
 
+        private void checkControllerRelativeUrl()
+        {
+            if (_actionId != null && _actionId.isControllerFirstUrl() && WebTestHelper.isUseContainerRelativeUrl())
+            {
+                RuntimeException ex = new RuntimeException("Found a controller-first URL (%s) on %s".formatted(getUrlText(), getOrigin()));
+                if (TestProperties.isControllerFirstUrlFatal())
+                    throw ex;
+                else
+                    TestLogger.warn(ex.getMessage(), ex);
+            }
+        }
+
         public boolean isVisitableURL()
         {
             if (StringUtils.isBlank(getRelativeURL()))
@@ -677,12 +691,14 @@ public class Crawler
         @NotNull private final String _controller;
         @NotNull private String _action = "";
         private final String _containerPath;
+        private final boolean _controllerFirstUrl;
 
         public ControllerActionId(@NotNull String controller, @NotNull String action)
         {
             _controller = controller;
             _action = action;
             _containerPath = null;
+            _controllerFirstUrl = false;
         }
 
         public ControllerActionId(@NotNull String url)
@@ -691,6 +707,7 @@ public class Crawler
 
             if (rootRelativeURL.startsWith("_webdav/"))
             {
+                _controllerFirstUrl = false;
                 _controller = "_webdav";
                 String path = EscapeUtil.decode(rootRelativeURL.substring("_webdav/".length()));
                 if (path.startsWith("@"))
@@ -711,6 +728,7 @@ public class Crawler
             }
             if (rootRelativeURL.startsWith("_webfiles/"))
             {
+                _controllerFirstUrl = false;
                 _controller = "_webfiles";
                 _containerPath = EscapeUtil.decode(rootRelativeURL.substring("_webfiles/".length()));
                 return;
@@ -735,6 +753,7 @@ public class Crawler
                 int dash = _action.lastIndexOf("-");
                 _controller = _action.substring(0,dash);
                 _action = _action.substring(dash+1);
+                _controllerFirstUrl = false;
             }
             else
             {
@@ -744,6 +763,7 @@ public class Crawler
                     throw new IllegalArgumentException("Unable to parse folder out of relative URL: \"" + rootRelativeURL + "\"");
                 _controller = rootRelativeURL.substring(0, postControllerSlashIdx);
                 rootRelativeURL = rootRelativeURL.substring(postControllerSlashIdx+1);
+                _controllerFirstUrl = true;
             }
             _containerPath = EscapeUtil.decode(StringUtils.strip(rootRelativeURL, "/"));
         }
@@ -766,6 +786,14 @@ public class Crawler
         public String getContainerPath()
         {
             return _containerPath;
+        }
+
+        /**
+         * Allows us to track down pages that still create controller-first URLs
+         */
+        public boolean isControllerFirstUrl()
+        {
+            return _controllerFirstUrl;
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
Setting has been removed, though I don't think any tests call this method. Tests do *check* the value of this setting, but that shouldn't be affected by the deprecation. (They should be adjusted once the deprecated feature is removed.)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6990