### PR TITLE
Make FilteringReactSelect prefer exact matches

### DIFF
--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -191,7 +191,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
         elementCache().input.sendKeys(value);
         try
         {
-            var optionElement = ReactSelect.Locators.options.containing(value);
+            var optionElement = Locators.option.containing(value);
             optionElement.waitForElement(elementCache().selectMenu, 4000);
             elementCache().input.clear();
             return true;
@@ -374,7 +374,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
         // Can only get the list of items once the list has been opened.
         if (!alreadyOpened)
             open();
-        return Locators.listItems.findElements(getComponentElement());
+        return Locators.option.findElements(getComponentElement());
     }
 
     /**
@@ -391,7 +391,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
         if (!alreadyOpened)
             open();
 
-        List<WebElement> optionElements = Locators.listItems.findElements(getComponentElement());
+        List<WebElement> optionElements = Locators.option.findElements(getComponentElement());
         List<String> rawItems = optionElements.stream().map(optionMapper).toList();
 
         // If it wasn't open before close it, otherwise leave it in the open state.
@@ -486,13 +486,13 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
 
         List<WebElement> getOptions()
         {
-            return Locators.options.findElements(selectMenu);
+            return Locators.option.findElements(selectMenu);
         }
 
         @NotNull
         WebElement findOption(String option)
         {
-            return Locators.options.withText(option).findElement(selectMenu);
+            return Locators.option.withText(option).findElement(selectMenu);
         }
     }
 
@@ -504,7 +504,6 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
         }
 
         public static final Locator.XPathLocator option = Locator.tagWithClass("div", "select-input__option");
-        public static final Locator options = Locator.tagWithClass("div", "select-input__option");
         public static final Locator placeholder = Locator.tagWithClass("div", "select-input__placeholder");
         public static final Locator clear = Locator.tagWithClass("div","select-input__clear-indicator");
         public static final Locator arrow = Locator.tagWithClass("div","select-input__dropdown-indicator");
@@ -514,7 +513,6 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
         public static final Locator.XPathLocator multiValueRemove = Locator.tagWithClass("div", "select-input__multi-value__remove");
         public static final Locator.XPathLocator singleValueLabel = Locator.tagWithClass("div", "select-input__single-value");
         public static final Locator loadingSpinner = Locator.tagWithClass("span", "select-input__loading-indicator");
-        public static final Locator listItems = Locator.tagWithClass("div", "select-input__option");
         public static final Locator.XPathLocator helpBlock = Locator.tagWithClass("span", "help-block");
 
         public static Locator.XPathLocator selectContainer()

--- a/src/org/labkey/test/components/react/FilteringReactSelect.java
+++ b/src/org/labkey/test/components/react/FilteringReactSelect.java
@@ -4,17 +4,15 @@
  */
 package org.labkey.test.components.react;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.FluentWait;
 
-import java.time.Duration;
 import java.util.List;
 
 import static org.labkey.test.BaseWebDriverTest.WAIT_FOR_JAVASCRIPT;
@@ -117,7 +115,7 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
 
     /* for use with editable instances of a reactSelect, where the options aren't shown
        unless type-ahead filter information is keyed in first */
-    public FilteringReactSelect filterSelect(String value, Locator elementToWaitFor)
+    public FilteringReactSelect filterSelect(String value, @Nullable Locator elementToWaitFor)
     {
         waitForReady();
         scrollIntoView();
@@ -148,7 +146,8 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
             }
         }, "failed to select item " + elemToClick.getAttribute("class") + " by clicking", WAIT_FOR_JAVASCRIPT);
 
-        elementToWaitFor.findElement(getComponentElement());
+        if (elementToWaitFor != null)
+            elementToWaitFor.findElement(getComponentElement());
 
         close();
         return this;

--- a/src/org/labkey/test/components/react/FilteringReactSelect.java
+++ b/src/org/labkey/test/components/react/FilteringReactSelect.java
@@ -53,7 +53,7 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
         scrollIntoView();
         open();
 
-        var elementToClick = ReactSelect.Locators.options.containing(optionText);
+        var elementToClick = Locators.option.containing(optionText);
         var elementToWaitFor = getValueLabelLocator().containing(selectedOptionLabel);
 
         List<WebElement> options = setFilter(value);
@@ -121,43 +121,34 @@ public class FilteringReactSelect extends BaseReactSelect<FilteringReactSelect>
     {
         waitForReady();
         scrollIntoView();
-        WebElement success = null;
-        int tryCount = 0;
-        while (null == success && tryCount < 6)
-        {
-            tryCount++;
-            open();
+        open();
 
-            if (isMulti() || hasValue())
+        if (isMulti() || hasValue())
+            sleep(250);
+        setFilter(value);
+
+        WebElement elemToClick = Locator.waitForAnyElement(getWrapper().shortWait(),
+            Locators.option.withDescendant(Locator.tagWithText("strong", value)), // Exact match
+            Locators.option.containing(value));
+
+        log("clicking item with value [" + value + "]");
+        getWrapper().scrollIntoView(elemToClick);
+
+        WebDriverWrapper.waitFor(() -> {
+            try
+            {
+                if (isExpanded())
+                    elemToClick.click();
                 sleep(250);
-            setFilter(value);
+                return !isExpanded();
+            }
+            catch (StaleElementReferenceException retry)
+            {
+                return false;
+            }
+        }, "failed to select item " + elemToClick.getAttribute("class") + " by clicking", WAIT_FOR_JAVASCRIPT);
 
-            WebElement elemToClick = Locator.waitForAnyElement(
-                    new FluentWait<SearchContext>(getComponentElement()).withTimeout(Duration.ofMillis(WAIT_FOR_JAVASCRIPT)),
-                    Locators.options.containing(value));
-
-            log("clicking item with value [" +value+"]");
-            getWrapper().scrollIntoView(elemToClick);
-
-            WebDriverWrapper.waitFor(()-> {
-                try
-                {
-                    if (isExpanded())
-                        elemToClick.click();
-                    sleep(250);
-                    return !isExpanded();
-                }
-                catch (StaleElementReferenceException retry)
-                {
-                    return false;
-                }
-            },"failed to select item "+ elemToClick.getAttribute("class")  +" by clicking", WAIT_FOR_JAVASCRIPT);
-
-            success = elementToWaitFor.findElement(getComponentElement());
-        }
-
-        if (success == null)
-            log("Expected selection was not found. Selected value(s) are:" + getSelections());
+        elementToWaitFor.findElement(getComponentElement());
 
         close();
         return this;

--- a/src/org/labkey/test/components/react/ReactSelect.java
+++ b/src/org/labkey/test/components/react/ReactSelect.java
@@ -24,7 +24,7 @@ import static org.labkey.test.WebDriverWrapper.waitFor;
 
 public class ReactSelect extends BaseReactSelect<ReactSelect>
 {
-    private Function<String, Locator> _optionLocFactory = Locators.options::withText;
+    private Function<String, Locator> _optionLocFactory = Locators.option::withText;
 
     public ReactSelect(WebElement element, WebDriver driver)
     {
@@ -34,6 +34,7 @@ public class ReactSelect extends BaseReactSelect<ReactSelect>
     public ReactSelect(ReactSelect wrapped)
     {
         this(wrapped.getComponentElement(), wrapped.getDriver());
+        setOptionLocator(wrapped._optionLocFactory);
     }
 
     public static ReactSelectFinder finder(WebDriver driver)


### PR DESCRIPTION
#### Rationale
`FilteringReactSelect. filterSelect` picks the first option that contains the provided filter text. This can easily pick the wrong option. 
For example, this failures where the test was trying to select `NS-5` but selected `m.sNS-50907jqB` instead.
```
org.openqa.selenium.NoSuchElementException: Expected condition failed: waiting for xpath=//div[contains(concat(' ',normalize-space(@class),' '), ' detail-component ')][.//div[contains(concat(' ',normalize-space(@class),' '), ' component-detail--child--title ')]//h4[normalize-space()='NS-5']] (tried for 2 second(s) with 100 milliseconds interval)
  at app//org.labkey.test.Locator.waitForElement(Locator.java:570)
  at app//org.labkey.test.Locator.waitForElement(Locator.java:546)
  at app//org.labkey.test.Locator.waitForElement(Locator.java:539)
  at app//org.labkey.test.pages.biologics.registry.molecule.AppRegisterMoleculePage$SelectComponentsStep.selectNucleotide(AppRegisterMoleculePage.java:318)
  at app//org.labkey.test.tests.biologics.BiologicsTest.testMoleculesWithTrickyNames(BiologicsTest.java:573)
  at app//org.labkey.test.tests.biologics.BiologicsTest.testRegisterMoleculeWithTrickyName(BiologicsTest.java:550)
```

We can have it prefer to find the option that matches exactly but leave the existing, more lax behavior:
```
WebElement elemToClick = Locator.waitForAnyElement(getWrapper().shortWait(),
    Locators.option.withDescendant(Locator.tagWithText("strong", value)), // Exact match
    Locators.option.containing(value));
```

#### Related Pull Requests
- N/A

#### Changes
- Make `FilteringReactSelect` prefer exact matches
- Remove invalid retry from `FilteringReactSelect. filterSelect`
- Remove redundant locators from `BaseReactSelect.Locators`
