### PR TITLE
Issue 53915: revert workaround

### DIFF
--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -1,7 +1,5 @@
 package org.labkey.test.components.ui.entities;
 
-import org.awaitility.Awaitility;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
@@ -16,7 +14,6 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -188,16 +185,12 @@ public class ParentEntityEditPanel extends Panel<ParentEntityEditPanel.ElementCa
         Panel<?> detailsPanel = new Panel.PanelFinder(getDriver()).withTitle(parentType).waitFor(getDriver());
         if (!selections.isEmpty())
         {
-            // Just wait for the correct number of parents/sources to appear for now.
-            Locator.CssLocator rowLocator = Locator.css(".grid-panel tbody tr");
-            Awaitility.await("Total " + parentType + " grid rows").atMost(Duration.ofSeconds(2))
-                .until(() -> rowLocator.findElements(detailsPanel).size(), CoreMatchers.equalTo(selections.size()));
             // Issue 53915: Lineage panel grids don't show IDs or links for parent sequences and molecules in Biologics
-            // for (String selection : selections)
-            // {
-            //     getWrapper().quickWait().until(ExpectedConditions.visibilityOf(
-            //         Locator.linkWithText(selection).findWhenNeeded(detailsPanel)));
-            // }
+            for (String selection : selections)
+            {
+                getWrapper().quickWait().until(ExpectedConditions.visibilityOf(
+                        Locator.linkWithText(selection).findWhenNeeded(detailsPanel)));
+            }
         }
         else
         {


### PR DESCRIPTION
#### Rationale
This addresses a few test failures that are identified in [Issue 53915](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53915) that are due to the fact that the tests cannot determine/see the name of parent sequences since the column is not visible.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2684 (when this workaround was introduced)
- https://github.com/LabKey/limsModules/pull/1666

#### Changes
- Restore behavior under test
