### PR TITLE
DetailTableEdit save and cancel buttons to include withText() in Locator

### DIFF
--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -635,7 +635,7 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         public Locator validationMsg = Locator.tagWithClass("span", "validation-message");
 
         public WebElement saveButton = Locator.tagWithAttribute("button", "type", "submit")
-                .withText("Save").findWhenNeeded(this);
+                .containing("Save").findWhenNeeded(this);
         public WebElement cancelButton = Locator.tagWithAttribute("button", "type", "button")
                 .withText("Cancel").findWhenNeeded(this);
 

--- a/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
+++ b/src/org/labkey/test/components/ui/grids/DetailTableEdit.java
@@ -635,9 +635,9 @@ public class DetailTableEdit extends WebDriverComponent<DetailTableEdit.ElementC
         public Locator validationMsg = Locator.tagWithClass("span", "validation-message");
 
         public WebElement saveButton = Locator.tagWithAttribute("button", "type", "submit")
-                .findWhenNeeded(this);
+                .withText("Save").findWhenNeeded(this);
         public WebElement cancelButton = Locator.tagWithAttribute("button", "type", "button")
-                .findWhenNeeded(this);
+                .withText("Cancel").findWhenNeeded(this);
 
         public WebElement commentInput = Locator.tagWithId("textarea", "actionComments").refindWhenNeeded(getDriver());
 


### PR DESCRIPTION
#### Rationale
SMEditableGridTest.testEditLookupNotFound randomly fails when trying to click the Cancel button on the detail edit panel. This is because when it randomly creates fields for the source type, it will occasionally include a date/time field. This field type includes a little "X" icon/button in the input field display which is used to clear the value in the input. The Locator for the cancel button is just looking for a "button" tag, which ends up clicking the date/time input clear icon/button.

<img width="1554" height="824" alt="Screenshot 2025-10-02 at 8 53 17 AM" src="https://github.com/user-attachments/assets/7e9c0d2b-e731-4c36-a48c-52d2e24bcbc6" />


#### Changes
- DetailTableEdit save and cancel buttons to include withText() in Locator
