### PR TITLE
Constants for many commonly used role names in tests

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1984,7 +1984,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         }
         else
         {
-            apiPermissionsHelper.setSiteRoleUserPermissions(userEmail, "Platform Developer");
+            apiPermissionsHelper.setSiteRoleUserPermissions(userEmail, PermissionsHelper.DEVELOPER_ROLE);
         }
 
         return apiPermissionsHelper;

--- a/src/org/labkey/test/pages/admin/PermissionsPage.java
+++ b/src/org/labkey/test/pages/admin/PermissionsPage.java
@@ -37,6 +37,9 @@ import java.util.Date;
 import java.util.List;
 
 import static org.labkey.test.WebTestHelper.buildURL;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 public class PermissionsPage extends LabKeyPage<PermissionsPage.ElementCache>
 {
@@ -104,7 +107,7 @@ public class PermissionsPage extends LabKeyPage<PermissionsPage.ElementCache>
         String R = "security.roles.";
         if ("No Permissions".equals(perm))
             return R + "NoPermissionsRole";
-        if ("Project Administrator".equals(perm))
+        if (PROJECT_ADMIN_ROLE.equals(perm))
             return R + "ProjectAdminRole";
         else if (!perm.contains("."))
             return R + perm + "Role";
@@ -498,9 +501,9 @@ public class PermissionsPage extends LabKeyPage<PermissionsPage.ElementCache>
 
         if (role.endsWith("security.roles.NoPermissionsRole"))
         {
-            assertNoPermission(userOrGroupName, "Reader");
-            assertNoPermission(userOrGroupName, "Editor");
-            assertNoPermission(userOrGroupName, "Project Administrator");
+            assertNoPermission(userOrGroupName, READER_ROLE);
+            assertNoPermission(userOrGroupName, EDITOR_ROLE);
+            assertNoPermission(userOrGroupName, PROJECT_ADMIN_ROLE);
             return this;
         }
         waitForElement(Locator.permissionRendered(), BaseWebDriverTest.WAIT_FOR_JAVASCRIPT);

--- a/src/org/labkey/test/tests/AbstractAdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AbstractAdminConsoleTest.java
@@ -24,6 +24,8 @@ import org.labkey.test.util.PermissionsHelper;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.labkey.test.util.PermissionsHelper.APP_ADMIN_ROLE;
+
 public abstract class AbstractAdminConsoleTest extends BaseWebDriverTest
 {
     protected static final String APP_ADMIN_USER = "app_admin_test_user@adminconsole.test";
@@ -73,7 +75,7 @@ public abstract class AbstractAdminConsoleTest extends BaseWebDriverTest
 
         int appAdminId = _userHelper.createUser(APP_ADMIN_USER, true, false).getUserId();
         setInitialPassword(appAdminId);
-        apiPermissionsHelper.addMemberToRole(APP_ADMIN_USER, "Application Admin", PermissionsHelper.MemberType.user, "/");
+        apiPermissionsHelper.addMemberToRole(APP_ADMIN_USER, APP_ADMIN_ROLE, PermissionsHelper.MemberType.user, "/");
 
         int troubleshooterId = _userHelper.createUser(TROUBLESHOOTER_USER, true, false).getUserId();
         setInitialPassword(troubleshooterId);

--- a/src/org/labkey/test/tests/AbstractAssayTest.java
+++ b/src/org/labkey/test/tests/AbstractAssayTest.java
@@ -34,6 +34,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.labkey.test.params.FieldDefinition.DOMAIN_TRICKY_CHARACTERS;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 /**
  * @deprecated TODO: Move shared functionality to a Helper class
@@ -42,8 +44,6 @@ import static org.labkey.test.params.FieldDefinition.DOMAIN_TRICKY_CHARACTERS;
 public abstract class AbstractAssayTest extends BaseWebDriverTest
 {
     //constants added for security tests
-    protected final static String TEST_ASSAY_PERMS_READER = "Reader";                 //name of built-in reader role
-    private final static String TEST_ASSAY_PERMS_EDITOR = "Editor";                 //name of built-in editor role
     private final static String TEST_ASSAY_PERMS_NONE = "No Permissions";           //name of built-in no perms role
 
     private final static String TEST_ASSAY_GRP_USERS = "Users";                     //name of built-in Users group
@@ -202,10 +202,10 @@ public abstract class AbstractAssayTest extends BaseWebDriverTest
         //we should now be sitting on the new project security page
         //create a group in the project for PIs and make them readers by default
         permissionsHelper.createPermissionsGroup(TEST_ASSAY_GRP_PIS);
-        permissionsHelper.setPermissions(TEST_ASSAY_GRP_PIS, TEST_ASSAY_PERMS_READER);
+        permissionsHelper.setPermissions(TEST_ASSAY_GRP_PIS, READER_ROLE);
 
         //set Users group to be Readers by default
-        permissionsHelper.setPermissions(TEST_ASSAY_GRP_USERS, TEST_ASSAY_PERMS_READER);
+        permissionsHelper.setPermissions(TEST_ASSAY_GRP_USERS, READER_ROLE);
 
         //add a PI user to that group
         permissionsHelper.addUserToProjGroup(TEST_ASSAY_USR_PI1, getProjectName(), TEST_ASSAY_GRP_PIS);
@@ -238,9 +238,9 @@ public abstract class AbstractAssayTest extends BaseWebDriverTest
         //setup security on sub-folders:
         // PIs should be Editors on Lab1 and Study1, but not Study2 or Study3
         // Users should be Editors on Lab1, readers on Study2, and nothing on Study3
-        setSubfolderSecurity(getProjectName(), TEST_ASSAY_FLDR_LAB1, TEST_ASSAY_GRP_PIS, TEST_ASSAY_PERMS_EDITOR);
-        setSubfolderSecurity(getProjectName(), TEST_ASSAY_FLDR_LAB1, TEST_ASSAY_GRP_USERS, TEST_ASSAY_PERMS_EDITOR);
-        setSubfolderSecurity(getProjectName(), TEST_ASSAY_FLDR_STUDY1, TEST_ASSAY_GRP_PIS, TEST_ASSAY_PERMS_EDITOR);
+        setSubfolderSecurity(getProjectName(), TEST_ASSAY_FLDR_LAB1, TEST_ASSAY_GRP_PIS, EDITOR_ROLE);
+        setSubfolderSecurity(getProjectName(), TEST_ASSAY_FLDR_LAB1, TEST_ASSAY_GRP_USERS, EDITOR_ROLE);
+        setSubfolderSecurity(getProjectName(), TEST_ASSAY_FLDR_STUDY1, TEST_ASSAY_GRP_PIS, EDITOR_ROLE);
         setSubfolderSecurity(getProjectName(), TEST_ASSAY_FLDR_STUDY3, TEST_ASSAY_GRP_USERS, TEST_ASSAY_PERMS_NONE);
 
         //setup study-level security:
@@ -287,8 +287,8 @@ public abstract class AbstractAssayTest extends BaseWebDriverTest
         waitForElement(Locator.permissionRendered());
         if (TEST_ASSAY_PERMS_NONE.equals(perms))
         {
-            _permissionsHelper.removePermission(group, "Editor");
-            _permissionsHelper.removePermission(group, "Reader");
+            _permissionsHelper.removePermission(group, EDITOR_ROLE);
+            _permissionsHelper.removePermission(group, READER_ROLE);
         }
         else
             _permissionsHelper.setPermissions(group, perms);

--- a/src/org/labkey/test/tests/AdminConsoleTest.java
+++ b/src/org/labkey/test/tests/AdminConsoleTest.java
@@ -46,6 +46,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.labkey.test.util.PermissionsHelper.APP_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
@@ -175,7 +177,7 @@ public class AdminConsoleTest extends AbstractAdminConsoleTest
         assertEquals("Incorrect URL", expected, href);
 
         goToHome();
-        impersonateRole("Reader");
+        impersonateRole(READER_ROLE);
         assertElementPresent(ribbon);
         assertElementPresent(ribbonLink);
         stopImpersonating();
@@ -229,7 +231,7 @@ public class AdminConsoleTest extends AbstractAdminConsoleTest
                 .verifyTrue("expect banner to be shown", bannerLoc.isDisplayed(getDriver()));
 
         // as app admin
-        impersonateRole("Application Admin");
+        impersonateRole(APP_ADMIN_ROLE);
         var reHideBannerCmd = new SimplePostCommand("admin", "setRibbonMessage.api");
         reHideBannerCmd.setParameters(Map.of("show", false));
         try

--- a/src/org/labkey/test/tests/AdvancedImportOptionsTest.java
+++ b/src/org/labkey/test/tests/AdvancedImportOptionsTest.java
@@ -49,6 +49,8 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category(Daily.class)
 @BaseWebDriverTest.ClassTimeout(minutes = 9)
@@ -324,11 +326,11 @@ public class AdvancedImportOptionsTest extends BaseWebDriverTest implements Post
 
         log("Setting up permissions for a limited user");
         clickFolder(IMPORT_FOLDER_MULTI01);
-        permissionsHelper.addMemberToRole(LIMITED_USER, "Folder Administrator", PermissionsHelper.MemberType.user);
+        permissionsHelper.addMemberToRole(LIMITED_USER, FOLDER_ADMIN_ROLE, PermissionsHelper.MemberType.user);
         clickFolder(IMPORT_FOLDER_MULTI02);
-        permissionsHelper.addMemberToRole(LIMITED_USER, "Reader", PermissionsHelper.MemberType.user);
+        permissionsHelper.addMemberToRole(LIMITED_USER, READER_ROLE, PermissionsHelper.MemberType.user);
         clickFolder(IMPORT_FOLDER_MULTI03);
-        permissionsHelper.addMemberToRole(LIMITED_USER, "Folder Administrator", PermissionsHelper.MemberType.user);
+        permissionsHelper.addMemberToRole(LIMITED_USER, FOLDER_ADMIN_ROLE, PermissionsHelper.MemberType.user);
 
         pushLocation();
         impersonate(LIMITED_USER);

--- a/src/org/labkey/test/tests/ApiKeyTest.java
+++ b/src/org/labkey/test/tests/ApiKeyTest.java
@@ -71,6 +71,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 4)
@@ -105,7 +107,7 @@ public class ApiKeyTest extends BaseWebDriverTest
 
         EDITOR_USER.create(this)
                 .setInitialPassword()
-                .addPermission("Editor", getProjectName());
+                .addPermission(EDITOR_ROLE, getProjectName());
 
         new IntListDefinition(LIST_NAME, "Key")
             .addField(new FieldDefinition(LIST_VALUE))
@@ -306,7 +308,7 @@ public class ApiKeyTest extends BaseWebDriverTest
 
         log("Verify " + APIKEYS_TABLE + " table is not accessible for non site-admin");
         goToProjectHome();
-        impersonateRoles("Project Administrator");
+        impersonateRoles(PROJECT_ADMIN_ROLE);
         verifyAPIKeysTablePresence(false);
     }
 

--- a/src/org/labkey/test/tests/AuditLogTest.java
+++ b/src/org/labkey/test/tests/AuditLogTest.java
@@ -64,6 +64,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
 import static org.labkey.test.util.PasswordUtil.getUsername;
 
 @Category({Daily.class, Hosting.class})
@@ -81,9 +85,6 @@ public class AuditLogTest extends BaseWebDriverTest
     private static final String AUDIT_TEST_USER3 = "audit_user3@auditlog.test";
 
     private static final String AUDIT_SECURITY_GROUP = "Testers";
-
-    private static final String PROJECT_ADMIN_ROLE = "Project Administrator";
-    private static final String AUTHOR_ROLE = "Author";
 
     private static final String AUDIT_TEST_PROJECT = "AuditVerifyTest";
     private static final String AUDIT_DETAILED_TEST_PROJECT = "AuditDetailedLogTest";
@@ -328,7 +329,7 @@ public class AuditLogTest extends BaseWebDriverTest
 
         _containerHelper.createProject(AUDIT_TEST_PROJECT, null);
         permissionsHelper.createPermissionsGroup(AUDIT_SECURITY_GROUP);
-        permissionsHelper.setPermissions(AUDIT_SECURITY_GROUP, "Editor");
+        permissionsHelper.setPermissions(AUDIT_SECURITY_GROUP, EDITOR_ROLE);
         _userHelper.createUser(AUDIT_TEST_USER, false, true);
         permissionsHelper.addUserToProjGroup(AUDIT_TEST_USER, getProjectName(), AUDIT_SECURITY_GROUP);
         _userHelper.deleteUsers(true, AUDIT_TEST_USER);
@@ -373,8 +374,8 @@ public class AuditLogTest extends BaseWebDriverTest
         createList(AUDIT_TEST_PROJECT, "Parent List", "Name\nData", new FieldDefinition("Name", ColumnType.String).setDescription("Name") );
         createList(AUDIT_TEST_PROJECT + "/" + AUDIT_TEST_SUBFOLDER, "Child List", "Name\nData", new FieldDefinition("Name", ColumnType.String).setDescription("Name"));
 
-        createUserWithPermissions(AUDIT_TEST_USER, AUDIT_TEST_PROJECT, "Editor");
-        createUserWithPermissions(AUDIT_TEST_USER2, AUDIT_TEST_PROJECT, "Project Administrator");
+        createUserWithPermissions(AUDIT_TEST_USER, AUDIT_TEST_PROJECT, EDITOR_ROLE);
+        createUserWithPermissions(AUDIT_TEST_USER2, AUDIT_TEST_PROJECT, PROJECT_ADMIN_ROLE);
 
         // signed in as an admin so we should see rows here
         verifyAuditQueries(true);
@@ -404,15 +405,15 @@ public class AuditLogTest extends BaseWebDriverTest
         navigateToFolder(AUDIT_TEST_PROJECT, AUDIT_TEST_SUBFOLDER);
 
         ApiPermissionsHelper ph = new ApiPermissionsHelper(this);
-        ph.addMemberToRole(AUDIT_TEST_USER2,"Folder Administrator", PermissionsHelper.MemberType.user);
+        ph.addMemberToRole(AUDIT_TEST_USER2,FOLDER_ADMIN_ROLE, PermissionsHelper.MemberType.user);
         impersonate(AUDIT_TEST_USER2);
         verifyListAuditLogQueries(Visibility.All);
         stopImpersonating();
 
         // verify issue 19832 - opposite of above.  Ensure that user who has access to child folder but not parent folder can still see
         // audit log events from the child forder if using a CurrentAndSubFolders container filter
-        createUserWithPermissions(AUDIT_TEST_USER3, AUDIT_TEST_PROJECT, "Editor");
-        permissionsHelper.addMemberToRole(AUDIT_TEST_USER3, "Folder Administrator", PermissionsHelper.MemberType.user, AUDIT_TEST_PROJECT + "/" + AUDIT_TEST_SUBFOLDER);
+        createUserWithPermissions(AUDIT_TEST_USER3, AUDIT_TEST_PROJECT, EDITOR_ROLE);
+        permissionsHelper.addMemberToRole(AUDIT_TEST_USER3, FOLDER_ADMIN_ROLE, PermissionsHelper.MemberType.user, AUDIT_TEST_PROJECT + "/" + AUDIT_TEST_SUBFOLDER);
         impersonate(AUDIT_TEST_USER3);
         verifyListAuditLogQueries(Visibility.ChildFolder);
         stopImpersonating();

--- a/src/org/labkey/test/tests/BaseTermsOfUseTest.java
+++ b/src/org/labkey/test/tests/BaseTermsOfUseTest.java
@@ -28,6 +28,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+
 public class BaseTermsOfUseTest extends BaseWebDriverTest
 {
     protected static final String PUBLIC_NO_TERMS_PROJECT_NAME = "Public No Terms Project";
@@ -80,9 +83,9 @@ public class BaseTermsOfUseTest extends BaseWebDriverTest
     {
         log("Create public project " + projectName);
         _containerHelper.createProject(projectName, null);
-        _permissionsHelper.setPermissions(USERS_GROUP, "Editor");
-        _permissionsHelper.setSiteGroupPermissions("All Site Users", "Reader");
-        _permissionsHelper.setSiteGroupPermissions("Guests", "Reader");
+        _permissionsHelper.setPermissions(USERS_GROUP, EDITOR_ROLE);
+        _permissionsHelper.setSiteGroupPermissions("All Site Users", READER_ROLE);
+        _permissionsHelper.setSiteGroupPermissions("Guests", READER_ROLE);
     }
 
     protected void createWikiTabForProject(String projectName)
@@ -102,10 +105,10 @@ public class BaseTermsOfUseTest extends BaseWebDriverTest
         log("Create project " + name);
         _containerHelper.createProject(name, null);
         createTermsOfUsePage(name, termsText);
-        _permissionsHelper.setSiteGroupPermissions("All Site Users", "Reader");
+        _permissionsHelper.setSiteGroupPermissions("All Site Users", READER_ROLE);
         if (isPublic)
         {
-            _permissionsHelper.setSiteGroupPermissions("Guests", "Reader");
+            _permissionsHelper.setSiteGroupPermissions("Guests", READER_ROLE);
         }
     }
 

--- a/src/org/labkey/test/tests/BasicAdminTest.java
+++ b/src/org/labkey/test/tests/BasicAdminTest.java
@@ -37,6 +37,8 @@ import org.openqa.selenium.WebElement;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+
 @Category({Base.class, DRT.class, Daily.class, Git.class, Hosting.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class BasicAdminTest extends BaseWebDriverTest
@@ -91,7 +93,7 @@ public class BasicAdminTest extends BaseWebDriverTest
         permissionsHelper.createPermissionsGroup("testers");
         _ext4Helper.clickTabContainingText("Permissions");
         permissionsHelper.assertPermissionSetting("testers", "No Permissions");
-        permissionsHelper.setPermissions("testers", "Editor");
+        permissionsHelper.setPermissions("testers", EDITOR_ROLE);
 
         clickButton("Save and Finish");
         log("Test folder aliasing");
@@ -100,7 +102,7 @@ public class BasicAdminTest extends BaseWebDriverTest
         popLocation();
         assertTextPresent(FOLDER_RENAME);
 
-        permissionsHelper.assertPermissionSetting("testers", "Editor");
+        permissionsHelper.assertPermissionSetting("testers", EDITOR_ROLE);
     }
 
     @Test @Ignore

--- a/src/org/labkey/test/tests/ClientAPITest.java
+++ b/src/org/labkey/test/tests/ClientAPITest.java
@@ -87,6 +87,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.WebTestHelper.getHttpResponse;
 import static org.labkey.test.params.FieldDefinition.DOMAIN_TRICKY_CHARACTERS;
+import static org.labkey.test.util.PermissionsHelper.APP_ADMIN_ROLE;
 
 @Category({BVT.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 14)
@@ -1114,7 +1115,7 @@ public class ClientAPITest extends BaseWebDriverTest
 
         enableEmailRecorder();
 
-        apiPermissionsHelper.addMemberToRole(EMAIL_SENDER, "Application Admin", PermissionsHelper.MemberType.user, "/");
+        apiPermissionsHelper.addMemberToRole(EMAIL_SENDER, APP_ADMIN_ROLE, PermissionsHelper.MemberType.user, "/");
 
         goToHome();
         impersonate(EMAIL_SENDER);

--- a/src/org/labkey/test/tests/CrawlerTest.java
+++ b/src/org/labkey/test/tests/CrawlerTest.java
@@ -27,6 +27,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class CrawlerTest extends BaseWebDriverTest
@@ -57,7 +59,7 @@ public class CrawlerTest extends BaseWebDriverTest
         CspConfigHelper.debugCspWarnings();
         _containerHelper.createProject(getProjectName(), null);
         _userHelper.createUser(USER);
-        new ApiPermissionsHelper(this).addMemberToRole(USER, "Reader", MemberType.user, getProjectName());
+        new ApiPermissionsHelper(this).addMemberToRole(USER, READER_ROLE, MemberType.user, getProjectName());
     }
 
     /**

--- a/src/org/labkey/test/tests/DataReportsTest.java
+++ b/src/org/labkey/test/tests/DataReportsTest.java
@@ -42,6 +42,10 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Daily.class, Reports.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
@@ -372,7 +376,7 @@ public class DataReportsTest extends ReportTest
         if (!TestProperties.isPrimaryUserAppAdmin())
         {
             log("Test user permissions");
-            createSiteDeveloper(AUTHOR_USER).addMemberToRole(AUTHOR_USER, "Author", PermissionsHelper.MemberType.user, getProjectName());
+            createSiteDeveloper(AUTHOR_USER).addMemberToRole(AUTHOR_USER, AUTHOR_ROLE, PermissionsHelper.MemberType.user, getProjectName());
             impersonate(AUTHOR_USER);
         }
         else
@@ -406,7 +410,7 @@ public class DataReportsTest extends ReportTest
 
         _userHelper.createUser(R_USER);
         _apiPermissionsHelper.addUserToProjGroup(R_USER, getProjectName(), "Users");
-        _apiPermissionsHelper.addMemberToRole("Users", "Editor", PermissionsHelper.MemberType.group, getProjectName());
+        _apiPermissionsHelper.addMemberToRole("Users", EDITOR_ROLE, PermissionsHelper.MemberType.group, getProjectName());
 
         //create R report with dev
         impersonate(R_USER);
@@ -424,7 +428,7 @@ public class DataReportsTest extends ReportTest
         stopImpersonating();
 
         log("Change user permission");
-        _apiPermissionsHelper.addMemberToRole("Users", "Project Administrator", PermissionsHelper.MemberType.group, getProjectName());
+        _apiPermissionsHelper.addMemberToRole("Users", PROJECT_ADMIN_ROLE, PermissionsHelper.MemberType.group, getProjectName());
 
         log("Create a new R script that uses other R scripts");
         navigateToFolder(getProjectName(), getFolderName());
@@ -495,7 +499,7 @@ public class DataReportsTest extends ReportTest
         log("Test showing the source tab to all users");
         createRReport(reportName, R_SCRIPT, true, true, new String[0]);
 
-        impersonateRole("Reader");
+        impersonateRole(READER_ROLE);
         clickFolder(getFolderName());
         scrollIntoView(Locator.linkWithText(DATA_SET_APX1));
         clickAndWait(Locator.linkWithText(DATA_SET_APX1));
@@ -515,7 +519,7 @@ public class DataReportsTest extends ReportTest
         _rReportHelper.clearOption(ScriptReportPage.StandardReportOption.showSourceTab);
         resaveReport();
 
-        impersonateRole("Reader");
+        impersonateRole(READER_ROLE);
 
         navigateToFolder(getProjectName(), getFolderName());
         scrollIntoView(Locator.linkWithText(DATA_SET_APX1));

--- a/src/org/labkey/test/tests/DataViewsPermissionsTest.java
+++ b/src/org/labkey/test/tests/DataViewsPermissionsTest.java
@@ -26,6 +26,8 @@ import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.PortalHelper;
 
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 10)
@@ -76,13 +78,13 @@ public class DataViewsPermissionsTest extends StudyBaseTest
         _permissionsHelper.enterPermissionsUI();
         _permissionsHelper.createPermissionsGroup("Editor Group");
         _permissionsHelper.assertPermissionSetting("Editor Group", "No Permissions");
-        _permissionsHelper.setPermissions("Editor Group", "Editor");
+        _permissionsHelper.setPermissions("Editor Group", EDITOR_ROLE);
         createUserInProjectForGroup(EDITOR_USER, "StudyVerifyProject", "Editor Group", false);
         clickFolder(getFolderName());
         _permissionsHelper.enterPermissionsUI();
         _permissionsHelper.createPermissionsGroup("Author Group");
         _permissionsHelper.assertPermissionSetting("Author Group", "No Permissions");
-        _permissionsHelper.setPermissions("Author Group", "Author");
+        _permissionsHelper.setPermissions("Author Group", AUTHOR_ROLE);
         createUserInProjectForGroup(AUTHOR_USER, "StudyVerifyProject", "Author Group", false);
 
         clickFolder(getFolderName());

--- a/src/org/labkey/test/tests/FilterTest.java
+++ b/src/org/labkey/test/tests/FilterTest.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.labkey.test.params.FieldDefinition.ColumnType;
 import static org.labkey.test.params.FieldDefinition.DOMAIN_TRICKY_CHARACTERS;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 import static org.labkey.test.util.PermissionsHelper.MemberType;
 
 @Category({Daily.class, Data.class})
@@ -115,8 +116,8 @@ public class FilterTest extends BaseWebDriverTest
         _userHelper.createUser(EDITOR1);
         _userHelper.createUser(EDITOR2);
         ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
-        apiPermissionsHelper.addMemberToRole(EDITOR1, "Editor", MemberType.user, getProjectName());
-        apiPermissionsHelper.addMemberToRole(EDITOR2, "Editor", MemberType.user, getProjectName());
+        apiPermissionsHelper.addMemberToRole(EDITOR1, EDITOR_ROLE, MemberType.user, getProjectName());
+        apiPermissionsHelper.addMemberToRole(EDITOR2, EDITOR_ROLE, MemberType.user, getProjectName());
 
         createList();
         createList2();

--- a/src/org/labkey/test/tests/FolderExportTest.java
+++ b/src/org/labkey/test/tests/FolderExportTest.java
@@ -59,6 +59,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+import static org.labkey.test.util.PermissionsHelper.SUBMITTER_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 17)
@@ -268,7 +274,7 @@ public class FolderExportTest extends BaseWebDriverTest
         _containerHelper.createSubfolder(importProjects[4], "Subfolder as Subfolder");
         importFolder("Subfolder as Subfolder", subfolderPermsZip);
         clickFolder("Subfolder as Subfolder");
-        _permissionsHelper.assertPermissionSetting(testUser1, "Reader");
+        _permissionsHelper.assertPermissionSetting(testUser1, READER_ROLE);
     }
 
     @Test
@@ -295,22 +301,22 @@ public class FolderExportTest extends BaseWebDriverTest
         if (groupsExist)
         {
             log("Verifying role assignments to groups");
-            _permissionsHelper.assertPermissionSetting(groupGroup, "Reader");
-            _permissionsHelper.assertPermissionSetting(superTesterGroup, "Author");
-            _permissionsHelper.assertPermissionSetting(groupGroup, "Author");
-            _permissionsHelper.assertPermissionSetting(submitterGroup, "Submitter");
-            _permissionsHelper.assertPermissionSetting(superTesterGroup, "Editor");
-            _permissionsHelper.assertPermissionSetting(parentGroup, "Editor");
+            _permissionsHelper.assertPermissionSetting(groupGroup, READER_ROLE);
+            _permissionsHelper.assertPermissionSetting(superTesterGroup, AUTHOR_ROLE);
+            _permissionsHelper.assertPermissionSetting(groupGroup, AUTHOR_ROLE);
+            _permissionsHelper.assertPermissionSetting(submitterGroup, SUBMITTER_ROLE);
+            _permissionsHelper.assertPermissionSetting(superTesterGroup, EDITOR_ROLE);
+            _permissionsHelper.assertPermissionSetting(parentGroup, EDITOR_ROLE);
         }
         if (usersExist)
         {
             log("Verifying role assignments to users");
-            _permissionsHelper.assertPermissionSetting(testUser3, "Author");
+            _permissionsHelper.assertPermissionSetting(testUser3, AUTHOR_ROLE);
             if (!isSubfolder)
-                _permissionsHelper.assertPermissionSetting(testUser3, "Project Administrator");
-            _permissionsHelper.assertPermissionSetting(testUser2, "Editor");
-            _permissionsHelper.assertPermissionSetting(testUser1, "Folder Administrator");
-            _permissionsHelper.assertPermissionSetting(testUser3, "Folder Administrator");
+                _permissionsHelper.assertPermissionSetting(testUser3, PROJECT_ADMIN_ROLE);
+            _permissionsHelper.assertPermissionSetting(testUser2, EDITOR_ROLE);
+            _permissionsHelper.assertPermissionSetting(testUser1, FOLDER_ADMIN_ROLE);
+            _permissionsHelper.assertPermissionSetting(testUser3, FOLDER_ADMIN_ROLE);
         }
     }
 
@@ -355,7 +361,7 @@ public class FolderExportTest extends BaseWebDriverTest
     @LogMethod
     private void verifyCreateFolderFromTemplate()
     {
-        impersonateRole("Folder Administrator"); // Issue 52254
+        impersonateRole(FOLDER_ADMIN_ROLE); // Issue 52254
         new UIContainerHelper(this).createSubFolderFromTemplate(getProjectName(), folderFromTemplate, "/" + getProjectName() + "/" + folderFromZip, new String[]{"Grid Views"});
         verifyExpectedWebPartsPresent();
         verifySubfolderImport(folderFromTemplate, true);
@@ -407,18 +413,18 @@ public class FolderExportTest extends BaseWebDriverTest
     @LogMethod
     private void setPermissions()
     {
-        _permissionsHelper.setUserPermissions(testUser1, "Folder Administrator");
-        _permissionsHelper.setUserPermissions(testUser2, "Editor");
-        _permissionsHelper.setUserPermissions(testUser3, "Project Administrator");
-        _permissionsHelper.setUserPermissions(testUser4, "Author");
-        _permissionsHelper.setUserPermissions(testUser3, "Author");
+        _permissionsHelper.setUserPermissions(testUser1, FOLDER_ADMIN_ROLE);
+        _permissionsHelper.setUserPermissions(testUser2, EDITOR_ROLE);
+        _permissionsHelper.setUserPermissions(testUser3, PROJECT_ADMIN_ROLE);
+        _permissionsHelper.setUserPermissions(testUser4, AUTHOR_ROLE);
+        _permissionsHelper.setUserPermissions(testUser3, AUTHOR_ROLE);
 
-        _permissionsHelper.setPermissions(superTesterGroup, "Author");
-        _permissionsHelper.setPermissions(superTesterGroup, "Editor");
-        _permissionsHelper.setPermissions(submitterGroup, "Submitter");
-        _permissionsHelper.setPermissions(parentGroup, "Editor");
-        _permissionsHelper.setPermissions(groupGroup, "Reader");
-        _permissionsHelper.setPermissions(groupGroup, "Author");
+        _permissionsHelper.setPermissions(superTesterGroup, AUTHOR_ROLE);
+        _permissionsHelper.setPermissions(superTesterGroup, EDITOR_ROLE);
+        _permissionsHelper.setPermissions(submitterGroup, SUBMITTER_ROLE);
+        _permissionsHelper.setPermissions(parentGroup, EDITOR_ROLE);
+        _permissionsHelper.setPermissions(groupGroup, READER_ROLE);
+        _permissionsHelper.setPermissions(groupGroup, AUTHOR_ROLE);
     }
 
     @LogMethod
@@ -432,7 +438,7 @@ public class FolderExportTest extends BaseWebDriverTest
         _containerHelper.createSubfolder(getProjectName(), folderWithPermissions);
 //         stop inheriting permissions from the parent project and set specific permissions in the subfolder
 
-        _permissionsHelper.setUserPermissions(testUser1, "Reader");
+        _permissionsHelper.setUserPermissions(testUser1, READER_ROLE);
         _containerHelper.createSubfolder(getProjectName() + "/" + folderWithPermissions, "Subfolder5", "Collaboration");
         _containerHelper.createSubfolder(getProjectName(), folderInheritingPermissions);
         _permissionsHelper.checkInheritedPermissions();

--- a/src/org/labkey/test/tests/GroupTest.java
+++ b/src/org/labkey/test/tests/GroupTest.java
@@ -44,6 +44,9 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category(Daily.class)
 @BaseWebDriverTest.ClassTimeout(minutes = 9)
@@ -129,9 +132,9 @@ public class GroupTest extends BaseWebDriverTest
         _permissionsHelper.enterPermissionsUI();
         waitForText("Author");
 
-        _permissionsHelper.setSiteGroupPermissions(COMPOUND_GROUP, "Author");
-        _permissionsHelper.setSiteGroupPermissions(COMPOUND_GROUP, "Reader");
-        _permissionsHelper.setSiteGroupPermissions(SIMPLE_GROUP, "Editor");
+        _permissionsHelper.setSiteGroupPermissions(COMPOUND_GROUP, AUTHOR_ROLE);
+        _permissionsHelper.setSiteGroupPermissions(COMPOUND_GROUP, READER_ROLE);
+        _permissionsHelper.setSiteGroupPermissions(SIMPLE_GROUP, EDITOR_ROLE);
         clickButton("Save and Finish");
         assertUserCanSeeProject(TEST_USERS_FOR_GROUP[0], getProjectName());
         //can't add built in group to regular group
@@ -141,7 +144,7 @@ public class GroupTest extends BaseWebDriverTest
         clickProject(getProjectName());
         _permissionsHelper.enterPermissionsUI();
         waitForText("Author");
-        _permissionsHelper.setSiteGroupPermissions("All Site Users", "Author");
+        _permissionsHelper.setSiteGroupPermissions("All Site Users", AUTHOR_ROLE);
         permissionsReportTest();
 
         // Ensure that deleting from the group's page works too. Issue 52614
@@ -178,7 +181,7 @@ public class GroupTest extends BaseWebDriverTest
         String displayName = _userHelper.getDisplayNameForEmail(TEST_USERS_FOR_GROUP[0]);
         int rowIndex = access.getRowIndex(userColumn, displayName) - headerIndex;
         assertTrue("Unable to find user: " + displayName, rowIndex >= 0);
-        List<String> expectedGroups = Arrays.asList("Author", "Reader", "Editor");
+        List<String> expectedGroups = Arrays.asList(AUTHOR_ROLE, READER_ROLE, EDITOR_ROLE);
         List<String> groupsForUser = Arrays.asList(access.getDataAsText(rowIndex + headerIndex, accessColumn).replace(" ", "").split(","));
 
         //confirm correct perms
@@ -205,7 +208,7 @@ public class GroupTest extends BaseWebDriverTest
         WikiHelper wikiHelper = new WikiHelper(this);
 
         //set simple group as editor
-        _permissionsHelper.setSiteGroupPermissions(SIMPLE_GROUP, "Editor");
+        _permissionsHelper.setSiteGroupPermissions(SIMPLE_GROUP, EDITOR_ROLE);
 
         //impersonate user 1, make several wiki edits
         impersonate(TEST_USERS_FOR_GROUP[0]);
@@ -229,11 +232,11 @@ public class GroupTest extends BaseWebDriverTest
         verifyAuthorPermission(nameTitleBody);
         stopImpersonating();
 
-        impersonateRoles("Author");
+        impersonateRoles(AUTHOR_ROLE);
         verifyAuthorPermission(nameTitleBody);
         stopImpersonating();
 
-        impersonateRoles("Editor");
+        impersonateRoles(EDITOR_ROLE);
         verifyEditorPermission(nameTitleBody);
         stopImpersonating();
 

--- a/src/org/labkey/test/tests/InvalidateSessionTest.java
+++ b/src/org/labkey/test/tests/InvalidateSessionTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.fail;
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
 
 @Category({Daily.class})
 public class InvalidateSessionTest extends BaseWebDriverTest
@@ -53,7 +54,7 @@ public class InvalidateSessionTest extends BaseWebDriverTest
     {
         CreateUserResponse response = _userHelper.createUser(USER);
         ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
-        permissionsHelper.addMemberToRole(USER, "Folder Administrator", PermissionsHelper.MemberType.user);
+        permissionsHelper.addMemberToRole(USER, FOLDER_ADMIN_ROLE, PermissionsHelper.MemberType.user);
         setInitialPassword(response.getUserId());
     }
 

--- a/src/org/labkey/test/tests/JavaClientApiTest.java
+++ b/src/org/labkey/test/tests/JavaClientApiTest.java
@@ -87,6 +87,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 
 /**
  * Tests for the Java Client API library.
@@ -192,7 +193,7 @@ public class JavaClientApiTest extends BaseWebDriverTest
 
         log("Setting permissions...");
         clickProject(PROJECT_NAME);
-        _permissionsHelper.setSiteGroupPermissions("Guests", "Editor");
+        _permissionsHelper.setSiteGroupPermissions("Guests", EDITOR_ROLE);
 
         clickProject(PROJECT_NAME);
         clickAndWait(Locator.linkWithText(LIST_NAME));
@@ -541,7 +542,7 @@ public class JavaClientApiTest extends BaseWebDriverTest
         // grant edit permission
         int userId = ensureUser(cn, USER2_NAME);
         ApiPermissionsHelper permHelper = new ApiPermissionsHelper(this);
-        permHelper.setUserPermissions(USER2_NAME, "Editor");
+        permHelper.setUserPermissions(USER2_NAME, EDITOR_ROLE);
 
         // check whoami
         WhoAmIResponse who = new WhoAmICommand().execute(cn, PROJECT_NAME);
@@ -594,7 +595,7 @@ public class JavaClientApiTest extends BaseWebDriverTest
         // grant edit permission
         int userId = ensureUser(createDefaultConnection(), USER2_NAME);
         ApiPermissionsHelper permHelper = new ApiPermissionsHelper(this);
-        permHelper.setUserPermissions(USER2_NAME, "Editor");
+        permHelper.setUserPermissions(USER2_NAME, EDITOR_ROLE);
 
         Connection cn = new Connection(WebTestHelper.getBaseURL(), PasswordUtil.getUsername(), PasswordUtil.getPassword())
                 .impersonate(USER2_NAME, PROJECT_NAME);

--- a/src/org/labkey/test/tests/LabkeyErrorPageTest.java
+++ b/src/org/labkey/test/tests/LabkeyErrorPageTest.java
@@ -13,6 +13,8 @@ import org.labkey.test.pages.LabkeyErrorPage;
 
 import java.util.List;
 
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 7)
 public class LabkeyErrorPageTest extends BaseWebDriverTest
@@ -29,7 +31,7 @@ public class LabkeyErrorPageTest extends BaseWebDriverTest
     private void doSetup()
     {
         _containerHelper.createProject(getProjectName(), null);
-        createUserWithPermissions(READER_USER, getProjectName(), "Reader");
+        createUserWithPermissions(READER_USER, getProjectName(), READER_ROLE);
     }
 
     @Test

--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -63,6 +63,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 /**
  * This test created linked schemas from a source container in a target container.
@@ -646,13 +647,13 @@ public class LinkedSchemaTest extends BaseWebDriverTest
         _userHelper.createUser(EXTERNAL_SCHEMA_USER);
 
         _containerHelper.createProject(getProjectName(), null);
-        apiPermissionsHelper.setUserPermissions(EXTERNAL_SCHEMA_USER, "Reader");
+        apiPermissionsHelper.setUserPermissions(EXTERNAL_SCHEMA_USER, READER_ROLE);
         _containerHelper.createSubfolder(getProjectName(), SOURCE_FOLDER);
         // Enable linkedschematest in source folder so the "BPeopleTemplate" is visible.
         _containerHelper.enableModule("linkedschematest");
 
         _containerHelper.createSubfolder(getProjectName(), TARGET_FOLDER);
-        apiPermissionsHelper.setUserPermissions(READER_USER, "Reader");
+        apiPermissionsHelper.setUserPermissions(READER_USER, READER_ROLE);
 
         // Create a study folder.
         _containerHelper.createSubfolder(getProjectName(), STUDY_FOLDER, "Study");

--- a/src/org/labkey/test/tests/MessagesLongTest.java
+++ b/src/org/labkey/test/tests/MessagesLongTest.java
@@ -51,6 +51,10 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.Locator.NBSP;
+import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
@@ -119,10 +123,10 @@ public class MessagesLongTest extends BaseWebDriverTest
     {
         clickProject(PROJECT_NAME);
         PermissionsPage permissionsPage = navBar().goToPermissionsPage()
-            .removePermission("Users", "Reader")
-            .removePermission("Users","Reader")
-            .removePermission("Users","Author")
-            .removePermission("Users","Editor")
+            .removePermission("Users", READER_ROLE)
+            .removePermission("Users",READER_ROLE)
+            .removePermission("Users",AUTHOR_ROLE)
+            .removePermission("Users",EDITOR_ROLE)
             .setPermissions("Users", permission);
         permissionsPage.clickSaveAndFinish();
         impersonate(USER1);
@@ -166,7 +170,7 @@ public class MessagesLongTest extends BaseWebDriverTest
         _containerHelper.createProject(PROJECT_NAME, "Collaboration");
         navBar().goToPermissionsPage()
                 .createPermissionsGroup("Administrators")
-                .setPermissions("Administrators", "Project Administrator")
+                .setPermissions("Administrators", PROJECT_ADMIN_ROLE)
                 .createPermissionsGroup("testers1")
                 .assertPermissionSetting("testers1", "No Permissions")
                 .clickSaveAndFinish();
@@ -343,8 +347,8 @@ public class MessagesLongTest extends BaseWebDriverTest
         clickButton("Update Group Membership");
 
         log("Check if permissions work without security");
-        permissionCheck("Reader", true);
-        permissionCheck("Editor", true);
+        permissionCheck(READER_ROLE, true);
+        permissionCheck(EDITOR_ROLE, true);
 
         log("Check with security");
         // TODO: Convert to test.pages.announcements.AdminPage
@@ -354,8 +358,8 @@ public class MessagesLongTest extends BaseWebDriverTest
         _portalHelper.clickWebpartMenuItem("Messages", true, "Admin");
         checkCheckbox(Locator.radioButtonByName("secure").index(1));
         clickButton("Save");
-        permissionCheck("Reader", false);
-        permissionCheck("Editor", true);
+        permissionCheck(READER_ROLE, false);
+        permissionCheck(EDITOR_ROLE, true);
 
         log("Check if the customized names work");
 
@@ -569,8 +573,8 @@ public class MessagesLongTest extends BaseWebDriverTest
         // USER1 is now a reader
         log("Test notify list");
         navBar().goToPermissionsPage()
-            .removePermission("Users", "Editor")
-            .setPermissions("Users", "Reader")
+            .removePermission("Users", EDITOR_ROLE)
+            .setPermissions("Users", READER_ROLE)
             .clickSaveAndFinish();
 
         // USER2 is a nobody
@@ -622,7 +626,7 @@ public class MessagesLongTest extends BaseWebDriverTest
 
         log("Verify member list failed user lookup reports error");
         clickProject(PROJECT_NAME);
-        impersonateRole("Editor");
+        impersonateRole(EDITOR_ROLE);
         clickAndWait(Locator.linkWithText(MSG3_TITLE));
         clickRespondButton();
         // enter invalid username, ensure error appears
@@ -667,7 +671,7 @@ public class MessagesLongTest extends BaseWebDriverTest
         String _messageTitle = "Mine Message";
         String _messageBody = "test";
 
-        createUserWithPermissions(RESPONDER, PROJECT_NAME, "Editor");
+        createUserWithPermissions(RESPONDER, PROJECT_NAME, EDITOR_ROLE);
         goToProjectHome(PROJECT_NAME);
 
         // Unlike EmailPrefsPage.beginAt(), this ensures returnUrl is passed to the action
@@ -729,7 +733,7 @@ public class MessagesLongTest extends BaseWebDriverTest
         goToProjectHome();
         navBar().goToPermissionsPage()
             .createPermissionsGroup(GROUP)
-            .setPermissions(GROUP, "Editor")
+            .setPermissions(GROUP, EDITOR_ROLE)
             .addUserToProjGroup(USER, getProjectName(), GROUP);
         goToProjectHome();
 

--- a/src/org/labkey/test/tests/NonStudyReportsTest.java
+++ b/src/org/labkey/test/tests/NonStudyReportsTest.java
@@ -36,6 +36,7 @@ import java.io.File;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 
 @Category({Daily.class, Reports.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
@@ -168,7 +169,7 @@ public class NonStudyReportsTest extends ReportTest
         _userHelper.createUser(ATTACHMENT_USER);
         clickProject(getProjectName());
         _permissionsHelper.enterPermissionsUI();
-        _permissionsHelper.setUserPermissions(ATTACHMENT_USER, "Editor");
+        _permissionsHelper.setUserPermissions(ATTACHMENT_USER, EDITOR_ROLE);
         impersonate(ATTACHMENT_USER);
         clickProject(getProjectName());
 

--- a/src/org/labkey/test/tests/PermissionsTestForJavascriptExecution.java
+++ b/src/org/labkey/test/tests/PermissionsTestForJavascriptExecution.java
@@ -15,6 +15,9 @@ import org.labkey.test.util.PermissionsHelper;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.labkey.test.util.PermissionsHelper.DEVELOPER_ROLE;
+import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
+
 @Category({Daily.class})
 public class PermissionsTestForJavascriptExecution extends BaseWebDriverTest
 {
@@ -73,7 +76,7 @@ public class PermissionsTestForJavascriptExecution extends BaseWebDriverTest
         _containerHelper.enableModule("simpletest");
 
         _userHelper.createUser(USER);
-        _apiPermissionsHelper.addMemberToRole(USER, "Project Administrator", PermissionsHelper.MemberType.user);
+        _apiPermissionsHelper.addMemberToRole(USER, PROJECT_ADMIN_ROLE, PermissionsHelper.MemberType.user);
     }
 
     /*
@@ -105,7 +108,7 @@ public class PermissionsTestForJavascriptExecution extends BaseWebDriverTest
         stopImpersonating();
 
         log("Adding developer role to the user");
-        _apiPermissionsHelper.setSiteRoleUserPermissions(USER, "Platform Developer");
+        _apiPermissionsHelper.setSiteRoleUserPermissions(USER, DEVELOPER_ROLE);
 
         log("Verifying editing metadata is success");
         goToProjectHome();

--- a/src/org/labkey/test/tests/PostgresQueriesTest.java
+++ b/src/org/labkey/test/tests/PostgresQueriesTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
@@ -54,7 +55,7 @@ public class PostgresQueriesTest extends AbstractAdminConsoleTest implements Pos
         // Verify project admin gets a 401 for activity grid
         pushLocation();
         goToHome();
-        impersonateRole("Project Administrator");
+        impersonateRole(PROJECT_ADMIN_ROLE);
         popLocation();
         LabkeyErrorPage errorPage = new LabkeyErrorPage(getDriver());
         errorPage.assertUnauthorized(checker());
@@ -69,7 +70,7 @@ public class PostgresQueriesTest extends AbstractAdminConsoleTest implements Pos
         // Verify project admin gets a 401 for locks grid
         pushLocation();
         goToHome();
-        impersonateRole("Project Administrator");
+        impersonateRole(PROJECT_ADMIN_ROLE);
         popLocation();
         errorPage = new LabkeyErrorPage(getDriver());
         errorPage.assertUnauthorized(checker());

--- a/src/org/labkey/test/tests/ProjectCreatorUserTest.java
+++ b/src/org/labkey/test/tests/ProjectCreatorUserTest.java
@@ -29,6 +29,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.WebTestHelper.getRemoteApiConnection;
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
 
 @Category(Daily.class)
 @BaseWebDriverTest.ClassTimeout(minutes = 2)
@@ -101,8 +103,8 @@ public class ProjectCreatorUserTest extends BaseWebDriverTest
 
         log("Verifying the permissions");
         goToProjectHome(PROJECT_NAME_PC);
-        navBar().goToPermissionsPage().assertPermissionSetting(PROJECT_CREATOR_USER, "Project Administrator");
-        navBar().goToPermissionsPage().assertPermissionSetting(PROJECT_CREATOR_USER, "Folder Administrator");
+        navBar().goToPermissionsPage().assertPermissionSetting(PROJECT_CREATOR_USER, PROJECT_ADMIN_ROLE);
+        navBar().goToPermissionsPage().assertPermissionSetting(PROJECT_CREATOR_USER, FOLDER_ADMIN_ROLE);
 
         log("Cleanup : Deleting the project");
         _containerHelper.deleteProject(PROJECT_NAME_PC, false, WAIT_FOR_PAGE);
@@ -157,8 +159,8 @@ public class ProjectCreatorUserTest extends BaseWebDriverTest
 
         goToProjectHome(PROJECT_NAME_PC);
         PermissionsPage permissionsPage = navBar().goToPermissionsPage();
-        permissionsPage.assertPermissionSetting(PROJECT_CREATOR_USER, "Project Administrator");
-        permissionsPage.assertPermissionSetting(PROJECT_CREATOR_USER, "Folder Administrator");
+        permissionsPage.assertPermissionSetting(PROJECT_CREATOR_USER, PROJECT_ADMIN_ROLE);
+        permissionsPage.assertPermissionSetting(PROJECT_CREATOR_USER, FOLDER_ADMIN_ROLE);
 
         ManageListsGrid listsGrid = goToManageLists().getGrid();
         listsGrid.setContainerFilter(DataRegionTable.ContainerFilterType.CURRENT_FOLDER);

--- a/src/org/labkey/test/tests/ReportSecurityTest.java
+++ b/src/org/labkey/test/tests/ReportSecurityTest.java
@@ -28,6 +28,8 @@ import org.labkey.test.pages.admin.PermissionsPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+
 @Category({Daily.class, Reports.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 8)
 public class ReportSecurityTest extends ReportTest
@@ -85,7 +87,7 @@ public class ReportSecurityTest extends ReportTest
         clickButton("Update Group Membership");
 
         navBar().goToPermissionsPage();
-        permissionsPage.setPermissions(TEST_GROUP, "Reader");
+        permissionsPage.setPermissions(TEST_GROUP, READER_ROLE);
         permissionsPage.clickSaveAndFinish();
 
         // give the test group read access to only the DEM-1 dataset
@@ -102,7 +104,7 @@ public class ReportSecurityTest extends ReportTest
         click(Locator.xpath("//td[.='" + TEST_GROUP + "']/..//td/input[@value='READOWN']"));
         clickAndWait(Locator.id("groupUpdateButton"));
 
-        selectOptionByText(Locator.name("dataset.1"), "Reader");
+        selectOptionByText(Locator.name("dataset.1"), READER_ROLE);
         clickAndWait(Locator.xpath("//form[@id='datasetSecurityForm']").append(Locator.lkButton("Save")));
     }
 

--- a/src/org/labkey/test/tests/ReportSharingTest.java
+++ b/src/org/labkey/test/tests/ReportSharingTest.java
@@ -32,6 +32,11 @@ import org.labkey.test.util.RReportHelper;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+import static org.labkey.test.util.PermissionsHelper.SITE_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.SUBMITTER_ROLE;
+
 @Category({Daily.class, Reports.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class ReportSharingTest extends BaseWebDriverTest
@@ -68,10 +73,10 @@ public class ReportSharingTest extends BaseWebDriverTest
 
         ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
         apiPermissionsHelper.addUserToProjGroup(USER_EDITOR, getProjectName(), "Users");
-        apiPermissionsHelper.setPermissions("Users", "Editor");
-        apiPermissionsHelper.setUserPermissions(USER_EDITOR,"Reader");
-        apiPermissionsHelper.setUserPermissions(USER_NON_EDITOR,"Submitter");
-        apiPermissionsHelper.setSiteRoleUserPermissions(USER_DEV, "Site Administrator");
+        apiPermissionsHelper.setPermissions("Users", EDITOR_ROLE);
+        apiPermissionsHelper.setUserPermissions(USER_EDITOR,READER_ROLE);
+        apiPermissionsHelper.setUserPermissions(USER_NON_EDITOR,SUBMITTER_ROLE);
+        apiPermissionsHelper.setSiteRoleUserPermissions(USER_DEV, SITE_ADMIN_ROLE);
     }
 
     @Before

--- a/src/org/labkey/test/tests/RlabkeyTest.java
+++ b/src/org/labkey/test/tests/RlabkeyTest.java
@@ -54,6 +54,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 8)
@@ -112,9 +113,9 @@ public class RlabkeyTest extends BaseWebDriverTest
         _userHelper.createUser(USER);
         ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
         apiPermissionsHelper.addUserToProjGroup(USER, PROJECT_NAME_2, "Users");
-        apiPermissionsHelper.addMemberToRole("Users", "Editor", PermissionsHelper.MemberType.group, PROJECT_NAME_2);
+        apiPermissionsHelper.addMemberToRole("Users", EDITOR_ROLE, PermissionsHelper.MemberType.group, PROJECT_NAME_2);
         apiPermissionsHelper.addUserToProjGroup(USER, PROJECT_NAME, "Users");
-        apiPermissionsHelper.addMemberToRole("Users", "Editor", PermissionsHelper.MemberType.group, PROJECT_NAME);
+        apiPermissionsHelper.addMemberToRole("Users", EDITOR_ROLE, PermissionsHelper.MemberType.group, PROJECT_NAME);
         IssuesHelper issuesHelper = new IssuesHelper(this);
 
         // create an site wide issues list

--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -41,6 +41,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
 public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
@@ -72,7 +74,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         _studyHelper.startCreateStudy()
                 .setTimepointType(StudyHelper.TimepointType.VISIT)
                 .createStudy();
-        createUserWithPermissions(READER_USER, VISIT_BASED_STUDY, "Reader");
+        createUserWithPermissions(READER_USER, VISIT_BASED_STUDY, READER_ROLE);
 
         _containerHelper.createProject(DATE_BASED_STUDY, "Study");
         _studyHelper.startCreateStudy()

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -92,6 +92,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.params.FieldDefinition.DOMAIN_TRICKY_CHARACTERS;
 import static org.labkey.test.util.DataRegionTable.DataRegion;
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 20)
@@ -352,7 +353,7 @@ public class SampleTypeTest extends BaseWebDriverTest
     public void testMeFilterOnSampleType()
     {
         USER_FOR_FILTERTEST.create(this)
-                .addPermission("Folder Administrator", getProjectName());
+                .addPermission(FOLDER_ADMIN_ROLE, getProjectName());
         String sampleType = "meFilterSamples";
         FieldInfo sizeField = FieldInfo.random("size", ColumnType.Integer);
         FieldInfo userField = FieldInfo.random("user", ColumnType.User);

--- a/src/org/labkey/test/tests/SecurityApiTest.java
+++ b/src/org/labkey/test/tests/SecurityApiTest.java
@@ -30,6 +30,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+import static org.labkey.test.util.PermissionsHelper.SITE_ADMIN_ROLE;
+
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class SecurityApiTest extends BaseWebDriverTest
@@ -76,13 +80,13 @@ public class SecurityApiTest extends BaseWebDriverTest
         ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
         apiPermissionsHelper.createPermissionsGroup(GROUP_1, USER_1);
         apiPermissionsHelper.createPermissionsGroup(GROUP_2, USER_1, USER_2);
-        apiPermissionsHelper.setPermissions(GROUP_1, "Editor");
-        apiPermissionsHelper.setPermissions(GROUP_2, "Reader");
+        apiPermissionsHelper.setPermissions(GROUP_1, EDITOR_ROLE);
+        apiPermissionsHelper.setPermissions(GROUP_2, READER_ROLE);
 
         // Create the admin user that will be used to call the APIs.
         int userId = _userHelper.createUserAndNotify(ADMIN_USER).getUserId();
         setInitialPassword(userId);
-        apiPermissionsHelper.setSiteRoleUserPermissions(ADMIN_USER, "Site Administrator");
+        apiPermissionsHelper.setSiteRoleUserPermissions(ADMIN_USER, SITE_ADMIN_ROLE);
 
     }
 

--- a/src/org/labkey/test/tests/SecurityTest.java
+++ b/src/org/labkey/test/tests/SecurityTest.java
@@ -38,6 +38,7 @@ import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.PasswordUtil;
+import org.labkey.test.util.PermissionsHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SimpleHttpResponse;
 import org.labkey.test.util.UIPermissionsHelper;
@@ -59,6 +60,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.labkey.test.WebTestHelper.buildURL;
+import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category(BVT.class)
 @BaseWebDriverTest.ClassTimeout(minutes = 11)
@@ -69,8 +73,6 @@ public class SecurityTest extends BaseWebDriverTest
     protected static final String NORMAL_USER_TEMPLATE = "_user.template@security.test";
     protected static final String BOGUS_USER_TEMPLATE = "bogus@bogus@bogus";
     protected static final String PROJECT_ADMIN_USER = "admin_securitytest@security.test";
-    private static final String PROJECT_ADMIN_ROLE = "Project Administrator";
-    private static final String FOLDER_ADMIN_ROLE = "Folder Administrator";
     protected static final String NORMAL_USER = "user_securitytest@security.test";
     private static final String ADDED_USER = "fromprojectusers@security.test";
     protected static final String TO_BE_DELETED_USER = "delete_me@security.test";
@@ -254,8 +256,8 @@ public class SecurityTest extends BaseWebDriverTest
     {
         goToProjectHome();
         ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
-        permissionsHelper.setSiteGroupPermissions("All Site Users", "Author");
-        permissionsHelper.setSiteGroupPermissions("Guests", "Reader");
+        permissionsHelper.setSiteGroupPermissions("All Site Users", AUTHOR_ROLE);
+        permissionsHelper.setSiteGroupPermissions("Guests", READER_ROLE);
 
         PortalHelper portalHelper = new PortalHelper(this);
         portalHelper.addWebPart("Messages");
@@ -305,19 +307,19 @@ public class SecurityTest extends BaseWebDriverTest
 
         goToProjectHome();
         // Add permissions for a site group
-        _permissionsHelper.setSiteGroupPermissions("Guests", "Reader");
+        _permissionsHelper.setSiteGroupPermissions("Guests", READER_ROLE);
         // Add a non-group permission
-        _permissionsHelper.setUserPermissions(ADMIN_USER_TEMPLATE, "Editor");
+        _permissionsHelper.setUserPermissions(ADMIN_USER_TEMPLATE, EDITOR_ROLE);
         _permissionsHelper.createPermissionsGroup("Administrators");
         _permissionsHelper.clickManageGroup("Administrators");
         setFormElement(Locator.name("names"), ADMIN_USER_TEMPLATE);
         clickButton("Update Group Membership");
         _permissionsHelper.enterPermissionsUI();
-        _permissionsHelper.setPermissions("Administrators", "Project Administrator");
+        _permissionsHelper.setPermissions("Administrators", PermissionsHelper.PROJECT_ADMIN_ROLE);
 
         _permissionsHelper.createPermissionsGroup("Testers");
         _permissionsHelper.assertPermissionSetting("Testers", "No Permissions");
-        _permissionsHelper.setPermissions("Testers", "Editor");
+        _permissionsHelper.setPermissions("Testers", EDITOR_ROLE);
         _permissionsHelper.clickManageGroup("Testers");
         setFormElement(Locator.name("names"), NORMAL_USER_TEMPLATE);
         clickButton("Update Group Membership");
@@ -339,11 +341,11 @@ public class SecurityTest extends BaseWebDriverTest
         log("Verify individual (non-group) permissions were cloned");
         goToProjectHome();
         ApiPermissionsHelper helper = new ApiPermissionsHelper(this);
-        helper.assertPermissionSetting(PROJECT_ADMIN_USER, "Editor");
+        helper.assertPermissionSetting(PROJECT_ADMIN_USER, EDITOR_ROLE);
         log("Verify that group permissions did not get assigned individually");
-        _permissionsHelper.assertNoPermission(PROJECT_ADMIN_USER, "Reader");
-        _permissionsHelper.assertNoPermission(NORMAL_USER, "Reader");
-        _permissionsHelper.assertNoPermission(NORMAL_USER, "Editor");
+        _permissionsHelper.assertNoPermission(PROJECT_ADMIN_USER, READER_ROLE);
+        _permissionsHelper.assertNoPermission(NORMAL_USER, READER_ROLE);
+        _permissionsHelper.assertNoPermission(NORMAL_USER, EDITOR_ROLE);
 
         // verify permissions
         checkGroupMembership(PROJECT_ADMIN_USER, "SecurityVerifyProject/Administrators", 2);
@@ -355,7 +357,7 @@ public class SecurityTest extends BaseWebDriverTest
     public void testAddUserAsProjAdmin()
     {
         beginAt(WebTestHelper.buildURL("project", getProjectName(), "begin"));
-        impersonateRoles(PROJECT_ADMIN_ROLE);
+        impersonateRoles(PermissionsHelper.PROJECT_ADMIN_ROLE);
         ShowUsersPage usersPage = goToProjectUsers();
 
         usersPage
@@ -372,7 +374,7 @@ public class SecurityTest extends BaseWebDriverTest
     public void testCantAddUserAsFolderAdmin()
     {
         beginAt(WebTestHelper.buildURL("project", getProjectName(), "begin"));
-        impersonateRoles(FOLDER_ADMIN_ROLE);
+        impersonateRoles(PermissionsHelper.FOLDER_ADMIN_ROLE);
         goToProjectUsers();
 
         assertElementNotPresent(Locator.lkButton("Add Users"));

--- a/src/org/labkey/test/tests/SimpleModuleTest.java
+++ b/src/org/labkey/test/tests/SimpleModuleTest.java
@@ -93,6 +93,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.labkey.test.TestFileUtils.getDefaultFileRoot;
 import static org.labkey.test.WebTestHelper.buildURL;
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 /**
 * Tests the simple module and file-based resources introduced in version 9.1
@@ -1862,12 +1864,12 @@ public class SimpleModuleTest extends BaseWebDriverTest
 
         log("folder admin without restricted permission can still see existing restricted folder, web parts");
         navigateToFolder(getProjectName(), RESTRICTED_FOLDER_NAME);
-        impersonateRole("Reader");
+        impersonateRole(READER_ROLE);
         assertTextPresent("This is a web part view in the restricted module.");     // Can still see web part
         stopImpersonating();
         goToProjectHome();
         navigateToFolder(getProjectName(), RESTRICTED_FOLDER_NAME);
-        impersonateRole("Folder Administrator");
+        impersonateRole(FOLDER_ADMIN_ROLE);
         goToFolderManagement();
         clickAndWait(Locator.linkWithText("Folder Type"));
         // Shouldn't see folder type, module name

--- a/src/org/labkey/test/tests/SubfolderWebPartTest.java
+++ b/src/org/labkey/test/tests/SubfolderWebPartTest.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
@@ -97,9 +98,8 @@ public class SubfolderWebPartTest extends BaseWebDriverTest
 
             // give a user folder-specific role here
             projectMenu().navigateToFolder(otherProjectName, FOLDER_WITH_USERS);
-            navBar().goToPermissionsPage().setUserPermissions(TEST_USER, "Editor");
+            navBar().goToPermissionsPage().setUserPermissions(TEST_USER, EDITOR_ROLE);
         }
-
     }
 
     @Before
@@ -141,7 +141,7 @@ public class SubfolderWebPartTest extends BaseWebDriverTest
         homeWebPart.goToSubfolder(FOLDER_TWO_A);
         homeWebPart = SubfoldersWebPart.getWebPart(getDriver());
         homeWebPart.goToSubfolder(FOLDER_WITH_USERS);
-        boolean userRoleMigratedAsExpected = navBar().goToPermissionsPage().isUserInRole(TEST_USER, "Editor");
+        boolean userRoleMigratedAsExpected = navBar().goToPermissionsPage().isUserInRole(TEST_USER, EDITOR_ROLE);
         assertTrue("The user role did not migrate with folder import", userRoleMigratedAsExpected);
 
         // now validate files

--- a/src/org/labkey/test/tests/SurveyTest.java
+++ b/src/org/labkey/test/tests/SurveyTest.java
@@ -37,6 +37,8 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 7)
@@ -250,11 +252,11 @@ public class SurveyTest extends BaseWebDriverTest
         _userHelper.createUser(EDITOR);
         clickProject(getProjectName());
         _permissionsHelper.enterPermissionsUI();
-        _permissionsHelper.setUserPermissions(EDITOR, "Reader");
+        _permissionsHelper.setUserPermissions(EDITOR, READER_ROLE);
         clickButton("Save and Finish");
         clickFolder(FOLDER_NAME);
         _permissionsHelper.enterPermissionsUI();
-        _permissionsHelper.setUserPermissions(EDITOR, "Editor");
+        _permissionsHelper.setUserPermissions(EDITOR, EDITOR_ROLE);
         clickButton("Save and Finish");
     }
 

--- a/src/org/labkey/test/tests/TimeChartDateBasedTest.java
+++ b/src/org/labkey/test/tests/TimeChartDateBasedTest.java
@@ -42,6 +42,8 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Daily.class, Reports.class, Charting.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
@@ -70,9 +72,9 @@ public class TimeChartDateBasedTest extends TimeChartTest
 
         navigateToFolder(getProjectName(), getFolderName());
         ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
-        permissionsHelper.setUserPermissions(USER1, "Reader");
-        permissionsHelper.setUserPermissions(USER2, "Editor");
-        permissionsHelper.setSiteGroupPermissions("Guests", "Reader");
+        permissionsHelper.setUserPermissions(USER1, READER_ROLE);
+        permissionsHelper.setUserPermissions(USER2, EDITOR_ROLE);
+        permissionsHelper.setSiteGroupPermissions("Guests", READER_ROLE);
 
         PortalHelper portalHelper = new PortalHelper(this);
         portalHelper.addWebPart("Views");

--- a/src/org/labkey/test/tests/UserClonePermissionTest.java
+++ b/src/org/labkey/test/tests/UserClonePermissionTest.java
@@ -17,6 +17,13 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
+import static org.labkey.test.util.PermissionsHelper.APP_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.DEVELOPER_ROLE;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.SITE_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.SUBMITTER_ROLE;
+
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
 public class UserClonePermissionTest extends BaseWebDriverTest
@@ -54,23 +61,23 @@ public class UserClonePermissionTest extends BaseWebDriverTest
         _permissionsHelper = new ApiPermissionsHelper(this);
 
         _userHelper.createUser(CLONED_SOURCE_SITE_USER);
-        _permissionsHelper.setSiteRoleUserPermissions(CLONED_SOURCE_SITE_USER, "Site Administrator");
+        _permissionsHelper.setSiteRoleUserPermissions(CLONED_SOURCE_SITE_USER, SITE_ADMIN_ROLE);
 
         _userHelper.createUser(CLONED_SOURCE_APP_USER);
         _permissionsHelper.addUserAsAppAdmin(CLONED_SOURCE_APP_USER);
 
         goToProjectHome();
         _permissionsHelper.createPermissionsGroup(CLONE_GROUP);
-        _permissionsHelper.setPermissions(CLONE_GROUP, "Editor");
-        _permissionsHelper.setPermissions(CLONE_GROUP, "Author");
+        _permissionsHelper.setPermissions(CLONE_GROUP, EDITOR_ROLE);
+        _permissionsHelper.setPermissions(CLONE_GROUP, AUTHOR_ROLE);
         _permissionsHelper.addUserToProjGroup(CLONED_SOURCE_SITE_USER, getProjectName(), CLONE_GROUP);
-        _permissionsHelper.addMemberToRole(CLONED_SOURCE_SITE_USER, "Author", PermissionsHelper.MemberType.user);
+        _permissionsHelper.addMemberToRole(CLONED_SOURCE_SITE_USER, AUTHOR_ROLE, PermissionsHelper.MemberType.user);
         _permissionsHelper.addUserToProjGroup(CLONED_SOURCE_APP_USER, getProjectName(), CLONE_GROUP);
 
-        _permissionsHelper.setSiteRoleUserPermissions(CLONED_SOURCE_SITE_USER, "Platform Developer");
+        _permissionsHelper.setSiteRoleUserPermissions(CLONED_SOURCE_SITE_USER, DEVELOPER_ROLE);
 
         _userHelper.createUser(CLONED_TARGET_SITE_USER);
-        _permissionsHelper.addMemberToRole(CLONED_TARGET_SITE_USER, "Submitter", PermissionsHelper.MemberType.user);
+        _permissionsHelper.addMemberToRole(CLONED_TARGET_SITE_USER, SUBMITTER_ROLE, PermissionsHelper.MemberType.user);
 
         _userHelper.createUser(CLONED_TARGET_APP_USER);
     }
@@ -102,9 +109,9 @@ public class UserClonePermissionTest extends BaseWebDriverTest
 
         log("Verifying project level permission");
         _permissionsHelper = new ApiPermissionsHelper(getProjectName());
-        _permissionsHelper.assertPermissionSetting(CLONED_TARGET_SITE_USER, "Author");
-        _permissionsHelper.assertPermissionSetting(CLONED_TARGET_SITE_USER, "Editor");
-        _permissionsHelper.assertNoPermission(CLONED_TARGET_SITE_USER, "Submitter");
+        _permissionsHelper.assertPermissionSetting(CLONED_TARGET_SITE_USER, AUTHOR_ROLE);
+        _permissionsHelper.assertPermissionSetting(CLONED_TARGET_SITE_USER, EDITOR_ROLE);
+        _permissionsHelper.assertNoPermission(CLONED_TARGET_SITE_USER, SUBMITTER_ROLE);
         Assert.assertTrue("Project group is not cloned",
                 _permissionsHelper.isUserInGroup(CLONED_TARGET_SITE_USER, CLONE_GROUP, getProjectName(), PermissionsHelper.PrincipalType.USER));
 
@@ -134,7 +141,7 @@ public class UserClonePermissionTest extends BaseWebDriverTest
     public void testAppAdminClonePermission()
     {
         goToSiteUsers();
-        impersonateRole("Application Admin");
+        impersonateRole(APP_ADMIN_ROLE);
         clickAndWait(Locator.linkWithText(_userHelper.getDisplayNameForEmail(CLONED_TARGET_APP_USER)));
         clickAndWait(Locator.linkWithText("Clone Permissions"));
         ClonePermissionsPage clonePermissionsPage = new ClonePermissionsPage(getDriver());
@@ -156,8 +163,8 @@ public class UserClonePermissionTest extends BaseWebDriverTest
 
         log("Verifying project level permission");
         _permissionsHelper = new ApiPermissionsHelper(getProjectName());
-        _permissionsHelper.assertPermissionSetting(CLONED_TARGET_APP_USER, "Author");
-        _permissionsHelper.assertPermissionSetting(CLONED_TARGET_APP_USER, "Editor");
+        _permissionsHelper.assertPermissionSetting(CLONED_TARGET_APP_USER, AUTHOR_ROLE);
+        _permissionsHelper.assertPermissionSetting(CLONED_TARGET_APP_USER, EDITOR_ROLE);
         Assert.assertTrue("Project group is not cloned",
                 _permissionsHelper.isUserInGroup(CLONED_TARGET_APP_USER, CLONE_GROUP, getProjectName(), PermissionsHelper.PrincipalType.USER));
 

--- a/src/org/labkey/test/tests/UserDetailsPermissionTest.java
+++ b/src/org/labkey/test/tests/UserDetailsPermissionTest.java
@@ -45,6 +45,8 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+import static org.labkey.test.util.PermissionsHelper.SITE_ADMIN_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
@@ -105,13 +107,13 @@ public class UserDetailsPermissionTest extends BaseWebDriverTest
 
         _containerHelper.createProject(getProjectName(), null);
 
-        new ApiPermissionsHelper(this).setSiteRoleUserPermissions(ADMIN_USER, "Site Administrator");
+        new ApiPermissionsHelper(this).setSiteRoleUserPermissions(ADMIN_USER, SITE_ADMIN_ROLE);
         // Use created user to ensure we have a known 'Modified by' column for created users
         ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this,
                 () -> new Connection(WebTestHelper.getBaseURL(), ADMIN_USER, PasswordUtil.getPassword()));
 
         apiPermissionsHelper.createPermissionsGroup(TEST_GROUP, USER_INFO_VIEWER, IMPERSONATED_USER, CHECKED_USER);
-        apiPermissionsHelper.setPermissions(TEST_GROUP, "Reader");
+        apiPermissionsHelper.setPermissions(TEST_GROUP, READER_ROLE);
         apiPermissionsHelper.setSiteRoleUserPermissions(USER_INFO_VIEWER, "See User and Group Details");
 
         impersonate(ADMIN_USER);

--- a/src/org/labkey/test/tests/UserPermissionsTest.java
+++ b/src/org/labkey/test/tests/UserPermissionsTest.java
@@ -40,6 +40,11 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+import static org.labkey.test.util.PermissionsHelper.SUBMITTER_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 7)
@@ -108,7 +113,7 @@ public class UserPermissionsTest extends BaseWebDriverTest
         _containerHelper.createProject(PERM_PROJECT_NAME, null);
         _permissionsHelper.createPermissionsGroup(GAMMA_EDITOR_GROUP_NAME);
         _permissionsHelper.assertPermissionSetting(GAMMA_EDITOR_GROUP_NAME, "No Permissions");
-        _permissionsHelper.setPermissions(GAMMA_EDITOR_GROUP_NAME, "Editor");
+        _permissionsHelper.setPermissions(GAMMA_EDITOR_GROUP_NAME, EDITOR_ROLE);
         createUserInProjectForGroup(GAMMA_EDITOR_USER, PERM_PROJECT_NAME, GAMMA_EDITOR_GROUP_NAME, false);
 
         _containerHelper.createSubfolder(PERM_PROJECT_NAME, PERM_PROJECT_NAME, DENIED_SUB_FOLDER_NAME, "None", new String[]{"Messages", "Wiki"}, true);
@@ -125,7 +130,7 @@ public class UserPermissionsTest extends BaseWebDriverTest
         _permissionsHelper.enterPermissionsUI();
         _permissionsHelper.createPermissionsGroup(GAMMA_READER_GROUP_NAME);
         _permissionsHelper.assertPermissionSetting(GAMMA_READER_GROUP_NAME, "No Permissions");
-        _permissionsHelper.setPermissions(GAMMA_READER_GROUP_NAME, "Reader");
+        _permissionsHelper.setPermissions(GAMMA_READER_GROUP_NAME, READER_ROLE);
         createUserInProjectForGroup(GAMMA_READER_USER, PERM_PROJECT_NAME, GAMMA_READER_GROUP_NAME, false);
 
         //Create Author User
@@ -133,7 +138,7 @@ public class UserPermissionsTest extends BaseWebDriverTest
         _permissionsHelper.enterPermissionsUI();
         _permissionsHelper.createPermissionsGroup(GAMMA_AUTHOR_GROUP_NAME);
         _permissionsHelper.assertPermissionSetting(GAMMA_AUTHOR_GROUP_NAME, "No Permissions");
-        _permissionsHelper.setPermissions(GAMMA_AUTHOR_GROUP_NAME, "Author");
+        _permissionsHelper.setPermissions(GAMMA_AUTHOR_GROUP_NAME, AUTHOR_ROLE);
         createUserInProjectForGroup(GAMMA_AUTHOR_USER, PERM_PROJECT_NAME, GAMMA_AUTHOR_GROUP_NAME, false);
 
         //Create the Submitter User
@@ -141,7 +146,7 @@ public class UserPermissionsTest extends BaseWebDriverTest
         _permissionsHelper.enterPermissionsUI();
         _permissionsHelper.createPermissionsGroup(GAMMA_SUBMITTER_GROUP_NAME);
         _permissionsHelper.assertPermissionSetting(GAMMA_SUBMITTER_GROUP_NAME, "No Permissions");
-        _permissionsHelper.setPermissions(GAMMA_SUBMITTER_GROUP_NAME, "Submitter");
+        _permissionsHelper.setPermissions(GAMMA_SUBMITTER_GROUP_NAME, SUBMITTER_ROLE);
 
         // TODO: Add submitter to a group
         /*
@@ -226,14 +231,14 @@ public class UserPermissionsTest extends BaseWebDriverTest
         clickFolder(DENIED_SUB_FOLDER_NAME);
         _permissionsHelper.enterPermissionsUI();
         _permissionsHelper.uncheckInheritedPermissions();
-        _permissionsHelper.removePermission(GAMMA_READER_GROUP_NAME, "Reader");
+        _permissionsHelper.removePermission(GAMMA_READER_GROUP_NAME, READER_ROLE);
         clickButton("Save and Finish");
 
         // Test that a project admin is confined to a single project when impersonating a project user. Site admins
         // are not restricted in this way, so we need to create and login as a new user with project admin permissions.
         clickProject(PERM_PROJECT_NAME);
         _permissionsHelper.createPermissionsGroup(GAMMA_ADMIN_GROUP_NAME);
-        _permissionsHelper.setPermissions(GAMMA_ADMIN_GROUP_NAME, "Project Administrator");
+        _permissionsHelper.setPermissions(GAMMA_ADMIN_GROUP_NAME, PROJECT_ADMIN_ROLE);
         createUserInProjectForGroup(GAMMA_PROJECT_ADMIN_USER, PERM_PROJECT_NAME, GAMMA_ADMIN_GROUP_NAME, true);
         setInitialPassword(GAMMA_PROJECT_ADMIN_USER);
         signOut();

--- a/src/org/labkey/test/tests/UserTest.java
+++ b/src/org/labkey/test/tests/UserTest.java
@@ -53,6 +53,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 9)
@@ -107,7 +108,7 @@ public class UserTest extends BaseWebDriverTest
     private void doSetup()
     {
         _containerHelper.createProject(getProjectName(), null);
-        _normalUserId = createUserWithPermissions(NORMAL_USER, getProjectName(), "Editor").getUserId();
+        _normalUserId = createUserWithPermissions(NORMAL_USER, getProjectName(), EDITOR_ROLE).getUserId();
     }
 
     @Override
@@ -365,7 +366,7 @@ public class UserTest extends BaseWebDriverTest
     @Test
     public void testDeactivatedUser()
     {
-        createUserWithPermissions(DEACTIVATED_USER, getProjectName(), "Editor");
+        createUserWithPermissions(DEACTIVATED_USER, getProjectName(), EDITOR_ROLE);
         goToSiteUsers();
         DataRegionTable usersTable = new DataRegionTable("Users", this);
         int row = usersTable.getRowIndex("Email", DEACTIVATED_USER);

--- a/src/org/labkey/test/tests/WebpartPermissionsTest.java
+++ b/src/org/labkey/test/tests/WebpartPermissionsTest.java
@@ -30,6 +30,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.fail;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
@@ -127,9 +130,9 @@ public class WebpartPermissionsTest extends BaseWebDriverTest
     {
         // Target permissions operations at non-default project
         PermissionsHelper helper = new ApiPermissionsHelper(DUMMY_PROJECT_NAME);
-        helper.setUserPermissions(users[0], "Reader");
-        helper.setUserPermissions(users[1], "Editor");
-        helper.setUserPermissions(users[2], "Project Administrator");
+        helper.setUserPermissions(users[0], READER_ROLE);
+        helper.setUserPermissions(users[1], EDITOR_ROLE);
+        helper.setUserPermissions(users[2], PROJECT_ADMIN_ROLE);
     }
 
     private void verifyNoWebpartsVisible()
@@ -155,7 +158,7 @@ public class WebpartPermissionsTest extends BaseWebDriverTest
         _containerHelper.createProject(getProjectName(), "Collaboration");
         importFolderFromZip(TestFileUtils.getSampleData("webpartPerm/webPerms.folder.zip"));
         //set all users to Reader so they have access to the folder
-        _permissionsHelper.setSiteGroupPermissions("All Site Users", "Reader");
+        _permissionsHelper.setSiteGroupPermissions("All Site Users", READER_ROLE);
     }
 
     //This folder contains no data, but will create users and set them with specific permissions

--- a/src/org/labkey/test/tests/announcements/AnnouncementAPITest.java
+++ b/src/org/labkey/test/tests/announcements/AnnouncementAPITest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Daily.class})
 public class AnnouncementAPITest extends BaseWebDriverTest
@@ -308,7 +309,7 @@ public class AnnouncementAPITest extends BaseWebDriverTest
         AnnouncementModel created = createThread(preThread);
 
         goToProjectHome(getProjectName());
-        impersonateRole("Reader");
+        impersonateRole(READER_ROLE);
 
         // Act and assert
         // as a Reader, attempt to do basic things that require permissions and confirm

--- a/src/org/labkey/test/tests/announcements/ModeratorReviewTest.java
+++ b/src/org/labkey/test/tests/announcements/ModeratorReviewTest.java
@@ -38,6 +38,9 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class ModeratorReviewTest extends BaseWebDriverTest
@@ -86,9 +89,9 @@ public class ModeratorReviewTest extends BaseWebDriverTest
         _userHelper.createUser(SPAM_USER);
         _userHelper.createUser(EDITOR_USER);
         ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
-        apiPermissionsHelper.addMemberToRole(APPROVED_USER, "Author", PermissionsHelper.MemberType.user);
-        apiPermissionsHelper.addMemberToRole(SPAM_USER, "Author", PermissionsHelper.MemberType.user);
-        apiPermissionsHelper.addMemberToRole(EDITOR_USER, "Editor", PermissionsHelper.MemberType.user);
+        apiPermissionsHelper.addMemberToRole(APPROVED_USER, AUTHOR_ROLE, PermissionsHelper.MemberType.user);
+        apiPermissionsHelper.addMemberToRole(SPAM_USER, AUTHOR_ROLE, PermissionsHelper.MemberType.user);
+        apiPermissionsHelper.addMemberToRole(EDITOR_USER, EDITOR_ROLE, PermissionsHelper.MemberType.user);
     }
 
     @Before

--- a/src/org/labkey/test/tests/api/CustomizeGridPermissionsTest.java
+++ b/src/org/labkey/test/tests/api/CustomizeGridPermissionsTest.java
@@ -37,7 +37,9 @@ import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 import static org.labkey.test.util.PermissionsHelper.MemberType;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 7)
@@ -78,8 +80,8 @@ public class CustomizeGridPermissionsTest extends BaseWebDriverTest
         _userHelper.createUser(VIEW_EDITOR);
 
         ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
-        permissionsHelper.addMemberToRole(READER, "Reader", MemberType.user, getProjectName());
-        permissionsHelper.addMemberToRole(EDITOR, "Editor", MemberType.user, getProjectName());
+        permissionsHelper.addMemberToRole(READER, READER_ROLE, MemberType.user, getProjectName());
+        permissionsHelper.addMemberToRole(EDITOR, EDITOR_ROLE, MemberType.user, getProjectName());
         permissionsHelper.addMemberToRole(VIEW_EDITOR, "Shared View Editor", MemberType.user, getProjectName());
     }
 

--- a/src/org/labkey/test/tests/assay/AssayTransformWarningTest.java
+++ b/src/org/labkey/test/tests/assay/AssayTransformWarningTest.java
@@ -41,6 +41,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.pages.ReactAssayDesignerPage.ScriptFileEvent.Edit;
 import static org.labkey.test.pages.ReactAssayDesignerPage.ScriptFileEvent.Import;
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
 
 @Category({Assays.class, Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 4)
@@ -322,7 +323,7 @@ public class AssayTransformWarningTest extends BaseWebDriverTest
 
         // verify file exists in @scripts dir via webdav page
         goToProjectHome();
-        impersonateRole("Folder Administrator");
+        impersonateRole(FOLDER_ADMIN_ROLE);
         WebDavPage.beginAt(this, getProjectName() + "/@scripts");
         waitForElement(Locators.labkeyErrorHeading.withText("/_webdav/" + getProjectName() + "/@scripts"));
         stopImpersonatingHTTP();

--- a/src/org/labkey/test/tests/component/GridPanelViewTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelViewTest.java
@@ -40,6 +40,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
+
 @Category({Daily.class})
 public class GridPanelViewTest extends GridPanelBaseTest
 {
@@ -130,7 +132,7 @@ public class GridPanelViewTest extends GridPanelBaseTest
         createSampleType(DEFAULT_VIEW_SAMPLE_TYPE, DEFAULT_VIEW_SAMPLE_PREFIX, DEFAULT_VIEW_SAMPLE_TYPE_SIZE, fields);
 
         _userHelper.createUser(OTHER_USER, true,false);
-        new ApiPermissionsHelper(this).addMemberToRole(OTHER_USER, "Folder Administrator", PermissionsHelper.MemberType.user, getProjectName());
+        new ApiPermissionsHelper(this).addMemberToRole(OTHER_USER, FOLDER_ADMIN_ROLE, PermissionsHelper.MemberType.user, getProjectName());
 
     }
 

--- a/src/org/labkey/test/tests/core/security/AppAdminRoleTest.java
+++ b/src/org/labkey/test/tests/core/security/AppAdminRoleTest.java
@@ -39,6 +39,7 @@ import static org.junit.Assert.fail;
 import static org.labkey.test.util.PermissionsHelper.APP_ADMIN_ROLE;
 import static org.labkey.test.util.PermissionsHelper.DEVELOPER_ROLE;
 import static org.labkey.test.util.PermissionsHelper.IMP_TROUBLESHOOTER_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 import static org.labkey.test.util.PermissionsHelper.SITE_ADMIN_ROLE;
 
 @Category({Daily.class})
@@ -123,7 +124,7 @@ public class AppAdminRoleTest extends BaseWebDriverTest
     @Test
     public void testAppAdminAssignPlatformDeveloper()
     {
-        CommandException apiException = getApiException(() -> permissionsApiAsAppAdmin().addMemberToRole(USER, "Platform Developer", MemberType.user, "/"));
+        CommandException apiException = getApiException(() -> permissionsApiAsAppAdmin().addMemberToRole(USER, DEVELOPER_ROLE, MemberType.user, "/"));
         if (apiException == null)
             fail("App Admin was able to assign Platform Developer role");
 
@@ -133,7 +134,7 @@ public class AppAdminRoleTest extends BaseWebDriverTest
     @Test
     public void testAssignGroupPlatformDeveloper()
     {
-        CommandException apiException = getApiException(() -> permissionsApiAsAppAdmin().addMemberToRole(SITE_GROUP, "Platform Developer", MemberType.group, "/"));
+        CommandException apiException = getApiException(() -> permissionsApiAsAppAdmin().addMemberToRole(SITE_GROUP, DEVELOPER_ROLE, MemberType.group, "/"));
         if (apiException == null)
             fail("App Admin was able to assign group to Platform Developer role");
 
@@ -143,7 +144,7 @@ public class AppAdminRoleTest extends BaseWebDriverTest
     @Test
     public void testAppAdminAssignReader()
     {
-        permissionsApiAsAppAdmin().addMemberToRole(USER, "Reader", MemberType.user, "home");
+        permissionsApiAsAppAdmin().addMemberToRole(USER, READER_ROLE, MemberType.user, "home");
     }
 
     @Test

--- a/src/org/labkey/test/tests/core/security/GetReadableContainersAPITest.java
+++ b/src/org/labkey/test/tests/core/security/GetReadableContainersAPITest.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Daily.class})
 public class GetReadableContainersAPITest extends BaseWebDriverTest
@@ -163,11 +164,11 @@ public class GetReadableContainersAPITest extends BaseWebDriverTest
 
         if (readable)
         {
-            _permissions.addMemberToRole(USER, "Reader", MemberType.user, path);
+            _permissions.addMemberToRole(USER, READER_ROLE, MemberType.user, path);
         }
         else
         {
-            _permissions.removeUserRoleAssignment(USER, "Reader", path);
+            _permissions.removeUserRoleAssignment(USER, READER_ROLE, path);
         }
 
         containerInfos.add(new ContainerInfo(path, readable, foldersReadable.length + 1));

--- a/src/org/labkey/test/tests/core/security/ImpersonatingTroubleshooterRoleTest.java
+++ b/src/org/labkey/test/tests/core/security/ImpersonatingTroubleshooterRoleTest.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.labkey.test.util.PermissionsHelper.IMP_TROUBLESHOOTER_ROLE;
+import static org.labkey.test.util.PermissionsHelper.SITE_ADMIN_ROLE;
 import static org.labkey.test.util.PermissionsHelper.toRole;
 
 @Category({Git.class})
@@ -61,7 +62,7 @@ public class ImpersonatingTroubleshooterRoleTest extends TroubleshooterRoleTest
                 .hasMessage(LabkeyErrorPage.UNAUTHORIZED_FULL_PAGE_MESSAGE);
 
         apiAsImpersonatingSiteAdmin().addMemberToRole(USER, "Site Admin", PermissionsHelper.MemberType.user, "/");
-        Assertions.assertThat(_apiPermissionsHelper.getUserRoles("/", USER)).contains(PermissionsHelper.toRole("Site Administrator"));
+        Assertions.assertThat(_apiPermissionsHelper.getUserRoles("/", USER)).contains(PermissionsHelper.toRole(SITE_ADMIN_ROLE));
     }
 
     @Override
@@ -73,7 +74,7 @@ public class ImpersonatingTroubleshooterRoleTest extends TroubleshooterRoleTest
         log("Verify permissions from troubleshooter");
         verifySitePermissionSetting(false);
 
-        impersonateRole("Site Administrator");
+        impersonateRole(SITE_ADMIN_ROLE);
         log("Verify the permissions while impersonating admin");
         verifySitePermissionSetting(true);
     }
@@ -86,7 +87,7 @@ public class ImpersonatingTroubleshooterRoleTest extends TroubleshooterRoleTest
     private ApiPermissionsHelper apiAsImpersonatingSiteAdmin() throws IOException, CommandException
     {
         Connection connection = new Connection(WebTestHelper.getBaseURL(), TROUBLESHOOTER, PasswordUtil.getPassword());
-        new ImpersonateRolesCommand(toRole("Site Administrator")).execute(connection, "/");
+        new ImpersonateRolesCommand(toRole(SITE_ADMIN_ROLE)).execute(connection, "/");
         return new ApiPermissionsHelper(this, () -> connection);
     }
 

--- a/src/org/labkey/test/tests/filecontent/FileContentActionButtonsTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentActionButtonsTest.java
@@ -40,6 +40,10 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+import static org.labkey.test.util.PermissionsHelper.SUBMITTER_ROLE;
 
 @Category({Daily.class, FileBrowser.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
@@ -94,7 +98,7 @@ public class FileContentActionButtonsTest extends BaseWebDriverTest
     @Test
     public void testEditorActions()
     {
-        impersonateRoles("Editor");
+        impersonateRoles(EDITOR_ROLE);
 
         assertActionsAvailable(
                 BrowserAction.FOLDER_TREE,
@@ -118,7 +122,7 @@ public class FileContentActionButtonsTest extends BaseWebDriverTest
     @Test
     public void testSubmitterReaderActions()
     {
-        impersonateRoles("Submitter", "Reader");
+        impersonateRoles(SUBMITTER_ROLE, READER_ROLE);
 
         assertActionsAvailable(
                 BrowserAction.FOLDER_TREE,
@@ -139,7 +143,7 @@ public class FileContentActionButtonsTest extends BaseWebDriverTest
     @Test
     public void testAuthorActions()
     {
-        impersonateRoles("Author");
+        impersonateRoles(AUTHOR_ROLE);
 
         assertActionsAvailable(
                 BrowserAction.FOLDER_TREE,
@@ -160,7 +164,7 @@ public class FileContentActionButtonsTest extends BaseWebDriverTest
     @Test
     public void testReaderActions()
     {
-        impersonateRoles("Reader");
+        impersonateRoles(READER_ROLE);
 
         assertActionsAvailable(
                 BrowserAction.FOLDER_TREE,

--- a/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
+++ b/src/org/labkey/test/tests/filecontent/FileContentUploadTest.java
@@ -69,6 +69,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.labkey.test.components.ext4.Window.Window;
 import static org.labkey.test.util.FileBrowserHelper.BrowserAction;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 
 @Category({Daily.class, FileBrowser.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
@@ -124,7 +125,7 @@ public class FileContentUploadTest extends BaseWebDriverTest
         portalHelper.addWebPart("Files");
         ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
         permissionsHelper.createPermissionsGroup(TEST_GROUP, TEST_USER);
-        permissionsHelper.setPermissions(TEST_GROUP, "Editor");
+        permissionsHelper.setPermissions(TEST_GROUP, EDITOR_ROLE);
 
         _containerHelper.createSubfolder(getProjectName(), subfolderName);
         clickFolder(subfolderName);

--- a/src/org/labkey/test/tests/filecontent/FilesQueryTest.java
+++ b/src/org/labkey/test/tests/filecontent/FilesQueryTest.java
@@ -38,6 +38,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
+
 @Category({Daily.class, FileBrowser.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class FilesQueryTest extends BaseWebDriverTest
@@ -90,7 +92,7 @@ public class FilesQueryTest extends BaseWebDriverTest
 
         ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
         permissionsHelper.createPermissionsGroup(TEST_GROUP, TEST_USER, TEST_USER_NO_PATHS);
-        permissionsHelper.setPermissions(TEST_GROUP, "Project Administrator");
+        permissionsHelper.setPermissions(TEST_GROUP, PROJECT_ADMIN_ROLE);
         permissionsHelper.setSiteRoleUserPermissions(TEST_USER, "See Absolute File Paths");
     }
 

--- a/src/org/labkey/test/tests/issues/IssueAPITest.java
+++ b/src/org/labkey/test/tests/issues/IssueAPITest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
 import static org.labkey.test.util.PasswordUtil.getUsername;
 
 @Category({Issues.class, Daily.class})
@@ -76,7 +77,7 @@ public class IssueAPITest extends BaseWebDriverTest
         TEST_BUDDY_ID = _userHelper.createUser(TEST_BUDDY_NAME).getUserId();
         TEST_BUDDY_DISPLAY_NAME = _userHelper.getDisplayNameForEmail(TEST_BUDDY_NAME);
         var permissionsHelper = new ApiPermissionsHelper(this);
-        permissionsHelper.addMemberToRole(TEST_BUDDY_NAME, "Project Administrator",
+        permissionsHelper.addMemberToRole(TEST_BUDDY_NAME, PROJECT_ADMIN_ROLE,
                 PermissionsHelper.MemberType.user, getProjectName());
     }
 

--- a/src/org/labkey/test/tests/issues/IssueDomainSharingTest.java
+++ b/src/org/labkey/test/tests/issues/IssueDomainSharingTest.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 
 @Category({Issues.class, Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
@@ -120,7 +121,7 @@ public class IssueDomainSharingTest extends BaseWebDriverTest
         final String projectGroup = "ProjectGroup";
         _permissionsHelper.createProjectGroup(projectGroup, getProjectName());
         _permissionsHelper.addUserToProjGroup(USER, getProjectName(), projectGroup);
-        _permissionsHelper.addMemberToRole(projectGroup, "Editor", PermissionsHelper.MemberType.group, getProjectName());
+        _permissionsHelper.addMemberToRole(projectGroup, EDITOR_ROLE, PermissionsHelper.MemberType.group, getProjectName());
 
         final String title = "Child Issue";
         final String assignTo = _userHelper.getDisplayNameForEmail(USER);

--- a/src/org/labkey/test/tests/issues/IssuesAdminTest.java
+++ b/src/org/labkey/test/tests/issues/IssuesAdminTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 
 @Category({Issues.class, Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
@@ -83,7 +84,7 @@ public class IssuesAdminTest extends BaseWebDriverTest
         _userHelper.createUser(TEST_USER);
         _permissionsHelper.createPermissionsGroup(TEST_GROUP);
         _permissionsHelper.assertPermissionSetting(TEST_GROUP, "No Permissions");
-        _permissionsHelper.setPermissions(TEST_GROUP, "Editor");
+        _permissionsHelper.setPermissions(TEST_GROUP, EDITOR_ROLE);
 
         _issuesHelper.createNewIssuesList(ISSUE_LIST_NAME, _containerHelper);
         IssuesAdminPage adminPage = IssuesAdminPage.beginAt(this, getProjectName(), ISSUE_LIST_NAME);

--- a/src/org/labkey/test/tests/issues/IssuesTest.java
+++ b/src/org/labkey/test/tests/issues/IssuesTest.java
@@ -73,6 +73,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.PasswordUtil.getUsername;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Issues.class, Daily.class, Data.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 20)
@@ -168,7 +170,7 @@ public class IssuesTest extends BaseWebDriverTest
         _containerHelper.createProject(getProjectName(), null);
         _permissionsHelper.createPermissionsGroup(TEST_GROUP);
         _permissionsHelper.assertPermissionSetting(TEST_GROUP, "No Permissions");
-        _permissionsHelper.setPermissions(TEST_GROUP, "Editor");
+        _permissionsHelper.setPermissions(TEST_GROUP, EDITOR_ROLE);
 
         _issuesHelper.createNewIssuesList("issues", _containerHelper);
         waitAndClickAndWait(Locator.linkContainingText(ISSUE_SUMMARY_WEBPART_NAME));
@@ -843,7 +845,7 @@ public class IssuesTest extends BaseWebDriverTest
         // create reader user (issue 20598)
         _userHelper.createUser(user);
         _permissionsHelper.createPermissionsGroup("Readers", user);
-        _permissionsHelper.setPermissions("Readers", "Reader");
+        _permissionsHelper.setPermissions("Readers", READER_ROLE);
 
         String user1DisplayName = _userHelper.getDisplayNameForEmail(USER1);
 

--- a/src/org/labkey/test/tests/list/ListArchiveExportTest.java
+++ b/src/org/labkey/test/tests/list/ListArchiveExportTest.java
@@ -24,6 +24,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+
 @Category({Daily.class, Hosting.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 2)
 public class ListArchiveExportTest extends BaseWebDriverTest
@@ -66,10 +69,10 @@ public class ListArchiveExportTest extends BaseWebDriverTest
 
         _userHelper.createUser(_listUser);
         ApiPermissionsHelper _permissionHelper = new ApiPermissionsHelper(LIST_FOLDER_A);
-        _permissionHelper.addMemberToRole(_listUser, "Folder Administrator", PermissionsHelper.MemberType.user);
+        _permissionHelper.addMemberToRole(_listUser, FOLDER_ADMIN_ROLE, PermissionsHelper.MemberType.user);
 
         _permissionHelper = new ApiPermissionsHelper(getProjectName());
-        _permissionHelper.addMemberToRole(_listUser, "Reader", PermissionsHelper.MemberType.user);
+        _permissionHelper.addMemberToRole(_listUser, READER_ROLE, PermissionsHelper.MemberType.user);
     }
 
     private void createListWithData(String name, Map<String, Object> rowData) throws IOException, CommandException

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -60,6 +60,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Daily.class, Assays.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
@@ -456,7 +457,7 @@ public class NabAssayTest extends AbstractAssayTest
             pushLocation();  // Save our location because impersonated user won't have permission to project
             PermissionsPage permissionsPage = navBar().goToPermissionsPage();
             permissionsPage.createPermissionsGroup(TEST_ASSAY_GRP_NAB_READER, TEST_ASSAY_USR_NAB_READER);
-            setSubfolderSecurity(TEST_ASSAY_PRJ_NAB, TEST_ASSAY_FLDR_STUDY1, TEST_ASSAY_GRP_NAB_READER, TEST_ASSAY_PERMS_READER);
+            setSubfolderSecurity(TEST_ASSAY_PRJ_NAB, TEST_ASSAY_FLDR_STUDY1, TEST_ASSAY_GRP_NAB_READER, READER_ROLE);
             setStudyPerms(TEST_ASSAY_PRJ_NAB, TEST_ASSAY_FLDR_STUDY1, TEST_ASSAY_GRP_NAB_READER, TEST_ASSAY_PERMS_STUDY_READALL);
 
             // view dataset, click [assay] link, see assay details in subfolder
@@ -880,15 +881,14 @@ public class NabAssayTest extends AbstractAssayTest
         DilutionAssayHelper detailHelper = new DilutionAssayHelper(this);
         waitForText("View QC");
         detailHelper.clickDetailsLink("View QC", "Review/QC Data");
-        RunQCPage runQCPage = new RunQCPage(getDriver());
+        RunQCPage<?> runQCPage = new RunQCPage<>(getDriver());
 
         log("Select a few values to remove from 'Plate 1'.");
         List<String> valuesToIgnore = new ArrayList<>();
-        List<String> allIgnoredValues = new ArrayList<>();
         valuesToIgnore.add("115243");
         valuesToIgnore.add("910");
         runQCPage.selectPlateItemsToIgnore("Plate 1 Controls", valuesToIgnore);
-        allIgnoredValues.addAll(valuesToIgnore);
+        List<String> allIgnoredValues = new ArrayList<>(valuesToIgnore);
 
         log("Select data points to remove from 'Specimen 2'.");
         valuesToIgnore = new ArrayList<>();
@@ -970,6 +970,6 @@ public class NabAssayTest extends AbstractAssayTest
         mouseOver(summaryPlateGrid.getCellElement("A", "2"));
         sleep(500); // Wait for a moment to allow the tool tip to show up.
         String tipText = getText(Locator.xpath("//div[contains(@class, 'x4-tip-body')]//span//div"));
-        assertTrue("Tool tip comment not as expected. Expected: '" + COMMENT + "' Found: '" + tipText + "'.", tipText.equals(COMMENT));
+        assertEquals("Tool tip comment not as expected. Expected: '" + COMMENT + "' Found: '" + tipText + "'.", COMMENT, tipText);
     }
 }

--- a/src/org/labkey/test/tests/visualization/LinePlotTest.java
+++ b/src/org/labkey/test/tests/visualization/LinePlotTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 
 @Category({Daily.class, Reports.class, Charting.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 10)
@@ -391,7 +392,7 @@ public class LinePlotTest extends GenericChartsTest
         _userHelper.createUser(DEVELOPER_USER);
         clickProject(getProjectName());
         _permissionsHelper.enterPermissionsUI();
-        _permissionsHelper.setUserPermissions(DEVELOPER_USER, "Editor");
+        _permissionsHelper.setUserPermissions(DEVELOPER_USER, EDITOR_ROLE);
         impersonate(DEVELOPER_USER);
         navigateToFolder(getProjectName(), getFolderName());
         clickAndWait(Locator.linkWithText(LINE_PLOT_NAME_MV + " PointClickFn"));

--- a/src/org/labkey/test/tests/visualization/ScatterPlotTest.java
+++ b/src/org/labkey/test/tests/visualization/ScatterPlotTest.java
@@ -62,6 +62,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 
 @Category({Daily.class, Reports.class, Charting.class, Hosting.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
@@ -803,7 +804,7 @@ public class ScatterPlotTest extends GenericChartsTest
         _userHelper.createUser(DEVELOPER_USER);
         clickProject(getProjectName());
         _permissionsHelper.enterPermissionsUI();
-        _permissionsHelper.setUserPermissions(DEVELOPER_USER, "Editor");
+        _permissionsHelper.setUserPermissions(DEVELOPER_USER, EDITOR_ROLE);
         impersonate(DEVELOPER_USER);
         navigateToFolder(getProjectName(), getFolderName());
         clickAndWait(Locator.linkWithText(SCATTER_PLOT_NAME_MV + " PointClickFn"));

--- a/src/org/labkey/test/tests/wiki/WikiLongTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiLongTest.java
@@ -38,6 +38,9 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
+import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Daily.class, Wiki.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 11)
@@ -180,13 +183,13 @@ public class WikiLongTest extends BaseWebDriverTest
         enableEmailRecorder();
         _containerHelper.createProject(PROJECT2_NAME, null);
         _containerHelper.enableModule(PROJECT2_NAME, "MS2");
-        _permissionsHelper.setPermissions(USERS_GROUP, "Editor");
+        _permissionsHelper.setPermissions(USERS_GROUP, EDITOR_ROLE);
         clickButton("Save and Finish");
         _containerHelper.createProject(PROJECT_NAME, null);
         _containerHelper.enableModule(PROJECT_NAME, "MS2");
         _permissionsHelper.createPermissionsGroup("testers");
-        _permissionsHelper.setPermissions("testers", "Editor");
-        _permissionsHelper.setPermissions(USERS_GROUP, "Editor");
+        _permissionsHelper.setPermissions("testers", EDITOR_ROLE);
+        _permissionsHelper.setPermissions(USERS_GROUP, EDITOR_ROLE);
         clickButton("Save and Finish");
         goToFolderManagement();
         clickAndWait(Locator.linkWithText("Folder Type"));
@@ -460,7 +463,7 @@ public class WikiLongTest extends BaseWebDriverTest
 
         log("Check if permissions work");
         _permissionsHelper.enterPermissionsUI();
-        _permissionsHelper.setPermissions(USERS_GROUP, "Reader");
+        _permissionsHelper.setPermissions(USERS_GROUP, READER_ROLE);
         clickButton("Save and Finish");
         impersonate(USER1);
         clickProject(PROJECT2_NAME);
@@ -471,10 +474,10 @@ public class WikiLongTest extends BaseWebDriverTest
         stopImpersonating();
         clickProject(PROJECT2_NAME);
         _permissionsHelper.enterPermissionsUI();
-        _permissionsHelper.removePermission(USERS_GROUP, "Editor");
+        _permissionsHelper.removePermission(USERS_GROUP, EDITOR_ROLE);
         clickButton("Save and Finish");
         _permissionsHelper.enterPermissionsUI();
-        _permissionsHelper.removePermission(USERS_GROUP, "Reader");
+        _permissionsHelper.removePermission(USERS_GROUP, READER_ROLE);
         clickButton("Save and Finish");
         impersonate(USER1);
         assertElementNotPresent(Locator.linkWithText(PROJECT2_NAME));     // Project should not be visible
@@ -495,7 +498,7 @@ public class WikiLongTest extends BaseWebDriverTest
         submit();
         assertTextPresent(WIKI_PAGE2_TITLE);
         _permissionsHelper.enterPermissionsUI();
-        _permissionsHelper.setPermissions(USERS_GROUP, "Project Administrator");
+        _permissionsHelper.setPermissions(USERS_GROUP, PROJECT_ADMIN_ROLE);
         clickButton("Save and Finish");
         impersonate(USER1);
         clickProject(PROJECT2_NAME);
@@ -522,7 +525,7 @@ public class WikiLongTest extends BaseWebDriverTest
         stopImpersonating();
         clickProject(PROJECT_NAME);
         _permissionsHelper.enterPermissionsUI();
-        _permissionsHelper.setPermissions(USERS_GROUP, "Project Administrator");
+        _permissionsHelper.setPermissions(USERS_GROUP, PROJECT_ADMIN_ROLE);
         clickButtonContainingText("Save and Finish");
 
         log("make sure the changes went through");

--- a/src/org/labkey/test/util/PermissionsHelper.java
+++ b/src/org/labkey/test/util/PermissionsHelper.java
@@ -38,6 +38,12 @@ public abstract class PermissionsHelper
     public static final String APP_ADMIN_ROLE = "Application Admin";
     public static final String DEVELOPER_ROLE = "Platform Developer";
     public static final String IMP_TROUBLESHOOTER_ROLE = "Impersonating Troubleshooter";
+    public static final String PROJECT_ADMIN_ROLE = "Project Administrator";
+    public static final String FOLDER_ADMIN_ROLE = "Folder Administrator";
+    public static final String READER_ROLE = "Reader";
+    public static final String EDITOR_ROLE = "Editor";
+    public static final String AUTHOR_ROLE = "Author";
+    public static final String SUBMITTER_ROLE = "Submitter";
 
     public static String toRole(final String name)
     {
@@ -100,21 +106,21 @@ public abstract class PermissionsHelper
     {user, group, siteGroup}
 
     @LogMethod
-    public void setPermissions(@LoggedParam String groupName, @LoggedParam String roleClass)
+    public void setPermissions(@LoggedParam String groupName, @LoggedParam String roleName)
     {
-        addMemberToRole(groupName, roleClass, MemberType.group);
+        addMemberToRole(groupName, roleName, MemberType.group);
     }
 
     @LogMethod
-    public void setSiteGroupPermissions(@LoggedParam String groupName, @LoggedParam String roleClass)
+    public void setSiteGroupPermissions(@LoggedParam String groupName, @LoggedParam String roleName)
     {
-        addMemberToRole(groupName, roleClass, MemberType.siteGroup);
+        addMemberToRole(groupName, roleName, MemberType.siteGroup);
     }
 
     @LogMethod
-    public void setUserPermissions(@LoggedParam String userName, @LoggedParam String roleClass)
+    public void setUserPermissions(@LoggedParam String userName, @LoggedParam String roleName)
     {
-        addMemberToRole(userName, roleClass, MemberType.user);
+        addMemberToRole(userName, roleName, MemberType.user);
     }
 
     @LogMethod

--- a/src/org/labkey/test/util/UIPermissionsHelper.java
+++ b/src/org/labkey/test/util/UIPermissionsHelper.java
@@ -24,7 +24,6 @@ import org.labkey.test.util.ext4cmp.Ext4CmpRef;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.Date;
@@ -145,9 +144,9 @@ public class UIPermissionsHelper extends PermissionsHelper
 
         if ("org.labkey.api.security.roles.NoPermissionsRole".equals(role))
         {
-            assertNoPermission(userOrGroupName, "Reader");
-            assertNoPermission(userOrGroupName, "Editor");
-            assertNoPermission(userOrGroupName, "Project Administrator");
+            assertNoPermission(userOrGroupName, READER_ROLE);
+            assertNoPermission(userOrGroupName, EDITOR_ROLE);
+            assertNoPermission(userOrGroupName, PROJECT_ADMIN_ROLE);
             return;
         }
         _driver.waitForElement(Locator.permissionRendered(), BaseWebDriverTest.WAIT_FOR_JAVASCRIPT);
@@ -425,47 +424,11 @@ public class UIPermissionsHelper extends PermissionsHelper
         _driver.waitForElement(loc);
     }
 
-    public void clickManageSiteGroup(String groupName, BaseWebDriverTest _test)
-    {
-        _driver._ext4Helper.clickTabContainingText("Site Groups");
-        // warning Administrators can appear multiple times
-        List<Ext4CmpRef> refs = _driver._ext4Helper.componentQuery("grid", Ext4CmpRef.class);
-        Ext4CmpRef ref = refs.get(0);
-        Long idx = (Long)ref.getEval("getStore().find(\"name\", \"" + groupName + "\")");
-        assertFalse("Unable to locate group: \"" + groupName + "\"", idx < 0);
-        ref.eval("getSelectionModel().select(" + idx + ")");
-        _driver.waitAndClickAndWait(Locator.tagContainingText("a", "manage group"));
-        _driver.waitForElement(Locator.name("names"));
-    }
-
-    @LogMethod(quiet = true)
-    public void dragGroupToRole(@LoggedParam String group, @LoggedParam String srcRole, @LoggedParam String destRole, BaseWebDriverTest _test)
-    {
-        Actions builder = new Actions(_driver.getDriver());
-        builder
-                .clickAndHold(Locator.permissionButton(group, srcRole).findElement(_driver.getDriver()))
-                .moveToElement(Locator.xpath("//div[contains(@class, 'rolepanel')][.//h3[text()='" + destRole + "']]/div/div").findElement(_driver.getDriver()))
-                .release()
-                .build().perform();
-
-        _driver.waitForElementToDisappear(Locator.permissionButton(group, srcRole), BaseWebDriverTest.WAIT_FOR_JAVASCRIPT);
-        _driver.waitForElement(Locator.permissionButton(group, destRole));
-    }
-
     public void addUserToGroupFromGroupScreen(String userName)
     {
         _driver.waitForElement(Locator.name("names"));
         _driver.uncheckCheckbox(Locator.name("sendEmail"));
         _driver.setFormElement(Locator.name("names"), userName);
         _driver.clickButton("Update Group Membership");
-    }
-
-    public void removeUserFromGroupFromGroupScreen(String userName)
-    {
-        _driver.checkCheckbox(Locator.checkboxByNameAndValue("delete", userName));
-        _driver.doAndWaitForPageToLoad(() -> {
-            _driver.clickButton("Update Group Membership", 0);
-            _driver.assertAlert("Are you sure you want to permanently remove the selected user from this group?");
-        }, BaseWebDriverTest.WAIT_FOR_PAGE);
     }
 }


### PR DESCRIPTION
#### Rationale
There's an exciting new computer science concept - using constants instead of many copies of hard-code values. Let's give it a try with our most commonly used role names in automated tests.

#### Changes
- Common role names available in PermissionsHelper
- Update tests to use them