### PR TITLE
GridPanelTest update to expect Units field in filter dialog

### DIFF
--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -72,6 +72,7 @@ public class GridPanelTest extends GridPanelBaseTest
     private static final FieldInfo FILTER_BOOL_COL = FieldInfo.random("Bool", FieldDefinition.ColumnType.Boolean);
     private static final FieldInfo FILTER_DATE_COL = FieldInfo.random("Date", FieldDefinition.ColumnType.DateAndTime);
     private static final String FILTER_STORED_AMOUNT_COL = "Amount";
+    private static final String FILTER_UNITS_COL = "Units";
 
     // Views and columns used in the views. The views are only applied to the small sample type (Small_SampleType).
     private static final String VIEW_EXTRA_COLUMNS = "Extra_Columns";
@@ -1742,6 +1743,7 @@ public class GridPanelTest extends GridPanelBaseTest
         expectedList.add(FILTER_STRING_COL.getLabel());
         expectedList.add(FILTER_DATE_COL.getLabel());
         expectedList.add(FILTER_STORED_AMOUNT_COL);
+        expectedList.add(FILTER_UNITS_COL);
 
         actualList = filterDialog.getAvailableFieldLabels();
 
@@ -1801,6 +1803,7 @@ public class GridPanelTest extends GridPanelBaseTest
         expectedList.add(FILTER_BOOL_COL.getLabel());
         expectedList.add(FILTER_DATE_COL.getLabel());
         expectedList.add(FILTER_STORED_AMOUNT_COL);
+        expectedList.add(FILTER_UNITS_COL);
 
         filterDialog = grid.getGridBar().openFilterDialog();
 


### PR DESCRIPTION
#### Rationale
GridPanelTest.testFilterDialogWithViews is failing from a recent change to allow for the Units column to be filterable. This PR updates that test to expect the Units column in the filter dialog

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6994

#### Changes
- filter dialog to expect Units column in test case check
