### PR TITLE
Issue 54094: escape form field names ending with "\"

### DIFF
--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -1054,7 +1054,7 @@ public class ListTest extends BaseWebDriverTest
         final String dummyCol = dummyBase + TRICKY_CHARACTERS;
         final String lookupField = "lookupField" + TRICKY_CHARACTERS;
         final String lookupSchema = "lists";
-        final String keyCol = "Key &%<+";
+        final String keyCol = "Key &%<+\\"; // Issue 54094: Verify key field ending with "\"
 
         log("Issue 6883: test list self join");
 


### PR DESCRIPTION
#### Rationale
Regression coverage for [Issue 54094](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=54094).

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7121

#### Changes
- Add regression coverage for Issue 54094 by updating the `ListTest.listSelfJoinTest` to use a key field that ends with "\\". This test subsequently visits the details and update pages for the row.
