### PR TITLE
Improve QueryGrid synchronization

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1235,6 +1235,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
             long elapsedTime = doAndWaitForPageToLoad(() -> {
                 try
                 {
+                    mouseOut();
                     getDriver().navigate().to(fullURL);
                 }
                 catch (TimeoutException ex)
@@ -3006,9 +3007,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
         try
         {
             scrollToTop();
-            WebElement root = Locators.documentRoot.findElement(getDriver());
-            final Dimension rootSize = root.getSize();
-            new Actions(getDriver()).moveToElement(root, - (rootSize.getWidth() / 2), - (rootSize.getHeight() / 2)).perform();
+            new Actions(getDriver()).moveToLocation(0, 0).perform();
         }
         catch (WebDriverException ignore) { }
     }

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -221,6 +221,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
     @Override
     public void doAndWaitForUpdate(Runnable func)
     {
+        waitForLoaded();
         Optional<WebElement> optionalStatus = elementCache().selectionStatusContainerLoc.findOptionalElement(elementCache());
 
         func.run();

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -66,10 +66,10 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
     public Boolean isLoaded()
     {
         return getComponentElement().isDisplayed() &&
-                (!Locators.loadingGrid.existsIn(this) &&
+                !Locators.loadingGrid.existsIn(this) &&
                 !Locators.spinner.existsIn(this) &&
-                Locator.tag("td").existsIn(this)) ||
-                getGridEmptyMessage().isPresent();
+            (Locator.tag("td").existsIn(this) ||
+                getGridEmptyMessage().isPresent());
     }
 
     protected void waitForLoaded()
@@ -788,7 +788,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
 
         try
         {
-            WebElement tr = Locator.tagWithClass("tr", "grid-empty").refindWhenNeeded(this);
+            WebElement tr = Locator.tagWithClass("tr", "grid-empty").findWhenNeeded(this);
             if (tr.isDisplayed())
             {
                 msg = Optional.of(Locator.tag("td").findElement(tr).getText());


### PR DESCRIPTION
#### Rationale
`QueryGrid.clearAllSelections` has been failing intermittently. Waiting for the grid to be loaded before the action seems to do the trick.
```
java.lang.AssertionError: Did not successfully clear all the selected items in the grid.
  at org.junit.Assert.fail(Assert.java:89)
  at org.junit.Assert.assertTrue(Assert.java:42)
  at org.junit.Assert.assertFalse(Assert.java:65)
  at org.labkey.test.components.ui.grids.QueryGrid.clearAllSelections(QueryGrid.java:352)
  at org.labkey.test.tests.biologics.registry.BiologicsBulkRegistryTest.testAddUpdateDeleteVectorsInGrid(BiologicsBulkRegistryTest.java:1374)
```

Some tooltip tests have been triggering (or failing to trigger) tooltips because the mouse is left in an inconvenient spot after a previous step. Moving the mouse to the corner of the page before navigations should prevent some of these accidental interactions.

#### Related Pull Requests
- N/A

#### Changes
- Move the mouse to the window corner before navigation
- Wait for query grid to load before most operations
