### PR TITLE
Ignore test failures caused by labkey.org maintenance

### DIFF
--- a/src/org/labkey/test/tests/LinkedReportTest.java
+++ b/src/org/labkey/test/tests/LinkedReportTest.java
@@ -8,6 +8,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.util.WebServicesUtil;
 
 import java.util.List;
 
@@ -53,7 +54,10 @@ public class LinkedReportTest extends BaseWebDriverTest
         waitAndClick(Locator.linkWithText(REPORT_NAME));
         switchToWindow(1);
 
-        waitForElement(Locator.linkWithText("Get a Demo"));
+        if (!WebServicesUtil.isLabKeyDotOrgMaintenance(getDriver()))
+        {
+            waitForElement(Locator.linkWithText("Get a Demo"));
+        }
         Assert.assertEquals("Linked report navigated to incorrect external link", LINK_REPORT_URL, getDriver().getCurrentUrl());
     }
 }

--- a/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
+++ b/src/org/labkey/test/tests/NonStandardDateAndTimeFormatTest.java
@@ -32,6 +32,7 @@ import org.labkey.test.util.APIContainerHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.URLBuilder;
+import org.labkey.test.util.WebServicesUtil;
 import org.openqa.selenium.WebElement;
 
 import java.io.IOException;
@@ -764,6 +765,7 @@ public class NonStandardDateAndTimeFormatTest extends BaseWebDriverTest
                 WebElement banner = Locator.tagWithText("h3", "Date & Number Display Formats").refindWhenNeeded(getDriver());
                 checker().withScreenshot()
                         .verifyTrue("'Click here' link did not navigate as expected.",
+                            WebServicesUtil.isLabKeyDotOrgMaintenance(getDriver()) ||
                                 waitFor(banner::isDisplayed, 1_000));
                 closeExtraWindows();
             }

--- a/src/org/labkey/test/util/WebServicesUtil.java
+++ b/src/org/labkey/test/util/WebServicesUtil.java
@@ -98,7 +98,7 @@ public class WebServicesUtil
 
     /**
      * Checks whether the current page is the maintenance page for labkey.org.
-     * This is usually indicated by a 502 response code but we will accept any 5xx response.
+     * This is usually indicated by a {@code 502}-{@code 504} status code.
      * Allows tests that check links to labkey.org to not fail during maintenance periods.
      *
      * @param driver The WebDriver instance to check
@@ -111,7 +111,7 @@ public class WebServicesUtil
             URL url = new URL(Objects.requireNonNull(driver.getCurrentUrl()));
             String title = driver.getTitle();
             int responseCode = Integer.parseInt(Objects.requireNonNull(title).substring(0, 3));
-            return url.getHost().endsWith("labkey.org") && responseCode >= 500 && responseCode < 600;
+            return url.getHost().endsWith("labkey.org") && 502 <= responseCode && responseCode <= 504;
         }
         catch (Exception e)
         {

--- a/src/org/labkey/test/util/WebServicesUtil.java
+++ b/src/org/labkey/test/util/WebServicesUtil.java
@@ -15,10 +15,14 @@
  */
 package org.labkey.test.util;
 
+import org.openqa.selenium.WebDriver;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.URL;
+import java.util.Objects;
 
 import static org.junit.Assert.assertTrue;
 
@@ -90,5 +94,28 @@ public class WebServicesUtil
         Socket socket = new Socket();
         socket.connect(new InetSocketAddress(hostIp, port), 2000);
         return socket;
+    }
+
+    /**
+     * Checks whether the current page is the maintenance page for labkey.org.
+     * This is usually indicated by a 502 response code but we will accept any 5xx response.
+     * Allows tests that check links to labkey.org to not fail during maintenance periods.
+     *
+     * @param driver The WebDriver instance to check
+     * @return true if the current page is the maintenance page for labkey.org, false otherwise.
+     */
+    public static boolean isLabKeyDotOrgMaintenance(WebDriver driver)
+    {
+        try
+        {
+            URL url = new URL(Objects.requireNonNull(driver.getCurrentUrl()));
+            String title = driver.getTitle();
+            int responseCode = Integer.parseInt(Objects.requireNonNull(title).substring(0, 3));
+            return url.getHost().endsWith("labkey.org") && responseCode >= 500 && responseCode < 600;
+        }
+        catch (Exception e)
+        {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
#### Rationale
Several tests check links to labkey.org. When labkey.org is undergoing maintenance, these tests fail. Such failures are not informative and just cause noise on TeamCity. We can safely skip such tests during maintenance windows.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2769
- https://github.com/LabKey/limsModules/pull/1765

#### Changes
- Ignore test failures caused by labkey.org maintenance