### PR TITLE
increment number to account for attachment as well as wiki

### DIFF
--- a/src/org/labkey/test/tests/wiki/WikiTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiTest.java
@@ -312,6 +312,8 @@ public class WikiTest extends BaseWebDriverTest
                 .as("expect strikethrough style not to be present")
                 .doesNotContain("text-decoration: line-through"));
         wikiHelper.saveWikiPage();
+        // note: attaching the file and leaving it there will create a search result, so increment wikiCreated count here
+        numberOfWikiCreated++;
 
         // verify save after undelete persists the attachment
         assertElementPresent(Locator.linkWithText(fileName));

--- a/src/org/labkey/test/tests/wiki/WikiTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiTest.java
@@ -270,10 +270,10 @@ public class WikiTest extends BaseWebDriverTest
         wikiHelper.setWikiBody("<p>" + wikiContent + "</p>");
         wikiHelper.saveWikiPage();
         numberOfWikiCreated++;
-        clickAndWait(wikiPageLinkLoc);
+        waitAndClickAndWait(wikiPageLinkLoc);
 
         log("adding an attachment");
-        clickAndWait(editLinkLoc);
+        waitAndClickAndWait(editLinkLoc);
         click(filePickerLinkLoc);
         setFormElement(fileInputLoc, testAttachment);
         waitForElement(removeLinkLoc);  // when just attached, 'remove' will be an option but delete will not be
@@ -287,7 +287,7 @@ public class WikiTest extends BaseWebDriverTest
         clickAndWait(wikiPageLinkLoc);
 
         log("Deleting attachment");
-        clickAndWait(editLinkLoc);
+        waitAndClickAndWait(editLinkLoc);
         click(deleteLinkLoc);
         waitForElement(attachmentParentLoc.withAttributeContaining("style", "text-decoration: line-through"));
         wikiHelper.saveWikiPage();
@@ -297,14 +297,14 @@ public class WikiTest extends BaseWebDriverTest
 
         log("prepare to delete/undelete attachment");
         // re-attach the file and save
-        clickAndWait(editLinkLoc);
+        waitAndClickAndWait(editLinkLoc);
         click(filePickerLinkLoc);
         setFormElement(fileInputLoc, testAttachment);
         wikiHelper.saveWikiPage();
         clickAndWait(wikiPageLinkLoc);
 
         log("Un-Deleting attachment");
-        clickAndWait(editLinkLoc);
+        waitAndClickAndWait(editLinkLoc);
         click(deleteLinkLoc);   // delete
         waitForElement(attachmentParentLoc.withAttributeContaining("style", "text-decoration: line-through"));
         waitAndClick(undeleteLinkLoc);


### PR DESCRIPTION
#### Rationale
[WikiTest.testSteps](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyPostgres_2/3684940?buildTab=tests&name=org.labkey.test.tests.wiki.WikiTest.testSteps) is failing because when new test method testDeleteUndeleteAttachment() leaves a saved attachment in the newly-created wiki, that attachment is indexed separately and appears as a search result when testSteps() searches and expects to find a specific number of results.

This change increments that counter by one to account for the new attachment in addition to the new wiki created by the test


