### PR TITLE
Remove unrelated test from API test suite

### DIFF
--- a/src/org/labkey/test/tests/query/CustomizeGridPermissionsTest.java
+++ b/src/org/labkey/test/tests/query/CustomizeGridPermissionsTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.labkey.test.tests.api;
+package org.labkey.test.tests.query;
 
 import org.junit.Before;
 import org.junit.BeforeClass;


### PR DESCRIPTION
#### Rationale
This test isn't really API-centric and shouldn't run with the mostly-headless API tests.

#### Related Pull Requests
- #2718 

#### Changes
- Remove `CustomizeGridPermissionsTest` from API test suite
