### PR TITLE
Update parent alias test to no longer use "parent" as alias name

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
@@ -443,7 +443,7 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         DataClassDefinition dataClassType = new DataClassDefinition(dataClass).setFields(DataClassAPIHelper.dataClassTestFields());
         SampleTypeDefinition parentType = new SampleTypeDefinition(parentSampleType).setFields(testFields);
         SampleTypeDefinition testSampleType = new SampleTypeDefinition(testSamples).setFields(testFields)
-                .addParentAlias("Parent", parentSampleType) // to derive from parent sampleType
+                .addParentAlias("ParentAlias", parentSampleType) // to derive from parent sampleType
                 .addDataParentAlias("DataClassParent", dataClass)
                 .addParentAlias("SelfParent"); // to derive from samles in the current type
 
@@ -461,19 +461,19 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
 
         TestDataGenerator testDgen = SampleTypeAPIHelper.createEmptySampleType(subfolderPath, testSampleType);
         testDgen.addCustomRow(Map.of("Name", "Child1", intColumn.getName(), 1, decimalColumn.getName(), 1.1, stringColumn.getName(), "one",
-                "Parent", "Parent1"));
+                "ParentAlias", "Parent1"));
         testDgen.addCustomRow(Map.of("Name", "Child2", intColumn.getName(), 2, decimalColumn.getName(), 2.2, stringColumn.getName(), "two",
-                "Parent", "Parent2"));
+                "ParentAlias", "Parent2"));
         testDgen.addCustomRow(Map.of("Name", "Child3", intColumn.getName(), 3, decimalColumn.getName(), 3.3, stringColumn.getName(), "three",
-                "Parent", "Parent3", "DataClassParent", "data1"));
+                "ParentAlias", "Parent3", "DataClassParent", "data1"));
         testDgen.addCustomRow(Map.of("Name", "Child4", intColumn.getName(), 4, decimalColumn.getName(), 4.4, stringColumn.getName(), "four",
-                "Parent", "Parent3, Parent2"));
+                "ParentAlias", "Parent3, Parent2"));
         testDgen.addCustomRow(Map.of("Name", "Child5", intColumn.getName(), 5, decimalColumn.getName(), 5.5, stringColumn.getName(), "five",
-                "Parent", "Parent1, Parent2"));
+                "ParentAlias", "Parent1, Parent2"));
         testDgen.addCustomRow(Map.of("Name", "Child6", intColumn.getName(), 6, decimalColumn.getName(), 6.6, stringColumn.getName(), "six",
-                "Parent", "Parent3, Parent2", "SelfParent", "Child5"));
+                "ParentAlias", "Parent3, Parent2", "SelfParent", "Child5"));
         testDgen.addCustomRow(Map.of("Name", "Child7", intColumn.getName(), 7, decimalColumn.getName(), 7.7, stringColumn.getName(), "seven",
-                "Parent", "Parent3, Parent2", "SelfParent", "Child5", "DataClassParent", "data2, data3"));
+                "ParentAlias", "Parent3, Parent2", "SelfParent", "Child5", "DataClassParent", "data2, data3"));
         testDgen.insertRows();
 
         PortalHelper portalHelper = new PortalHelper(this);

--- a/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
+++ b/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
@@ -568,9 +568,9 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
     {
         verifyNames(
                 "ParentAliasInputsExpressionTest",
-                "Name\tFieldB\tParent",
-                "${Parent:first:defaultValue('" + DEFAULT_SAMPLE_PARENT_VALUE + "')}_${batchRandomId}",
-                "Parent", "Jessi");
+                "Name\tFieldB\tParentAlias",
+                "${ParentAlias:first:defaultValue('" + DEFAULT_SAMPLE_PARENT_VALUE + "')}_${batchRandomId}",
+                "ParentAlias", "Jessi");
     }
 
     // Issue 42857: samples: bulk import with name expression containing lookup fails to convert lookup string value
@@ -627,9 +627,9 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
     {
         verifyNames(
                 "MaterialInputsExpressionWithParentAliasData",
-                "Name\tFieldB\tParent",
+                "Name\tFieldB\tParentAlias",
                 "${MaterialInputs:first:defaultValue('" + DEFAULT_SAMPLE_PARENT_VALUE + "')}_${batchRandomId}",
-                "Parent", "Sam");
+                "ParentAlias", "Sam");
     }
 
     private void verifyNames(String sampleTypeName, String header, String nameExpression, @Nullable String currentTypeAlias, String namePrefix)


### PR DESCRIPTION
#### Rationale
Change was made so "Parent" can no longer be used as a import alias. This PR updates tests to stop using it.

[SampleTypeNameExpressionTest](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyPostgres_2/3659597?buildTab=tests&status=failed&suite=org.labkey.test.Runner%3A+&package=org.labkey.test.tests&class=SampleTypeNameExpressionTest), [SampleTypeFolderExportImportTest](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyPostgres_2/3659597?buildTab=tests&status=failed&suite=org.labkey.test.Runner%3A+&package=org.labkey.test.tests&class=SampleTypeFolderExportImportTest)
Failed to create sample type. Parent alias header is reserved: Parent

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6998

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
