### PR TITLE
Form element name casing adjustments

### DIFF
--- a/src/org/labkey/test/tests/issues/IssuesTest.java
+++ b/src/org/labkey/test/tests/issues/IssuesTest.java
@@ -848,10 +848,9 @@ public class IssuesTest extends BaseWebDriverTest
         assertElementNotVisible(related);
 
         // related issue permission tests
-        Locator commentLocator = Locator.name("related");
         goToProjectHome(CLIENT_PORTAL);
         waitAndClickAndWait(Locator.linkContainingText(ISSUE_SUMMARY_WEBPART_NAME));
-        String clientIssueId = _issuesHelper.addIssue(Maps.of("assignedTo", NAME, "title", "Client ticket", "priority", "3", "related", issueIdA)).getIssueId();
+        String clientIssueId = _issuesHelper.addIssue(Maps.of("AssignedTo", NAME, "title", "Client ticket", "Priority", "3", "related", issueIdA)).getIssueId();
 
         // impersonate a user without permissions to the related issues
         impersonate(CLIENT_USER1);


### PR DESCRIPTION
#### Rationale
A previous [PR](https://github.com/LabKey/platform/pull/6804) to `develop` altered the rendering of form field element to switch from `ColumnInfo.getPropertyName` to `ColumnInfo.getName`. 

We needed to apply some similar fixes to test code merged forward.