### PR TITLE
give parent panel more time to refresh after clicking 'save'

### DIFF
--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -188,13 +188,13 @@ public class ParentEntityEditPanel extends Panel<ParentEntityEditPanel.ElementCa
             // Issue 53915: Lineage panel grids don't show IDs or links for parent sequences and molecules in Biologics
             for (String selection : selections)
             {
-                getWrapper().quickWait().until(ExpectedConditions.visibilityOf(
+                getWrapper().shortWait().until(ExpectedConditions.visibilityOf(
                         Locator.linkWithText(selection).findWhenNeeded(detailsPanel)));
             }
         }
         else
         {
-            getWrapper().quickWait().until(ExpectedConditions.visibilityOf(
+            getWrapper().shortWait().until(ExpectedConditions.visibilityOf(
                 Locator.tag("td").containing("has been set for this").findWhenNeeded(detailsPanel))); // e.g. "No source parent type has been set for this source."
         }
     }


### PR DESCRIPTION
#### Rationale
[CrossFolderActionsTest.testEntityParentEditIsAllowedCrossfolder](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsPostgres/3676170?buildTab=tests&status=failed&name=org.labkey.test.tests.biologics.crossfolder.CrossFolderActionsTest.testEntityParentEditIsAllowedCrossfolder) has been failing recently because apparently a quickWait (1 sec) is short enough duration that after clicking 'Save' of a parent entity the expected td showing the selection-link or an empty placeholder is still rendering, spinner shown

#### Related Pull Requests
n/a

#### Changes
Replace quickWaits with shortWaits
