### PR TITLE
Move InventoryMetricUnit enum to testAutomation to share between LKS and apps

### DIFF
--- a/src/org/labkey/test/params/experiment/InventoryMetricUnit.java
+++ b/src/org/labkey/test/params/experiment/InventoryMetricUnit.java
@@ -1,0 +1,50 @@
+package org.labkey.test.params.experiment;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Enum of the various storage amount types.
+ */
+public enum InventoryMetricUnit
+{
+    // If you add a value here you will also need to update SMSampleTypeDefinition.getInventoryMetricUnit.
+    G("g", "g (grams)"),
+    MG("mg", "mg (milligrams)"),
+    KG("kg", "kg (kilograms)"),
+    ML("mL", "mL (milliliters)"),
+    UL("uL", "uL (microliters)"),
+    L("L", "L (liters)"),
+    UNIT("unit", "unit"),
+    UNKNOWN("unknown", "unknown"); // Used by getInventoryMetricUnit. Return if an unknown value is in the UI.
+
+    private final String _value; // Used when creating a sample type with the API and setting this property.
+    private final String _label; // Used when setting the property through the UI.
+
+    InventoryMetricUnit(String value, String label)
+    {
+        _value = value;
+        _label = label;
+    }
+
+    public String getLabel()
+    {
+        return _label;
+    }
+
+    public String getValue()
+    {
+        return _value;
+    }
+
+    public static String getStandardUnit(String unitString)
+    {
+        if (StringUtils.isEmpty(unitString))
+            return unitString;
+        for (InventoryMetricUnit unit : values())
+        {
+            if (unit.getValue().toLowerCase().equals(unitString))
+                return unit.getValue();
+        }
+        return unitString;
+    }
+}

--- a/src/org/labkey/test/params/experiment/MetricUnit.java
+++ b/src/org/labkey/test/params/experiment/MetricUnit.java
@@ -1,7 +1,0 @@
-package org.labkey.test.params.experiment;
-
-public interface MetricUnit
-{
-    String getLabel(); // For UI
-    String getValue(); // For API
-}

--- a/src/org/labkey/test/params/experiment/SampleTypeDefinition.java
+++ b/src/org/labkey/test/params/experiment/SampleTypeDefinition.java
@@ -32,7 +32,7 @@ public class SampleTypeDefinition extends DomainProps
     private final Set<String> _dataParentAliases = new HashSet<>();
 
     // Currently, these values are only used by the SampleManager module.
-    private MetricUnit _inventoryMetricUnit;
+    private InventoryMetricUnit _inventoryMetricUnit;
     private String _labelColor;
     private String _aliquotNameExpression;
 
@@ -96,12 +96,12 @@ public class SampleTypeDefinition extends DomainProps
         return this;
     }
 
-    protected MetricUnit getInventoryMetricUnit()
+    protected InventoryMetricUnit getInventoryMetricUnit()
     {
         return _inventoryMetricUnit;
     }
 
-    public SampleTypeDefinition setInventoryMetricUnit(MetricUnit inventoryMetricUnit)
+    public SampleTypeDefinition setInventoryMetricUnit(InventoryMetricUnit inventoryMetricUnit)
     {
         _inventoryMetricUnit = inventoryMetricUnit;
         return this;

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -52,7 +52,7 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.params.FieldDefinition.LookupInfo;
 import org.labkey.test.params.FieldInfo;
-import org.labkey.test.params.experiment.MetricUnit;
+import org.labkey.test.params.experiment.InventoryMetricUnit;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.AuditLogHelper;
@@ -1868,7 +1868,7 @@ public class SampleTypeTest extends BaseWebDriverTest
 
         clickProject(PROJECT_NAME);
         SampleTypeDefinition sampleTypeDefinition = new SampleTypeDefinition(sampleTypeName);
-        sampleTypeDefinition.setInventoryMetricUnit(TestMetricUnit.L);
+        sampleTypeDefinition.setInventoryMetricUnit(InventoryMetricUnit.L);
         SampleTypeAPIHelper.createEmptySampleType(getProjectName(), sampleTypeDefinition);
         refresh();
         sampleHelper.goToSampleType(sampleTypeName);
@@ -2067,37 +2067,5 @@ public class SampleTypeTest extends BaseWebDriverTest
     public BrowserType bestBrowser()
     {
         return BrowserType.CHROME;
-    }
-
-    public enum TestMetricUnit implements MetricUnit
-    {
-        G("g", "g (grams)"),
-        MG("mg", "mg (milligrams)"),
-        KG("kg", "kg (kilograms)"),
-        ML("mL", "mL (milliliters)"),
-        UL("uL", "uL (microliters)"),
-        L("L", "L (liters)"),
-        UNIT("unit", "unit");
-
-        private final String _value;
-        private final String _label;
-
-        TestMetricUnit(String value, String label)
-        {
-            _value = value;
-            _label = label;
-        }
-
-        @Override
-        public String getLabel()
-        {
-            return _label;
-        }
-
-        @Override
-        public String getValue()
-        {
-            return _value;
-        }
     }
 }


### PR DESCRIPTION
#### Rationale
Follow-up from recently merged PR regarding sample amounts/units. This PR does some cleanup on the test side to move an enum to a shared location in testAutomation.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1653
- https://github.com/LabKey/testAutomation/pull/2688
- https://github.com/LabKey/limsModules/pull/1668

#### Changes
- move enum and update imports and usages
