### PR TITLE
Add explicit permissions to GitHub workflows

### DIFF
--- a/.github/workflows/branch_release.yml
+++ b/.github/workflows/branch_release.yml
@@ -8,6 +8,10 @@ on:
     tags:
       - '*'
 
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   branch_release:
     if: github.event.created && github.event.sender.login == 'labkey-teamcity'

--- a/.github/workflows/merge_release.yml
+++ b/.github/workflows/merge_release.yml
@@ -8,6 +8,10 @@ on:
     types:
       - submitted
 
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   merge_release:
     if: >

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -10,6 +10,9 @@ on:
       - reopened
       - ready_for_review
 
+permissions:
+  pull-requests: write
+
 jobs:
   validate_pr:
     if: github.event.pull_request.head.repo.owner.login == 'LabKey'

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -11,7 +11,7 @@ on:
       - ready_for_review
 
 permissions:
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   validate_pr:

--- a/modules/simpletest/resources/scripts/validationTest/actionUrlTest.js
+++ b/modules/simpletest/resources/scripts/validationTest/actionUrlTest.js
@@ -21,21 +21,21 @@ function doTest()
 
     if (contextPath.length > 0) {
         var baseUrl = LABKEY.ActionURL.getBaseURL();
-        if (baseUrl.indexOf("labkey/") != baseUrl.length - 7)
+        if (!baseUrl.endsWith(contextPath + "/"))
             errors[errors.length] = new Error("ActionURL.getBaseURL() = " + baseUrl);
     }
 
     var queryString = LABKEY.ActionURL.queryString(urlParameters);
-    if( queryString != 'x=fred&y=barney' )
+    if( queryString !== 'x=fred&y=barney' )
         errors[errors.length] = new Error("ActionURL.queryString = " + queryString);
 
     var url = LABKEY.ActionURL.buildURL(controller, action, containerPath, urlParameters);
-    if( url != contextPath + "/" + controller + "/" + containerPath + "/" + action + ".view?" + queryString  &&
-        url != contextPath + "/" + containerPath + "/" + controller + "-" + action + ".view?" + queryString)
+    if( url !== contextPath + "/" + controller + "/" + containerPath + "/" + action + ".view?" + queryString  &&
+        url !== contextPath + "/" + containerPath + "/" + controller + "-" + action + ".view?" + queryString)
         errors[errors.length] = new Error("ActionURL.buildUrl() = " + url);
 
     var parameters = LABKEY.ActionURL.getParameters(url);
-    if( Ext.util.JSON.encode(parameters) != Ext.util.JSON.encode(urlParameters) )
+    if( Ext.util.JSON.encode(parameters) !== Ext.util.JSON.encode(urlParameters) )
         errors[errors.length] = new Error("ActionURL.getParameters() = " + Ext.util.JSON.encode(parameters));
 
     if( errors.length > 0 )

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -543,7 +543,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                 else
                     minutes = ClassTimeout.DEFAULT;
 
-                minutes *= timeoutMultiplier;
+                minutes = Math.round(minutes * timeoutMultiplier);
 
                 if (minutes == 0)
                     minutes = 1;

--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -632,11 +632,13 @@ public abstract class TestFileUtils
              TarArchiveInputStream inputStream = new ArchiveStreamFactory().createArchiveInputStream("tar", is))
         {
             TarArchiveEntry entry;
+            Path normalizedOutputPath = outputDir.toPath().normalize();
+
             while ((entry = inputStream.getNextEntry()) != null)
             {
                 final File outputFile = new File(outputDir, entry.getName());
 
-                if (!outputFile.toPath().normalize().startsWith(outputDir.toPath()))
+                if (!outputFile.toPath().normalize().startsWith(normalizedOutputPath))
                     throw new IOException("Bad zip entry (" + entry.getName() + ") in " + inputFile.getAbsolutePath());
 
                 if (entry.isDirectory())

--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -635,6 +635,10 @@ public abstract class TestFileUtils
             while ((entry = inputStream.getNextEntry()) != null)
             {
                 final File outputFile = new File(outputDir, entry.getName());
+
+                if (!outputFile.toPath().normalize().startsWith(outputDir.toPath()))
+                    throw new IOException("Bad zip entry (" + entry.getName() + ") in " + inputFile.getAbsolutePath());
+
                 if (entry.isDirectory())
                 {
                     if (!outputFile.exists())

--- a/src/org/labkey/test/tests/SpecimenTest.java
+++ b/src/org/labkey/test/tests/SpecimenTest.java
@@ -825,7 +825,7 @@ public class SpecimenTest extends SpecimenBaseTest
         waitForElement(Locators.bodyTitle().withText("New Specimen Request"));
         int expectedLocationCount = StudyLocationType.untypedSites();
 
-        long additionalLocations = Math.round(Math.pow(2, StudyLocationType.values().length - 1));
+        int additionalLocations = (int) Math.round(Math.pow(2, StudyLocationType.values().length - 1));
 
         for (StudyLocationType type : StudyLocationType.values())
         {


### PR DESCRIPTION
#### Rationale
Cleaning up several security warnings.
We should validate that the workflow permission changes work correctly before we roll out to other repositories.

#### Related Pull Requests
- N/A

#### Changes
- Add explicit permissions to GitHub workflows
- Fix ZipSlip in `TestFileUtils`
- Explicitly cast numbers
