### PR TITLE
Fix the specimen controller name in SpecimenGridExportTest

### DIFF
--- a/src/org/labkey/test/tests/SpecimenGridExportTest.java
+++ b/src/org/labkey/test/tests/SpecimenGridExportTest.java
@@ -172,7 +172,7 @@ public class SpecimenGridExportTest extends AbstractExportTest
     @Override
     protected void goToDataRegionPage()
     {
-        beginAt(WebTestHelper.buildURL("specimens", getProjectName(), "specimens", Map.of("showVials", false)));
+        beginAt(WebTestHelper.buildURL("specimen", getProjectName(), "specimens", Map.of("showVials", false)));
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
I accidentally added an `s` to the controller name when updating a URL in `SpecimenGridExportTest`.

```
No LabKey Server module registered to handle request for controller: specimens
```
```
org.openqa.selenium.NoSuchElementException: Expected condition failed: waiting for css=form[data-region-form="SpecimenSummary"] (tried for 30 second(s) with 100 milliseconds interval)
  at app//org.labkey.test.Locator.waitForElement(Locator.java:570)
  at app//org.labkey.test.selenium.LazyWebElement.findWrappedElement(LazyWebElement.java:69)
  at app//org.labkey.test.selenium.BaseLazyWebElement.getWrappedElement(BaseLazyWebElement.java:14)
  at app//org.labkey.test.selenium.RefindingWebElement.getWrappedElement(RefindingWebElement.java:77)
  at app//org.labkey.test.selenium.WebElementWrapper.isEnabled(WebElementWrapper.java:79)
  at app//org.labkey.test.util.DataRegion.elementCache(DataRegion.java:97)
  at app//org.labkey.test.util.DataRegionTable.elementCache(DataRegionTable.java:107)
  at app//org.labkey.test.util.DataRegionTable.uncheckAllOnPage(DataRegionTable.java:1192)
  at app//org.labkey.test.tests.AbstractExportTest.preTest(AbstractExportTest.java:106)
```

#### Related Pull Requests
- #2681 

#### Changes
- Fix the specimen controller name in SpecimenGridExportTest
