### PR TITLE
Use Query Report to verify root folder manage views

### DIFF
--- a/src/org/labkey/test/tests/DataViewsReportOrderingTest.java
+++ b/src/org/labkey/test/tests/DataViewsReportOrderingTest.java
@@ -138,10 +138,10 @@ public class DataViewsReportOrderingTest extends BaseWebDriverTest
     @Test
     public void testRootFolderAccess()
     {
-        // Regression for issue 53630
+        // Regression for Issue 53630
         ShowUsersPage showUsersPage = goToSiteUsers();
         ManageViewsPage mvp = showUsersPage.getUsersTable().openManageViews();
-        mvp.clickAddReport("R Report");
+        mvp.clickAddReport("Query Report");
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
If an R scripting engine is not configured, this test fails because "R Report" isn't an available report type. "Query Report" will always be available.

#### Related Pull Requests
- #2657 

#### Changes
- Use Query Report to verify root folder manage views
