### PR TITLE
Base classes for upgrade pipeline

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1333,11 +1333,16 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         }
     }
 
+    protected boolean skipCleanup(boolean afterTest)
+    {
+        return false;
+    }
+
     private void cleanup(boolean afterTest)
     {
         ensureSignedInAsPrimaryTestUser();
 
-        if (!ClassUtils.getAllInterfaces(getClass()).contains(ReadOnlyTest.class) || ((ReadOnlyTest) this).needsSetup())
+        if (!skipCleanup(afterTest) && (!(this instanceof ReadOnlyTest readOnlyTest) || readOnlyTest.needsSetup()))
         {
             if (afterTest)
                 waitForPendingRequests(WAIT_FOR_PAGE);

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -373,7 +373,7 @@ public abstract class TestProperties
      * @param def Default value
      * @return value of the specified property
      */
-    private static boolean getBooleanProperty(String key, boolean def)
+    public static boolean getBooleanProperty(String key, boolean def)
     {
         String prop = System.getProperty(key);
         if (!StringUtils.isBlank(prop))
@@ -393,7 +393,7 @@ public abstract class TestProperties
      * @param def Default value
      * @return value of the specified property
      */
-    private static int getIntegerProperty(String key, int def)
+    public static int getIntegerProperty(String key, int def)
     {
         String prop = System.getProperty(key);
         if (!StringUtils.isBlank(prop))
@@ -417,7 +417,7 @@ public abstract class TestProperties
      * @param def Default value
      * @return value of the specified property
      */
-    private static double getDoubleProperty(String key, double def)
+    public static double getDoubleProperty(String key, double def)
     {
         String prop = System.getProperty(key);
         if (!StringUtils.isBlank(prop))

--- a/src/org/labkey/test/tests/upgrade/BaseUpgradeTest.java
+++ b/src/org/labkey/test/tests/upgrade/BaseUpgradeTest.java
@@ -1,0 +1,91 @@
+package org.labkey.test.tests.upgrade;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.TestProperties;
+import org.labkey.test.util.TestLogger;
+
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class BaseUpgradeTest extends BaseWebDriverTest
+{
+
+    protected static final boolean isUpgradeSetupPhase = TestProperties.getBooleanProperty("webtest.upgradeSetup", true);
+    protected static final double previousVersion = TestProperties.getDoubleProperty("webtest.upgradePreviousVersion", 0.0);
+
+    @Override
+    protected boolean skipCleanup(boolean afterTest)
+    {
+        return afterTest || !isUpgradeSetupPhase;
+    }
+
+    @BeforeClass
+    public static void setupProject() throws Exception
+    {
+        BaseUpgradeTest currentTest = BaseWebDriverTest.getCurrentTest();
+
+        if (isUpgradeSetupPhase)
+        {
+            currentTest.doSetup();
+        }
+        else
+        {
+            TestLogger.info("Skipping setup for %s. Verifying upgrade.". formatted(currentTest.getClass().getSimpleName()));
+        }
+    }
+
+    protected abstract void doSetup() throws Exception;
+
+    @Rule
+    public final TestRule upgradeVersionCheck = new UpgradeVersionCheck();
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Arrays.asList();
+    }
+
+    protected @interface EariestVersion {
+        double value();
+    }
+
+    protected @interface LatestVersion {
+        double value();
+    }
+
+    private static class UpgradeVersionCheck implements TestRule
+    {
+
+        @Override
+        public @NotNull Statement apply(Statement base, Description description)
+        {
+            EariestVersion eariestVersion = description.getAnnotation(EariestVersion.class);
+            LatestVersion latestVersion = description.getAnnotation(LatestVersion.class);
+            if (isUpgradeSetupPhase || previousVersion <= 0)
+            {
+                return base; // Run the test normally
+            }
+
+            return new Statement()
+            {
+                @Override
+                public void evaluate() throws Throwable
+                {
+                    Assume.assumeTrue("Test doesn't support upgrading from version: " + previousVersion,
+                        (eariestVersion == null || eariestVersion.value() <= previousVersion) &&
+                            (latestVersion == null || previousVersion <= latestVersion.value())
+                    );
+                    base.evaluate();
+                }
+            };
+        }
+    }
+
+}

--- a/src/org/labkey/test/tests/upgrade/BaseUpgradeTest.java
+++ b/src/org/labkey/test/tests/upgrade/BaseUpgradeTest.java
@@ -10,15 +10,33 @@ import org.junit.runners.model.Statement;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.TestProperties;
 import org.labkey.test.util.TestLogger;
+import org.labkey.test.util.Version;
+import org.labkey.test.util.VersionRange;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
+import static org.apache.commons.lang3.StringUtils.trimToNull;
+
+/**
+ * Base test class for tests that setup data and configure a server then verify the persistence or modification of those
+ * data and configurations after upgrading to a newer version of LabKey.<br>
+ * The {@code EariestVersion} and {@code LatestVersion} annotations can be used to skip particular tests when they are
+ * not relevant to the version of LabKey being upgraded from (specified in the {@code webtest.upgradePreviousVersion}
+ * system property).<br>
+ * The setup steps will be skipped if the {@code webtest.upgradeSetup} system property is set to {@code false}.
+ */
 public abstract class BaseUpgradeTest extends BaseWebDriverTest
 {
 
     protected static final boolean isUpgradeSetupPhase = TestProperties.getBooleanProperty("webtest.upgradeSetup", true);
-    protected static final double previousVersion = TestProperties.getDoubleProperty("webtest.upgradePreviousVersion", 0.0);
+    protected static final Version previousVersion = Optional.ofNullable(trimToNull(System.getProperty("webtest.upgradePreviousVersion")))
+        .map(Version::new).orElse(null);
 
     @Override
     protected boolean skipCleanup(boolean afterTest)
@@ -52,12 +70,26 @@ public abstract class BaseUpgradeTest extends BaseWebDriverTest
         return Arrays.asList();
     }
 
+    /**
+     * Annotates test methods that should only run when upgrading from particular LabKey versions, as specified in
+     * {@code webtest.upgradePreviousVersion}.<br>
+     * Specifies the earliest version of the test class that performed the required setup for the annotated method.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.METHOD})
     protected @interface EariestVersion {
-        double value();
+        String value();
     }
 
+    /**
+     * Annotates test methods that should only run when upgrading from particular LabKey versions, as specified in
+     * {@code webtest.upgradePreviousVersion}.<br>
+     * Specifies the latest version of the test class that performed the required setup for the annotated method.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.METHOD})
     protected @interface LatestVersion {
-        double value();
+        String value();
     }
 
     private static class UpgradeVersionCheck implements TestRule
@@ -66,9 +98,12 @@ public abstract class BaseUpgradeTest extends BaseWebDriverTest
         @Override
         public @NotNull Statement apply(Statement base, Description description)
         {
-            EariestVersion eariestVersion = description.getAnnotation(EariestVersion.class);
-            LatestVersion latestVersion = description.getAnnotation(LatestVersion.class);
-            if (isUpgradeSetupPhase || previousVersion <= 0)
+            String eariestVersion = Optional.ofNullable(description.getAnnotation(EariestVersion.class))
+                .map(EariestVersion::value).orElse(null);
+            String latestVersion = Optional.ofNullable(description.getAnnotation(LatestVersion.class))
+                .map(LatestVersion::value).orElse(null);
+
+            if (isUpgradeSetupPhase || previousVersion == null || (eariestVersion == null && latestVersion == null))
             {
                 return base; // Run the test normally
             }
@@ -79,8 +114,7 @@ public abstract class BaseUpgradeTest extends BaseWebDriverTest
                 public void evaluate() throws Throwable
                 {
                     Assume.assumeTrue("Test doesn't support upgrading from version: " + previousVersion,
-                        (eariestVersion == null || eariestVersion.value() <= previousVersion) &&
-                            (latestVersion == null || previousVersion <= latestVersion.value())
+                        VersionRange.versionRange(eariestVersion, latestVersion).contains(previousVersion)
                     );
                     base.evaluate();
                 }

--- a/src/org/labkey/test/tests/upgrade/BasicUpgradeTest.java
+++ b/src/org/labkey/test/tests/upgrade/BasicUpgradeTest.java
@@ -1,0 +1,98 @@
+package org.labkey.test.tests.upgrade;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.query.SelectRowsCommand;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.params.FieldInfo;
+import org.labkey.test.params.experiment.SampleTypeDefinition;
+import org.labkey.test.util.ApiPermissionsHelper;
+import org.labkey.test.util.PasswordUtil;
+import org.labkey.test.util.PermissionsHelper;
+import org.labkey.test.util.PermissionsHelper.MemberType;
+import org.labkey.test.util.TestUser;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+
+@Category({})
+public class BasicUpgradeTest extends BaseUpgradeTest
+{
+    private static final TestUser USER = new TestUser("basic_upgrade_reader@sampletypeupgradetest.test");
+    private static final String SAMPLE_TYPE = "UpgradeTestSamples";
+
+    private static final FieldInfo STR_COL = new FieldInfo("String Col1");
+
+    @Override
+    protected void doCleanup(boolean afterTest)
+    {
+        _containerHelper.deleteProject(getProjectName(), afterTest);
+        _userHelper.deleteUsers(afterTest, USER);
+    }
+
+    @Override
+    protected void doSetup() throws Exception
+    {
+        _containerHelper.createProject(getProjectName(), null);
+        USER.create(this);
+        USER.setInitialPassword();
+        USER.addPermission(READER_ROLE, getProjectName());
+
+        new SampleTypeDefinition(SAMPLE_TYPE)
+            .setFields(List.of(STR_COL.getFieldDefinition()))
+            .create(createDefaultConnection(), getProjectName())
+            .insertRows(createDefaultConnection(), List.of(Map.of(
+                "Name", "S-1",
+                STR_COL.getName(), "Test String Value"
+            )) );
+    }
+
+    @Before
+    public void preTest()
+    {
+        USER.load(this);
+    }
+
+    @Test
+    public void testSampleRowsExist() throws Exception
+    {
+        // Use primary user to verify data
+        queryData(createDefaultConnection());
+    }
+
+    @Test
+    public void testUserPassword() throws Exception
+    {
+        // Use password authentication for USER
+        queryData(USER.getUserConnection());
+    }
+
+    @Test
+    public void testUserPermissions() throws Exception
+    {
+        // Impersonate to test USER's permission level
+        queryData(createDefaultConnection().impersonate(USER.getEmail()));
+    }
+
+    private void queryData(Connection connection) throws IOException, CommandException
+    {
+        List<Map<String, Object>> rows = new SelectRowsCommand("samples", SAMPLE_TYPE)
+            .execute(connection, getProjectName())
+            .getRows();
+        assertFalse("Expected at least one row", rows.isEmpty());
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return "SampleTypeUpgradeTest Project";
+    }
+}

--- a/src/org/labkey/test/tests/upgrade/BasicUpgradeTest.java
+++ b/src/org/labkey/test/tests/upgrade/BasicUpgradeTest.java
@@ -6,13 +6,8 @@ import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.query.SelectRowsCommand;
-import org.labkey.test.WebTestHelper;
 import org.labkey.test.params.FieldInfo;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
-import org.labkey.test.util.ApiPermissionsHelper;
-import org.labkey.test.util.PasswordUtil;
-import org.labkey.test.util.PermissionsHelper;
-import org.labkey.test.util.PermissionsHelper.MemberType;
 import org.labkey.test.util.TestUser;
 
 import java.io.IOException;
@@ -20,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({})

--- a/src/org/labkey/test/tests/upgrade/BasicUpgradeTest.java
+++ b/src/org/labkey/test/tests/upgrade/BasicUpgradeTest.java
@@ -20,7 +20,7 @@ import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 @Category({})
 public class BasicUpgradeTest extends BaseUpgradeTest
 {
-    private static final TestUser USER = new TestUser("basic_upgrade_reader@sampletypeupgradetest.test");
+    private static final TestUser USER = new TestUser("basic_upgrade_reader@basicupgradetest.test");
     private static final String SAMPLE_TYPE = "UpgradeTestSamples";
 
     private static final FieldInfo STR_COL = new FieldInfo("String Col1");

--- a/src/org/labkey/test/tests/upgrade/BasicUpgradeTest.java
+++ b/src/org/labkey/test/tests/upgrade/BasicUpgradeTest.java
@@ -87,6 +87,6 @@ public class BasicUpgradeTest extends BaseUpgradeTest
     @Override
     protected String getProjectName()
     {
-        return "SampleTypeUpgradeTest Project";
+        return getClass().getSimpleName() + " Project";
     }
 }

--- a/src/org/labkey/test/util/APIUserHelper.java
+++ b/src/org/labkey/test/util/APIUserHelper.java
@@ -217,6 +217,14 @@ public class APIUserHelper extends AbstractUserHelper
         return getUserIds(Arrays.asList(userEmail)).get(userEmail);
     }
 
+    public int getUserIdStrict(String userEmail)
+    {
+        Integer userId = getUserIds(Arrays.asList(userEmail)).get(userEmail);
+        if (userId == null)
+            throw new IllegalStateException("No user with email " + userEmail + " found.");
+        return userId;
+    }
+
     @Override
     protected void _deleteUser(String userEmail)
     {
@@ -254,6 +262,11 @@ public class APIUserHelper extends AbstractUserHelper
     }
 
     private static final Pattern regEmailVerification = Pattern.compile("verification=([A-Za-z0-9]+)");
+
+    public String setInitialPassword(String email)
+    {
+        return setInitialPassword(getUserIdStrict(email));
+    }
 
     @Override
     public String setInitialPassword(int userId)

--- a/src/org/labkey/test/util/APIUserHelper.java
+++ b/src/org/labkey/test/util/APIUserHelper.java
@@ -219,7 +219,7 @@ public class APIUserHelper extends AbstractUserHelper
 
     public int getUserIdStrict(String userEmail)
     {
-        Integer userId = getUserIds(Arrays.asList(userEmail)).get(userEmail);
+        Integer userId = getUserId(userEmail);
         if (userId == null)
             throw new IllegalStateException("No user with email " + userEmail + " found.");
         return userId;

--- a/src/org/labkey/test/util/PermissionsHelper.java
+++ b/src/org/labkey/test/util/PermissionsHelper.java
@@ -38,6 +38,12 @@ public abstract class PermissionsHelper
     public static final String APP_ADMIN_ROLE = "Application Admin";
     public static final String DEVELOPER_ROLE = "Platform Developer";
     public static final String IMP_TROUBLESHOOTER_ROLE = "Impersonating Troubleshooter";
+    public static final String PROJECT_ADMIN_ROLE = "Project Administrator";
+    public static final String FOLDER_ADMIN_ROLE = "Folder Administrator";
+    public static final String READER_ROLE = "Reader";
+    public static final String EDITOR_ROLE = "Editor";
+    public static final String AUTHOR_ROLE = "Author";
+    public static final String SUBMITTER_ROLE = "Submitter";
 
     public static String toRole(final String name)
     {

--- a/src/org/labkey/test/util/TestUser.java
+++ b/src/org/labkey/test/util/TestUser.java
@@ -2,8 +2,8 @@ package org.labkey.test.util;
 
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.security.CreateUserResponse;
 import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.WebTestHelper;
 
 import java.io.IOException;
 
@@ -117,6 +117,15 @@ public class TestUser
             throw new IllegalStateException("Password has not been set for user: " + _email);
         }
         return _password;
+    }
+
+    /**
+     * Create a non-impersonating API connection for the user.
+     * @return new Connection
+     */
+    public Connection getUserConnection()
+    {
+        return new Connection(WebTestHelper.getBaseURL(), getEmail(), getPassword());
     }
 
     public TestUser addPermission(String role, String containerPath)

--- a/src/org/labkey/test/util/TestUser.java
+++ b/src/org/labkey/test/util/TestUser.java
@@ -13,7 +13,7 @@ public class TestUser
 {
     private WebDriverWrapper _test;
     private final String _email;
-    private CreateUserResponse _createUserResponse;
+    private Integer _userId;
     private String _password;
     private APIUserHelper _apiUserHelper;
     private Connection _impersonationConnection;
@@ -31,9 +31,22 @@ public class TestUser
     {
         _test = test;
         _apiUserHelper = new APIUserHelper(_test);
-        _createUserResponse = _apiUserHelper.createUser(_email);
+        _userId = _apiUserHelper.createUser(_email).getUserId();
         _impersonationConnection = null;
         _password = null;
+        return this;
+    }
+
+    /**
+     * Gets info for an already existing user
+     */
+    public TestUser load(WebDriverWrapper test)
+    {
+        _test = test;
+        _apiUserHelper = new APIUserHelper(_test);
+        _userId = _apiUserHelper.getUserId(_email);
+        _impersonationConnection = null;
+        _password = PasswordUtil.getPassword();
         return this;
     }
 
@@ -44,7 +57,11 @@ public class TestUser
 
     public Integer getUserId()
     {
-        return getCreateUserResponse().getUserId();
+        if (_userId == null)
+        {
+            throw new IllegalStateException("User" + _email + " has not yet been created");
+        }
+        return _userId;
     }
 
     public String getEmail()
@@ -68,7 +85,7 @@ public class TestUser
     {
         if (_password == null)  // if null, this is the initial password - we can use the UI to set it now
         {
-            _password = _apiUserHelper.setInitialPassword(_createUserResponse.getUserId());
+            _password = _apiUserHelper.setInitialPassword(_userId);
         }
         else
         {
@@ -150,15 +167,6 @@ public class TestUser
 
         if (refresh)
             getWrapper().refresh();
-    }
-
-    private CreateUserResponse getCreateUserResponse()
-    {
-        if (_createUserResponse == null)
-        {
-            throw new IllegalStateException("User" + _email + " has not yet been created");
-        }
-        return _createUserResponse;
     }
 
     private APIUserHelper getApiUserHelper()

--- a/src/org/labkey/test/util/Version.java
+++ b/src/org/labkey/test/util/Version.java
@@ -1,0 +1,114 @@
+package org.labkey.test.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A simple class for parsing and comparing version numbers
+ */
+public class Version implements Comparable<Version>
+{
+    private final List<Integer> _version;
+
+    public Version(Integer... version)
+    {
+        _version = validate(version);
+    }
+
+    public Version(String version)
+    {
+        this(Arrays.stream(version.split("\\.")).map(Integer::parseInt).toArray(Integer[]::new));
+    }
+
+    public Version(Double version)
+    {
+        this(version.toString());
+    }
+
+    private static List<Integer> validate(Integer... versionParts)
+    {
+        List<Integer> partList = List.of(versionParts);
+        if (partList.isEmpty())
+        {
+            throw new IllegalArgumentException("Version must have at least one part");
+        }
+        for (Integer part : partList)
+        {
+            if (part < 0)
+            {
+                throw new IllegalArgumentException("Version parts must be non-negative");
+            }
+        }
+        return partList;
+    }
+
+    @Override
+    public int compareTo(@NotNull Version o)
+    {
+        int i = 0;
+        for (; i < _version.size() && i < o._version.size(); i++)
+        {
+            Integer versionPart = _version.get(i);
+            Integer otherVersionPart = o._version.get(i);
+            int result = versionPart.compareTo(otherVersionPart);
+            if (result != 0)
+            {
+                return result;
+            }
+        }
+        // Treat the less specific version as higher
+        if (i < _version.size())
+            return -1; // this version is more specific
+        if (i < o._version.size())
+            return 1; // the other version is more specific
+        return 0;
+    }
+
+    @Override
+    public final boolean equals(Object o)
+    {
+        if (!(o instanceof Version version)) return false;
+
+        return _version.equals(version._version);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return _version.hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return _version.stream().map(Object::toString).collect(Collectors.joining("."));
+    }
+
+
+    public static class VersionTest
+    {
+        @Test
+        public void testConstructors()
+        {
+            Assert.assertEquals("Integer constructor comparison", new Version("25.7"), new Version(25, 7));
+            Assert.assertEquals("Integer constructor comparison", new Version("25.7.3"), new Version(25, 7, 3));
+            Assert.assertEquals("Double constructor comparison", new Version("25.7"), new Version(25.7));
+        }
+
+        @Test
+        public void testCompareTo()
+        {
+            Assert.assertEquals("CompareTo equal version", 0, new Version("25.7").compareTo(new Version("25.7")));
+            Assert.assertEquals("CompareTo earlier version", 1, new Version("25.7").compareTo(new Version("25.3")));
+            Assert.assertEquals("CompareTo later version", -1, new Version("25.7").compareTo(new Version("25.11")));
+            Assert.assertEquals("CompareTo less specific version", -1, new Version("25.7.0").compareTo(new Version("25.7")));
+            Assert.assertEquals("CompareTo more specific version", 1, new Version("25.7.0").compareTo(new Version("25.7.0.0")));
+        }
+    }
+
+}

--- a/src/org/labkey/test/util/VersionRange.java
+++ b/src/org/labkey/test/util/VersionRange.java
@@ -1,0 +1,34 @@
+package org.labkey.test.util;
+
+public class VersionRange
+{
+    private final Version eariestVersion;
+    private final Version latestVersion;
+
+    public VersionRange(Version eariestVersion, Version latestVersion)
+    {
+        this.eariestVersion = eariestVersion;
+        this.latestVersion = latestVersion;
+    }
+
+    public static VersionRange from(String version)
+    {
+        return new VersionRange(new Version(version), null);
+    }
+
+    public static VersionRange until(String version)
+    {
+        return new VersionRange(null, new Version(version));
+    }
+
+    public static VersionRange versionRange(String earliestVersion, String latestVersion)
+    {
+        return new VersionRange(new Version(earliestVersion), new Version(latestVersion));
+    }
+
+    public boolean contains(Version version)
+    {
+        return (eariestVersion == null || eariestVersion.compareTo(version) <= 0) &&
+            (latestVersion == null || latestVersion.compareTo(version) >= 0);
+    }
+}


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/kanban/issues/1267
[Spec](https://docs.google.com/document/d/1a872oOxuwXB8tJTA6xjzagt2_QjcE0GShsQvqL7GI4I/edit?tab=t.0)

Adding a base class and simple proof of concept test for a TeamCity upgrade pipeline.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2727

#### Changes
- Base classes for upgrade pipeline
- Update `TestUser` to handle pre-existing users
- Make some test property getters public
