### PR TITLE
Fix synchronization of ResponsiveGrid.editColumnLabel

### DIFF
--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -4,6 +4,7 @@
  */
 package org.labkey.test.components.ui.grids;
 
+import org.awaitility.Awaitility;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.test.Locator;
@@ -17,6 +18,7 @@ import org.labkey.test.components.react.ReactCheckBox;
 import org.labkey.test.components.ui.grids.FieldReferenceManager.FieldReference;
 import org.labkey.test.components.ui.search.FilterExpressionPanel;
 import org.labkey.test.params.FieldKey;
+import org.labkey.test.util.LabKeyExpectedConditions;
 import org.labkey.test.util.selenium.WebElementUtils;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NotFoundException;
@@ -26,6 +28,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -325,13 +328,13 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
         // Use getDriver() because the grid menus are rendered in a "react portal" at the end of the HTML body, so they
         // are totally detached from the rest of the grid.
         WebElement menu = Locator.css("ul.grid-header-cell__dropdown-menu.open").findWhenNeeded(getDriver());
-        WebElement menuItem = Locator.css("li > a").containing(menuText).findWhenNeeded(menu);
-        waitFor(menuItem::isDisplayed, 1000);
+        WebElement menuItem = getWrapper().quickWait().until(LabKeyExpectedConditions
+            .visibilityOf(Locator.css("li > a").containing(menuText), menu));
         if (waitForUpdate)
             doAndWaitForUpdate(menuItem::click);
         else
             menuItem.click();
-        waitFor(()-> !menuItem.isDisplayed(), 1000);
+        getWrapper().quickWait().until(ExpectedConditions.invisibilityOf(menuItem));
     }
 
     /**
@@ -357,20 +360,16 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
                 .keyUp(Keys.SHIFT)
                 .perform();
 
-        // Enter the new text.
-        textEdit.sendKeys(newColumnLabel, Keys.RETURN);
+        doAndWaitForUpdate(()-> {
+            textEdit.sendKeys(newColumnLabel, Keys.RETURN);
 
-        getWrapper().shortWait()
+            getWrapper().shortWait()
                 .withMessage("Column label edit text box did not go away.")
                 .until(ExpectedConditions.stalenessOf(textEdit));
 
-        doAndWaitForUpdate(()->
-                WebDriverWrapper.waitFor(()-> WebElementUtils.getTextContent(headerCell).equals(newColumnLabel),
-                        "Column header not updated.", 1_000)
-        );
-        waitForLoaded();
-        clearElementCache();
-
+            Awaitility.await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertEquals("Column label",
+                newColumnLabel, WebElementUtils.getTextContent(headerCell)));
+        });
     }
 
     /**

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -18,7 +18,6 @@ import org.labkey.test.components.react.ReactCheckBox;
 import org.labkey.test.components.ui.grids.FieldReferenceManager.FieldReference;
 import org.labkey.test.components.ui.search.FilterExpressionPanel;
 import org.labkey.test.params.FieldKey;
-import org.labkey.test.util.LabKeyExpectedConditions;
 import org.labkey.test.util.selenium.WebElementUtils;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NotFoundException;
@@ -328,13 +327,13 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
         // Use getDriver() because the grid menus are rendered in a "react portal" at the end of the HTML body, so they
         // are totally detached from the rest of the grid.
         WebElement menu = Locator.css("ul.grid-header-cell__dropdown-menu.open").findWhenNeeded(getDriver());
-        WebElement menuItem = getWrapper().quickWait().until(LabKeyExpectedConditions
-            .visibilityOf(Locator.css("li > a").containing(menuText), menu));
+        WebElement menuItem = Locator.css("li > a").containing(menuText).findWhenNeeded(menu);
+        waitFor(menuItem::isDisplayed, 1000);
         if (waitForUpdate)
             doAndWaitForUpdate(menuItem::click);
         else
             menuItem.click();
-        getWrapper().quickWait().until(ExpectedConditions.invisibilityOf(menuItem));
+        waitFor(()-> !menuItem.isDisplayed(), 1000);
     }
 
     /**

--- a/src/org/labkey/test/util/LabKeyExpectedConditions.java
+++ b/src/org/labkey/test/util/LabKeyExpectedConditions.java
@@ -23,6 +23,7 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.NoSuchWindowException;
 import org.openqa.selenium.Point;
+import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -178,6 +179,42 @@ public class LabKeyExpectedConditions
             public String toString()
             {
                 return staleCheck + " after clicking";
+            }
+        };
+    }
+
+    /**
+     * An expectation for checking child WebElement as a part of parent element to be visible
+     *
+     * @param childLocator used to find the child element. For example, {@code Locator.css("tr > td")}
+     * @param context      used as the search context. For example, table with {@code Locator.tag("table")}
+     * @return visible sub-element
+     */
+    public static ExpectedCondition<WebElement> visibilityOf(By childLocator, SearchContext context)
+    {
+        return new ExpectedCondition<>()
+        {
+            @Override
+            public WebElement apply(WebDriver webDriver)
+            {
+                try
+                {
+                    WebElement element = context.findElement(childLocator);
+                    if (element.isDisplayed())
+                        return element;
+                    else
+                        return null;
+                }
+                catch (NoSuchElementException | StaleElementReferenceException ex)
+                {
+                    return null;
+                }
+            }
+
+            @Override
+            public String toString()
+            {
+                return "visibility of element located by %s -> %s".formatted(context, childLocator);
             }
         };
     }

--- a/src/org/labkey/test/util/LabKeyExpectedConditions.java
+++ b/src/org/labkey/test/util/LabKeyExpectedConditions.java
@@ -23,7 +23,6 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.NoSuchWindowException;
 import org.openqa.selenium.Point;
-import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -179,42 +178,6 @@ public class LabKeyExpectedConditions
             public String toString()
             {
                 return staleCheck + " after clicking";
-            }
-        };
-    }
-
-    /**
-     * An expectation for checking child WebElement as a part of parent element to be visible
-     *
-     * @param childLocator used to find the child element. For example, {@code Locator.css("tr > td")}
-     * @param context      used as the search context. For example, table with {@code Locator.tag("table")}
-     * @return visible sub-element
-     */
-    public static ExpectedCondition<WebElement> visibilityOf(By childLocator, SearchContext context)
-    {
-        return new ExpectedCondition<>()
-        {
-            @Override
-            public WebElement apply(WebDriver webDriver)
-            {
-                try
-                {
-                    WebElement element = context.findElement(childLocator);
-                    if (element.isDisplayed())
-                        return element;
-                    else
-                        return null;
-                }
-                catch (NoSuchElementException | StaleElementReferenceException ex)
-                {
-                    return null;
-                }
-            }
-
-            @Override
-            public String toString()
-            {
-                return "visibility of element located by %s -> %s".formatted(context, childLocator);
             }
         };
     }


### PR DESCRIPTION
#### Rationale
`ResponsiveGrid.editColumnLabel` triggered the grid refresh outside of the `doAndWaitForUpdate` runnable. This started causing errors when I updated `QueryGrid.doAndWaitForUpdate` to wait for the grid to be ready before executing the runnable.

#### Related Pull Requests
- #2762 

#### Changes
- Fix synchronization of ResponsiveGrid.editColumnLabel
