### PR TITLE
Try to fix mouse position issue with column headers.

### DIFF
--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -156,6 +156,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         doAndWaitForColumnUpdate(() ->
         {
             WebElement headerCell = elementCache().getColumnHeaderCell(columnIdentifier);
+            getWrapper().scrollToMiddle(headerCell);
             Locator.byClass("fa-chevron-circle-down").findElement(headerCell).click();
             Locator.tagWithText("a", "Remove Column").findElement(headerCell).click();
         });


### PR DESCRIPTION
#### Rationale
I've seen some failures in the app where the mouse has a hard time clicking the correct grid header. The column is not always scrolled horizontally into view.
<img width="1280" height="891" alt="0_testCreateWithMultipleTypesViaGrid" src="https://github.com/user-attachments/assets/f2ef77fb-4145-4547-a1cf-d7276a7fe567" />

I don't know if this fix will work, or is the right one. It may not work if the column is the last one (might fail with cannot scroll into view).

#### Related Pull Requests
- None.

#### Changes
- Try to scroll the column.
