### PR TITLE
Test updates to escape special characters in form field names

### DIFF
--- a/src/org/labkey/test/pages/DatasetInsertPage.java
+++ b/src/org/labkey/test/pages/DatasetInsertPage.java
@@ -18,10 +18,13 @@ package org.labkey.test.pages;
 import org.apache.tika.utils.StringUtils;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
+import org.labkey.test.util.EscapeUtil;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.util.Map;
+
+import static org.labkey.test.util.EscapeUtil.FORM_FIELD_PREFIX;
 
 public class DatasetInsertPage extends InsertPage
 {
@@ -39,7 +42,7 @@ public class DatasetInsertPage extends InsertPage
     protected void waitForReady()
     {
         super.waitForReady();
-        waitForElement(Locator.tag("*").attributeStartsWith("name", "quf_"));
+        waitForElement(Locator.tag("*").attributeStartsWith("name", FORM_FIELD_PREFIX));
     }
 
     public void insert(Map<String, String> values)
@@ -79,7 +82,7 @@ public class DatasetInsertPage extends InsertPage
     {
         for (Map.Entry<String, String> entry : values.entrySet())
         {
-            WebElement fieldInput = Locator.name("quf_" + entry.getKey()).findElement(getDriver());
+            WebElement fieldInput = Locator.name(EscapeUtil.getFormFieldName(entry.getKey())).findElement(getDriver());
             String type = fieldInput.getAttribute("type");
             switch (type)
             {

--- a/src/org/labkey/test/pages/query/UpdateQueryRowPage.java
+++ b/src/org/labkey/test/pages/query/UpdateQueryRowPage.java
@@ -12,6 +12,7 @@ import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.html.OptionSelect;
 import org.labkey.test.pages.LabKeyPage;
+import org.labkey.test.util.EscapeUtil;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -185,7 +186,7 @@ public class UpdateQueryRowPage extends LabKeyPage<UpdateQueryRowPage.ElementCac
         {
             if (!fieldMap.containsKey(name))
             {
-                fieldMap.put(name, Locator.name("quf_" + name).findElement(this));
+                fieldMap.put(name, Locator.name(EscapeUtil.getFormFieldName(name)).findElement(this));
             }
             return fieldMap.get(name);
         }

--- a/src/org/labkey/test/pages/user/UpdateUserDetailsPage.java
+++ b/src/org/labkey/test/pages/user/UpdateUserDetailsPage.java
@@ -5,6 +5,7 @@ import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.pages.LabKeyPage;
+import org.labkey.test.util.EscapeUtil;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -109,7 +110,7 @@ public class UpdateUserDetailsPage extends LabKeyPage<UpdateUserDetailsPage.Elem
         {
             if (!formElements.containsKey(fieldName))
             {
-                Input input = Input.Input(Locator.name("quf_" + fieldName), getDriver()).find();
+                Input input = Input.Input(Locator.name(EscapeUtil.getFormFieldName(fieldName)), getDriver()).find();
                 formElements.put(fieldName, input);
             }
             return formElements.get(fieldName);

--- a/src/org/labkey/test/tests/AliquotTest.java
+++ b/src/org/labkey/test/tests/AliquotTest.java
@@ -24,6 +24,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Specimen;
 import org.labkey.test.components.html.BootstrapMenu;
+import org.labkey.test.components.html.OptionSelect;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
@@ -274,12 +275,12 @@ public class AliquotTest extends SpecimenBaseTest
 
         // verify insert new here
         DataRegionTable detail = new DataRegionTable("SpecimenDetail", this);
-        detail.clickInsertNewRow();
-        setFormElement(Locator.xpath("//input[@name='quf_GlobalUniqueId']"), "Global");
-        setFormElement(Locator.xpath("//input[@name='quf_VisitDescription']"), "NewVisit");
-        setFormElement(Locator.xpath("//input[@name='quf_SequenceNum']"), "001");
-        selectOptionByText(Locator.name("quf_ParticipantId"), "618005775");
-        clickButton("Submit");
+        detail.clickInsertNewRow()
+                .setField("GlobalUniqueId", "Global")
+                .setField("VisitDescription", "NewVisit")
+                .setField("SequenceNum", "001")
+                .setField("ParticipantId", OptionSelect.SelectOption.textOption("618005775"))
+                .submit();
         assertElementNotPresent(Locator.tagWithClass("*", "labkey-error").withText());
         detail.setFilter("VisitDescription", "Equals", "NewVisit");
         assertTextPresent("NewVisit");

--- a/src/org/labkey/test/tests/AttachmentFieldTest.java
+++ b/src/org/labkey/test/tests/AttachmentFieldTest.java
@@ -3,6 +3,7 @@ package org.labkey.test.tests;
 import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -10,15 +11,12 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.components.DomainDesignerPage;
-import org.labkey.test.components.domain.DomainFieldRow;
-import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.admin.FileRootsManagementPage;
 import org.labkey.test.pages.experiment.UpdateSampleTypePage;
+import org.labkey.test.pages.list.EditListDefinitionPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
 import org.labkey.test.util.TestDataGenerator;
@@ -59,14 +57,18 @@ public class AttachmentFieldTest extends BaseWebDriverTest
         portalHelper.addBodyWebPart("Lists");
     }
 
+    @Before
+    public void preTest()
+    {
+        goToProjectHome();
+    }
+
     @Test
     public void testFileFieldInSampleType()
     {
-        goToProjectHome();
         String sampleTypeName = "Sample type with attachment";
         String fieldName = "testFile";
         SampleTypeHelper sampleTypeHelper = new SampleTypeHelper(this);
-        goToProjectHome();
 
         log("Create a sample type with attachment field");
         sampleTypeHelper.createSampleType(new SampleTypeDefinition(sampleTypeName)
@@ -77,11 +79,13 @@ public class AttachmentFieldTest extends BaseWebDriverTest
         log("Inserting samples in sample Type");
         goToProjectHome();
         clickAndWait(Locator.linkWithText(sampleTypeName));
-        DataRegionTable samplesTable = DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
-        samplesTable.clickInsertNewRow();
-        setFormElement(Locator.name(EscapeUtil.getFormFieldName("Name")), "S1");
-        setFormElement(Locator.name(EscapeUtil.getFormFieldName(fieldName)), SAMPLE_FILE);
-        clickButton("Submit");
+
+        DataRegionTable.DataRegion(getDriver()).withName("Material")
+                .waitFor()
+                .clickInsertNewRow()
+                .setField("Name", "S1")
+                .setField(fieldName, SAMPLE_FILE)
+                .submit();
 
         assertElementPresent(Locator.tagWithAttribute("a", "title", "Download attached file"));
 
@@ -114,7 +118,7 @@ public class AttachmentFieldTest extends BaseWebDriverTest
         fileRootsManagementPage = goToFolderManagement().goToFilesTab();
         fileRootsManagementPage.useCustomFileRoot(childFileRoot).clickSave();
 
-        // verify file path display for files that's present but outside of current file root
+        // verify file path display for files that are present but outside the current file root
         verifyUnavailableFile();
 
         // reset file root to default
@@ -126,7 +130,7 @@ public class AttachmentFieldTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(sampleTypeName));
         assertElementPresent(Locator.tagWithAttribute("a", "title", "Download attached file"));
 
-        // delete the file and verify file path that doesn't exist
+        // delete the file and verify the file path that doesn't exist
         goToModule("FileContent");
         _fileBrowserHelper.deleteFile("sampletype");
         verifyUnavailableFile();
@@ -140,12 +144,11 @@ public class AttachmentFieldTest extends BaseWebDriverTest
         waitForElement(Locator.tagContainingText("td", "jpg_sample.jpg (unavailable)"));
         assertElementNotPresent(Locator.tagWithAttribute("a", "title", "Download attached file"));
 
-        // "(unavailable)" suffix is present in update view
+        // "(unavailable)" suffix is present in the update view
         clickAndWait(Locator.tagWithText("a", "S1"));
         clickAndWait(Locator.tagWithClass("a", "labkey-text-link").withText("edit"));
         waitForElement(Locator.tagContainingText("div", "jpg_sample.jpg (unavailable)"));
         assertElementNotPresent(Locator.tagWithAttributeContaining("img", "src", "/_icons/image.png"));
-
     }
 
     @Test
@@ -153,26 +156,23 @@ public class AttachmentFieldTest extends BaseWebDriverTest
     {
         String listName = TestDataGenerator.randomDomainName("List with attachment field");
         String fieldName = TestDataGenerator.randomFieldName("Test File");
-        goToProjectHome();
         log("Creating the list");
         _listHelper.createList(getProjectName(), listName, "id");
 
         log("Adding a attachment field with Show attachment in Browser");
-        DomainDesignerPage domainDesignerPage = DomainDesignerPage.beginAt(this, getProjectName(), "lists", listName);
-        DomainFormPanel panel = domainDesignerPage.fieldsPanel();
-        DomainFieldRow stringRow = panel
-                .addField(fieldName)
-                .setType(FieldDefinition.ColumnType.Attachment);
-        stringRow.setAttachmentBehavior("Show Attachment in Browser");
-        domainDesignerPage.clickFinish();
+        EditListDefinitionPage editPage = _listHelper.goToEditDesign(listName)
+                .addField(new FieldDefinition(fieldName, FieldDefinition.ColumnType.Attachment));
+        editPage.getFieldsPanel()
+                .getField(fieldName)
+                .setAttachmentBehavior("Show Attachment in Browser");
+        editPage.clickSave();
 
         log("Insert row in list");
-        goToProjectHome();
-        clickAndWait(Locator.linkWithText(listName));
-        DataRegionTable listTable = new DataRegionTable("query", getDriver());
-        listTable.clickInsertNewRow();
-        setFormElement(Locator.name(EscapeUtil.getFormFieldName(fieldName)), SAMPLE_FILE);
-        clickButton("Submit");
+        _listHelper.beginAtList(getProjectName(), listName);
+        new DataRegionTable("query", getDriver())
+                .clickInsertNewRow()
+                .setField(fieldName, SAMPLE_FILE)
+                .submit();
 
         log("Verify file opened in browser");
         Locator.tagWithAttributeContaining("img", "title", SAMPLE_FILE.getName()).findElement(getDriver()).click();
@@ -182,13 +182,12 @@ public class AttachmentFieldTest extends BaseWebDriverTest
         switchToMainWindow();
 
         log("Verify file is downloaded");
-        domainDesignerPage = DomainDesignerPage.beginAt(this, getProjectName(), "lists", listName);
-        panel = domainDesignerPage.fieldsPanel();
-        panel.getField(fieldName).setAttachmentBehavior("Download Attachment");
-        domainDesignerPage.clickFinish();
+        editPage = _listHelper.goToEditDesign(listName);
+        editPage.getFieldsPanel()
+                .getField(fieldName)
+                .setAttachmentBehavior("Download Attachment");
+        editPage.clickSave();
 
-        goToProjectHome();
-        clickAndWait(Locator.linkWithText(listName));
         File downloadedFile = doAndWaitForDownload(() -> Locator.tagWithAttributeContaining("img", "title", SAMPLE_FILE.getName()).findElement(getDriver()).click());
         Assert.assertTrue("Downloaded file is empty", downloadedFile.length() > 0);
     }

--- a/src/org/labkey/test/tests/AttachmentFieldTest.java
+++ b/src/org/labkey/test/tests/AttachmentFieldTest.java
@@ -18,6 +18,7 @@ import org.labkey.test.pages.experiment.UpdateSampleTypePage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
 import org.labkey.test.util.TestDataGenerator;
@@ -78,8 +79,8 @@ public class AttachmentFieldTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(sampleTypeName));
         DataRegionTable samplesTable = DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
         samplesTable.clickInsertNewRow();
-        setFormElement(Locator.name("quf_Name"), "S1");
-        setFormElement(Locator.name("quf_" + fieldName), SAMPLE_FILE);
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName("Name")), "S1");
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(fieldName)), SAMPLE_FILE);
         clickButton("Submit");
 
         assertElementPresent(Locator.tagWithAttribute("a", "title", "Download attached file"));
@@ -170,7 +171,7 @@ public class AttachmentFieldTest extends BaseWebDriverTest
         clickAndWait(Locator.linkWithText(listName));
         DataRegionTable listTable = new DataRegionTable("query", getDriver());
         listTable.clickInsertNewRow();
-        setFormElement(Locator.name("quf_" + fieldName), SAMPLE_FILE);
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(fieldName)), SAMPLE_FILE);
         clickButton("Submit");
 
         log("Verify file opened in browser");

--- a/src/org/labkey/test/tests/DataClassFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/DataClassFolderExportImportTest.java
@@ -14,6 +14,7 @@ import org.labkey.test.components.CustomizeView;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.DataClassDefinition;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.TestDataGenerator;
@@ -129,7 +130,7 @@ public class DataClassFolderExportImportTest extends BaseWebDriverTest
                                     // issue https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42191 tracks this
                                     // until it is fixed we will have to add attachments via the UI, like this
             sourceTable.clickEditRow(i);
-            setFormElement(Locator.input("quf_" + attachmentColumnName), _attachments.get(i));
+            setFormElement(Locator.input(EscapeUtil.getFormFieldName(attachmentColumnName)), _attachments.get(i));
             clickButton("Submit");
         }
         List<Map<String, String>> sourceRowData = sourceTable.getTableData();

--- a/src/org/labkey/test/tests/DataClassFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/DataClassFolderExportImportTest.java
@@ -14,7 +14,6 @@ import org.labkey.test.components.CustomizeView;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.DataClassDefinition;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.TestDataGenerator;
@@ -125,13 +124,13 @@ public class DataClassFolderExportImportTest extends BaseWebDriverTest
 
         clickAndWait(Locator.linkWithText(testDataClass));
         DataRegionTable sourceTable = DataRegionTable.DataRegion(getDriver()).withName("query").waitFor();
-        for (int i=0; i<_attachments.size(); i++)
-        {                           // for the nonce, we cannot add file attachments to an attachment column via remoteAPI
-                                    // issue https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42191 tracks this
-                                    // until it is fixed we will have to add attachments via the UI, like this
-            sourceTable.clickEditRow(i);
-            setFormElement(Locator.input(EscapeUtil.getFormFieldName(attachmentColumnName)), _attachments.get(i));
-            clickButton("Submit");
+        for (int i = 0; i < _attachments.size(); i++)
+        {
+            // For the nonce, we cannot add file attachments to an attachment column via remoteAPI
+            // Issue 42191 tracks this until it is fixed we will have to add attachments via the UI
+            sourceTable.clickEditRow(i)
+                    .setField(attachmentColumnName, _attachments.get(i))
+                    .submit();
         }
         List<Map<String, String>> sourceRowData = sourceTable.getTableData();
 
@@ -307,7 +306,7 @@ public class DataClassFolderExportImportTest extends BaseWebDriverTest
             shortWait().until(ExpectedConditions.stalenessOf(deleteButton));
         }
 
-        for(int index = 0; index < missingValueIndicators.size(); index++)
+        for (int index = 0; index < missingValueIndicators.size(); index++)
         {
             clickButton("Add", 0);
             WebElement mvInd = Locator.css("#mvIndicatorsDiv input[name=mvIndicators]").index(index).waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT);

--- a/src/org/labkey/test/tests/SampleTypeRemoteAPITest.java
+++ b/src/org/labkey/test/tests/SampleTypeRemoteAPITest.java
@@ -45,6 +45,7 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.AbstractDataRegionExportOrSignHelper;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.TestDataGenerator;
 import org.labkey.test.util.TestDataValidator;
@@ -272,7 +273,7 @@ public class SampleTypeRemoteAPITest extends BaseWebDriverTest
         String mvIndicatorColName = "mvStringDataMVIndicator";
         materialsList.updateRow(dIndex, Map.of("mvStringData", "reallyUpdatedValue", mvIndicatorColName, "Q"));  // update the underlying value but set it mv-Q
         materialsList.clickEditRow(eIndex);
-        selectOptionByText(Locator.name("quf_"+mvIndicatorColName), "");    // clear the mv value, reveal underlying value
+        selectOptionByText(Locator.name(EscapeUtil.getFormFieldName(mvIndicatorColName)), "");    // clear the mv value, reveal underlying value
         clickButton("Submit");
 
         eIndex = materialsList.getRowIndex("Name", "E");

--- a/src/org/labkey/test/tests/UserDetailsPermissionTest.java
+++ b/src/org/labkey/test/tests/UserDetailsPermissionTest.java
@@ -32,6 +32,7 @@ import org.labkey.test.pages.query.ExecuteQueryPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable.DataRegionFinder;
+import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.PortalHelper;
@@ -117,8 +118,8 @@ public class UserDetailsPermissionTest extends BaseWebDriverTest
         {
             goToMyAccount();
             clickButton("Edit");
-            setFormElement(Locator.name("quf_Phone"), HIDDEN_STRING);
-            setFormElement(Locator.name("quf_" + CUSTOM_USER_COLUMN), HIDDEN_STRING);
+            setFormElement(Locator.name(EscapeUtil.getFormFieldName("Phone")), HIDDEN_STRING);
+            setFormElement(Locator.name(EscapeUtil.getFormFieldName(CUSTOM_USER_COLUMN)), HIDDEN_STRING);
             clickButton("Submit");
         }
         stopImpersonating();
@@ -126,8 +127,8 @@ public class UserDetailsPermissionTest extends BaseWebDriverTest
         {
             goToMyAccount();
             clickButton("Edit");
-            setFormElement(Locator.name("quf_Phone"), HIDDEN_STRING);
-            setFormElement(Locator.name("quf_" + CUSTOM_USER_COLUMN), HIDDEN_STRING);
+            setFormElement(Locator.name(EscapeUtil.getFormFieldName("Phone")), HIDDEN_STRING);
+            setFormElement(Locator.name(EscapeUtil.getFormFieldName(CUSTOM_USER_COLUMN)), HIDDEN_STRING);
             clickButton("Submit");
         }
         stopImpersonating();

--- a/src/org/labkey/test/tests/UserDetailsPermissionTest.java
+++ b/src/org/labkey/test/tests/UserDetailsPermissionTest.java
@@ -29,10 +29,10 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.components.DomainDesignerPage;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.query.ExecuteQueryPage;
+import org.labkey.test.pages.user.UpdateUserDetailsPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable.DataRegionFinder;
-import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.PortalHelper;
@@ -116,20 +116,18 @@ public class UserDetailsPermissionTest extends BaseWebDriverTest
 
         impersonate(ADMIN_USER);
         {
-            goToMyAccount();
-            clickButton("Edit");
-            setFormElement(Locator.name(EscapeUtil.getFormFieldName("Phone")), HIDDEN_STRING);
-            setFormElement(Locator.name(EscapeUtil.getFormFieldName(CUSTOM_USER_COLUMN)), HIDDEN_STRING);
-            clickButton("Submit");
+            UpdateUserDetailsPage page = goToMyAccount().clickEdit();
+            page.setField("Phone", HIDDEN_STRING);
+            page.setField(CUSTOM_USER_COLUMN, HIDDEN_STRING);
+            page.clickSubmit();
         }
         stopImpersonating();
         impersonate(CHECKED_USER);
         {
-            goToMyAccount();
-            clickButton("Edit");
-            setFormElement(Locator.name(EscapeUtil.getFormFieldName("Phone")), HIDDEN_STRING);
-            setFormElement(Locator.name(EscapeUtil.getFormFieldName(CUSTOM_USER_COLUMN)), HIDDEN_STRING);
-            clickButton("Submit");
+            UpdateUserDetailsPage page = goToMyAccount().clickEdit();
+            page.setField("Phone", HIDDEN_STRING);
+            page.setField(CUSTOM_USER_COLUMN, HIDDEN_STRING);
+            page.clickSubmit();
         }
         stopImpersonating();
     }

--- a/src/org/labkey/test/tests/UserTableCustomFieldUpdateTest.java
+++ b/src/org/labkey/test/tests/UserTableCustomFieldUpdateTest.java
@@ -8,7 +8,6 @@ import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.query.UpdateRowsCommand;
 import org.labkey.test.BaseWebDriverTest;
-import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
@@ -16,12 +15,12 @@ import org.labkey.test.components.DomainDesignerPage;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.EscapeUtil;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
@@ -63,10 +62,7 @@ public class UserTableCustomFieldUpdateTest extends BaseWebDriverTest
         _userHelper.createUser(TEST_USER);
     }
 
-    /*
-        Regression coverage for Issue 48185: Update of the User table clears any non-specified custom fields
-     */
-    @Test
+    @Test // Issue 48185
     public void testCustomFieldUpdate() throws IOException, CommandException
     {
         log("Extract the userId");
@@ -78,15 +74,15 @@ public class UserTableCustomFieldUpdateTest extends BaseWebDriverTest
         goToHome();
         impersonate(TEST_USER);
         {
-            goToMyAccount();
-            clickButton("Edit");
-            setFormElement(Locator.name(EscapeUtil.getFormFieldName(CUSTOM_FIELD1)), "Value for " + CUSTOM_FIELD1);
-            setFormElement(Locator.name(EscapeUtil.getFormFieldName(CUSTOM_FIELD2)), "Value for " + CUSTOM_FIELD2);
-            clickButton("Submit");
+            goToMyAccount()
+                .clickEdit()
+                .setField(CUSTOM_FIELD1, "Value for " + CUSTOM_FIELD1)
+                .setField(CUSTOM_FIELD2, "Value for " + CUSTOM_FIELD2)
+                .clickSubmit();
         }
         stopImpersonating();
 
-        HashMap row = new HashMap<String, String>();
+        Map<String, Object> row = new HashMap<>();
         row.put("UserId", userId);
         row.put(CUSTOM_FIELD1, "Updated value for " + CUSTOM_FIELD1);
 
@@ -109,5 +105,4 @@ public class UserTableCustomFieldUpdateTest extends BaseWebDriverTest
     {
         _userHelper.deleteUsers(false, TEST_USER);
     }
-
 }

--- a/src/org/labkey/test/tests/UserTableCustomFieldUpdateTest.java
+++ b/src/org/labkey/test/tests/UserTableCustomFieldUpdateTest.java
@@ -16,6 +16,7 @@ import org.labkey.test.components.DomainDesignerPage;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.EscapeUtil;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -79,8 +80,8 @@ public class UserTableCustomFieldUpdateTest extends BaseWebDriverTest
         {
             goToMyAccount();
             clickButton("Edit");
-            setFormElement(Locator.name("quf_" + CUSTOM_FIELD1), "Value for " + CUSTOM_FIELD1);
-            setFormElement(Locator.name("quf_" + CUSTOM_FIELD2), "Value for " + CUSTOM_FIELD2);
+            setFormElement(Locator.name(EscapeUtil.getFormFieldName(CUSTOM_FIELD1)), "Value for " + CUSTOM_FIELD1);
+            setFormElement(Locator.name(EscapeUtil.getFormFieldName(CUSTOM_FIELD2)), "Value for " + CUSTOM_FIELD2);
             clickButton("Submit");
         }
         stopImpersonating();

--- a/src/org/labkey/test/tests/UserTest.java
+++ b/src/org/labkey/test/tests/UserTest.java
@@ -35,6 +35,7 @@ import org.labkey.test.components.dumbster.EmailRecordTable;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.IssuesHelper;
 import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.UIUserHelper;
@@ -481,7 +482,7 @@ public class UserTest extends BaseWebDriverTest
         clickAndWait(Locator.lkButton("Edit"));
         for (String field : REQUIRED_FIELDS)
         {
-            WebElement el = Locator.name("quf_" + field).waitForElement(new WebDriverWait(getDriver(), Duration.ofSeconds(5)));
+            WebElement el = Locator.name(EscapeUtil.getFormFieldName(field)).waitForElement(new WebDriverWait(getDriver(), Duration.ofSeconds(5)));
             if (getFormElement(el).isEmpty())
                 setFormElement(el, getDisplayName());
         }

--- a/src/org/labkey/test/tests/core/admin/AllowedFileExtensionTest.java
+++ b/src/org/labkey/test/tests/core/admin/AllowedFileExtensionTest.java
@@ -18,6 +18,7 @@ import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.params.list.IntListDefinition;
 import org.labkey.test.params.list.ListDefinition;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
@@ -303,11 +304,12 @@ public class AllowedFileExtensionTest extends AllowedFileExtensionBaseTest
         waitForElement(Locator.button("Back"));
         clickButton("Back");
 
-        waitForElement(Locator.name("quf_" + attachmentField));
+        var attachmentFieldLocator = Locator.name(EscapeUtil.getFormFieldName(attachmentField));
+        waitForElement(attachmentFieldLocator);
 
         // Issue 53026, the fields are cleared after hitting the back button. Unlikely the issue will be fixed.
         log("Clear the file field.");
-        FileInput el = FileInput.FileInput(Locator.name("quf_" + attachmentField), getDriver()).findWhenNeeded();
+        FileInput el = FileInput.FileInput(attachmentFieldLocator, getDriver()).findWhenNeeded();
         el.clear();
 
         File fileAgain = fileMap.get(".txt");

--- a/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
+++ b/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.test.BaseWebDriverTest;
-import org.labkey.test.Locator;
 import org.labkey.test.SortDirection;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebTestHelper;
@@ -30,7 +29,6 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.AuditLogHelper;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.ExcelHelper;
 
 import java.io.File;
@@ -46,7 +44,6 @@ import java.util.Map;
 @Category({Daily.class, Data.class, Hosting.class})
 public class ListDateAndTimeTest extends BaseWebDriverTest
 {
-
     private static final String PROJECT_NAME = "List Date And Time Test";
     private static SimpleDateFormat _defaultDateFormat = null;
     private static SimpleDateFormat _defaultTimeFormat = null;
@@ -118,16 +115,16 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
                 expectedData.size(), table.getDataRowCount());
 
         int rowIndex = 0;
-        for(Map<String, String> expectedRowMap : expectedData)
+        for (Map<String, String> expectedRowMap : expectedData)
         {
             // Protect against the table having fewer rows than expected (index out of bounds error).
-            if(rowIndex < table.getDataRowCount())
+            if (rowIndex < table.getDataRowCount())
             {
                 Map<String, String> tableRowMap = table.getRowDataAsMap(rowIndex);
 
-                for(Map.Entry<String, String> expectedEntry : expectedRowMap.entrySet())
+                for (Map.Entry<String, String> expectedEntry : expectedRowMap.entrySet())
                 {
-                    if(checker().verifyTrue(String.format("Could not find column '%s' in rowmap for row %d", expectedEntry.getKey(), rowIndex),
+                    if (checker().verifyTrue(String.format("Could not find column '%s' in rowmap for row %d", expectedEntry.getKey(), rowIndex),
                             tableRowMap.containsKey(expectedEntry.getKey())))
                     {
                         checker().verifyEquals(String.format("For row %d column %s not as expected.", rowIndex, expectedEntry.getKey()),
@@ -156,7 +153,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
      * </p>
      */
     @Test
-    public void testDateAndTimeColumnsInsert() throws IOException, CommandException
+    public void testDateAndTimeColumnsInsert()
     {
 
         SimpleDateFormat variantDateFormat = new SimpleDateFormat("MMMM dd, yyyy");
@@ -223,7 +220,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         _listHelper.importDataFromFile(excelDateTimeFile);
 
-        // Note, the month is zero based. The value of the month here is one less than what is seen in the file.
+        // Note, the month is zero-based. The value of the month here is one less than what is seen in the file.
         // Also of note the xlsx used has a column formatted as time and another as date. Excel does not have a DateTime specific format.
         testDate01 = new Calendar.Builder()
                 .setDate(2024, 1, 29)
@@ -302,9 +299,8 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
     }
 
     @Test
-    public void testExcelImportExport() throws IOException, CommandException
+    public void testExcelImportExport() throws IOException
     {
-
         String listName = "Date and Time Export List";
         String dateCol = "Date";
         String timeCol = "Time";
@@ -407,12 +403,12 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         File exportedFile = exportHelper.exportExcel(DataRegionExportHelper.ExcelFileType.XLSX);
 
-        try(Workbook workbook = ExcelHelper.create(exportedFile))
+        try (Workbook workbook = ExcelHelper.create(exportedFile))
         {
             Sheet sheet = workbook.getSheetAt(workbook.getActiveSheetIndex());
 
             int row = 1;
-            for(List<Date> expectedDate : expectedExportedData)
+            for (List<Date> expectedDate : expectedExportedData)
             {
 
                 for (int column = 0; column < 3; column++)
@@ -521,11 +517,9 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
      * <p>
      *     Test will sort different values, that include duplicates, blanks and dates in the future.
      * </p>
-     * @throws IOException Can be thrown by helper that checks if the list already exists.
-     * @throws CommandException Can be thrown by helper that checks if the list already exists.
      */
     @Test
-    public void testDateAndTimeColumnSorting() throws IOException, CommandException
+    public void testDateAndTimeColumnSorting()
     {
 
         String listName = "Date and Time Sort List";
@@ -563,15 +557,15 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
         StringBuilder bulkInsertText = new StringBuilder();
         bulkInsertText.append(String.format("%s\t%s\n", dateCol, timeCol));
 
-        for(Date date : dates)
+        for (Date date : dates)
         {
 
-            if(date.equals(dateUseDateOnly))
+            if (date.equals(dateUseDateOnly))
             {
                 // Add a line with only a date.
                 bulkInsertText.append(String.format("%s\t\n", _defaultDateFormat.format(date)));
             }
-            else if(date.equals(dateUseTimeOnly))
+            else if (date.equals(dateUseTimeOnly))
             {
                 // Add a line with only a time.
                 bulkInsertText.append(String.format("\t%s\n", _defaultTimeFormat.format(date)));
@@ -730,22 +724,24 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
     }
 
-    private void testFiltering(String column, String keyCol, List<String> expectedKeyCol,
-                               String filterType01, @Nullable String filter01,
-                               @Nullable String filterType02, @Nullable String filter02,
-                               String errorMsg, String screenshotName)
+    private void testFiltering(
+        String column,
+        String keyCol,
+        List<String> expectedKeyCol,
+        String filterType01,
+        @Nullable String filter01,
+        @Nullable String filterType02,
+        @Nullable String filter02,
+        String errorMsg,
+        String screenshotName
+    )
     {
         DataRegionTable table = new DataRegionTable("query", getDriver());
 
-        if(null == filter01)
-        {
+        if (null == filter01)
             table.setFilter(column, filterType01);
-        }
         else
-        {
             table.setFilter(column, filterType01, filter01, filterType02, filter02);
-        }
-
 
         List<String> actualKeyCol = table.getColumnDataAsText(keyCol);
 
@@ -754,7 +750,6 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
                         expectedKeyCol, actualKeyCol);
 
         table.clearFilter(column);
-
     }
 
     /**
@@ -771,13 +766,10 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
      *         <li>Filtering time-only column also validates when the value given as the filter has only hh:mm (no seconds)</li>
      *     </ul>
      * </p>
-     * @throws IOException Can be thrown by helper that checks if the list already exists.
-     * @throws CommandException Can be thrown by helper that checks if the list already exists.
      */
     @Test
-    public void testDateAndTimeColumnFiltering() throws IOException, CommandException
+    public void testDateAndTimeColumnFiltering()
     {
-
         String listName = "Date and Time Filter List";
         String dateCol = "Date";
         String timeCol = "Time";
@@ -803,15 +795,15 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
         StringBuilder bulkInsertText = new StringBuilder();
         bulkInsertText.append(String.format("%s\t%s\n", dateCol, timeCol));
 
-        for(Date date : dates)
+        for (Date date : dates)
         {
 
-            if(date.equals(dateUseDateOnlyKey10))
+            if (date.equals(dateUseDateOnlyKey10))
             {
                 // Add a line with only a date.
                 bulkInsertText.append(String.format("%s\t\n", _defaultDateFormat.format(date)));
             }
-            else if(date.equals(dateUseTimeOnlyKey11))
+            else if (date.equals(dateUseTimeOnlyKey11))
             {
                 // Add a line with only a time.
                 bulkInsertText.append(String.format("\t%s\n", _defaultTimeFormat.format(date)));
@@ -821,7 +813,6 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
                 bulkInsertText.append(String.format("%s\t%s\n",
                         _defaultDateFormat.format(date), _defaultTimeFormat.format(date)));
             }
-
         }
 
         log("Use bulk insert to populate the list.");
@@ -862,7 +853,6 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
                 String.format("Filtering date-only column to equal '%s' (duplicate values) not as expected.", filterValue01),
                 "Error_Date_Filter_Equals_Duplicates");
 
-
         Date filterDate01 = new Calendar.Builder()
                 .setDate(2010, 1, 1)
                 .build().getTime();
@@ -878,7 +868,6 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
                 null, null,
                 String.format("Filtering date-only column greater than or equal to '%s' not as expected.", filterValue01),
                 "Error_Date_Filter_Greater");
-
 
         // Filter between two dates.
         filterDate01 = new Calendar.Builder()
@@ -904,7 +893,6 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
                 String.format("Filtering date-only column between '%s' and '%s' not as expected.", filterValue01, filterValue02),
                 "Error_Date_Filter_Between");
 
-
         log("Filter the date-only is blank.");
 
         expectedKeyCol = new ArrayList<>();
@@ -915,7 +903,6 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
                 null, null,
                 "Filtering date-only to 'Is Blank' not as expected.",
                 "Error_Date_Filter_Blank");
-
 
         log("Now filter the time-only field.");
 
@@ -943,7 +930,6 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
                 String.format("Filtering time-only column to equal '%s' (no seconds) not as expected.", filterValue01),
                 "Error_Time_Filter_No_Seconds");
 
-
         filterValue01 = _defaultTimeFormat.format(dateDuplicate);
         log(String.format("Filter the time-only field equals '%s' which has duplicates.", filterValue01));
         expectedKeyCol = new ArrayList<>();
@@ -955,7 +941,6 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
                 null, null,
                 String.format("Filtering time-only column to equal '%s' (duplicate values) not as expected.", filterValue01),
                 "Error_Time_Filter_Equals_Duplicates");
-
 
         filterDate01 = new Calendar.Builder()
                 .setTimeOfDay(14, 0, 0)
@@ -974,7 +959,6 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
                 null, null,
                 String.format("Filtering time-only column greater than or equal to '%s' not as expected.", filterValue01),
                 "Error_Time_Filter_Greater");
-
 
         filterDate01 = new Calendar.Builder()
                 .setTimeOfDay(9, 0, 0)
@@ -1003,7 +987,6 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
                 String.format("Filtering time-only column between '%s' and '%s' not as expected.", filterValue01, filterValue02),
                 "Error_Time_Filter_Between");
 
-
         log("Filter the time-only is blank.");
         expectedKeyCol = new ArrayList<>();
         expectedKeyCol.add("10"); // 1989-08-12 (empty)
@@ -1013,7 +996,6 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
                 null, null,
                 "Filtering time-only to 'Is Blank' not as expected.",
                 "Error_Time_Filter_Blank");
-
     }
 
     /**
@@ -1021,13 +1003,10 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
      *     Validate error messages are expected for invalid values in date-only, time-only and DateTime fields.
      *     Validates bulk import, file (xlsx) and UI.
      * </p>
-     * @throws IOException Can be thrown by helper that checks if the list already exists.
-     * @throws CommandException Can be thrown by helper that checks if the list already exists.
      */
     @Test
-    public void testInvalidDateAndTimeInsert() throws IOException, CommandException
+    public void testInvalidDateAndTimeInsert()
     {
-
         String listName = "Date and Time Invalid Insert List";
         String dateCol = "Date";
         String timeCol = "Time";
@@ -1051,7 +1030,6 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
         String badDateTime = "1/1/22 4:55 pm And Some Text";
 
         ImportDataPage importPage = _listHelper.clickImportData();
-
 
         String bulkImportText = String.format("%s\t\n%s", dateCol, badDate);
         importPage.setText(bulkImportText);
@@ -1100,18 +1078,17 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         _listHelper.beginAtList(getProjectName(), listName);
 
-        DataRegionTable regionTable = new DataRegionTable("query", getDriver());
-        regionTable.clickInsertNewRow();
-        setFormElement(Locator.name(EscapeUtil.getFormFieldName(timeCol)), badTime);
-        setFormElement(Locator.name(EscapeUtil.getFormFieldName(dateCol)), badDate);
-        setFormElement(Locator.name(EscapeUtil.getFormFieldName(dateTimeCol)), badDateTime);
-        clickButton("Submit");
+        new DataRegionTable("query", getDriver())
+                .clickInsertNewRow()
+                .setField(timeCol, badTime)
+                .setField(dateCol, badDate)
+                .setField(dateTimeCol, badDateTime)
+                .submit();
 
         checker().verifyTrue("Bad value error message in UI not as expected.",
                 isTextPresent(String.format("Could not convert value: %s", badTime),
                         String.format("Could not convert value: %s", badDate),
                         String.format("Could not convert value: %s", badDateTime)));
-
     }
 
     /**
@@ -1181,7 +1158,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
         SimpleDateFormat inputTimeFormatter = new SimpleDateFormat("hh:mm:ss aa");
         SimpleDateFormat inputDateTimeFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
-        for(Date date : dates)
+        for (Date date : dates)
         {
             bulkImportText.append(String.format("%s\t%s\t%s\n",
                     inputDateFormatter.format(date), inputTimeFormatter.format(date), inputDateTimeFormatter.format(date)
@@ -1194,7 +1171,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         List<Map<String, String>> expectedData = new ArrayList<>();
 
-        for(Date date : dates)
+        for (Date date : dates)
         {
             expectedData.add(
                     Map.of(
@@ -1238,7 +1215,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         expectedData = new ArrayList<>();
 
-        for(Date date : dates)
+        for (Date date : dates)
         {
             expectedData.add(
                     Map.of(
@@ -1257,13 +1234,10 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
      *     Test converting a DateTime filed to a date-only and time-only field. Test also validates that a date-only
      *     field can be converted to a DateTime field, but a time-only field can not.
      * </p>
-     * @throws IOException Can be thrown by helper that checks if the list already exists.
-     * @throws CommandException Can be thrown by helper that checks if the list already exists.
      */
     @Test
-    public void testConvertDateTimeField() throws IOException, CommandException
+    public void testConvertDateTimeField()
     {
-
         String listName = "Convert DateTime Field List";
         String dateTimeToTimeCol = "DT_To_Time";
         String dateTimeToDateCol = "DT_To_Date";
@@ -1322,7 +1296,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         bulkImportText.append(String.format("%s\t%s\n", dateTimeToDateCol, dateTimeToTimeCol));
 
-        for(Date date : dates)
+        for (Date date : dates)
         {
             bulkImportText.append(String.format("%s\t%s\n",
                     _defaultDateTimeFormat.format(date), formatterFormatTime.format(date)
@@ -1382,7 +1356,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         List<Map<String, String>> expectedData = new ArrayList<>();
 
-        for(Date date : dates)
+        for (Date date : dates)
         {
             expectedData.add(
                     Map.of(
@@ -1430,7 +1404,7 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         expectedData = new ArrayList<>();
 
-        for(Date date : dates)
+        for (Date date : dates)
         {
             expectedData.add(
                     Map.of(
@@ -1443,7 +1417,5 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         validateListDataInUI(table, expectedData);
         checker().screenShotIfNewError("Convert_To_DateTime_Error");
-
     }
-
 }

--- a/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
+++ b/src/org/labkey/test/tests/list/ListDateAndTimeTest.java
@@ -30,6 +30,7 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.AuditLogHelper;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.ExcelHelper;
 
 import java.io.File;
@@ -1101,9 +1102,9 @@ public class ListDateAndTimeTest extends BaseWebDriverTest
 
         DataRegionTable regionTable = new DataRegionTable("query", getDriver());
         regionTable.clickInsertNewRow();
-        setFormElement(Locator.name("quf_" + timeCol), badTime);
-        setFormElement(Locator.name("quf_" + dateCol), badDate);
-        setFormElement(Locator.name("quf_" + dateTimeCol), badDateTime);
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(timeCol)), badTime);
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(dateCol)), badDate);
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(dateTimeCol)), badDateTime);
         clickButton("Submit");
 
         checker().verifyTrue("Bad value error message in UI not as expected.",

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -329,14 +329,14 @@ public class ListTest extends BaseWebDriverTest
         // Second row (Green)
         assertEquals(1, table.getRowIndex(TEST_DATA[TD_COLOR][1]));
         table.clickEditRow(1);
-        setFormElement(Locator.name("quf_" + _listColMonth.getName()), VALID_MONTHS[1]);  // Has a funny format -- need to post converted date
-        checkCheckbox(Locator.checkboxByName("quf_JewelTone"));
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(_listColMonth.getName())), VALID_MONTHS[1]);  // Has a funny format -- need to post converted date
+        checkCheckbox(Locator.checkboxByName(EscapeUtil.getFormFieldName("JewelTone")));
         clickButton("Submit");
         // Third row (Red)
         assertEquals(2, table.getRowIndex(TEST_DATA[TD_COLOR][2]));
         table.clickEditRow(2);
-        setFormElement(Locator.name("quf_" + _listColMonth.getName()), VALID_MONTHS[2]);  // Has a funny format -- need to post converted date
-        uncheckCheckbox(Locator.checkboxByName("quf_JewelTone"));
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(_listColMonth.getName())), VALID_MONTHS[2]);  // Has a funny format -- need to post converted date
+        uncheckCheckbox(Locator.checkboxByName(EscapeUtil.getFormFieldName("JewelTone")));
         clickButton("Submit");
 
         table = new DataRegionTable("query", getDriver());
@@ -413,12 +413,12 @@ public class ListTest extends BaseWebDriverTest
         String html = getHtmlSource();
         assertTrue("Description \"" + _listColDesc.getDescription() + "\" not present.", html.contains(_listColDesc.getDescription()));
         assertTrue("Description \"" + _listColTone.getDescription() + "\" not present.", html.contains(_listColTone.getDescription()));
-        setFormElement(Locator.name("quf_" + _listColDesc.getName()), TEST_DATA[TD_DESC][3]);
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(_listColDesc.getName())), TEST_DATA[TD_DESC][3]);
         // Jewel Tone checkbox is left blank -- we'll make sure it's posted as false below
-        setFormElement(Locator.name("quf_" + _listColGood.getName()), TEST_DATA[TD_GOOD][3]);
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(_listColGood.getName())), TEST_DATA[TD_GOOD][3]);
         clickButton("Submit");
         assertTextPresent("This field is required");
-        setFormElement(Locator.name("quf_" + LIST_KEY_NAME2), TEST_DATA[TD_COLOR][3]);
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(LIST_KEY_NAME2)), TEST_DATA[TD_COLOR][3]);
         clickButton("Submit");
 
         log("Check new row was added");
@@ -1649,9 +1649,9 @@ public class ListTest extends BaseWebDriverTest
         // insert a new row and verify the key is encoded in the form input
         table.clickInsertNewRow();
         String html = getHtmlSource();
-        checker().verifyFalse("List key hidden input not present.", html.contains("quf_" + encodedKeyName));
+        checker().verifyFalse("List key hidden input not present.", html.contains(EscapeUtil.getFormFieldName(encodedKeyName)));
         String nameValue = "test";
-        setFormElement(Locator.name("quf_Name"), nameValue);
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName("Name")), nameValue);
         clickButton("Submit");
 
         // verify the name value is persisted
@@ -1662,9 +1662,9 @@ public class ListTest extends BaseWebDriverTest
         // verify name value can be updated
         table.clickEditRow(0);
         html = getHtmlSource();
-        checker().verifyTrue("List key hidden input not present.", html.contains("quf_" + encodedKeyName));
+        checker().verifyTrue("List key hidden input not present.", html.contains(EscapeUtil.getFormFieldName(encodedKeyName)));
         nameValue = "test updated";
-        setFormElement(Locator.name("quf_Name"), nameValue);
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName("Name")), nameValue);
         clickButton("Submit");
 
         // verify the name value is persisted

--- a/src/org/labkey/test/util/DataClassHelper.java
+++ b/src/org/labkey/test/util/DataClassHelper.java
@@ -143,7 +143,7 @@ public class DataClassHelper extends WebDriverWrapper
                 .clickInsertNewRow();
         for (Map.Entry<String, String> fieldValue : fieldValues.entrySet())
         {
-            setFormElement(Locator.name("quf_" + fieldValue.getKey()), fieldValue.getValue());
+            setFormElement(Locator.name(EscapeUtil.getFormFieldName(fieldValue.getKey())), fieldValue.getValue());
         }
         clickButton("Submit");
     }

--- a/src/org/labkey/test/util/EscapeUtil.java
+++ b/src/org/labkey/test/util/EscapeUtil.java
@@ -239,6 +239,10 @@ public class EscapeUtil
             .replace("%29", ")");
     }
 
+    /**
+     * Form field prefix prepended to all query update form field names.
+     * See {@link org.labkey.api.query.QueryUpdateForm#PREFIX}.
+     */
     public static final String FORM_FIELD_PREFIX = "quf_";
     private static final char BACKSLASH = '\\';
     private static final String SPECIAL_CHARS = BACKSLASH + "\";=,";

--- a/src/org/labkey/test/util/EscapeUtil.java
+++ b/src/org/labkey/test/util/EscapeUtil.java
@@ -18,6 +18,7 @@ package org.labkey.test.util;
 import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.jetty.util.URIUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.test.params.FieldKey;
 
 import java.net.URLDecoder;
@@ -236,5 +237,31 @@ public class EscapeUtil
             // We generally don't encode parentheses in app resource paths
             .replace("%28", "(")
             .replace("%29", ")");
+    }
+
+    public static final String FORM_FIELD_PREFIX = "quf_";
+    private static final char BACKSLASH = '\\';
+    private static final String SPECIAL_CHARS = BACKSLASH + "\";=,";
+
+    public static String getFormFieldName(String columnName)
+    {
+        return getFormFieldName(columnName, FORM_FIELD_PREFIX);
+    }
+
+    /**
+     * Escapes special characters in a column name to be used as a form field name.
+     * See associated {@link org.labkey.api.query.QueryUpdateForm#getFormFieldName}
+     */
+    public static String getFormFieldName(String columnName, @Nullable String prefix)
+    {
+        StringBuilder fieldName = new StringBuilder();
+        for (char c : columnName.toCharArray())
+        {
+            if (SPECIAL_CHARS.indexOf(c) >= 0)
+                fieldName.append(BACKSLASH);
+            fieldName.append(c);
+        }
+
+        return prefix == null ? fieldName.toString() : prefix + fieldName;
     }
 }

--- a/src/org/labkey/test/util/ListHelper.java
+++ b/src/org/labkey/test/util/ListHelper.java
@@ -113,7 +113,7 @@ public class ListHelper extends LabKeySiteWrapper
     {
         for (String key : data.keySet())
         {
-            WebElement field = waitForElement(Locator.name("quf_" + key));
+            WebElement field = waitForElement(Locator.name(EscapeUtil.getFormFieldName(key)));
             String inputType = field.getAttribute("type");
             Object value = data.get(key);
             if (value instanceof File)

--- a/src/org/labkey/test/util/SampleTypeHelper.java
+++ b/src/org/labkey/test/util/SampleTypeHelper.java
@@ -200,7 +200,7 @@ public class SampleTypeHelper extends WebDriverWrapper
                 .clickInsertNewRow();
         for (Map.Entry<String, String> fieldValue : fieldValues.entrySet())
         {
-            setFormElement(Locator.name("quf_" + fieldValue.getKey()), fieldValue.getValue());
+            setFormElement(Locator.name(EscapeUtil.getFormFieldName(fieldValue.getKey())), fieldValue.getValue());
         }
         clickButton("Submit");
     }


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/platform/pull/7033 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7033
- https://github.com/LabKey/limsModules/pull/1661
- https://github.com/LabKey/testAutomation/pull/2683
- https://github.com/LabKey/premiumModules/pull/353

#### Changes
- Add `EscapeUtils.getFormFieldName()` to account for escaped characters in form field names.
- Update tests to use `EscapeUtils.getFormFieldName()`.