### PR TITLE
Selenium tests - Workflow: Change Required Template Fields to be Required at the start of a Job

### DIFF
--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -649,7 +649,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
         public BaseReactSelectFinder<Select> withinFormGroupSkipSelect(String labelText)
         {
             _locator = Locator.tagWithClass("div", "form-group")
-                    .withChild(Locator.tag("label").withPredicate("text() = " + Locator.xq(labelText)));
+                    .withChild(Locator.tag("label").withChild(Locator.tagWithText("span", labelText)));
             return this;
         }
 

--- a/src/org/labkey/test/components/ui/edit/EditInlineField.java
+++ b/src/org/labkey/test/components/ui/edit/EditInlineField.java
@@ -40,7 +40,9 @@ public class EditInlineField extends WebDriverComponent<EditInlineField.ElementC
         // 'setFormElement' calls 'WebElement.clear()' which can close the edit-in-place input
         getWrapper().actionClear(input);
 
-        if (!skipEnter)
+        if (skipEnter)
+            input.sendKeys(value);
+        else
         {
             input.sendKeys(value, Keys.ENTER);
             getWrapper().shortWait().until(ExpectedConditions.stalenessOf(input));

--- a/src/org/labkey/test/components/ui/edit/EditInlineField.java
+++ b/src/org/labkey/test/components/ui/edit/EditInlineField.java
@@ -33,14 +33,23 @@ public class EditInlineField extends WebDriverComponent<EditInlineField.ElementC
         return _driver;
     }
 
-    public void setValue(String value)
+    public void setValue(String value, boolean skipEnter)
     {
         open();
         WebElement input = elementCache().input;
         // 'setFormElement' calls 'WebElement.clear()' which can close the edit-in-place input
         getWrapper().actionClear(input);
-        input.sendKeys(value, Keys.ENTER);
-        getWrapper().shortWait().until(ExpectedConditions.stalenessOf(input));
+
+        if (!skipEnter)
+        {
+            input.sendKeys(value, Keys.ENTER);
+            getWrapper().shortWait().until(ExpectedConditions.stalenessOf(input));
+        }
+    }
+
+    public void setValue(String value)
+    {
+        setValue(value, false);
     }
 
     public String getLabel()


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1854
- https://github.com/LabKey/labkey-ui-premium/pull/819
- https://github.com/LabKey/limsModules/pull/1674
- https://github.com/LabKey/testAutomation/pull/2698

#### Changes
- Add util for inlineEdit to set value without hitting Enter key