### PR TITLE
refactor testLongName to use FieldInfo

### DIFF
--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -545,7 +545,7 @@ public class ListTest extends BaseWebDriverTest
                 .getField(fieldWithDefault.getName())
                 .clickAdvancedSettings()
                 .clickDefaultValuesLink();
-        var input = Locator.tagContainingText("td", fieldWithDefault.getName()).followingSibling("td")
+        var input = Locator.tagContainingText("td", fieldWithDefault.getLabel()).followingSibling("td")
                 .descendant("input").findElement(page.getDriver());
         setFormElement(input, "42");
         clickButton("Save Defaults");

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -52,8 +52,8 @@ import org.labkey.test.pages.list.GridPage;
 import org.labkey.test.pages.query.UpdateQueryRowPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.StringLookup;
+import org.labkey.test.params.FieldInfo;
 import org.labkey.test.params.FieldKey;
-import org.labkey.test.params.list.IntListDefinition;
 import org.labkey.test.params.list.VarListDefinition;
 import org.labkey.test.tests.AuditLogTest;
 import org.labkey.test.util.AbstractDataRegionExportOrSignHelper.ColumnHeaderType;
@@ -533,26 +533,27 @@ public class ListTest extends BaseWebDriverTest
     public void testLongName()
     {
         String listName = "A_+-:''.¡™£¢∞§¶•ªº–≠œ∑´®†¥¨ˆøπ“‘«æ…¬˚∆˙©√ƒ∂ßΩ≈ç√∫µ≤≥÷‹›ﬁﬂ‡°·‚—±⁄€‹›‡‰Æ«»¢∫√∑∏∂";
-        String fieldWithDefault = TestDataGenerator.randomFieldName("With Default");
+        var fieldWithDefault = FieldInfo.random("With Default", ColumnType.String);
         EditListDefinitionPage listEditPage = _listHelper.beginCreateList(getProjectName(), listName);
         listEditPage.manuallyDefineFieldsWithAutoIncrementingKey("Key");
-        listEditPage.addField(new FieldDefinition(fieldWithDefault, ColumnType.String));
+        listEditPage.addField(fieldWithDefault.getFieldDefinition());
         listEditPage.clickSave();
 
         listEditPage = _listHelper.goToEditDesign(listName);
         var page = listEditPage.getFieldsPanel()
                 .expand()
-                .getField(fieldWithDefault)
+                .getField(fieldWithDefault.getName())
                 .clickAdvancedSettings()
                 .clickDefaultValuesLink();
-        var input = Locator.tagContainingText("td", "With Default").followingSibling("td").descendant("input").findElement(page.getDriver());
+        var input = Locator.tagContainingText("td", fieldWithDefault.getName()).followingSibling("td")
+                .descendant("input").findElement(page.getDriver());
         setFormElement(input, "42");
         clickButton("Save Defaults");
         _listHelper.beginAtList(getProjectName(), listName);
 
         DataRegionTable list = new DataRegionTable("query", getDriver());
         UpdateQueryRowPage updatePage = list.clickInsertNewRow();
-        checker().verifyEquals("Default value not as expected ", "42", updatePage.getTextInputValue(fieldWithDefault));
+        checker().verifyEquals("Default value not as expected ", "42", updatePage.getTextInputValue(fieldWithDefault.getName()));
         updatePage.submit();
     }
 


### PR DESCRIPTION
#### Rationale
Recently, [ListTest.testLongName](https://teamcity.labkey.org/buildConfiguration/LabKey_257Release_Community_DailyPostgres2/3691902?buildTab=tests&status=failed&name=org.labkey.test.tests.list.ListTest.testLongName) failed because it couldn't find a UI field based on the namePart given to generate a random field.  This change refactors the test to use a FieldInfo and refer to it for field information

#### Related Pull Requests
n/a


