### PR TITLE
Test updates for errors where amount and units are now both required when one is provided

### DIFF
--- a/src/org/labkey/test/tests/core/admin/AllowedFileExtensionTest.java
+++ b/src/org/labkey/test/tests/core/admin/AllowedFileExtensionTest.java
@@ -397,12 +397,14 @@ public class AllowedFileExtensionTest extends AllowedFileExtensionBaseTest
         log("Create a sample that tries to upload a disallowed file type.");
         String sampleId = String.format("S-%d", i);
         String description= "Some text for the description.";
-        String amount = "5.0";
+        String amount = "5.1";
+        String units = "mg";
 
         fieldMap = Map.of("Name", sampleId,
                 "Description", description,
                 stFileField, fileMap.get(excludedType).getAbsolutePath(),
-                "StoredAmount", amount);
+                "StoredAmount", amount,
+                "Units", units);
         sampleTypeHelper.insertRow(fieldMap);
 
         validateErrorPage(fileMap.get(excludedType).getName(), allowedTypes);
@@ -413,7 +415,8 @@ public class AllowedFileExtensionTest extends AllowedFileExtensionBaseTest
         sampleTypeHelper.goToSampleType(stName);
         fieldMap = Map.of("Name", sampleId,
                 "Description", description,
-                "StoredAmount", amount);
+                "StoredAmount", amount,
+                "Units", units);
         sampleTypeHelper.insertRow(fieldMap);
 
         Map<String, String> rowMap = sampleTypeHelper.getSamplesDataRegionTable().getRowDataAsMap(0);
@@ -423,6 +426,9 @@ public class AllowedFileExtensionTest extends AllowedFileExtensionBaseTest
 
         checker().verifyEquals("'Amount' field in grid does not have expected value.",
                 amount, rowMap.get("StoredAmount"));
+
+        checker().verifyEquals("'Units' field in grid does not have expected value.",
+                units, rowMap.get("Units"));
 
         checker().verifyEquals(String.format("'%s' field in grid does not have expected value.", stFileField),
                 " ", rowMap.get(stFileField));

--- a/src/org/labkey/test/tests/experiment/SampleTypeLookupDisplayColumnTest.java
+++ b/src/org/labkey/test/tests/experiment/SampleTypeLookupDisplayColumnTest.java
@@ -94,7 +94,7 @@ public class SampleTypeLookupDisplayColumnTest extends BaseWebDriverTest
         sampleTypeList.clickInsertNewRow();
 
         String comment = "inserted with lookup by ingredient.intcolumn";
-        setFieldValues("intSample", comment, "3.5", "2");
+        setFieldValues("intSample", comment, "3.5", "mL", "2");
 
         sampleTypeList =  DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
         var row = sampleTypeList.getRowDataAsMap("Comment", comment);
@@ -111,7 +111,7 @@ public class SampleTypeLookupDisplayColumnTest extends BaseWebDriverTest
         sampleTypeList.clickInsertNewRow();
 
         String comment = "inserted with lookup by ingredient.titleColumn";
-        setFieldValues("nameSample", comment, "3.5", "sodium hexafluoride");
+        setFieldValues("nameSample", comment, "3.5", "mL", "sodium hexafluoride");
 
         sampleTypeList =  DataRegionTable.DataRegion(getDriver()).withName("Material").waitFor();
         var row = sampleTypeList.getRowDataAsMap("Comment", comment);
@@ -129,13 +129,14 @@ public class SampleTypeLookupDisplayColumnTest extends BaseWebDriverTest
 
     }
 
-    private void setFieldValues(String name, String comment, String amount, String ingredient)
+    private void setFieldValues(String name, String comment, String amount, String units, String ingredient)
     {
         var insertPage = new UpdateQueryRowPage(getDriver());
         if (name != null)   // for update, name field is disabled
             insertPage.setField("Name", name);
         insertPage.setField("comment", comment);
         insertPage.setField("StoredAmount", amount);
+        insertPage.setField("Units", units);
         insertPage.setField("ingredient", ingredient);
         insertPage.submit();
     }


### PR DESCRIPTION
#### Rationale
Related to the recent work for amounts/units (https://github.com/LabKey/platform/pull/6994), this PR updates a couple tests that now need to set both amounts and units when either one is provided.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6994
- https://github.com/LabKey/testAutomation/pull/2692
- https://github.com/LabKey/premiumModules/pull/356

#### Changes
- provide units when sample amount is set
