### PR TITLE
backport Locator.xq fix

### DIFF
--- a/src/org/labkey/test/Locator.java
+++ b/src/org/labkey/test/Locator.java
@@ -985,10 +985,39 @@ public abstract class Locator extends By
      *     Direct port from attibuteValue function in selenium IDE locatorBuilders.js
      * @param value to be quoted
      * @return value with either ' or " around it or assembled from parts
+     * @implNote {@link Quotes#escape(String)} doesn't handle trailing quotes correctly
      */
     public static String xq(String value)
     {
-        return Quotes.escape(value);
+        if (!value.contains("'")) {
+            return "'" + value + "'";
+        } else if (!value.contains("\"")) {
+            return '"' + value + '"';
+        } else {
+            StringBuilder result = new StringBuilder("concat(");
+            while (true) {
+                int apos = value.indexOf("'");
+                int quot = value.indexOf('"');
+                if (apos < 0) {
+                    result.append("'").append(value).append("'");
+                    break;
+                } else if (quot < 0) {
+                    result.append('"').append(value).append('"');
+                    break;
+                } else if (quot < apos) {
+                    String part = value.substring(0, apos);
+                    result.append("'").append(part).append("'");
+                    value = value.substring(part.length());
+                } else {
+                    String part = value.substring(0, quot);
+                    result.append('"').append(part).append('"');
+                    value = value.substring(part.length());
+                }
+                result.append(',');
+            }
+            result.append(')');
+            return result.toString();
+        }
     }
 
     /**


### PR DESCRIPTION
#### Rationale
This change backports a fix Trey made in develop to address how we generate locators for elements with double-quotes.

Recently, [PlateSamplesTest.testCreateChildPlateSetInProject](https://teamcity.labkey.org/buildConfiguration/LabKey_257Release_Premium_ProductSuites_Biologics_BiologicsPostgres/3683710?buildTab=tests&status=failed&name=org.labkey.test.tests.biologics.plates.PlateSamplesTest.testCreateChildPlateSetInProject) failed in 25.7 in a way that his change would address.

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/2633

#### Changes
backport https://github.com/LabKey/testAutomation/pull/2633
