### PR TITLE
Fix tests for Firefox and Selenium updates

### DIFF
--- a/src/org/labkey/test/pages/core/admin/CustomizeSitePage.java
+++ b/src/org/labkey/test/pages/core/admin/CustomizeSitePage.java
@@ -47,7 +47,7 @@ public class CustomizeSitePage extends LabKeyPage<CustomizeSitePage.ElementCache
 
     public ShowAdminPage save()
     {
-        clickAndWait(elementCache().saveButton);
+        clickAndWait(scrollIntoView(elementCache().saveButton));
 
         return new ShowAdminPage(getDriver());
     }
@@ -217,7 +217,7 @@ public class CustomizeSitePage extends LabKeyPage<CustomizeSitePage.ElementCache
         return new ElementCache();
     }
 
-    protected class ElementCache extends LabKeyPage.ElementCache
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
         protected final WebElement saveButton = Locator.lkButton("Save").findWhenNeeded(this);
 

--- a/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
+++ b/src/org/labkey/test/tests/flow/FlowSpecimenTest.java
@@ -32,6 +32,7 @@ import org.labkey.test.util.PipelineStatusTable;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -227,7 +228,8 @@ public class FlowSpecimenTest extends BaseFlowTest
         beginAt(WebTestHelper.buildURL("flow", getContainerPath(), "query", Map.of("schemaName", "flow", "query.queryName", "FCSAnalyses")));
         click(Locator.checkboxByName(".toggle"));
         clickButton("Link to Study");
-        selectOptionByText(AssayConstants.TARGET_STUDY_FIELD_LOCATOR, "/" + getProjectName() + "/" + STUDY_FOLDER + " (" + STUDY_FOLDER + " Study)");
+        // Target study is fixed
+        assertFalse("Target study selector visibility", AssayConstants.TARGET_STUDY_FIELD_LOCATOR.findElement(getDriver()).isDisplayed());
         clickButton("Next");
         assertTitleContains("Link to " + STUDY_FOLDER + " Study: Verify Results");
         // verify specimen information is filled in for '118795.fcs' FCS file

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -208,6 +208,13 @@ public class ListTest extends BaseWebDriverTest
         return PROJECT_VERIFY;
     }
 
+    @Override
+    protected void doCleanup(boolean afterTest)
+    {
+        _containerHelper.deleteProject(PROJECT_VERIFY, afterTest);
+        _containerHelper.deleteProject(PROJECT_OTHER, afterTest);
+    }
+
     @BeforeClass
     public static void setupProject()
     {
@@ -1629,7 +1636,7 @@ public class ListTest extends BaseWebDriverTest
         // setup a list with an auto-increment key that we need to make sure is encoded in the form input
         String encodedListName = "autoIncrementEncodeList";
         String keyName = "'><script>alert(\":(\")</script>'";
-        String encodedKeyFieldName = EscapeUtil.getFormFieldName(keyName).replaceAll("\"", "&quot;");
+        String encodedKeyFieldName = EscapeUtil.getFormFieldName(keyName);
         _listHelper.createList(PROJECT_VERIFY, encodedListName, keyName, col("Name", ColumnType.String));
         _listHelper.goToList(encodedListName);
 
@@ -1639,10 +1646,9 @@ public class ListTest extends BaseWebDriverTest
         customizeView.addColumn(EscapeUtil.fieldKeyEncodePart(keyName));
         customizeView.applyCustomView();
 
-        // insert a new row and verify the key is encoded in the form input
+        // insert a new row and verify the key field is not present
         table.clickInsertNewRow();
-        String html = getHtmlSource();
-        checker().verifyFalse("List key hidden input not present.", html.contains(encodedKeyFieldName));
+        checker().withScreenshot().verifyEquals("List fields on insert form.", List.of("quf_Name"), getQueryFormFieldNames());
         String nameValue = "test";
         setFormElement(Locator.name(EscapeUtil.getFormFieldName("Name")), nameValue);
         clickButton("Submit");
@@ -1654,8 +1660,7 @@ public class ListTest extends BaseWebDriverTest
 
         // verify name value can be updated
         table.clickEditRow(0);
-        html = getHtmlSource();
-        checker().verifyTrue("List key hidden input not present.", html.contains(encodedKeyFieldName));
+        checker().withScreenshot().verifyEquals("List fields on update form.", List.of("quf_Name", encodedKeyFieldName), getQueryFormFieldNames());
         nameValue = "test updated";
         setFormElement(Locator.name(EscapeUtil.getFormFieldName("Name")), nameValue);
         clickButton("Submit");
@@ -1666,6 +1671,14 @@ public class ListTest extends BaseWebDriverTest
         checker().verifyEquals("Name value not as expected", nameValue, table.getDataAsText(0, "Name"));
 
         _listHelper.deleteList();
+    }
+
+    private List<String> getQueryFormFieldNames()
+    {
+        return Locator.tag("input").attributeStartsWith("name", "quf_")
+            .findElements(getDriver()).stream()
+            .map(el -> el.getDomAttribute("name"))
+            .toList();
     }
 
     private void viewRawTableMetadata(String listName)


### PR DESCRIPTION
#### Rationale
- FlowTest started failing with the latest Selenium update. It caught the test attempting to interact with a hidden form element. That interaction was unnecessary so I updated the test to assert that the element is hidden instead.
- `ListTest.testAutoIncrementKeyEncoded` started failing with Firefox 140. `WebDriver.getPageSource()` returns the source with slightly different encoding than earlier Firefox versions. There's no particular reason to check the page source in this way; we can check the name attribute of each form input instead.

#### Related Pull Requests
- #2749 

#### Changes
- Update `ListTest.testAutoIncrementKeyEncoded` to work on Firefox 140
- Don't try to interact with hidden select in "link to study" form
