### PR TITLE
ListTest update for quoting the random field name in the tsv import string generation

### DIFF
--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -66,6 +66,7 @@ import org.labkey.test.util.Maps;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.TestDataGenerator;
 import org.labkey.test.util.TextSearcher;
+import org.labkey.test.util.data.TestDataUtils;
 import org.labkey.test.util.search.SearchAdminAPIHelper;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -2050,11 +2051,16 @@ public class ListTest extends BaseWebDriverTest
 
     void createList(String name, List<FieldDefinition> cols, String[][] data)
     {
+        createList(name, cols, toTSV(cols,data));
+    }
+
+    void createList(String name, List<FieldDefinition> cols, String tsvData)
+    {
         log("Add List -- " + name);
         _listHelper.createList(PROJECT_VERIFY, name, cols.get(0), cols.subList(1, cols.size()).toArray(new FieldDefinition[cols.size() - 1]));
         _listHelper.goToList(name);
         _listHelper.clickImportData();
-        setListImportAsTestDataField(toTSV(cols,data));
+        setListImportAsTestDataField(tsvData);
     }
 
     private void setListImportAsTestDataField(String data, String... expectedErrors)
@@ -2164,21 +2170,20 @@ public class ListTest extends BaseWebDriverTest
     {
         String listName = "DecimalFieldList";
         FieldInfo decField = FieldInfo.random("decimalField", ColumnType.Decimal);
-        String[][] data = new String[][]
-        {
-                {"1", "1.1"},
-                {"2", "1.7976931348623157e+308"},
-                {"3", "-1.7976931348623157e+308"},
-                {"4", "Infinity"},
-                {"5", "-Infinity"},
-                {"6", "Inf"},
-                {"7", "-Inf"},
-                {"8", "NaN"}
-        };
+        List<Map<String, Object>> rowMaps = new ArrayList<>();
+        rowMaps.add(Map.of("key", 1, decField.getName(), "1.1"));
+        rowMaps.add(Map.of("key", 2, decField.getName(), "1.7976931348623157e+308"));
+        rowMaps.add(Map.of("key", 3, decField.getName(), "-1.7976931348623157e+308"));
+        rowMaps.add(Map.of("key", 4, decField.getName(), "Infinity"));
+        rowMaps.add(Map.of("key", 5, decField.getName(), "-Infinity"));
+        rowMaps.add(Map.of("key", 6, decField.getName(), "Inf"));
+        rowMaps.add(Map.of("key", 7, decField.getName(), "-Inf"));
+        rowMaps.add(Map.of("key", 8, decField.getName(), "NaN"));
+
         createList(listName, List.of(
                 new FieldDefinition("key", ColumnType.Integer),
                 decField.getFieldDefinition()
-        ), data);
+        ), TestDataUtils.tsvStringFromRowMaps(rowMaps, List.of("key", decField.getName()), true));
 
         DataRegionTable table = new DataRegionTable("query", getDriver());
         checker().verifyEquals("Decimal field values not as expected",


### PR DESCRIPTION
#### Rationale
A recent ListTest test case was added that uses a random field name. This randomly fails if the generated name has a quote in it. This PR updates the tsv import string generation to quote the headers using TestDataUtils.tsvStringFromRowMaps().

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2707

#### Changes
- use TestDataUtils.tsvStringFromRowMaps
