### PR TITLE
Multi chart rendering

### DIFF
--- a/src/org/labkey/test/components/html/BootstrapMenu.java
+++ b/src/org/labkey/test/components/html/BootstrapMenu.java
@@ -20,6 +20,7 @@ import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.react.BaseBootstrapMenu;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -120,6 +121,9 @@ public class BootstrapMenu extends BaseBootstrapMenu
 
     public boolean menuItemIsDisabled(String text)
     {
+        if (findVisibleMenuItemOrNull(text) == null)
+            throw new NoSuchElementException("Menu item not found: " + text);
+
         return findDisabledMenuItemOrNull(text) != null;
     }
 

--- a/src/org/labkey/test/components/html/BootstrapMenu.java
+++ b/src/org/labkey/test/components/html/BootstrapMenu.java
@@ -118,6 +118,11 @@ public class BootstrapMenu extends BaseBootstrapMenu
         clickSubMenu(wait ? getWrapper().getDefaultWaitForPage() : 0, subMenuLabels);
     }
 
+    public boolean menuItemIsDisabled(String text)
+    {
+        return findDisabledMenuItemOrNull(text) != null;
+    }
+
     @Override
     protected Locator getToggleLocator()
     {

--- a/src/org/labkey/test/components/react/QueryChartDialog.java
+++ b/src/org/labkey/test/components/react/QueryChartDialog.java
@@ -394,8 +394,9 @@ public class QueryChartDialog extends ModalDialog
     {
         WebDriverWrapper.waitFor(this::isCreateChartButtonEnabled,
                 "the create chart button did not become enabled", 2000);
+        String name = getName();
         dismiss("Create Chart");
-        return _queryGrid.getChartPanel();
+        return _queryGrid.getChartPanel(name);
     }
 
     /*
@@ -405,8 +406,9 @@ public class QueryChartDialog extends ModalDialog
     {
         WebDriverWrapper.waitFor(this::isSaveChartButtonEnabled,
                 "the Save chart button did not become enabled", 2000);
+        String name = getName();
         dismiss("Save Chart");
-        return _queryGrid.getChartPanel();
+        return _queryGrid.getChartPanel(name);
     }
 
     /*

--- a/src/org/labkey/test/components/react/QueryChartPanel.java
+++ b/src/org/labkey/test/components/react/QueryChartPanel.java
@@ -100,13 +100,13 @@ public class QueryChartPanel extends WebDriverComponent<QueryChartPanel.ElementC
     {
         private final QueryGrid _queryGrid;
         private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "chart-panel");
-        private final String _title;
+        private final String _name;
 
-        public QueryChartPanelFinder(WebDriver driver, QueryGrid queryGrid, String title)
+        public QueryChartPanelFinder(WebDriver driver, QueryGrid queryGrid, String name)
         {
             super(driver);
             _queryGrid = queryGrid;
-            _title = title;
+            _name = name;
         }
 
         @Override
@@ -118,7 +118,7 @@ public class QueryChartPanel extends WebDriverComponent<QueryChartPanel.ElementC
         @Override
         protected Locator locator()
         {
-            Locator.XPathLocator headingLocator = Locator.tagWithClass("div", "chart-panel__heading").withChild(Locator.tagWithClass("div", "chart-panel__heading-title").containing(_title));
+            Locator.XPathLocator headingLocator = Locator.tagWithClass("div", "chart-panel__heading").withChild(Locator.tagWithClass("div", "chart-panel__heading-title").containing(_name));
             return _baseLocator.withChild(headingLocator);
         }
     }

--- a/src/org/labkey/test/components/react/QueryChartPanel.java
+++ b/src/org/labkey/test/components/react/QueryChartPanel.java
@@ -100,11 +100,13 @@ public class QueryChartPanel extends WebDriverComponent<QueryChartPanel.ElementC
     {
         private final QueryGrid _queryGrid;
         private final Locator.XPathLocator _baseLocator = Locator.tagWithClass("div", "chart-panel");
+        private final String _title;
 
-        public QueryChartPanelFinder(WebDriver driver, QueryGrid queryGrid)
+        public QueryChartPanelFinder(WebDriver driver, QueryGrid queryGrid, String title)
         {
             super(driver);
             _queryGrid = queryGrid;
+            _title = title;
         }
 
         @Override
@@ -116,7 +118,8 @@ public class QueryChartPanel extends WebDriverComponent<QueryChartPanel.ElementC
         @Override
         protected Locator locator()
         {
-            return _baseLocator;
+            Locator.XPathLocator headingLocator = Locator.tagWithClass("div", "chart-panel__heading").withChild(Locator.tagWithClass("div", "chart-panel__heading-title").containing(_title));
+            return _baseLocator.withChild(headingLocator);
         }
     }
 }

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -732,8 +732,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
 
     public boolean createChartIsDisabled()
     {
-        elementCache().chartsMenu.expand();
-        return elementCache().chartsMenu.menuItemIsDisabled("Create Chart");
+        return chartIsDisabled("Create Chart");
     }
 
     public boolean chartIsDisabled(String name)

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -16,6 +16,7 @@ import org.labkey.test.components.react.ReactCheckBox;
 import org.labkey.test.components.ui.FilterStatusValue;
 import org.labkey.test.util.selenium.WebElementUtils;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
@@ -720,7 +721,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
     public QueryChartPanel showChart(String chartName)
     {
         elementCache().chartsMenu.clickSubMenu(false, chartName);
-        return getChartPanel();
+        return getChartPanel(chartName);
     }
 
     public QueryChartDialog createChart()
@@ -729,12 +730,40 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         return new QueryChartDialog("Create Chart", getDriver(), this);
     }
 
-    /*
-        gets a chart panel that is already being shown
-     */
-    public QueryChartPanel getChartPanel()
+    public boolean createChartIsDisabled()
     {
-        return new QueryChartPanel.QueryChartPanelFinder(getDriver(), this).waitFor(this);
+        elementCache().chartsMenu.expand();
+        return elementCache().chartsMenu.menuItemIsDisabled("Create Chart");
+    }
+
+    public boolean chartIsDisabled(String name)
+    {
+        elementCache().chartsMenu.expand();
+        return elementCache().chartsMenu.menuItemIsDisabled(name);
+    }
+
+    public boolean chartIsSelected(String name)
+    {
+        elementCache().chartsMenu.expand();
+        List<WebElement> menuItems = elementCache().chartsMenu.findVisibleMenuItems();
+
+        Optional<WebElement> menuItem = menuItems.stream().filter(item -> item.getText().contains(name)).findFirst();
+
+        if (menuItem.isEmpty()) {
+            throw new NoSuchElementException(String.format("Could not find chart menu item %s", name));
+        }
+
+        WebElement checkbox = menuItem.get().findElement(Locator.byClass("chart-menu-checkbox"));
+
+        return checkbox.getAttribute("class").contains("fa-check-square");
+    }
+
+    /*
+        gets a chart panel that is already being shown for a given chart name
+     */
+    public QueryChartPanel getChartPanel(String name)
+    {
+        return new QueryChartPanel.QueryChartPanelFinder(getDriver(), this, name).waitFor(this);
     }
 
     public WebElement showRReport(String reportName)
@@ -743,9 +772,9 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         return elementCache().rReport();
     }
 
-    public void closeChart()
+    public void closeChart(String name)
     {
-        getChartPanel().clickClose();
+        getChartPanel(name).clickClose();
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
This PR adds the necessary infrastructure to test for multiple charts on a grid

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1867
- https://github.com/LabKey/platform/pull/7113
- https://github.com/LabKey/limsModules/pull/1721
- https://github.com/LabKey/testAutomation/pull/2750

#### Changes
- BootstrapMenu: add menuItemIsDisabled
- QueryChartDialog: update usages of getChartPanel
- QueryChartPanelFinder: add required name parameter
- QueryGrid:
    - Add createChartIsDisbled
    - Add chartIsDisabled
    - Add chartIsSelected
    - Add name argument to closeChart, getChartPanel
