### PR TITLE
Issue 53831: check the true assay name length since we append onto the name when creating the assay domains (ex. "<assay nam> Batch Fields")

### DIFF
--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -723,7 +723,7 @@ public class TestDataGenerator
 
             int maxLength = switch (domainKind)
             {
-                case Assay -> 200 - 13; // Make room for "{$domainName} Batch Fields" domain
+                case Assay -> 186; // Make room for "{$domainName} Batch Fields" domain
                 case SampleSet -> 100;
                 default -> 200; // Sources, lists, and datasets allow 200 character names
             };

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -723,7 +723,7 @@ public class TestDataGenerator
 
             int maxLength = switch (domainKind)
             {
-                case Assay -> 186; // Make room for "{$domainName} Batch Fields" domain
+                case Assay -> 150; // Make room for "{$domainName} Batch Fields" domain
                 case SampleSet -> 100;
                 default -> 200; // Sources, lists, and datasets allow 200 character names
             };


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53831

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7150

#### Changes
- adjust TestDataGenerator max assay name length check
