### PR TITLE
GridPanelBaseTest: use the collaboration folder type

### DIFF
--- a/src/org/labkey/test/tests/component/GridPanelBaseTest.java
+++ b/src/org/labkey/test/tests/component/GridPanelBaseTest.java
@@ -73,7 +73,7 @@ public class GridPanelBaseTest extends BaseWebDriverTest
 
     protected void initProject()
     {
-        _containerHelper.createProject(getProjectName(), null);
+        _containerHelper.createProject(getProjectName(), "Collaboration");
 
         // Add the 'Sample Types' web part. It is easier when debugging etc...
         new PortalHelper(this).addWebPart("Sample Types");


### PR DESCRIPTION
#### Rationale
This fixes the failures in `GridPanelTest` where the "Select All" button is not appearing in the grid panel component.

#### Related Pull Requests
- #2738

#### Changes
- Switch the `GridPanelBaseTest` to a "Collaboration" folder type so that the query module context is available on the page.
