### PR TITLE
Add methods to limit random field name length

### DIFF
--- a/src/org/labkey/test/components/domain/ConditionalFormatPanel.java
+++ b/src/org/labkey/test/components/domain/ConditionalFormatPanel.java
@@ -151,7 +151,7 @@ public class ConditionalFormatPanel extends WebDriverComponent<ConditionalFormat
         expand();
         elementCache().fillColor.click();
         getWrapper().click(Locator.tagWithAttribute("div", "title", colorHex));
-        getWrapper().click(Locator.tagWithClass("div", "domain-validator-color-cover")); // click elsewhere on the dialog to close the color picker
+        getWrapper().actionClick(elementCache().fillColor); // close the color picker
         return this;
     }
 

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -972,7 +972,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
 
         static final Locator loadingGrid = Locator.css("tbody tr.grid-loading");
         static final Locator emptyGrid = Locator.css("tbody tr.grid-empty");
-        static final Locator spinner = Locator.css("span i.fa-spinner");
+        static final Locator spinner = Locator.byClass("fa-spinner");
         static final Locator headerCells = Locator.tagWithClass("th", "grid-header-cell");
         static public Locator.XPathLocator headerCellBody(String label)
         {

--- a/src/org/labkey/test/params/FieldInfo.java
+++ b/src/org/labkey/test/params/FieldInfo.java
@@ -58,9 +58,25 @@ public class FieldInfo implements CharSequence, WrapsFieldKey
     /**
      * Creates a FieldInfo with a semi-random name
      */
+    public static FieldInfo random(String namePart, ColumnType columnType, DomainUtils.DomainKind domainKind, Integer maxLength)
+    {
+        return new FieldInfo(FieldKey.fromParts(TestDataGenerator.randomFieldName(namePart, domainKind, maxLength)), null, columnType, null, namePart);
+    }
+
+    /**
+     * Creates a FieldInfo with a semi-random name
+     */
     public static FieldInfo random(String namePart, ColumnType columnType, DomainUtils.DomainKind domainKind)
     {
-        return new FieldInfo(FieldKey.fromParts(TestDataGenerator.randomFieldName(namePart)), null, columnType, null, namePart);
+        return random(namePart, columnType, domainKind, null);
+    }
+
+    /**
+     * Creates a FieldInfo with a semi-random name
+     */
+    public static FieldInfo random(String namePart, ColumnType columnType, int maxLength)
+    {
+        return random(namePart, columnType, null, maxLength);
     }
 
     /**

--- a/src/org/labkey/test/tests/component/EditableGridTest.java
+++ b/src/org/labkey/test/tests/component/EditableGridTest.java
@@ -51,27 +51,28 @@ import static org.labkey.test.util.TestDataGenerator.randomDomainName;
 @Category({Daily.class})
 public class EditableGridTest extends BaseWebDriverTest
 {
+    private static final int MAX_LENGTH = 32; // Avoid excessively long field names to avoid blocking clicks
     private static final String EXTRAPOLATING_SAMPLE_TYPE = randomDomainName("ExtrapolatingSampleType");
-    private static final FieldInfo ASC_STRING = FieldInfo.random("Ascending String");
-    private static final FieldInfo DESC_STRING = FieldInfo.random("Descending String");
-    private static final FieldInfo ASC_INT = FieldInfo.random("Ascending Int", ColumnType.Integer);
-    private static final FieldInfo DESC_INT = FieldInfo.random("Descending Int", ColumnType.Integer);
-    private static final FieldInfo ASC_DATE = FieldInfo.random("Ascending Date", ColumnType.DateAndTime);
-    private static final FieldInfo DESC_DATE = FieldInfo.random("Descending Date", ColumnType.DateAndTime);
+    private static final FieldInfo ASC_STRING = FieldInfo.random("Ascending String", ColumnType.String, MAX_LENGTH);
+    private static final FieldInfo DESC_STRING = FieldInfo.random("Descending String", ColumnType.String, MAX_LENGTH);
+    private static final FieldInfo ASC_INT = FieldInfo.random("Ascending Int", ColumnType.Integer, MAX_LENGTH);
+    private static final FieldInfo DESC_INT = FieldInfo.random("Descending Int", ColumnType.Integer, MAX_LENGTH);
+    private static final FieldInfo ASC_DATE = FieldInfo.random("Ascending Date", ColumnType.DateAndTime, MAX_LENGTH);
+    private static final FieldInfo DESC_DATE = FieldInfo.random("Descending Date", ColumnType.DateAndTime, MAX_LENGTH);
 
     private static final String FILLING_SAMPLE_TYPE = randomDomainName("FillingSampleType");
-    private static final FieldInfo FILL_STRING = FieldInfo.random("Filling String");
-    private static final FieldInfo FILL_MULTI_LINE = FieldInfo.random("Filling Multi Line", ColumnType.MultiLine);
-    private static final FieldInfo FILL_INT = FieldInfo.random("Filling Int", ColumnType.Integer);
-    private static final FieldInfo FILL_DATE = FieldInfo.random("Filling Date", ColumnType.DateAndTime);
+    private static final FieldInfo FILL_STRING = FieldInfo.random("Filling String", ColumnType.String, MAX_LENGTH);
+    private static final FieldInfo FILL_MULTI_LINE = FieldInfo.random("Filling Multi Line", ColumnType.MultiLine, MAX_LENGTH);
+    private static final FieldInfo FILL_INT = FieldInfo.random("Filling Int", ColumnType.Integer, MAX_LENGTH);
+    private static final FieldInfo FILL_DATE = FieldInfo.random("Filling Date", ColumnType.DateAndTime, MAX_LENGTH);
 
     private static final String PASTING_SAMPLE_TYPE = randomDomainName("PastingSampleType");
-    private static final FieldInfo PASTE_1 = FieldInfo.random("Paste Column 1");
-    private static final FieldInfo PASTE_2 = FieldInfo.random("Paste Column 2");
-    private static final FieldInfo PASTE_3 = FieldInfo.random("Paste Column 3");
-    private static final FieldInfo PASTE_4 = FieldInfo.random("Paste Column 4");
-    private static final FieldInfo PASTE_5 = FieldInfo.random("Paste Column 5");
-    private static final FieldInfo PASTE_ML = FieldInfo.random("Paste Multi Line", ColumnType.MultiLine);
+    private static final FieldInfo PASTE_1 = FieldInfo.random("Paste Column 1", ColumnType.String, MAX_LENGTH);
+    private static final FieldInfo PASTE_2 = FieldInfo.random("Paste Column 2", ColumnType.String, MAX_LENGTH);
+    private static final FieldInfo PASTE_3 = FieldInfo.random("Paste Column 3", ColumnType.String, MAX_LENGTH);
+    private static final FieldInfo PASTE_4 = FieldInfo.random("Paste Column 4", ColumnType.String, MAX_LENGTH);
+    private static final FieldInfo PASTE_5 = FieldInfo.random("Paste Column 5", ColumnType.String, MAX_LENGTH);
+    private static final FieldInfo PASTE_ML = FieldInfo.random("Paste Multi Line", ColumnType.MultiLine, MAX_LENGTH);
 
     private static final List<String> TEXT_CHOICES = Arrays.asList("red", "Orange", "YELLOW");
     private static final String LOOKUP_LIST = randomDomainName("Fruits");
@@ -79,24 +80,24 @@ public class EditableGridTest extends BaseWebDriverTest
 
     private static final String ALL_TYPE_SAMPLE_TYPE = randomDomainName("AllFieldsSampleType");
 
-    private static final FieldInfo STR_FIELD = FieldInfo.random("strCol")
+    private static final FieldInfo STR_FIELD = FieldInfo.random("strCol", ColumnType.String, MAX_LENGTH)
         .customizeFieldDefinition(fd -> fd.setScale(10));
-    private static final FieldInfo REQ_STR_FIELD = FieldInfo.random("strColReq")
+    private static final FieldInfo REQ_STR_FIELD = FieldInfo.random("strColReq", ColumnType.String, MAX_LENGTH)
         .customizeFieldDefinition(fd -> fd.setScale(10).setRequired(true));
-    private static final FieldInfo INT_FIELD = FieldInfo.random("intCol", ColumnType.Integer);
-    private static final FieldInfo REQ_INT_FIELD = FieldInfo.random("intColReq", ColumnType.Integer)
+    private static final FieldInfo INT_FIELD = FieldInfo.random("intCol", ColumnType.Integer, MAX_LENGTH);
+    private static final FieldInfo REQ_INT_FIELD = FieldInfo.random("intColReq", ColumnType.Integer, MAX_LENGTH)
         .customizeFieldDefinition(fd -> fd.setRequired(true));
-    private static final FieldInfo DATE_FIELD = FieldInfo.random("dateCol", ColumnType.Date);
-    private static final FieldInfo REQ_DATETIME_FIELD = FieldInfo.random("datetimeColReq", ColumnType.DateAndTime)
+    private static final FieldInfo DATE_FIELD = FieldInfo.random("dateCol", ColumnType.Date, MAX_LENGTH);
+    private static final FieldInfo REQ_DATETIME_FIELD = FieldInfo.random("datetimeColReq", ColumnType.DateAndTime, MAX_LENGTH)
         .customizeFieldDefinition(fd -> fd.setRequired(true));
-    private static final FieldInfo TIME_FIELD = FieldInfo.random("timeCol", ColumnType.Time);
-    private static final FieldInfo REQ_TIME_FIELD = FieldInfo.random("timeColReq", ColumnType.Time)
+    private static final FieldInfo TIME_FIELD = FieldInfo.random("timeCol", ColumnType.Time, MAX_LENGTH);
+    private static final FieldInfo REQ_TIME_FIELD = FieldInfo.random("timeColReq", ColumnType.Time, MAX_LENGTH)
         .customizeFieldDefinition(fd -> fd.setRequired(true));
-    private static final FieldInfo BOOL_FIELD = FieldInfo.random("boolCol", ColumnType.Boolean);
-    private static final FieldInfo FLOAT_FIELD = FieldInfo.random("floatCol", ColumnType.Decimal);
-    private static final FieldInfo TEXTCHOICE_FIELD = FieldInfo.random("textchoiceCol", ColumnType.TextChoice)
+    private static final FieldInfo BOOL_FIELD = FieldInfo.random("boolCol", ColumnType.Boolean, MAX_LENGTH);
+    private static final FieldInfo FLOAT_FIELD = FieldInfo.random("floatCol", ColumnType.Decimal, MAX_LENGTH);
+    private static final FieldInfo TEXTCHOICE_FIELD = FieldInfo.random("textchoiceCol", ColumnType.TextChoice, MAX_LENGTH)
         .customizeFieldDefinition(fd -> fd.setTextChoiceValues(TEXT_CHOICES));
-    private static final FieldInfo REQ_TEXTCHOICE_FIELD = FieldInfo.random("textchoiceColReq", ColumnType.TextChoice)
+    private static final FieldInfo REQ_TEXTCHOICE_FIELD = FieldInfo.random("textchoiceColReq", ColumnType.TextChoice, MAX_LENGTH)
         .customizeFieldDefinition(fd -> fd.setRequired(true).setTextChoiceValues(TEXT_CHOICES));
     private static final FieldInfo LOOKUP_FIELD = FieldInfo.random("lookupCol", new IntLookup(null, "lists", LOOKUP_LIST));
     private static final FieldInfo REQ_LOOKUP_FIELD = FieldInfo.random("lookupColReq", new IntLookup(null, "lists", LOOKUP_LIST))

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -612,6 +612,16 @@ public class TestDataGenerator
         return randomFieldName(part, null);
     }
 
+    public static String randomFieldName(String part, int maxLength)
+    {
+        return randomFieldName(part, null, null, null, null, maxLength);
+    }
+
+    public static String randomFieldName(String part, @Nullable DomainKind domainKind, Integer maxLength)
+    {
+        return randomFieldName(part, null, null, null, domainKind, maxLength);
+    }
+
     public static String randomFieldName(String part, @Nullable String exclusion)
     {
         return randomFieldName(part, exclusion, null);
@@ -624,6 +634,11 @@ public class TestDataGenerator
 
     public static String randomFieldName(@NotNull String part, @Nullable Integer numStartChars, @Nullable Integer numEndChars, @Nullable String exclusion, @Nullable DomainKind domainKind)
     {
+        return randomFieldName(part, numStartChars, numEndChars, exclusion, domainKind, null);
+    }
+
+    public static String randomFieldName(@NotNull String part, @Nullable Integer numStartChars, @Nullable Integer numEndChars, @Nullable String exclusion, @Nullable DomainKind domainKind, @Nullable Integer maxLength)
+    {
         DomainKind _domainKind = domainKind == null ? DomainKind.SampleSet : domainKind;
 
         // use the characters that we know are encoded in fieldKeys plus characters that we know clients are using
@@ -633,7 +648,7 @@ public class TestDataGenerator
 
         int currentTries = 0;
         RandomName randomFieldName = randomName(part, getNumChars(numStartChars, 5), getNumChars(numEndChars, 50), chars, exclusion);
-        while (isDomainAndFieldNameInvalid(_domainKind, null, randomFieldName))
+        while ((maxLength != null && randomFieldName.name().length() > maxLength) || isDomainAndFieldNameInvalid(_domainKind, null, randomFieldName))
         {
             randomFieldName = randomName(part, getNumChars(numStartChars, 5), getNumChars(numEndChars, 50), chars, exclusion);
             if (++currentTries >= MAX_RANDOM_TRIES)


### PR DESCRIPTION
#### Rationale
Various tests need an easy way to limit the length of randomly generated field names.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Add methods to limit random field name length
- Limit the length of field names in `EditableGridTest`
