### PR TITLE
Update tests to stop using controller-first URLs

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1418,7 +1418,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                 }
             }
             msSinceTestStart = System.currentTimeMillis() - previousLeakCheck;
-            beginAt("/admin/memTracker.view?gc=1&clearCaches=1", 120000);
+            beginAt(WebTestHelper.buildURL("admin", "memTracker", Map.of("gc", 1, "clearCaches", 1)), 120000);
             if (!isTextPresent("In-Use Objects"))
                 throw new IllegalStateException("Asserts must be enabled to track memory leaks; add -ea to your server VM params and restart or add -DmemCheck=false to your test VM params.");
             leakCount = getImageWithAltTextCount("expand/collapse");
@@ -1612,7 +1612,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         int rowCount, coveredActions, totalActions;
         double actionCoveragePercent;
         String actionCoveragePercentString;
-        beginAt("/admin/actions.view");
+        beginAt(WebTestHelper.buildURL("admin", "actions"));
 
         rowCount = getTableRowCount(ACTION_SUMMARY_TABLE_NAME);
         if (getTableCellText(Locator.id(ACTION_SUMMARY_TABLE_NAME), rowCount - 1, 0).equals("Total"))
@@ -1689,7 +1689,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     protected void setSelectedFields(String containerPath, String schema, String query, String viewName, String[] fields)
     {
         pushLocation();
-        beginAt("/query" + containerPath + "/internalNewView.view");
+        beginAt(WebTestHelper.buildURL("query", containerPath, "internalNewView"));
         setFormElement(Locator.name("ff_schemaName"), schema);
         setFormElement(Locator.name("ff_queryName"), query);
         if (viewName != null)

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -1095,7 +1095,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
     {
         if ( isGuestModeTest() )
             return;
-        beginAt("/admin/customizeSite.view");
+        beginAt(WebTestHelper.buildURL("admin", "customizeSite"));
         click(Locator.radioButtonByNameAndValue("systemMaintenanceInterval", "never"));
         clickButton("Save");
     }

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -98,7 +98,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.labkey.test.TestProperties.isDevModeEnabled;
 import static org.labkey.test.WebTestHelper.buildURL;
-import static org.labkey.test.WebTestHelper.getBaseURL;
 import static org.labkey.test.WebTestHelper.getHttpClientBuilder;
 import static org.labkey.test.WebTestHelper.getHttpResponse;
 import static org.labkey.test.WebTestHelper.getRemoteApiConnection;
@@ -853,16 +852,16 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         String initialText = "Welcome! We see that this is your first time logging in.";
 
         // These requests should redirect to the initial user page
-        beginAt("/login/resetPassword.view");
+        beginAt(WebTestHelper.buildURL("login", "resetPassword"));
         assertTextPresent(initialText);
-        beginAt("/admin/maintenance.view");
+        beginAt(WebTestHelper.buildURL("admin", "maintenance"));
         assertTextPresent(initialText);
     }
 
     @LogMethod
     private void verifyRedirectBehavior(String upgradeText) throws IOException
     {
-        // Do these checks via direct http requests the primary upgrade window seems to interfere with this test, #15853
+        // Do these checks via direct http requests the primary upgrade window seems to interfere with this test, F15853
 
         CloseableHttpResponse response = null;
         HttpUriRequest method;
@@ -872,14 +871,14 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         {
             // These requests should NOT redirect to the upgrade page
 
-            method = new HttpGet(getBaseURL() + "/login/resetPassword.view");
+            method = new HttpGet(WebTestHelper.buildURL("login", "resetPassword"));
             response = client.execute(method, WebTestHelper.getBasicHttpContext());
             status = response.getCode();
             assertEquals("Unexpected response", HttpStatus.SC_OK, status);
             assertFalse("Upgrade text found", WebTestHelper.getHttpResponseBody(response).contains(upgradeText));
             EntityUtils.consume(response.getEntity());
 
-            method = new HttpGet(getBaseURL() + "/admin/maintenance.view");
+            method = new HttpGet(WebTestHelper.buildURL("admin", "maintenance"));
             response = client.execute(method, WebTestHelper.getBasicHttpContext());
             status = response.getCode();
             assertEquals("Unexpected response", HttpStatus.SC_OK, status);
@@ -941,7 +940,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                 loginParams.add(new BasicNameValuePair("password", PasswordUtil.getPassword()));
 
                 // Login to get CSRF token
-                HttpPost loginMethod = new HttpPost(getBaseURL() + "/login/loginApi.api");
+                HttpPost loginMethod = new HttpPost(WebTestHelper.buildURL("login", "loginApi.api"));
                 loginMethod.setEntity(new UrlEncodedFormEntity(loginParams));
                 HttpClientContext httpContext = WebTestHelper.getBasicHttpContext();
                 response = redirectClient.execute(loginMethod, httpContext);
@@ -953,7 +952,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
                 Optional<Cookie> csrfToken = httpContext.getCookieStore().getCookies().stream().filter(c -> c.getName().equals(Connection.X_LABKEY_CSRF)).findAny();
                 csrfToken.ifPresent(cookie -> logoutParams.add(new BasicNameValuePair(Connection.X_LABKEY_CSRF, cookie.getValue())));
                 // Logout to verify redirect
-                HttpPost logoutMethod = new HttpPost(getBaseURL() + "/login/logout.view");
+                HttpPost logoutMethod = new HttpPost(WebTestHelper.buildURL("login", "logout"));
                 logoutMethod.setEntity(new UrlEncodedFormEntity(logoutParams));
                 response = redirectClient.execute(logoutMethod, httpContext);
                 status = response.getCode();

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -861,7 +861,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
     @LogMethod
     private void verifyRedirectBehavior(String upgradeText) throws IOException
     {
-        // Do these checks via direct http requests the primary upgrade window seems to interfere with this test, F15853
+        // Do these checks via direct http requests the primary upgrade window seems to interfere with this test, #15853
 
         CloseableHttpResponse response = null;
         HttpUriRequest method;

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -434,7 +434,6 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         assertTrue(String.format("Wrong errors.\nExpected: ['%s']\nActual: '%s'", String.join("',\n'", expectedMessages), errorText), missingErrors.isEmpty());
     }
 
-    @Deprecated // TODO: Call the variant that takes a userId instead
     protected String setInitialPassword(String email)
     {
         return setInitialPassword(_userHelper.getUserId(email));

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -135,6 +135,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -187,6 +188,8 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
     private final Stack<String> _locationStack = new Stack<>();
     private String _savedLocation = null;
+
+    private static final Set<String> _controllerFirstUrls = new HashSet<>();
 
     static
     {
@@ -1210,9 +1213,10 @@ public abstract class WebDriverWrapper implements WrapsDriver
             {
                 try
                 {
-                    if (new Crawler.ControllerActionId(relativeURL).isControllerFirstUrl())
+                    if (new Crawler.ControllerActionId(relativeURL).isControllerFirstUrl() && !_controllerFirstUrls.contains(url))
                     {
-                        RuntimeException ex = new RuntimeException("Controller first url found in URL: " + relativeURL);
+                        _controllerFirstUrls.add(url);
+                        RuntimeException ex = new RuntimeException("Controller-first url used: " + relativeURL);
                         if (TestProperties.isControllerFirstUrlFatal())
                             throw ex;
                         else

--- a/src/org/labkey/test/pages/OlapTestJson.java
+++ b/src/org/labkey/test/pages/OlapTestJson.java
@@ -38,7 +38,7 @@ public class OlapTestJson
 
     public void goToPage(String path, String configId, String schemaName, String cubeName)
     {
-        _test.beginAt(WebTestHelper.buildURL("olap", path, "testJson.view", Map.of(
+        _test.beginAt(WebTestHelper.buildURL("olap", path, "testJson", Map.of(
                 "configId", configId,
                 "schemaName", schemaName,
                 "cubeName", cubeName)));

--- a/src/org/labkey/test/pages/OlapTestJson.java
+++ b/src/org/labkey/test/pages/OlapTestJson.java
@@ -18,6 +18,9 @@ package org.labkey.test.pages;
 import org.apache.commons.lang3.StringUtils;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.WebTestHelper;
+
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -35,7 +38,10 @@ public class OlapTestJson
 
     public void goToPage(String path, String configId, String schemaName, String cubeName)
     {
-        _test.beginAt("/olap/" + path + "/testJson.view?configId=" + configId + "&schemaName=" + schemaName + "&cubeName=" + cubeName);
+        _test.beginAt(WebTestHelper.buildURL("olap", path, "testJson.view", Map.of(
+                "configId", configId,
+                "schemaName", schemaName,
+                "cubeName", cubeName)));
     }
 
     public void submitQueryAsJson(String query)

--- a/src/org/labkey/test/pages/query/ExecuteQueryPage.java
+++ b/src/org/labkey/test/pages/query/ExecuteQueryPage.java
@@ -44,7 +44,7 @@ public class ExecuteQueryPage extends LabKeyPage<ExecuteQueryPage.ElementCache>
     {
         return new RelativeUrl("query", "executeQuery")
                 .addParameters(Maps.of("schemaName", schemaName, "query.queryName", queryName))
-                .getPageFactory(wd -> new ExecuteQueryPage(wd));
+                .getPageFactory(ExecuteQueryPage::new);
     }
 
     public DataRegionTable getDataRegion()
@@ -58,7 +58,7 @@ public class ExecuteQueryPage extends LabKeyPage<ExecuteQueryPage.ElementCache>
         return new ElementCache();
     }
 
-    protected class ElementCache extends LabKeyPage.ElementCache
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
         DataRegionTable _dataRegionTable = new DataRegionTable.DataRegionFinder(getDriver()).withName("query").findWhenNeeded(this);
     }

--- a/src/org/labkey/test/pages/query/UpdateQueryRowPage.java
+++ b/src/org/labkey/test/pages/query/UpdateQueryRowPage.java
@@ -48,6 +48,13 @@ public class UpdateQueryRowPage extends LabKeyPage<UpdateQueryRowPage.ElementCac
         return new UpdateQueryRowPage(webDriverWrapper.getDriver());
     }
 
+    public static UpdateQueryRowPage beginAtInsertRowPage(WebDriverWrapper webDriverWrapper, String containerPath, String schemaName, String queryName)
+    {
+        webDriverWrapper.beginAt(WebTestHelper.buildURL("query", containerPath, "insertQueryRow",
+            Map.of("schemaName", schemaName, "query.queryName", queryName)));
+        return new UpdateQueryRowPage(webDriverWrapper.getDriver());
+    }
+
     public void update(Map<String, ?> fields)
     {
         setFields(fields);

--- a/src/org/labkey/test/tests/AbstractQWPTest.java
+++ b/src/org/labkey/test/tests/AbstractQWPTest.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
+import org.labkey.test.WebTestHelper;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -39,7 +40,7 @@ public abstract class AbstractQWPTest extends BaseWebDriverTest
     protected void testQWPDemoPage()
     {
         log("Begin testing QWPDemo page");
-        beginAt("/simpletest/" + getProjectName() + "/QWPDemo.view");
+        beginAt(WebTestHelper.buildURL("simpletest", getProjectName(), "QWPDemo"));
 
         log("Drop and reload QWPDemo test data");
         clickButton("Drop schema and clear test data");
@@ -60,7 +61,7 @@ public abstract class AbstractQWPTest extends BaseWebDriverTest
         getTabSignalsPairs().stream().forEach(this::testQWPTab);
 
         log("Drop QWPDemo test data");
-        beginAt("/simpletest/" + getProjectName() + "/QWPDemo.view");
+        beginAt(WebTestHelper.buildURL("simpletest", getProjectName(), "QWPDemo"));
         clickButton("Drop schema and clear test data"); // drop domain, needed for clean up project
     }
 

--- a/src/org/labkey/test/tests/AuditLogTest.java
+++ b/src/org/labkey/test/tests/AuditLogTest.java
@@ -63,6 +63,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.labkey.test.WebTestHelper.buildURL;
 import static org.labkey.test.util.PasswordUtil.getUsername;
 
 @Category({Daily.class, Hosting.class})
@@ -526,20 +527,27 @@ public class AuditLogTest extends BaseWebDriverTest
 
     protected void verifyListAuditLogQueries(Visibility v)
     {
-        beginAt("/query/" + getProjectName() + "/executeQuery.view?schemaName=auditLog&query.queryName=ListAuditEvent&query.containerFilterName=CurrentAndSubfolders");
+        beginAt(buildURL("query", getProjectName(), "executeQuery",
+            Map.of("schemaName", "auditLog",
+                "query.queryName", "ListAuditEvent",
+                "query.containerFilterName", "CurrentAndSubfolders")));
         verifyAuditQueryEvent(this, "List", "Parent List", 1, canSeeParent(v));
         verifyAuditQueryEvent(this, "List", "Child List", 1, canSeeChild(v));
     }
 
     protected void verifyAuditQueries(boolean canSeeAuditLog)
     {
-        beginAt("/query/" + getProjectName() + "/executeQuery.view?schemaName=auditLog&query.queryName=ContainerAuditEvent");
+        beginAt(buildURL("query", getProjectName(), "executeQuery",
+            Map.of("schemaName", "auditLog",
+                "query.queryName", "ContainerAuditEvent")));
         if (canSeeAuditLog)
             verifyAuditQueryEvent(this, COMMENT_COLUMN, AUDIT_TEST_PROJECT + " was created", 1);
         else
             assertTextPresent("No data to show.");
 
-        beginAt("/query/" + getProjectName() + "/executeQuery.view?schemaName=auditLog&query.queryName=GroupAuditEvent");
+        beginAt(buildURL("query", getProjectName(), "executeQuery",
+            Map.of("schemaName", "auditLog",
+                "query.queryName", "GroupAuditEvent")));
         if (canSeeAuditLog)
             verifyAuditQueryEvent(this, COMMENT_COLUMN, "The user " + AUDIT_TEST_USER + " was assigned to the security role Editor.", 1);
         else

--- a/src/org/labkey/test/tests/AuditLogTest.java
+++ b/src/org/labkey/test/tests/AuditLogTest.java
@@ -38,6 +38,7 @@ import org.labkey.test.components.domain.DomainFieldRow;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.core.admin.logger.ManagerPage.LoggingLevel;
 import org.labkey.test.pages.list.EditListDefinitionPage;
+import org.labkey.test.pages.query.ExecuteQueryPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.util.ApiPermissionsHelper;
@@ -63,7 +64,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.labkey.test.WebTestHelper.buildURL;
 import static org.labkey.test.util.PasswordUtil.getUsername;
 
 @Category({Daily.class, Hosting.class})
@@ -527,27 +527,22 @@ public class AuditLogTest extends BaseWebDriverTest
 
     protected void verifyListAuditLogQueries(Visibility v)
     {
-        beginAt(buildURL("query", getProjectName(), "executeQuery",
-            Map.of("schemaName", "auditLog",
-                "query.queryName", "ListAuditEvent",
-                "query.containerFilterName", "CurrentAndSubfolders")));
+        ExecuteQueryPage.getPageFactory("auditLog", "ListAuditEvent")
+                .addParameter("query.containerFilterName", "CurrentAndSubfolders")
+                .navigate(this, getProjectName());
         verifyAuditQueryEvent(this, "List", "Parent List", 1, canSeeParent(v));
         verifyAuditQueryEvent(this, "List", "Child List", 1, canSeeChild(v));
     }
 
     protected void verifyAuditQueries(boolean canSeeAuditLog)
     {
-        beginAt(buildURL("query", getProjectName(), "executeQuery",
-            Map.of("schemaName", "auditLog",
-                "query.queryName", "ContainerAuditEvent")));
+        ExecuteQueryPage.beginAt(this, getProjectName(), "auditLog", "ContainerAuditEvent");
         if (canSeeAuditLog)
             verifyAuditQueryEvent(this, COMMENT_COLUMN, AUDIT_TEST_PROJECT + " was created", 1);
         else
             assertTextPresent("No data to show.");
 
-        beginAt(buildURL("query", getProjectName(), "executeQuery",
-            Map.of("schemaName", "auditLog",
-                "query.queryName", "GroupAuditEvent")));
+        ExecuteQueryPage.beginAt(this, getProjectName(), "auditLog", "GroupAuditEvent");
         if (canSeeAuditLog)
             verifyAuditQueryEvent(this, COMMENT_COLUMN, "The user " + AUDIT_TEST_USER + " was assigned to the security role Editor.", 1);
         else

--- a/src/org/labkey/test/tests/BaseTermsOfUseTest.java
+++ b/src/org/labkey/test/tests/BaseTermsOfUseTest.java
@@ -19,12 +19,14 @@ import org.junit.BeforeClass;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.WikiHelper;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class BaseTermsOfUseTest extends BaseWebDriverTest
 {
@@ -119,7 +121,7 @@ public class BaseTermsOfUseTest extends BaseWebDriverTest
         else // site-wide terms of use page
         {
             message = "Create site-wide terms of use page";
-            beginAt("/wiki/page.view?name=_termsOfUse");
+            beginAt(WebTestHelper.buildURL("wiki", "page", Map.of("name", TERMS_OF_USE_NAME)));
         }
         if (isElementPresent(Locator.linkContainingText("add a new page")))
         {

--- a/src/org/labkey/test/tests/BasicAdminTest.java
+++ b/src/org/labkey/test/tests/BasicAdminTest.java
@@ -24,6 +24,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestProperties;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Base;
 import org.labkey.test.categories.DRT;
 import org.labkey.test.categories.Daily;
@@ -108,7 +109,7 @@ public class BasicAdminTest extends BaseWebDriverTest
         goToHome();
         final String expectedTitle = getDriver().getTitle();
 
-        beginAt("/login/initialUser.view");
+        beginAt(WebTestHelper.buildURL("login", "initialUser"));
         Assert.assertEquals("Initial user action did not redirect properly when logged in", expectedTitle, getDriver().getTitle());
     }
 

--- a/src/org/labkey/test/tests/ButtonCustomizationTest.java
+++ b/src/org/labkey/test/tests/ButtonCustomizationTest.java
@@ -21,6 +21,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
@@ -107,9 +108,9 @@ public class ButtonCustomizationTest extends BaseWebDriverTest
             .update(Map.of("name", "Seattle"));
         new DataRegionFinder(getDriver()).find().clickInsertNewRow()
             .update(Map.of("name", "Portland"));
-        
+
         // assert custom buttons can be added to the standard set:
-        beginAt("/query/" + PROJECT_NAME + "/schema.view?schemaName=lists");
+        beginAt(WebTestHelper.buildURL("query", PROJECT_NAME, "schema", Map.of("schemaName", "lists")));
         selectQuery("lists", "Cities");
         waitForText(10000, "edit metadata");
         clickAndWait(Locator.linkWithText("edit metadata"));
@@ -131,7 +132,7 @@ public class ButtonCustomizationTest extends BaseWebDriverTest
         assertElementPresent(Locator.tagWithAttribute("a", "data-original-title","Insert data"));
 
         // assert custom buttons can REPLACE the standard set:
-        beginAt("/query/" + PROJECT_NAME + "/schema.view?schemaName=lists");
+        beginAt(WebTestHelper.buildURL("query", PROJECT_NAME, "schema", Map.of("schemaName", "lists")));
         selectQuery("lists", "Cities");
         waitForText(10000, "edit metadata");
         clickAndWait(Locator.linkWithText("edit metadata"));
@@ -198,7 +199,7 @@ public class ButtonCustomizationTest extends BaseWebDriverTest
 
         // wait for the button to enable:
         waitForElement(Locator.lkButton(METADATA_GET_BUTTON), 10000);
-        
+
         // Verify that GET buttons to send form values as GET parameters:
         clickButton(METADATA_GET_BUTTON);
         assertElementPresent(Locator.id("params").containing(".select: 2"));

--- a/src/org/labkey/test/tests/ContainerContextTest.java
+++ b/src/org/labkey/test/tests/ContainerContextTest.java
@@ -33,6 +33,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Data;
+import org.labkey.test.pages.query.ExecuteQueryPage;
 import org.labkey.test.pages.reports.ScriptReportPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldKey;
@@ -336,7 +337,9 @@ public class ContainerContextTest extends BaseWebDriverTest
 
         // Verify Issue 16243: Details URL creating URLs with null container unless the container column is actually added to current view
         log("** Removing container column and rechecking lookup URLs...");
-        beginAt(WebTestHelper.buildURL("query", getProjectName(), "executeQuery", Map.of("schemaName", "vehicle", "query.queryName", "EmissionTest", "query.sort", "RowId")));
+        ExecuteQueryPage queryPage = ExecuteQueryPage.getPageFactory("vehicle", "EmissionTest")
+                .addParameter("query.sort", "RowId")
+                .navigate(this, getProjectName());
         _customizeViewsHelper.openCustomizeViewPanel();
         _customizeViewsHelper.showHiddenItems();
         _customizeViewsHelper.removeColumn("Container");
@@ -504,9 +507,11 @@ public class ContainerContextTest extends BaseWebDriverTest
             int vehicleId)
     {
         log("** Checking containers on lookup URLs for '" + queryName + "'");
-        beginAt(WebTestHelper.buildURL("query", getProjectName(), "executeQuery", Map.of("schemaName", "vehicle", "query.queryName", queryName, "query.sort", "RowId")));
+        ExecuteQueryPage queryPage = ExecuteQueryPage.getPageFactory("vehicle", queryName)
+                .addParameter("query.sort", "RowId")
+                .navigate(this, getProjectName());
 
-        DataRegionTable dr = new DataRegionTable("query", this);
+        DataRegionTable dr = queryPage.getDataRegion();
 
         for (int i = 0; i < max; i++)
         {

--- a/src/org/labkey/test/tests/ContainerContextTest.java
+++ b/src/org/labkey/test/tests/ContainerContextTest.java
@@ -337,7 +337,7 @@ public class ContainerContextTest extends BaseWebDriverTest
 
         // Verify Issue 16243: Details URL creating URLs with null container unless the container column is actually added to current view
         log("** Removing container column and rechecking lookup URLs...");
-        ExecuteQueryPage queryPage = ExecuteQueryPage.getPageFactory("vehicle", "EmissionTest")
+        ExecuteQueryPage.getPageFactory("vehicle", "EmissionTest")
                 .addParameter("query.sort", "RowId")
                 .navigate(this, getProjectName());
         _customizeViewsHelper.openCustomizeViewPanel();

--- a/src/org/labkey/test/tests/ContainerContextTest.java
+++ b/src/org/labkey/test/tests/ContainerContextTest.java
@@ -212,7 +212,7 @@ public class ContainerContextTest extends BaseWebDriverTest
         insertJobIntoSubFolder(SUB_FOLDER_B);
 
         log("** Viewing pipeline status from project container. Sort by Description (report name) and include sub-folders");
-        beginAt("/" + getProjectName() + "/pipeline-status-showList.view?StatusFiles.sort=Description&StatusFiles.containerFilterName=CurrentAndSubfolders");
+        beginAt(WebTestHelper.buildURL("pipeline-status", getProjectName(), "showList", Map.of("StatusFiles.sort", "Description", "StatusFiles.containerFilterName", "CurrentAndSubfolders")));
 
         log("** Checking URLs go to correct container...");
         String href = getAttribute(Locator.tagWithText("a", "COMPLETE").index(0), "href");
@@ -336,7 +336,7 @@ public class ContainerContextTest extends BaseWebDriverTest
 
         // Verify Issue 16243: Details URL creating URLs with null container unless the container column is actually added to current view
         log("** Removing container column and rechecking lookup URLs...");
-        beginAt("/query/" + getProjectName() + "/executeQuery.view?schemaName=vehicle&query.queryName=EmissionTest&query.sort=RowId");
+        beginAt(WebTestHelper.buildURL("query", getProjectName(), "executeQuery", Map.of("schemaName", "vehicle", "query.queryName", "EmissionTest", "query.sort", "RowId")));
         _customizeViewsHelper.openCustomizeViewPanel();
         _customizeViewsHelper.showHiddenItems();
         _customizeViewsHelper.removeColumn("Container");
@@ -365,7 +365,7 @@ public class ContainerContextTest extends BaseWebDriverTest
         overrideMetadata(getProjectName(), "vehicle", emissionTestQuery, customMetadata.apply(emissionTestQuery));
         verifySimpleModuleTables(emissionTestQuery, "XXX.view", "XXX.view", max, workbookIds, emissionIds, parentRowIds, rowIdToWorkbookId, false, true, vehicleId);
         removeMetadata(getProjectName(), "vehicle", emissionTestQuery);
-        
+
         log("** Create custom query with custom metadata over vehicle.emissiontest table WITH container");
         String customQueryWithContainer =
                 "SELECT emissiontest.rowid,\n" +
@@ -504,7 +504,7 @@ public class ContainerContextTest extends BaseWebDriverTest
             int vehicleId)
     {
         log("** Checking containers on lookup URLs for '" + queryName + "'");
-        beginAt("/query/" + getProjectName() + "/executeQuery.view?schemaName=vehicle&query.queryName=" + queryName + "&query.sort=RowId");
+        beginAt(WebTestHelper.buildURL("query", getProjectName(), "executeQuery", Map.of("schemaName", "vehicle", "query.queryName", queryName, "query.sort", "RowId")));
 
         DataRegionTable dr = new DataRegionTable("query", this);
 

--- a/src/org/labkey/test/tests/ExternalSchemaTest.java
+++ b/src/org/labkey/test/tests/ExternalSchemaTest.java
@@ -42,7 +42,9 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Data;
 import org.labkey.test.pages.core.admin.ShowAuditLogPage;
+import org.labkey.test.pages.query.ExecuteQueryPage;
 import org.labkey.test.pages.query.InsertExternalSchemaPage;
+import org.labkey.test.pages.query.UpdateQueryRowPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.SchemaHelper;
 import org.labkey.test.util.SimpleHttpResponse;
@@ -87,7 +89,7 @@ public class ExternalSchemaTest extends BaseWebDriverTest
         {
             this(null, text, intNotNull, dateTimeNotNull);
         }
-        
+
         public Row(Integer rowid, String text, int intNotNull, Date dateTimeNotNull)
         {
             this.rowid = rowid;
@@ -108,7 +110,7 @@ public class ExternalSchemaTest extends BaseWebDriverTest
         {
             this(test, intNotNull, null);
         }
-        
+
         public Row(int rowid, String test, int intNotNull)
         {
             this(rowid, test, intNotNull, null);
@@ -188,7 +190,7 @@ public class ExternalSchemaTest extends BaseWebDriverTest
     void ensureExternalSchema(String containerPath)
     {
         log("** Create ExternalSchema: " + USER_SCHEMA_NAME);
-        beginAt("/query/" + containerPath + "/admin.view");
+        beginAt(WebTestHelper.buildURL("query", containerPath, "admin"));
 
         if (!isElementPresent(Locator.linkWithText("reload")))
         {
@@ -206,7 +208,7 @@ public class ExternalSchemaTest extends BaseWebDriverTest
 
     void setEditable(String containerPath, boolean editable)
     {
-        beginAt("/query/" + containerPath + "/admin.view");
+        beginAt(WebTestHelper.buildURL("query", containerPath, "admin"));
         clickAndWait(Locator.linkWithText("edit"));
         if (editable)
             checkCheckbox(Locator.checkboxByName("editable"));
@@ -322,10 +324,11 @@ public class ExternalSchemaTest extends BaseWebDriverTest
     void doTestContainer()
     {
         log("** Trying to visit schema in container where it hasn't been configured");
-        beginAt("/query/" + PROJECT_NAME + "/" + FOLDER_NAME + "/executeQuery.view?query.queryName=" + TABLE_NAME + "&schemaName=" + USER_SCHEMA_NAME);
+        ExecuteQueryPage.getPageFactory(USER_SCHEMA_NAME, TABLE_NAME)
+                .navigate(this, PROJECT_NAME + "/" + FOLDER_NAME);
         assertTitleEquals("404: Error Page -- The specified schema does not exist");
     }
-    
+
     void doTestViaForm()
     {
         String containerPath = StringUtils.join(Arrays.asList(PROJECT_NAME, FOLDER_NAME), "/");
@@ -348,7 +351,7 @@ public class ExternalSchemaTest extends BaseWebDriverTest
         log("** Delete via form");
         deleteViaForm(containerPath, new int[] { pk1, pk2});
     }
-    
+
     void doTestViaJavaApi() throws Exception
     {
         String containerPath = StringUtils.join(Arrays.asList(PROJECT_NAME, FOLDER_NAME), "/");
@@ -360,7 +363,7 @@ public class ExternalSchemaTest extends BaseWebDriverTest
         Row[] selected = selectViaJavaApi(containerPath, cn, pks);
         for (int i = 0; i < inserted.length; i++)
             assertEquals(inserted[i], selected[i]);
-        
+
         Row[] updated = new Row[] {new Row(pks[0], "AA", 30), new Row(pks[1], "BB", 40)};
         updateViaJavaApi(containerPath, cn, updated);
 
@@ -379,7 +382,7 @@ public class ExternalSchemaTest extends BaseWebDriverTest
         }
 
         updateDuplicateRows(PROJECT_NAME, cn, updated);
-        
+
         try
         {
             log("** Try to delete via api from a different container");
@@ -392,20 +395,20 @@ public class ExternalSchemaTest extends BaseWebDriverTest
 //            assertEquals("The row is from the wrong container.", ex.getMessage());
 //            assertEquals("org.labkey.api.view.UnauthorizedException", ex.getProperties().get("exceptionClass"));
         }
-        
+
         deleteViaJavaApi(containerPath, cn, pks);
     }
-    
+
     int[] insertViaJavaApi(String containerPath, Connection cn, Row... rows) throws IOException, CommandException
     {
         log("** Inserting via api...");
         InsertRowsCommand cmd = new InsertRowsCommand(USER_SCHEMA_NAME, TABLE_NAME);
         for (Row row : rows)
             cmd.addRow(row.toMap());
-        
+
         RowsResponse resp = cmd.execute(cn, containerPath);
         assertEquals("Expected to insert " + rows.length + " rows", rows.length, resp.getRowsAffected().intValue());
-        
+
         int[] pks = new int[rows.length];
         for (int i = 0; i < rows.length; i++)
         {
@@ -413,10 +416,10 @@ public class ExternalSchemaTest extends BaseWebDriverTest
             assertTrue(row.containsKey("rowid"));
             pks[i] = ((Number)row.get("rowid")).intValue();
         }
-        
+
         return pks;
     }
-    
+
     Row[] selectViaJavaApi(String containerPath, Connection cn, int... pks) throws IOException, CommandException
     {
         log("** Select via api: " + join(",", pks) + "...");
@@ -433,7 +436,7 @@ public class ExternalSchemaTest extends BaseWebDriverTest
             Map<String, Object> row = resp.getRows().get(i);
             Integer rowid = (Integer)row.get("RowId");
             assertEquals("Expected requested rowid and selected rowid to be the same", rowid.intValue(), pks[i]);
-            
+
             String text = (String)row.get("Text");
             int intNotNull = ((Number)row.get("IntNotNull")).intValue();
             Date datetimeNotNull = (Date)row.get("DatetimeNotNull");
@@ -442,7 +445,7 @@ public class ExternalSchemaTest extends BaseWebDriverTest
         }
         return rows.toArray(new Row[0]);
     }
-    
+
     Row[] updateViaJavaApi(String containerPath, Connection cn, Row... rows) throws ParseException, IOException, CommandException
     {
         log("** Updating via api...");
@@ -483,17 +486,17 @@ public class ExternalSchemaTest extends BaseWebDriverTest
         }
 
     }
-    
+
     void deleteViaJavaApi(String containerPath, Connection cn, int... pks) throws IOException, CommandException
     {
         log("** Deleting via api: pks=" + join(",", pks) + "...");
         DeleteRowsCommand cmd = new DeleteRowsCommand(USER_SCHEMA_NAME, TABLE_NAME);
         for (Integer pk : pks)
             cmd.addRow(Collections.singletonMap("RowId", pk));
-        
+
         RowsResponse resp = cmd.execute(cn, containerPath);
         assertEquals("Expected to delete " + pks.length + " rows", pks.length, resp.getRowsAffected().intValue());
-        
+
         SelectRowsCommand selectCmd = new SelectRowsCommand(USER_SCHEMA_NAME, TABLE_NAME);
         selectCmd.addFilter("RowId", join(";", pks), Filter.Operator.IN);
         SelectRowsResponse selectResp = selectCmd.execute(cn, containerPath);
@@ -512,17 +515,17 @@ public class ExternalSchemaTest extends BaseWebDriverTest
     private void _insertViaForm(String containerPath, String text, int intNotNull)
     {
         log("** Inserting via form: text='" + text + "', intNotNull=" + intNotNull + "...");
-        beginAt("/query/" + containerPath + "/insertQueryRow.view?query.queryName=" + TABLE_NAME + "&schemaName=" + USER_SCHEMA_NAME);
-        setFormElement(Locator.name("quf_Text"), text);
-        setFormElement(Locator.name("quf_IntNotNull"), String.valueOf(intNotNull));
-        setFormElement(Locator.name("quf_DatetimeNotNull"), "2008-09-25");
-        submit();
+        UpdateQueryRowPage page = UpdateQueryRowPage.beginAtInsertRowPage(this, containerPath, USER_SCHEMA_NAME, TABLE_NAME);
+        page.setField("Text", text);
+        page.setField("IntNotNull", String.valueOf(intNotNull));
+        page.setField("DatetimeNotNull", "2008-09-25");
+        page.submit();
     }
 
     public void insertViaFormNoPerms(String containerPath, String text, int intNotNull)
     {
         log("** Inserting via form: text='" + text + "', intNotNull=" + intNotNull + "...");
-        beginAt("/query/" + containerPath + "/insertQueryRow.view?query.queryName=" + TABLE_NAME + "&schemaName=" + USER_SCHEMA_NAME);
+        UpdateQueryRowPage.beginAtInsertRowPage(this, containerPath, USER_SCHEMA_NAME, TABLE_NAME);
         assertTextPresent("You do not have permission");
     }
 
@@ -552,11 +555,11 @@ public class ExternalSchemaTest extends BaseWebDriverTest
     private void _updateViaForm(String containerPath, int pk, String text, int intNotNull)
     {
         log("** Updating via form: RowId=" + pk + ", text='" + text + "', intNotNull=" + intNotNull + "...");
-        beginAt("/query/" + containerPath + "/updateQueryRow.view?query.queryName=" + TABLE_NAME + "&schemaName=" + USER_SCHEMA_NAME + "&RowId=" + pk);
-        setFormElement(Locator.name("quf_Text"), text);
-        setFormElement(Locator.name("quf_IntNotNull"), String.valueOf(intNotNull));
-        setFormElement(Locator.name("quf_DatetimeNotNull"), "2008-09-25");
-        submit();
+        UpdateQueryRowPage page = UpdateQueryRowPage.beginAt(this, containerPath, USER_SCHEMA_NAME, TABLE_NAME, pk);
+        page.setField("Text", text);
+        page.setField("IntNotNull", String.valueOf(intNotNull));
+        page.setField("DatetimeNotNull", "2008-09-25");
+        page.submit();
     }
 
     public void updateViaFormNoPerms(String containerPath, int pk, String text, int intNotNull) throws IOException
@@ -585,9 +588,11 @@ public class ExternalSchemaTest extends BaseWebDriverTest
     private void _deleteViaForm(String containerPath, int[] pk)
     {
         log("** Deleting via form: pks=" + join(",", pk) + "...");
-        beginAt("/query/" + containerPath + "/executeQuery.view?query.queryName=" + TABLE_NAME + "&schemaName=" + USER_SCHEMA_NAME);
+        ExecuteQueryPage page = ExecuteQueryPage.getPageFactory(USER_SCHEMA_NAME, TABLE_NAME)
+                .setContainerPath(containerPath)
+                .navigate(this);
 
-        DataRegionTable drt = new DataRegionTable("query", getDriver());
+        DataRegionTable drt = page.getDataRegion();
         for (int aPk : pk)
             drt.checkCheckboxByPrimaryKey(aPk);
         doAndWaitForPageToLoad(() ->

--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -29,9 +29,11 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Data;
 import org.labkey.test.components.CustomizeView;
+import org.labkey.test.pages.list.BeginPage;
 import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.pages.list.GridPage;
 import org.labkey.test.pages.query.QueryMetadataEditorPage;
+import org.labkey.test.pages.query.SourceQueryPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldInfo;
 import org.labkey.test.params.experiment.DataClassDefinition;
@@ -44,7 +46,6 @@ import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.AuditLogHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
-import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SchemaHelper;
 import org.labkey.test.util.TestDataGenerator;
 import org.labkey.test.util.exp.DataClassAPIHelper;
@@ -680,18 +681,16 @@ public class LinkedSchemaTest extends BaseWebDriverTest
         listDef.getCreateCommand().execute(createDefaultConnection(), getProjectName() + "/" + SOURCE_FOLDER);
 
         log("** Importing some data...");
-        beginAt("/" + PROJECT_NAME + "/" + SOURCE_FOLDER + "/list-begin.view");
+        BeginPage.beginAt(this, PROJECT_NAME + "/" + SOURCE_FOLDER);
         _listHelper.goToList(LIST_NAME);
         _listHelper.clickImportData()
                 .setText(LIST_DATA)
                 .submit();
 
         log("** Applying metadata xml override to list...");
-        beginAt("/query/" + PROJECT_NAME + "/" + SOURCE_FOLDER + "/sourceQuery.view?schemaName=lists&query.queryName=" + LIST_NAME + "#metadata");
-        setCodeEditorValue("metadataText", LIST_METADATA_OVERRIDE);
-        clickButton("Save", 0);
-        waitForElement(Locator.id("status").withText("Saved"), WAIT_FOR_JAVASCRIPT);
-        waitForElementToDisappear(Locator.id("status").withText("Saved"), WAIT_FOR_JAVASCRIPT);
+        SourceQueryPage page = SourceQueryPage.beginAt(this, PROJECT_NAME + "/" + SOURCE_FOLDER, "lists", LIST_NAME);
+        page.setMetadataXml(LIST_METADATA_OVERRIDE);
+        page.clickSaveAndFinish();
     }
 
     @LogMethod
@@ -713,20 +712,15 @@ public class LinkedSchemaTest extends BaseWebDriverTest
         _schemaHelper.createLinkedSchema(getProjectName() + "/" + TARGET_FOLDER, A_PEOPLE_SCHEMA_NAME, sourceContainerPath, null, "lists", LIST_NAME + "," + QUERY_NAME, A_PEOPLE_METADATA);
 
         log("** Applying metadata to " + LIST_NAME + " in linked schema container");
-        beginAt("/query/" + PROJECT_NAME + "/" + TARGET_FOLDER + "/sourceQuery.view?schemaName=" + A_PEOPLE_SCHEMA_NAME + "&query.queryName=" + LIST_NAME + "#metadata");
-        setCodeEditorValue("metadataText", A_PEOPLE_LIST_METADATA_OVERRIDE);
-        clickButton("Save", 0);
-        waitForElement(Locator.id("status").withText("Saved"), WAIT_FOR_JAVASCRIPT);
-        waitForElementToDisappear(Locator.id("status").withText("Saved"), WAIT_FOR_JAVASCRIPT);
+        SourceQueryPage sourceQueryPage = SourceQueryPage.beginAt(this, PROJECT_NAME + "/" + TARGET_FOLDER, A_PEOPLE_SCHEMA_NAME, LIST_NAME);
+        sourceQueryPage.setMetadataXml(A_PEOPLE_LIST_METADATA_OVERRIDE);
+        sourceQueryPage.clickSaveAndFinish();
 
         log("** Applying metadata to " + QUERY_NAME + " in linked schema container");
-        beginAt("/query/" + PROJECT_NAME + "/" + TARGET_FOLDER + "/sourceQuery.view?schemaName=" + A_PEOPLE_SCHEMA_NAME + "&queryName=" + QUERY_NAME);
+        sourceQueryPage = SourceQueryPage.beginAt(this, PROJECT_NAME + "/" + TARGET_FOLDER, A_PEOPLE_SCHEMA_NAME, QUERY_NAME);
         assertElementPresent(Locator.tagWithClass("div", "labkey-customview-message").withText("This query is not editable"));
-        _ext4Helper.clickExt4Tab("XML Metadata");
-        setCodeEditorValue("metadataText", A_PEOPLE_QUERY_METADATA_OVERRIDE);
-        clickButton("Save", 0);
-        waitForElement(Locator.id("status").withText("Saved"), WAIT_FOR_JAVASCRIPT);
-        waitForElementToDisappear(Locator.id("status").withText("Saved"), WAIT_FOR_JAVASCRIPT);
+        sourceQueryPage.setMetadataXml(A_PEOPLE_QUERY_METADATA_OVERRIDE);
+        sourceQueryPage.clickSaveAndFinish();
     }
 
     @LogMethod

--- a/src/org/labkey/test/tests/PivotQueryTest.java
+++ b/src/org/labkey/test/tests/PivotQueryTest.java
@@ -25,6 +25,7 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Data;
 import org.labkey.test.components.ChartTypeDialog;
+import org.labkey.test.pages.query.ExecuteQueryPage;
 import org.labkey.test.pages.query.SourceQueryPage;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.params.FieldDefinition;
@@ -38,8 +39,8 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 @Category({Daily.class, Data.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 7)
@@ -86,8 +87,8 @@ public class PivotQueryTest extends ReportTest
     @Test
     public void testPivotQuery()
     {
-        beginAt("/query/" + getProjectName() + "/executeQuery.view?schemaName=study&query.queryName=LuminexPivot");
-        DataRegionTable pivotTable = new DataRegionTable("query", this);
+        ExecuteQueryPage queryPage = ExecuteQueryPage.beginAt(this, getProjectName(), "study", "LuminexPivot");
+        DataRegionTable pivotTable = queryPage.getDataRegion();
         pivotTable.setSort("ParticipantId", SortDirection.ASC);
 
         Locator.XPathLocator region = Locator.tagWithAttribute("table", "data-region-name", "query");
@@ -119,7 +120,7 @@ public class PivotQueryTest extends ReportTest
         String contents = getText(ConcInRange_CONCAT_cell);
         assertNotNull("The GROUP_CONCAT cell is empty", contents);
         String[] concats = contents.split(", *");
-        assertTrue("Expected 5 GROUP_CONCAT values", concats.length == 5);
+        assertEquals("Expected 5 GROUP_CONCAT values", 5, concats.length);
     }
 
     @Test

--- a/src/org/labkey/test/tests/SampleTypeExportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeExportTest.java
@@ -19,6 +19,7 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
@@ -49,7 +50,7 @@ public class SampleTypeExportTest extends AbstractExportTest
 
         initTest._containerHelper.createProject(initTest.getProjectName(), null);
 
-        initTest.beginAt("/" + initTest.getProjectName() + "/experiment-listSampleTypes.view");
+        initTest.beginAt(WebTestHelper.buildURL("experiment", initTest.getProjectName(), "listSampleTypes"));
         SampleTypeHelper sampleHelper = new SampleTypeHelper(initTest);
         sampleHelper.createSampleType(new SampleTypeDefinition(SAMPLE_TYPE_NAME)
                         .setFields(List.of(new FieldDefinition("Barcode", FieldDefinition.ColumnType.String))),
@@ -143,7 +144,7 @@ public class SampleTypeExportTest extends AbstractExportTest
     @Override
     protected void goToDataRegionPage()
     {
-        beginAt("/" + getProjectName() + "/experiment-listSampleTypes.view");
+        beginAt(WebTestHelper.buildURL("experiment", getProjectName(), "listSampleTypes"));
         clickAndWait(Locator.linkWithText(SAMPLE_TYPE_NAME));
     }
 

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -51,6 +51,7 @@ import org.labkey.test.components.html.SiteNavBar;
 import org.labkey.test.pages.core.admin.BaseSettingsPage;
 import org.labkey.test.pages.core.admin.LookAndFeelSettingsPage;
 import org.labkey.test.pages.core.admin.ProjectSettingsPage;
+import org.labkey.test.pages.query.ExecuteQueryPage;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.list.IntListDefinition;
@@ -91,6 +92,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.labkey.test.TestFileUtils.getDefaultFileRoot;
+import static org.labkey.test.WebTestHelper.buildURL;
 
 /**
 * Tests the simple module and file-based resources introduced in version 9.1
@@ -213,7 +215,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
         SimpleModuleTest init = getCurrentTest();
         init.doSetup();
     }
-    
+
     protected void doSetup()
     {
         assertModuleDeployed(MODULE_NAME);
@@ -483,7 +485,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
     private void doTestSchemas() throws Exception
     {
         log("** Testing schemas in modules...");
-        beginAt("/query/" + getProjectName() + "/begin.view?schemaName=" + VEHICLE_SCHEMA);
+        beginAt(buildURL("query", getProjectName(), "begin", Map.of("schemaName", VEHICLE_SCHEMA)));
 
         Connection cn = WebTestHelper.getRemoteApiConnection();
 
@@ -599,13 +601,15 @@ public class SimpleModuleTest extends BaseWebDriverTest
         updateCmd.execute(cn, getProjectName());
 
         log("** Testing vehicle.Manufacturers default queryDetailsRow.view url link...");
-        beginAt("/query/" + getProjectName() + "/executeQuery.view?schemaName=" + VEHICLE_SCHEMA + "&query.queryName=Manufacturers&query.Name~eq=Toyota");
+        ExecuteQueryPage.getPageFactory(VEHICLE_SCHEMA, "Manufacturers")
+                .addParameter("query.Name~eq", "Toyota")
+                .navigate(this, getProjectName());
         DataRegionTable table = new DataRegionTable("query", getDriver());
         clickAndWait(table.detailsLink(0));
         assertTextPresent("Name", "Toyota");
 
         log("** Testing vehicle.Model RowId url link...");
-        beginAt(getProjectName() + "/query-begin.view");
+        beginAt(buildURL("query", getProjectName(), "begin"));
         viewQueryData(VEHICLE_SCHEMA, "Models");
         clickAndWait(Locator.linkWithText("Prius"));
         assertTextPresent("Hooray!");
@@ -615,7 +619,9 @@ public class SimpleModuleTest extends BaseWebDriverTest
 
 
         log("** Testing url expression null behavior for null InitialReleaseYear...");
-        beginAt("/query/" + getProjectName() + "/executeQuery.view?schemaName=vehicle&query.queryName=Models&query.InitialReleaseYear~isblank=");
+        ExecuteQueryPage.getPageFactory("vehicle", "Models")
+                .addParameter("query.InitialReleaseYear~isblank", "")
+                .navigate(this, getProjectName());
         DataRegionTable modelsGrid = new DataRegionTable("query", this);
 
         // URLs with a bad (missing) column should result in no URL being rendered
@@ -647,7 +653,9 @@ public class SimpleModuleTest extends BaseWebDriverTest
 
 
         log("** Testing url expression null behavior for non-null InitialReleaseYear...");
-        beginAt("/query/" + getProjectName() + "/executeQuery.view?schemaName=vehicle&query.queryName=Models&query.InitialReleaseYear~isnonblank=");
+        ExecuteQueryPage.getPageFactory("vehicle", "Models")
+                .addParameter("query.InitialReleaseYear~isnonblank", "")
+                .navigate(this, getProjectName());
         modelsGrid = new DataRegionTable("query", this);
 
         href = modelsGrid.getHref(0, "urlNullableColumnWithDefaultBehavior");
@@ -758,7 +766,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
 
 
         log("** Testing vehicle.Vehicles details url link...");
-        beginAt("/query/" + getProjectName() + "/schema.view?schemaName=" + VEHICLE_SCHEMA);
+        beginAt(buildURL("query", getProjectName(), "schema", Map.of("schemaName", VEHICLE_SCHEMA)));
         viewQueryData(VEHICLE_SCHEMA, "Vehicles");
         DataRegionTable vehicles = new DataRegionTable("query", getDriver());
         clickAndWait(vehicles.detailsLink(0));
@@ -870,23 +878,23 @@ public class SimpleModuleTest extends BaseWebDriverTest
     @LogMethod
     private void doTestViewEditing()
     {
-        beginAt("/" + getProjectName() + "/query-executeQuery.view?schemaName=" + VEHICLE_SCHEMA + "&query.queryName=Vehicles");
+        ExecuteQueryPage page = ExecuteQueryPage.beginAt(this, getProjectName(), VEHICLE_SCHEMA, "Vehicles");
 
-        DataRegionTable dr = new DataRegionTable("query", this);
+        DataRegionTable dr = page.getDataRegion();
 
         log("** Try to edit file-based default view");
-        _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.removeColumn("Color");
-        CustomizeView.SaveWindow saveWindow = _customizeViewsHelper.clickSave();
+        CustomizeView customizeView = dr.openCustomizeGrid();
+        customizeView.removeColumn("Color");
+        CustomizeView.SaveWindow saveWindow = customizeView.clickSave();
         assertFalse("should not be able to select default view", saveWindow.defaultViewRadio.isEnabled());
         saveWindow.cancel();
 
         dr.goToView("EditableFileBasedView");
 
         log("** Try to edit overridable file-based view");
-        _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn("Color");
-        saveWindow = _customizeViewsHelper.clickSave();
+        customizeView = dr.openCustomizeGrid();
+        customizeView.addColumn("Color");
+        saveWindow = customizeView.clickSave();
 
         assertTrue("should be able to select default view", saveWindow.defaultViewRadio.isEnabled());
         saveWindow.defaultViewRadio.check();
@@ -1023,7 +1031,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
                     deleteCmd.setRows(rows);
                     deleteCmd.execute(cn, c);
                 }
-                
+
                 assertEquals("Expected no rows remaining", 0, selectCmd.execute(cn, "Home").getRowCount().intValue());
             }
         }
@@ -1285,7 +1293,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
     @LogMethod
     private void doTestRowLevelContainerPath()
     {
-        beginAt("/simpletest/" + getProjectName() + "/workbookTest.view");
+        beginAt(buildURL("simpletest", getProjectName(), "workbookTest"));
 
         clickButton("RunContainerPathTest", 0);
 
@@ -1806,7 +1814,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
         lookAndFeelSettingsPage.save();
         signOut();
 
-        beginAt(WebTestHelper.buildURL("login", "login"));
+        beginAt(buildURL("login", "login"));
         waitForAnyElement("Should be on login or Home portal", Locator.id("email"), SiteNavBar.Locators.userMenu);
         assertElementPresent(Locator.tagWithText("p", "SimpleTest Module Custom Sign In"));
         signIn();
@@ -1819,7 +1827,7 @@ public class SimpleModuleTest extends BaseWebDriverTest
         lookAndFeelSettingsPage.save();
         signOut();
 
-        beginAt(WebTestHelper.buildURL("login", "login"));
+        beginAt(buildURL("login", "login"));
         waitForAnyElement("Should be on login or Home portal", Locator.id("email"), SiteNavBar.Locators.userMenu);
         assertElementPresent(Locator.tagWithText("p", "SimpleTest Module Custom Sign In With Custom ReturnUrl"));
         signIn();

--- a/src/org/labkey/test/tests/SpecimenGridExportTest.java
+++ b/src/org/labkey/test/tests/SpecimenGridExportTest.java
@@ -21,12 +21,14 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Specimen;
 import org.labkey.test.util.AbstractDataRegionExportOrSignHelper.ColumnHeaderType;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Test exporting rows from a specimen grid (not folder/study specimen export.)
@@ -170,7 +172,7 @@ public class SpecimenGridExportTest extends AbstractExportTest
     @Override
     protected void goToDataRegionPage()
     {
-        beginAt("/" + getProjectName() + "/specimen-specimens.view?showVials=false");
+        beginAt(WebTestHelper.buildURL("specimens", getProjectName(), "specimens", Map.of("showVials", false)));
     }
 
     @Override

--- a/src/org/labkey/test/tests/TimeChartImportTest.java
+++ b/src/org/labkey/test/tests/TimeChartImportTest.java
@@ -23,6 +23,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Charting;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Reports;
@@ -34,6 +35,7 @@ import org.labkey.test.util.WikiHelper;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This test imports a folder archive that has 2 subfolders (a date based study and a visit based study) which have been
@@ -314,8 +316,9 @@ public class TimeChartImportTest extends StudyBaseTest
         {
             clickTab("Clinical and Assay Data");
             waitAndClickAndWait(Locator.linkWithText(chartInfo.getName()));
-            beginAt("/reports/" + getProjectName() + "/" + VISIT_STUDY_FOLDER_NAME + "/" + publishFolderName + "/reportInfo.view?reportId="
-                    + getUrlParam("reportId"));
+            beginAt(WebTestHelper.buildURL("reports",
+                getProjectName() + "/" + VISIT_STUDY_FOLDER_NAME + "/" + publishFolderName,
+                "reportInfo", Map.of("reportId", getUrlParam("reportId"))));
             waitForText("Report Debug Information");
             for (String origMouseId : origMouseIds)
             {

--- a/src/org/labkey/test/tests/TourTest.java
+++ b/src/org/labkey/test/tests/TourTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.TourEditor;
 import org.labkey.test.util.DataRegionTable;
@@ -204,7 +205,7 @@ public class TourTest extends BaseWebDriverTest
 
     private DataRegionTable navigateToTours(String folder)
     {
-        beginAt("/tours/" + getProjectName() + "/" + folder + "/begin.view");
+        beginAt(WebTestHelper.buildURL("tours", getProjectName() + "/" + folder, "begin"));
         return new DataRegionTable("query", getDriver());
     }
 

--- a/src/org/labkey/test/tests/UserTest.java
+++ b/src/org/labkey/test/tests/UserTest.java
@@ -49,6 +49,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -222,14 +223,14 @@ public class UserTest extends BaseWebDriverTest
         goToHome();
 
         log("Validate that only the user who requested the change can use the link");
-        goToURL(resetUrl, 30000);
+        beginAt(resetUrl.toString(), 30000);
         assertTextPresent("The current user is not the same user that initiated this request. Please log in with the account you used to make this email change request.");
         goToHome();
 
         log("Again impersonate user " + SELF_SERVICE_EMAIL_USER + " to validate the confirmation link.");
         impersonate(SELF_SERVICE_EMAIL_USER);
 
-        goToURL(resetUrl, 30000);
+        beginAt(resetUrl.toString(), 30000);
 
         String tempStr = AFFIRM_CHANGE_MSG.replace("@1", SELF_SERVICE_EMAIL_USER);
         tempStr = tempStr.replace("@2", SELF_SERVICE_EMAIL_USER_CHANGED);
@@ -239,7 +240,7 @@ public class UserTest extends BaseWebDriverTest
         stopImpersonating();
 
         log("Go to dumpster and make sure the notification email was there.");
-        assertTrue(null != getEmailChangeMsgBody("Notification .* Web Site email has changed.*"));
+        assertNotNull(getEmailChangeMsgBody("Notification .* Web Site email has changed.*"));
 
         log("Validate that the old email address has been removed.");
 
@@ -251,7 +252,7 @@ public class UserTest extends BaseWebDriverTest
         impersonate(SELF_SERVICE_EMAIL_USER_CHANGED);
 
         log("Validate that trying to use the link from the email message again will result in an error.");
-        goToURL(resetUrl, 30000);
+        beginAt(resetUrl.toString(), 30000);
         assertTextPresent("Verification failed.");
         goToHome();
 
@@ -313,8 +314,7 @@ public class UserTest extends BaseWebDriverTest
 
     private String getEmailChangeMsgBody(String subjectRegex)
     {
-        EmailRecordTable ert = new EmailRecordTable(getDriver());
-        beginAt("/dumbster-begin.view");
+        EmailRecordTable ert = goToEmailRecord();
         EmailRecordTable.EmailMessage eMsg = ert.getMessageRegEx(subjectRegex);
         ert.clickMessage(eMsg);
         eMsg = ert.getMessageRegEx(subjectRegex);
@@ -348,7 +348,7 @@ public class UserTest extends BaseWebDriverTest
             }
         }
 
-        assertTrue("Could not find a url in the email to follow.", !urlString.isEmpty());
+        assertFalse("Could not find a url in the email to follow.", urlString.isEmpty());
         try
         {
             resetUrl = new URL(urlString);
@@ -503,8 +503,7 @@ public class UserTest extends BaseWebDriverTest
 
         StringBuilder sb = new StringBuilder();
         final int maxFieldLength = 64;
-        for (int i = 0; i < maxFieldLength + 1; i++)
-            sb.append("X");
+        sb.append("X".repeat(maxFieldLength + 1));
         String illegalLongProperty = sb.toString();
 
         log("Set illegal properties");

--- a/src/org/labkey/test/tests/filecontent/FilesQueryTest.java
+++ b/src/org/labkey/test/tests/filecontent/FilesQueryTest.java
@@ -21,11 +21,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
-import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.FileBrowser;
 import org.labkey.test.components.DomainDesignerPage;
+import org.labkey.test.pages.query.UpdateQueryRowPage;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.FileBrowserExtendedProperty;
@@ -35,6 +36,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 @Category({Daily.class, FileBrowser.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
@@ -169,17 +171,17 @@ public class FilesQueryTest extends BaseWebDriverTest
     private void ensureFilesUpToDate()
     {
         log("Clear cache so that exp.files will do a sync immediately");
-        beginAt("/admin/caches.view?clearCaches=1", 120000);
+        beginAt(WebTestHelper.buildURL("admin", "caches", Map.of("clearCaches", "1")), 120000);
         goToProjectHome();
     }
 
     private void insertFileRecord(String absoluteFilePath, String customProp)
     {
         DataRegionTable table = new DataRegionTable.DataRegionFinder(getDriver()).find();
-        table.clickInsertNewRow();
-        setFormElement(Locator.name("quf_CustomProp"), customProp);
-        setFormElement(Locator.name("quf_AbsoluteFilePath"), absoluteFilePath);
-        clickButton("Submit");
+        UpdateQueryRowPage page = table.clickInsertNewRow();
+        page.setField("CustomProp", customProp);
+        page.setField("AbsoluteFilePath", absoluteFilePath);
+        page.submit();
     }
 
     private void verifyFileRecordsGrid(boolean canSeeAbsolutePath, String filename, String customPropValue, String relativeFolder)
@@ -206,9 +208,9 @@ public class FilesQueryTest extends BaseWebDriverTest
     {
         DataRegionTable table = new DataRegionTable.DataRegionFinder(getDriver()).find();
         int rowIndex = table.getRowIndex("Name", filename);
-        table.clickEditRow(rowIndex);
-        setFormElement(Locator.name("quf_CustomProp"), updatedCustomPropValue);
-        clickButton("Submit");
+        UpdateQueryRowPage page = table.clickEditRow(rowIndex);
+        page.setField("CustomProp", updatedCustomPropValue);
+        page.submit();
 
         List<String> results = table.getRowDataAsText(rowIndex, "Custom Prop");
         Assert.assertEquals("Custom Prop is not as expected", updatedCustomPropValue, results.get(0));

--- a/src/org/labkey/test/tests/flow/BaseFlowTest.java
+++ b/src/org/labkey/test/tests/flow/BaseFlowTest.java
@@ -26,6 +26,7 @@ import org.labkey.test.components.BodyWebPart;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.experiment.CreateSampleTypePage;
 import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
+import org.labkey.test.pages.query.ExecuteQueryPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
@@ -87,7 +88,6 @@ abstract public class BaseFlowTest extends BaseWebDriverTest
 
     private void init()
     {
-        beginAt("/admin/begin.view");
         goToAdminConsole().goToSettingsSection();
         clickAndWait(Locator.linkWithText("flow cytometry"));
         getPipelineWorkDirectory().mkdir();
@@ -162,7 +162,7 @@ abstract public class BaseFlowTest extends BaseWebDriverTest
         _containerHelper.deleteProject(getProjectName(), afterTest);
         try
         {
-            beginAt("/admin/begin.view");
+            goToAdminConsole();
             clickAndWait(Locator.linkWithText("flow cytometry"));
             setFormElement(Locator.id("workingDirectory"), "");
             clickButton("update");
@@ -179,8 +179,8 @@ abstract public class BaseFlowTest extends BaseWebDriverTest
             return;
         }
 
-        beginAt("/query/" + getProjectName() + "/" + getFolderName() + "/executeQuery.view?schemaName=exp&query.queryName=Runs");
-        DataRegionTable table = new DataRegionTable("query", this);
+        DataRegionTable table = ExecuteQueryPage.beginAt(this, getContainerPath(), "exp", "Runs")
+            .getDataRegion();
         if (table.getDataRowCount() > 0)
         {
             // Delete all runs
@@ -189,11 +189,15 @@ abstract public class BaseFlowTest extends BaseWebDriverTest
             assertEquals("Expected all experiment Runs to be deleted", 0, table.getDataRowCount());
 
             // Check all DataInputs were deleted
-            beginAt("/query/" + getProjectName() + "/" + getFolderName() + "/executeQuery.view?schemaName=exp&query.queryName=DataInputs");
+            table = ExecuteQueryPage.beginAt(this, getContainerPath(), "exp", "DataInputs")
+                .getDataRegion();
             assertEquals("Expected all experiment DataInputs to be deleted", 0, table.getDataRowCount());
 
             // Check all Datas were deleted except for flow analysis scripts (FlowDataType.Script)
-            beginAt("/query/" + getProjectName() + "/" + getFolderName() + "/executeQuery.view?schemaName=exp&query.queryName=Datas&query.LSID~doesnotcontain=Flow-AnalysisScript");
+            table = ExecuteQueryPage.getPageFactory("exp", "Datas")
+                .addParameter("query.LSID~doesnotcontain", "Flow-AnalysisScript")
+                .navigate(this)
+                .getDataRegion();
             assertEquals("Expected all experiment Datas to be deleted", 0, table.getDataRowCount());
         }
     }

--- a/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
+++ b/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Flow;
 import org.labkey.test.categories.Specimen;
@@ -27,6 +28,8 @@ import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PipelineStatusTable;
+
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -134,7 +137,7 @@ public class FlowSpecimenTest extends BaseFlowTest
         assertTextPresent("Confirm Deletion");
         assertTextNotPresent("One dataset(s) have one or more rows which will also be deleted", String.format("/%1$s/%2$s", getProjectName(), STUDY_FOLDER), fcsAnalysisName);
         clickAndWait(Locator.lkButton("Confirm Delete"));
-        beginAt("/study/" + getProjectName() + "/" + STUDY_FOLDER + "/dataset.view?datasetId=5001");
+        beginAt(WebTestHelper.buildURL("study", getProjectName() + "/" + STUDY_FOLDER, "dataset", Map.of("datasetId", "5001")));
         DataRegionTable table = new DataRegionTable(getDriver().getCurrentUrl().contains("dataset.view") ? "Dataset" : "query", this);
         assertEquals("Dataset data not as expected after FCSFile delete", 2, table.getDataRowCount());
         log("Non-Study data delete successful");
@@ -148,7 +151,7 @@ public class FlowSpecimenTest extends BaseFlowTest
         assertTextPresent("Confirm Deletion", "One dataset(s) have one or more rows which will also be deleted", String.format("/%1$s/%2$s", getProjectName(), STUDY_FOLDER));
         clickAndWait(Locator.lkButton("Confirm Delete"));
         assertTextPresent("No data to show.");
-        beginAt("/study/" + getProjectName() + "/" + STUDY_FOLDER + "/dataset.view?datasetId=5001");
+        beginAt(WebTestHelper.buildURL("study", getProjectName() + "/" + STUDY_FOLDER, "dataset", Map.of("datasetId", "5001")));
         assertTextPresent("No data to show.");
         log("Study linked data delete successful");
     }
@@ -167,7 +170,7 @@ public class FlowSpecimenTest extends BaseFlowTest
         waitForPipelineComplete();
 
         log("** Verify Target Study is set on FCSFile run");
-        beginAt("/flow-run/" + getContainerPath() + "/showRuns.view");
+        beginAt(WebTestHelper.buildURL("flow-run", getContainerPath(), "showRuns"));
         DataRegionTable table = new DataRegionTable("query", this);
         assertEquals(STUDY_FOLDER + " Study", table.getDataAsText(0, "Target Study"));
         table.clickRowDetails(0);
@@ -221,7 +224,7 @@ public class FlowSpecimenTest extends BaseFlowTest
     private void linkFlowResultsToStudy()
     {
         // Link the sample wells to the STUDY_FOLDER
-        beginAt("/flow" + getContainerPath() + "/query.view?schemaName=flow&query.queryName=FCSAnalyses");
+        beginAt(WebTestHelper.buildURL("flow", getContainerPath(), "query", Map.of("schemaName", "flow", "query.queryName", "FCSAnalyses")));
         click(Locator.checkboxByName(".toggle"));
         clickButton("Link to Study");
         selectOptionByText(AssayConstants.TARGET_STUDY_FIELD_LOCATOR, "/" + getProjectName() + "/" + STUDY_FOLDER + " (" + STUDY_FOLDER + " Study)");
@@ -242,7 +245,7 @@ public class FlowSpecimenTest extends BaseFlowTest
     protected void verifyFCSFileSpecimenFK()
     {
         log("** Verify specimen FK from flow.FCSFile table");
-        beginAt("/flow" + getContainerPath() + "/query.view?schemaName=flow&query.queryName=FCSFiles");
+        beginAt(WebTestHelper.buildURL("flow", getContainerPath(), "query", Map.of("schemaName", "flow", "query.queryName", "FCSFiles")));
         verifySpecimenFK("");
     }
 
@@ -250,7 +253,7 @@ public class FlowSpecimenTest extends BaseFlowTest
     protected void verifyFCSAnalysisSpecimenFK()
     {
         log("** Verify specimen FK from flow.FCSAnalysis table");
-        beginAt("/flow" + getContainerPath() + "/query.view?schemaName=flow&query.queryName=FCSAnalyses");
+        beginAt(WebTestHelper.buildURL("flow", getContainerPath(), "query", Map.of("schemaName", "flow", "query.queryName", "FCSAnalyses")));
         verifySpecimenFK("FCSFile/");
     }
 
@@ -258,7 +261,7 @@ public class FlowSpecimenTest extends BaseFlowTest
     protected void verifyFlowDatasetSpecimenFK()
     {
         log("** Verify specimen FK from flow dataset");
-        beginAt("/study/" + getProjectName() + "/" + STUDY_FOLDER + "/dataset.view?datasetId=5001");
+        beginAt(WebTestHelper.buildURL("study", getProjectName() + "/" + STUDY_FOLDER, "dataset", Map.of("datasetId", "5001")));
         verifySpecimenFK("FCSFile/");
     }
 

--- a/src/org/labkey/test/tests/flow/FlowTest.java
+++ b/src/org/labkey/test/tests/flow/FlowTest.java
@@ -38,7 +38,6 @@ import org.labkey.test.params.FieldKey;
 import org.labkey.test.tests.AuditLogTest;
 import org.labkey.test.util.DataRegion;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.FileBrowserHelper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
@@ -59,6 +58,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.WebTestHelper.buildURL;
 
 @Category({Daily.class, Flow.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 18)
@@ -250,7 +250,7 @@ public class FlowTest extends BaseFlowTest
 
     private void beginAtFCSFileQueryView()
     {
-        beginAt("/flow" + getContainerPath() + "/query.view?schemaName=flow&query.queryName=FCSFiles");
+        beginAt(buildURL("flow", getContainerPath(), "query", Map.of("schemaName", "flow", "query.queryName", "FCSFiles")));
     }
 
     private void confirmKeywordValue(String keywordName, String expectedKeywordValue)
@@ -581,7 +581,8 @@ public class FlowTest extends BaseFlowTest
         createQuery(getProjectName(), "GraphQuery", graphQuery, null, true);
 
         log("** Executing custom query with Graph columns");
-        beginAt("/flow" + getContainerPath() + "/query.view?schemaName=flow&query.queryName=GraphQuery&query.showGraphs=Inline");
+        beginAt(buildURL("flow", getContainerPath(), "query",
+            Map.of("schemaName", "flow", "query.queryName", "GraphQuery", "query.showGraphs", "Inline")));
 
         // verify Issue 16304: query over flow.FCSFiles doesn't include URL for Name column
         DataRegionTable table = new DataRegionTable("query", getDriver());
@@ -786,7 +787,7 @@ public class FlowTest extends BaseFlowTest
     @LogMethod
     private void verifyReport(@LoggedParam String reportName)
     {
-        beginAt("/flow" + getContainerPath() + "/query.view?schemaName=flow&query.queryName=FCSAnalyses");
+        beginAt(buildURL("flow", getContainerPath(), "query", Map.of("schemaName", "flow", "query.queryName", "FCSAnalyses")));
 
         FieldKey reportNameFk = FieldKey.fromParts(reportName);
 
@@ -817,7 +818,7 @@ public class FlowTest extends BaseFlowTest
     @LogMethod(quiet = true)
     private void verifyDeleted(@LoggedParam String reportName)
     {
-        beginAt("/flow" + getContainerPath() + "/query.view?schemaName=flow&query.queryName=FCSAnalyses");
+        beginAt(buildURL("flow", getContainerPath(), "query", Map.of("schemaName", "flow", "query.queryName", "FCSAnalyses")));
         DataRegionTable drt = new DataRegionTable("query", getDriver());
         String error = BootstrapLocators.warningBanner.findElement(drt.getComponentElement()).getText();
         assertEquals("Ignoring filter/sort on column '" + reportName + ".Response' because it does not exist.", error);

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -55,6 +55,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -493,7 +494,9 @@ public class NabAssayTest extends AbstractAssayTest
     //Issue 17050: UnsupportedOperationException from org.labkey.nab.query.NabProtocolSchema$NabResultsQueryView.createDataView
     private void directBrowserQueryTest()
     {
-        beginAt("/query/Nab%20Test%20Verify%20Project/selectRows.api?schemaName=assay&queryName=TestAssayNab%20Data");
+        beginAt(WebTestHelper.buildURL("query", "Nab Test Verify Project", "selectRows.api", Map.of(
+                "schemaName", "assay",
+                "queryName", "TestAssayNab Data")));
         assertTextPresent("metaData");
     }
 

--- a/src/org/labkey/test/tests/perf/SchemaBrowserPerfTest.java
+++ b/src/org/labkey/test/tests/perf/SchemaBrowserPerfTest.java
@@ -20,6 +20,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.serverapi.writer.PrintWriters;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Perf;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
@@ -27,6 +28,7 @@ import org.labkey.test.params.FieldDefinition.ColumnType;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Map;
 
 // this test generates ball park times for Schema Browser use cases on a study that has 200 dataSets.
 //
@@ -86,7 +88,7 @@ public class SchemaBrowserPerfTest extends PerformanceTest
         long[] emptyCacheOpenStudyTimes = new long[5];
         // run tests
         for (int x = 0 ; x < 5; x++) {
-            beginAt("/admin/caches.view?clearCaches=1", 120000);
+            beginAt(WebTestHelper.buildURL("admin", "caches", Map.of("clearCaches", 1)), 120000);
             goToHome();
             clickProject(getProjectName());
             goToSchemaBrowser();
@@ -101,7 +103,7 @@ public class SchemaBrowserPerfTest extends PerformanceTest
     private long[] studyBaselineFullCache() {
         long[] fullCacheOpenStudyTimes = new long[5];
         // prepare cache
-        beginAt("/admin/caches.view?clearCaches=1", 120000);
+        beginAt(WebTestHelper.buildURL("admin", "caches", Map.of("clearCaches", 1)), 120000);
         goToHome();
         clickProject(getProjectName());
         goToSchemaBrowser();
@@ -123,7 +125,7 @@ public class SchemaBrowserPerfTest extends PerformanceTest
     private long[] studyDataBaselineFullCache() {
         long[] emptyCacheOpenStudyDataTimes = new long[5];
         // prepare cache
-        beginAt("/admin/caches.view?clearCaches=1", 120000);
+        beginAt(WebTestHelper.buildURL("admin", "caches", Map.of("clearCaches", 1)), 120000);
         goToHome();
         clickProject(getProjectName());
         goToSchemaBrowser();

--- a/src/org/labkey/test/tests/remoteapi/BulkUpdateGroupApiTest.java
+++ b/src/org/labkey/test/tests/remoteapi/BulkUpdateGroupApiTest.java
@@ -24,6 +24,7 @@ import org.labkey.remoteapi.security.BulkUpdateGroupCommand;
 import org.labkey.remoteapi.security.BulkUpdateGroupResponse;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.TestTimeoutException;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.tests.AuditLogTest;
 import org.labkey.test.util.APIUserHelper;
@@ -75,7 +76,10 @@ public class BulkUpdateGroupApiTest extends BaseWebDriverTest
         if (suffix.length() < 10)
             throw new IllegalArgumentException("Use a longer suffix for test user emails.");
 
-        beginAt("user/showUsers.view?inactive=true&Users.showRows=all&Users.Email~contains=" + suffix);
+        beginAt(WebTestHelper.buildURL("user", "showUsers", Map.of(
+            "inactive", "true",
+            "Users.showRows", "all",
+            "Users.Email~contains", suffix)));
         DataRegionTable usersTable = new DataRegionTable("Users", this);
 
         if (usersTable.getDataRowCount() > 0)

--- a/src/org/labkey/test/tests/viability/ViabilityTest.java
+++ b/src/org/labkey/test/tests/viability/ViabilityTest.java
@@ -25,6 +25,7 @@ import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.pages.ReactAssayDesignerPage;
+import org.labkey.test.pages.query.ExecuteQueryPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.QCAssayScriptHelper;
@@ -226,8 +227,8 @@ public class ViabilityTest extends AbstractViabilityTest
     protected void runResultSpecimenLookupTest()
     {
         log("** Checking ResultSpecimens lookups");
-        beginAt("/" + getProjectName() + "/" + getFolderName() + "/query-executeQuery.view?schemaName=assay&query.queryName=" + getAssayName() + " ResultSpecimens");
-        DataRegionTable table = new DataRegionTable("query", this);
+        ExecuteQueryPage page = ExecuteQueryPage.beginAt(this, getProjectName() + "/" + getFolderName(), "assay", getAssayName() + " ResultSpecimens");
+        DataRegionTable table = page.getDataRegion();
         assertTextPresent(new TextSearcher(table.getComponentElement()::getText), "foobar", "vial1", "xyzzy", "160450533-5", "161400006.11-5");
 
         setSelectedFields("/" + getProjectName() + "/" + getFolderName(), "assay", getAssayName() + " ResultSpecimens", null,

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -86,6 +86,7 @@ public class Crawler
     private static final Set<ControllerActionId> _actionsWithErrors = new HashSet<>();
     private static final Set<String> _urlsChecked = new HashSet<>();
     private static final Map<String, CrawlStats> _crawlStats = new LinkedHashMap<>();
+    private static final Set<ControllerActionId> _controllerFirstUrls = new HashSet<>();
 
     // All parameters seen by the crawler. Used to randomly attempt injection against parameters not found in UI
     private static final LinkedHashMap<String,String> _dictionary = new LinkedHashMap<>();
@@ -609,8 +610,9 @@ public class Crawler
 
         private void checkControllerRelativeUrl()
         {
-            if (_actionId != null && _actionId.isControllerFirstUrl() && WebTestHelper.isUseContainerRelativeUrl())
+            if (_actionId != null && _actionId.isControllerFirstUrl() && WebTestHelper.isUseContainerRelativeUrl() && !_controllerFirstUrls.contains(_actionId))
             {
+                _controllerFirstUrls.add(_actionId);
                 RuntimeException ex = new RuntimeException("Found a controller-first URL (%s) on %s".formatted(getUrlText(), getOrigin()));
                 if (TestProperties.isControllerFirstUrlFatal())
                     throw ex;

--- a/src/org/labkey/test/util/PageFactory.java
+++ b/src/org/labkey/test/util/PageFactory.java
@@ -21,32 +21,37 @@ import org.openqa.selenium.WebDriver;
 
 import java.util.function.Function;
 
-public class PageFactory<P extends LabKeyPage>
+public class PageFactory<P extends LabKeyPage<?>>
 {
-    private final RelativeUrl url;
-    private final Function<WebDriver, P> pageConstructor;
-    private final String containerPath = null;
+    private final RelativeUrl _url;
+    private final Function<WebDriver, P> _pageConstructor;
 
     PageFactory(RelativeUrl url, Function<WebDriver, P> pageConstructor)
     {
-        this.url = url.copy();
-        this.pageConstructor = pageConstructor;
+        this._url = url.copy();
+        this._pageConstructor = pageConstructor;
     }
 
     public final PageFactory<P> setContainerPath(String containerPath)
     {
-        url.setContainerPath(containerPath);
+        _url.setContainerPath(containerPath);
+        return this;
+    }
+
+    public final <T> PageFactory<P> addParameter(String name, T value)
+    {
+        _url.addParameter(name, value);
         return this;
     }
 
     public final P navigate(WebDriverWrapper driverWrapper)
     {
-        return navigate(driverWrapper, url);
+        return navigate(driverWrapper, _url);
     }
 
     public final P navigate(WebDriverWrapper driverWrapper, Integer msTimeout)
     {
-        return navigate(driverWrapper, url.copy().setTimeout(msTimeout));
+        return navigate(driverWrapper, _url.copy().setTimeout(msTimeout));
     }
 
     protected P navigate(WebDriverWrapper driverWrapper, RelativeUrl url)
@@ -56,6 +61,6 @@ public class PageFactory<P extends LabKeyPage>
             url = url.copy().setContainerPath(driverWrapper.getCurrentContainerPath());
         }
         url.navigate(driverWrapper);
-        return pageConstructor.apply(driverWrapper.getDriver());
+        return _pageConstructor.apply(driverWrapper.getDriver());
     }
 }

--- a/src/org/labkey/test/util/PageFactory.java
+++ b/src/org/labkey/test/util/PageFactory.java
@@ -49,6 +49,11 @@ public class PageFactory<P extends LabKeyPage<?>>
         return navigate(driverWrapper, _url);
     }
 
+    public final P navigate(WebDriverWrapper driverWrapper, String containerPath)
+    {
+        return navigate(driverWrapper, _url.copy().setContainerPath(containerPath));
+    }
+
     public final P navigate(WebDriverWrapper driverWrapper, Integer msTimeout)
     {
         return navigate(driverWrapper, _url.copy().setTimeout(msTimeout));

--- a/src/org/labkey/test/util/RelativeUrl.java
+++ b/src/org/labkey/test/util/RelativeUrl.java
@@ -29,7 +29,7 @@ public class RelativeUrl
     private final String _controller;
     private String _containerPath = null;
     private final String _action;
-    private final Map<String, String> _parameters;
+    private final Map<String, Object> _parameters;
     private Integer _msTimeout;
 
     public RelativeUrl(String controller, String action)
@@ -66,13 +66,13 @@ public class RelativeUrl
         return this;
     }
 
-    public RelativeUrl addParameters(Map<String, String> params)
+    public RelativeUrl addParameters(Map<String, ?> params)
     {
         _parameters.putAll(params);
         return this;
     }
 
-    public RelativeUrl addParameter(String param, String value)
+    public <T> RelativeUrl addParameter(String param, T value)
     {
         _parameters.put(param, value);
         return this;
@@ -103,7 +103,7 @@ public class RelativeUrl
         return this;
     }
 
-    public <P extends LabKeyPage> PageFactory<P> getPageFactory(Function<WebDriver, P> pageConstructor)
+    public <P extends LabKeyPage<?>> PageFactory<P> getPageFactory(Function<WebDriver, P> pageConstructor)
     {
         return new PageFactory<>(this, pageConstructor);
     }

--- a/src/org/labkey/test/util/SchemaHelper.java
+++ b/src/org/labkey/test/util/SchemaHelper.java
@@ -45,7 +45,7 @@ public class SchemaHelper
     @LogMethod
     public void deleteSchema(String containerPath, String schemaToDelete)
     {
-        _test.beginAt("/query/" + containerPath + "/admin.view");
+        _test.beginAt(WebTestHelper.buildURL("query", containerPath, "admin"));
         Locator link = Locator.xpath("//td[text()='" + schemaToDelete + "']/..//a[text()='delete']");
         _test.waitAndClickAndWait(link);
         _test.assertTextPresent("Are you sure you want to delete the schema '" + schemaToDelete + "'? The tables and queries defined in this schema will no longer be accessible.");


### PR DESCRIPTION
#### Rationale
Controller-first URLs are [now deprecated](https://github.com/LabKey/platform/pull/6990); tests should also stop using them. Specifically, tests should use `WebTestHelper.buildURL` to create URLs that match the preferred server format.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Update many tests to use WebTestHelper to build URLs
- Only log the first time a particular controller-first URL is found
