### PR TITLE
Make `TestDataGenerator.isNameInvalidLocal` check for blank names

### DIFF
--- a/src/org/labkey/test/util/RandomName.java
+++ b/src/org/labkey/test/util/RandomName.java
@@ -15,7 +15,7 @@ public record RandomName(String part, String name)
     public RandomName(String part, String name)
     {
         this.part = part == null ? "" : part; // Don't trim
-        this.name = Objects.requireNonNull(name);
+        this.name = Objects.requireNonNull(name).trim();
     }
 
     @Override

--- a/src/org/labkey/test/util/RandomName.java
+++ b/src/org/labkey/test/util/RandomName.java
@@ -15,7 +15,7 @@ public record RandomName(String part, String name)
     public RandomName(String part, String name)
     {
         this.part = part == null ? "" : part; // Don't trim
-        this.name = Objects.requireNonNull(name).trim();
+        this.name = Objects.requireNonNull(name);
     }
 
     @Override

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -702,6 +702,8 @@ public class TestDataGenerator
     {
         if (domainName != null)
         {
+            if (domainName.name().isEmpty())
+                return true;
             if (!Character.isLetterOrDigit(domainName.name().charAt(0)))
                 return true; // domain needs to start with alphanumeric char
             if (Pattern.matches("(.*\\s--[^ ].*)|(.*\\s-[^- ].*)", domainName.name()))
@@ -722,6 +724,8 @@ public class TestDataGenerator
         }
         if (fieldName != null)
         {
+            if (fieldName.name().isEmpty())
+                return true;
             if (fieldName.name().length() > 200)
                 return true;
             if (COLON_NAME_PATTERN.matcher(fieldName.name())

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -702,7 +702,7 @@ public class TestDataGenerator
     {
         if (domainName != null)
         {
-            if (domainName.name().isEmpty())
+            if (domainName.name().isBlank())
                 return true;
             if (!Character.isLetterOrDigit(domainName.name().charAt(0)))
                 return true; // domain needs to start with alphanumeric char
@@ -724,7 +724,7 @@ public class TestDataGenerator
         }
         if (fieldName != null)
         {
-            if (fieldName.name().isEmpty())
+            if (fieldName.name().isBlank())
                 return true;
             if (fieldName.name().length() > 200)
                 return true;


### PR DESCRIPTION
#### Rationale
Avoid generating blank domain or field names.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2674

#### Changes
- Make `TestDataGenerator.isNameInvalidLocal` check for blank names