### PR TITLE
GridPanelTest.testFilterDialogWithViews fix for double decoding of filter columnName

### DIFF
--- a/src/org/labkey/test/tests/component/GridPanelTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelTest.java
@@ -69,7 +69,7 @@ public class GridPanelTest extends GridPanelBaseTest
     private static final FieldInfo FILTER_STRING_COL = new FieldInfo("Str\uD83D\uDC7E]|*안", FieldDefinition.ColumnType.String);
     private static final FieldInfo FILTER_INT_COL = new FieldInfo("Int&`~_@", FieldDefinition.ColumnType.Integer);
     private static final FieldInfo FILTER_EXTEND_CHAR_COL = FieldInfo.random("\u0106\u00D8\u0139", FieldDefinition.ColumnType.String);
-    private static final FieldInfo FILTER_BOOL_COL = FieldInfo.random("Bool", FieldDefinition.ColumnType.Boolean);
+    private static final FieldInfo FILTER_BOOL_COL = FieldInfo.random("$Bool", FieldDefinition.ColumnType.Boolean);
     private static final FieldInfo FILTER_DATE_COL = FieldInfo.random("Date", FieldDefinition.ColumnType.DateAndTime);
     private static final String FILTER_STORED_AMOUNT_COL = "Amount";
     private static final String FILTER_UNITS_COL = "Units";


### PR DESCRIPTION
#### Rationale
see ui-components PR for rationale

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1866
- https://github.com/LabKey/limsModules/pull/1714
- https://github.com/LabKey/platform/pull/7109
- https://github.com/LabKey/testAutomation/pull/2732

#### Changes
- minor test update to get coverage for filter pill decoding fix
