### PR TITLE
Avoid known issues with random name generation

### DIFF
--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -257,6 +257,11 @@ public abstract class TestProperties
         return getBooleanProperty("webtest.server.trial", false);
     }
 
+    public static boolean isRemoteNameValidationEnabled()
+    {
+        return getBooleanProperty("webtest.remote.domain.validation", false);
+    }
+
     public static boolean isCheckerFatal()
     {
         return "true".equals(System.getProperty("webtest.checker.fatal"));

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -316,7 +316,7 @@ public class DomainDesignerTest extends BaseWebDriverTest
     public void testInvalidSampleFieldFromDelete() throws Exception
     {
         String listName = TestDataGenerator.randomDomainName("Sample Lookups List", DomainUtils.DomainKind.IntList);
-        String listKey = TestDataGenerator.randomFieldName("Id", null, 10, null, DomainUtils.DomainKind.IntList);
+        String listKey = DomainUtils.DomainKind.IntList.randomFieldName("Key");
         String sampleType1 = TestDataGenerator.randomDomainName("Sample Type 1");
         String sampleType2 = TestDataGenerator.randomDomainName("Sample Type 2");
         SampleTypeAPIHelper.createEmptySampleType(getProjectName(), new SampleTypeDefinition(sampleType1));

--- a/src/org/labkey/test/tests/query/QueryLookupTest.java
+++ b/src/org/labkey/test/tests/query/QueryLookupTest.java
@@ -29,7 +29,7 @@ public class QueryLookupTest extends BaseWebDriverTest
     private static final String PROJECT_NAME = "QueryLookupTest" + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
     private static final String LIST_NAME = "l&ist q";
 
-    private static final FieldInfo NAME_COLUMN = FieldInfo.random("Name", FieldDefinition.ColumnType.String, DomainUtils.DomainKind.VarList);
+    private static final FieldInfo NAME_COLUMN = FieldInfo.random("Key", FieldDefinition.ColumnType.String, DomainUtils.DomainKind.VarList);
     private static final FieldInfo TSHIRT_COLUMN = FieldInfo.random("TShirt", FieldDefinition.ColumnType.String, DomainUtils.DomainKind.VarList);
 
     @Override

--- a/src/org/labkey/test/util/DomainUtils.java
+++ b/src/org/labkey/test/util/DomainUtils.java
@@ -6,6 +6,8 @@ import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.domain.DropDomainCommand;
 import org.labkey.remoteapi.domain.GetDomainDetailsCommand;
 import org.labkey.test.WebTestHelper;
+import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldInfo;
 
 import java.io.IOException;
 
@@ -107,6 +109,21 @@ public final class DomainUtils
         public String randomName(String namePart)
         {
             return TestDataGenerator.randomDomainName(namePart, this);
+        }
+
+        public String randomFieldName(String namePart)
+        {
+            return randomField(namePart).getName();
+        }
+
+        public FieldInfo randomField(String namePart)
+        {
+            return randomField(namePart, null);
+        }
+
+        public FieldInfo randomField(String namePart, FieldDefinition.ColumnType columnType)
+        {
+            return FieldInfo.random(namePart, columnType, this);
         }
     }
 }

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -37,6 +37,7 @@ import org.labkey.remoteapi.query.RowsResponse;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.remoteapi.query.Sort;
 import org.labkey.serverapi.reader.TabLoader;
+import org.labkey.test.TestProperties;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.data.ColumnNameMapper;
@@ -594,7 +595,8 @@ public class TestDataGenerator
         }
 
         // Multiple spaces in the UI are collapsed into a single space. If we need to test for handling of multiple spaces, we'll not use this generator
-        domainName = domainName.replaceAll("\\s+", " ");
+        // Capitalize to make it easier to match grid header labels and audit events
+        domainName = StringUtils.capitalize(domainName).replaceAll("\\s+", " ");
 
         TestLogger.log("Generated random domain name for domainKind " + _domainKind + ": " + domainName);
         return domainName;
@@ -644,6 +646,31 @@ public class TestDataGenerator
 
     private static boolean isDomainAndFieldNameInvalid(DomainUtils.DomainKind domainKind, @Nullable String domainName, @Nullable String fieldName)
     {
+        if (TestProperties.isTrialServer()) // WebTestHelper.getRemoteApiConnection() won't work against trial server
+        {
+            if (domainName != null)
+            {
+                int maxLength = switch (domainKind)
+                {
+                    case Assay -> 200 - 13; // Make room for "{$domainName} Batch Fields" domain
+                    case SampleSet -> 100;
+                    default -> 200; // Sources, lists, and datasets allow 200 character names
+                };
+                if (domainName.length() > maxLength)
+                    return true;
+            }
+            if (fieldName != null)
+            {
+                if (fieldName.length() > 200 || Pattern.matches(".*:[a-zA-Z]{3}.*", fieldName)) // Avoid illegal patterns like ":Date"
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
         SimplePostCommand command = new SimplePostCommand("property", "validateDomainAndFieldNames");
         JSONObject domainDesign = new JSONObject();
         if (domainName != null)

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -646,7 +646,7 @@ public class TestDataGenerator
 
     private static boolean isDomainAndFieldNameInvalid(DomainUtils.DomainKind domainKind, @Nullable String domainName, @Nullable String fieldName)
     {
-        if (TestProperties.isTrialServer()) // WebTestHelper.getRemoteApiConnection() won't work against trial server
+        if (TestProperties.isTrialServer()) // WebTestHelper.getRemoteApiConnection() won't work against trial server before logging in via UI
         {
             if (domainName != null)
             {

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -647,6 +647,9 @@ public class TestDataGenerator
 
     private static boolean isDomainAndFieldNameInvalid(DomainKind domainKind, @Nullable String domainName, @Nullable String fieldName)
     {
+        if (fieldName != null && fieldName.length() > 64 && fieldName.toLowerCase().contains("key")) // Not guaranteed but likely a list key
+            return true; // Issue 53706: List key field name length is limited to 64 characters
+
         if (TestProperties.isRemoteNameValidationEnabled())
         {
             return isNameInvalidRemote(domainKind, domainName, fieldName);
@@ -718,8 +721,6 @@ public class TestDataGenerator
                 return true;
             if (Pattern.matches(".*:[a-zA-Z]{3}.*", fieldName)) // Avoid illegal patterns like ":Date"
                 return true;
-            if (fieldName.toLowerCase().contains("key")) // Not guaranteed but likely a list key
-                return true; // Issue 53706: List key field name length is limited to 64 characters
         }
 
         return false;

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -40,6 +40,7 @@ import org.labkey.serverapi.reader.TabLoader;
 import org.labkey.test.TestProperties;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.util.DomainUtils.DomainKind;
 import org.labkey.test.util.data.ColumnNameMapper;
 import org.labkey.test.util.data.TestDataUtils;
 import org.labkey.test.util.query.QueryApiHelper;
@@ -567,7 +568,7 @@ public class TestDataGenerator
         return domainName;
     }
 
-    public static String randomDomainName(@Nullable String namePart, @Nullable DomainUtils.DomainKind domainKind)
+    public static String randomDomainName(@Nullable String namePart, @Nullable DomainKind domainKind)
     {
         return randomDomainName(namePart, null, null, domainKind);
     }
@@ -580,10 +581,10 @@ public class TestDataGenerator
      * @param numEndChars Number of random characters at end of name
      * @return name containing the given name part and appended random characters that should be a valid domain name
      */
-    public static String randomDomainName(@Nullable String namePart, @Nullable Integer numStartChars, @Nullable Integer numEndChars, @Nullable DomainUtils.DomainKind domainKind)
+    public static String randomDomainName(@Nullable String namePart, @Nullable Integer numStartChars, @Nullable Integer numEndChars, @Nullable DomainKind domainKind)
     {
         String _namePart = namePart == null ? "" : namePart;
-        DomainUtils.DomainKind _domainKind = domainKind == null ? DomainUtils.DomainKind.SampleSet : domainKind;
+        DomainKind _domainKind = domainKind == null ? DomainKind.SampleSet : domainKind;
         String charSet = ALPHANUMERIC_STRING + DOMAIN_SPECIAL_STRING;
         int currentTries = 0;
         String domainName = randomName(_namePart, getNumChars(numStartChars, 5), getNumChars(numEndChars, 50), charSet, null);
@@ -617,14 +618,14 @@ public class TestDataGenerator
         return randomFieldName(part, exclusion, null);
     }
 
-    public static String randomFieldName(String part, @Nullable String exclusion, DomainUtils.DomainKind domainKind)
+    public static String randomFieldName(String part, @Nullable String exclusion, DomainKind domainKind)
     {
         return randomFieldName(part, null, null, exclusion, domainKind);
     }
 
-    public static String randomFieldName(@NotNull String part, @Nullable Integer numStartChars, @Nullable Integer numEndChars, @Nullable String exclusion, @Nullable DomainUtils.DomainKind domainKind)
+    public static String randomFieldName(@NotNull String part, @Nullable Integer numStartChars, @Nullable Integer numEndChars, @Nullable String exclusion, @Nullable DomainKind domainKind)
     {
-        DomainUtils.DomainKind _domainKind = domainKind == null ? DomainUtils.DomainKind.SampleSet : domainKind;
+        DomainKind _domainKind = domainKind == null ? DomainKind.SampleSet : domainKind;
 
         // use the characters that we know are encoded in fieldKeys plus characters that we know clients are using
         // Issue 53197: Field name with double byte character can cause client side exception in Firefox when trying to customize grid view.
@@ -644,33 +645,20 @@ public class TestDataGenerator
         return randomFieldName;
     }
 
-    private static boolean isDomainAndFieldNameInvalid(DomainUtils.DomainKind domainKind, @Nullable String domainName, @Nullable String fieldName)
+    private static boolean isDomainAndFieldNameInvalid(DomainKind domainKind, @Nullable String domainName, @Nullable String fieldName)
     {
-        if (TestProperties.isTrialServer()) // WebTestHelper.getRemoteApiConnection() won't work against trial server before logging in via UI
+        if (TestProperties.isRemoteNameValidationEnabled())
         {
-            if (domainName != null)
-            {
-                int maxLength = switch (domainKind)
-                {
-                    case Assay -> 200 - 13; // Make room for "{$domainName} Batch Fields" domain
-                    case SampleSet -> 100;
-                    default -> 200; // Sources, lists, and datasets allow 200 character names
-                };
-                if (domainName.length() > maxLength)
-                    return true;
-            }
-            if (fieldName != null)
-            {
-                if (fieldName.length() > 200 || Pattern.matches(".*:[a-zA-Z]{3}.*", fieldName)) // Avoid illegal patterns like ":Date"
-                {
-                    return true;
-                }
-            }
-            else
-            {
-                return false;
-            }
+            return isNameInvalidRemote(domainKind, domainName, fieldName);
         }
+        else
+        {
+            return isNameInvalidLocal(domainKind, domainName, fieldName);
+        }
+    }
+
+    private static boolean isNameInvalidRemote(DomainKind domainKind, @Nullable String domainName, @Nullable String fieldName)
+    {
         SimplePostCommand command = new SimplePostCommand("property", "validateDomainAndFieldNames");
         JSONObject domainDesign = new JSONObject();
         if (domainName != null)
@@ -704,6 +692,37 @@ public class TestDataGenerator
         {
             throw new RuntimeException("Failed to validate domain field name: %s.".formatted(fieldName), e);
         }
+    }
+
+    public static boolean isNameInvalidLocal(DomainKind domainKind, @Nullable String domainName, @Nullable String fieldName)
+    {
+        if (domainName != null)
+        {
+            if (!Character.isLetterOrDigit(domainName.charAt(0)))
+                return true; // domain needs to start with alphanumeric char
+            if (Pattern.matches("(.*\\s--[^ ].*)|(.*\\s-[^- ].*)", domainName))
+                return true; // domain name must not contain space followed by dash. (command like: Issue 49161)
+
+            int maxLength = switch (domainKind)
+            {
+                case Assay -> 200 - 13; // Make room for "{$domainName} Batch Fields" domain
+                case SampleSet -> 100;
+                default -> 200; // Sources, lists, and datasets allow 200 character names
+            };
+            if (domainName.length() > maxLength)
+                return true;
+        }
+        if (fieldName != null)
+        {
+            if (fieldName.length() > 200)
+                return true;
+            if (Pattern.matches(".*:[a-zA-Z]{3}.*", fieldName)) // Avoid illegal patterns like ":Date"
+                return true;
+            if (fieldName.toLowerCase().contains("key")) // Not guaranteed but likely a list key
+                return true; // Issue 53706: List key field name length is limited to 64 characters
+        }
+
+        return false;
     }
 
     public static <T> T randomChoice(List<T> choices)

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -596,8 +596,7 @@ public class TestDataGenerator
         }
 
         // Multiple spaces in the UI are collapsed into a single space. If we need to test for handling of multiple spaces, we'll not use this generator
-        // Capitalize to make it easier to match grid header labels and audit events
-        domainName = StringUtils.capitalize(domainName).replaceAll("\\s+", " ");
+        domainName = domainName.replaceAll("\\s+", " ");
 
         TestLogger.log("Generated random domain name for domainKind " + _domainKind + ": " + domainName);
         return domainName;


### PR DESCRIPTION
#### Rationale
There are some known issues with random field and domain name generation.

[Issue 53706: List key field name length is limited to 64 characters](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53706). We should avoid long list key names until this issue is resolved. Limiting the length of names containing "key" should be sufficient to prevent test failures due to this issue.

Numerous SM Starter and SM Trial tests fail because they can't validate names using the `validateDomainAndFieldNames` API; either because the initial user hasn't been created or there isn't a browser session available to piggy-back. I've reimplemented the test-side name validation that we did before that API was created. We can revisit this this later but I'd like to get those tests passing; making the API work reliably would be a much more involved update. (The existing API validation can be enabled via the new `webtest.remote.domain.validation` test property)

#### Related Pull Requests
- #2571 

#### Changes
- Avoid creating long list key field names
- Stop using the server to validate random field and domain names
