### PR TITLE
Fix various intermittent test issues

### DIFF
--- a/modules/simpletest/resources/scripts/validationTest/actionUrlTest.js
+++ b/modules/simpletest/resources/scripts/validationTest/actionUrlTest.js
@@ -21,7 +21,7 @@ function doTest()
 
     if (contextPath.length > 0) {
         var baseUrl = LABKEY.ActionURL.getBaseURL();
-        if (!baseUrl.endsWith(contextPath + "/"))
+        if (baseUrl.indexOf(contextPath + "/") !== baseUrl.length - (contextPath.length + 1))
             errors[errors.length] = new Error("ActionURL.getBaseURL() = " + baseUrl);
     }
 

--- a/modules/simpletest/resources/scripts/validationTest/actionUrlTest.js
+++ b/modules/simpletest/resources/scripts/validationTest/actionUrlTest.js
@@ -21,7 +21,9 @@ function doTest()
 
     if (contextPath.length > 0) {
         var baseUrl = LABKEY.ActionURL.getBaseURL();
-        if (baseUrl.indexOf(contextPath + "/") !== baseUrl.length - (contextPath.length + 1))
+        var suffix = contextPath + "/";
+        var idx = baseUrl.indexOf(suffix);
+        if (idx === -1 || idx !== baseUrl.length - suffix.length)
             errors[errors.length] = new Error("ActionURL.getBaseURL() = " + baseUrl);
     }
 

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -405,11 +405,14 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         setFormElement(Locator.id("email"), email);
         setFormElement(Locator.id("password"), password);
         WebElement signInButton = Locator.lkButton("Sign In").findElement(getDriver());
-        signInButton.click();
-        shortWait().until(ExpectedConditions.invisibilityOfElementLocated(Locator.byClass("signing-in-msg")));
-        shortWait().until(ExpectedConditions.or(
-                ExpectedConditions.stalenessOf(signInButton), // Successful login
-                ExpectedConditions.presenceOfElementLocated(Locators.labkeyError.withText()))); // Error during sign-in
+        doAndMaybeWaitForPageToLoad(10_000, () -> {
+            signInButton.click();
+            shortWait().until(ExpectedConditions.invisibilityOfElementLocated(Locator.byClass("signing-in-msg")));
+            shortWait().until(ExpectedConditions.or(
+                    ExpectedConditions.stalenessOf(signInButton), // Successful login
+                    ExpectedConditions.presenceOfElementLocated(Locators.labkeyError.withText()))); // Error during sign-in
+            return ExpectedConditions.stalenessOf(signInButton).apply(null);
+        });
     }
 
     public void signInShouldFail(String email, String password, String... expectedMessages)

--- a/src/org/labkey/test/Locators.java
+++ b/src/org/labkey/test/Locators.java
@@ -30,6 +30,7 @@ public abstract class Locators
     public static final Locator.XPathLocator folderTab = Locator.tagWithClass("div", "lk-nav-tabs-ct").append(Locator.tagWithClass("ul", "lk-nav-tabs")).childTag("li");
     public static final Locator.XPathLocator panelWebpartTitle = Locator.byClass("labkey-wp-title-text");
     public static final Locator.XPathLocator folderTitle = Locator.tagWithClass("a", "lk-body-title-folder");
+    public static final Locator.XPathLocator loadingSpinner = Locator.byClass("fa-spinner");
 
     public static Locator.XPathLocator headerContainer()
     {

--- a/src/org/labkey/test/TestScrubber.java
+++ b/src/org/labkey/test/TestScrubber.java
@@ -20,6 +20,7 @@ import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.components.html.Checkbox;
+import org.labkey.test.components.pipeline.PipelineTriggerWizard;
 import org.labkey.test.pages.core.admin.AllowedFileExtensionAdminPage;
 import org.labkey.test.pages.core.admin.BaseSettingsPage;
 import org.labkey.test.pages.core.admin.ConfigureFileSystemAccessPage;
@@ -158,6 +159,16 @@ public class TestScrubber extends ExtraSiteWrapper
         catch (IOException | CommandException e)
         {
             TestLogger.error("Failed to reset site look and feel properties after test.", e);
+        }
+
+        try
+        {
+            // Disable all pipeline triggers so that they don't show up as memory leaks in subsequent tests.
+            PipelineTriggerWizard.disableAllPipelineTriggers(createDefaultConnection());
+        }
+        catch (Exception e)
+        {
+            TestLogger.error("Failed to disable pipeline triggers after test", e);
         }
 
     }

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3007,7 +3007,12 @@ public abstract class WebDriverWrapper implements WrapsDriver
         try
         {
             scrollToTop();
-            new Actions(getDriver()).moveToLocation(0, 0).perform();
+            new Actions(getDriver())
+                    .moveToLocation(0, 0)
+                    // Add a little wiggle to make sure tooltips notice
+                    .moveByOffset(4, 4)
+                    .moveByOffset(-2, -2)
+                    .perform();
         }
         catch (WebDriverException ignore) { }
     }

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -3000,13 +3000,11 @@ public abstract class WebDriverWrapper implements WrapsDriver
 
     /**
      * Move mouse to the upper left corner of the document to dismiss tooltips and the like
-     * Will scroll page if necessary
      */
     public void mouseOut()
     {
         try
         {
-            scrollToTop();
             new Actions(getDriver())
                     .moveToLocation(0, 0)
                     // Add a little wiggle to make sure tooltips notice

--- a/src/org/labkey/test/components/domain/DomainDesigner.java
+++ b/src/org/labkey/test/components/domain/DomainDesigner.java
@@ -48,7 +48,7 @@ public abstract class DomainDesigner<EC extends DomainDesigner<?>.ElementCache> 
         protected final DomainPanel<?, ?> propertiesPanel = new DomainPanel.DomainPanelFinder(getDriver()).index(0)
                 .timeout(WAIT_FOR_JAVASCRIPT).findWhenNeeded(this);
         protected final DomainFormPanel fieldsPanel = new DomainFormPanel.DomainFormPanelFinder(getDriver())
-                .index(getFieldPanelIndex()).timeout(1000).findWhenNeeded();
+                .index(getFieldPanelIndex()).timeout(2_000).findWhenNeeded();
 
         protected int getFieldPanelIndex()
         {

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -47,7 +47,7 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
     @Override
     protected void waitForReady()
     {
-        waitFor(() -> !BootstrapLocators.loadingSpinner.existsIn(this), "Loading spinner still present", 2_000);
+        waitFor(() -> !BootstrapLocators.loadingSpinner.existsIn(this), "Loading spinner still present", 5_000);
     }
 
     public static List<AdvancedFieldSetting> advancedSettingsFromFieldDefinition(FieldDefinition def)

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -47,7 +47,7 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
     @Override
     protected void waitForReady()
     {
-        waitFor(() -> !BootstrapLocators.loadingSpinner.existsIn(this), "Loading spinner still present", 5_000);
+        waitFor(() -> !BootstrapLocators.loadingSpinner.existsIn(this), "Loading spinner still present", 2_000);
     }
 
     public static List<AdvancedFieldSetting> advancedSettingsFromFieldDefinition(FieldDefinition def)

--- a/src/org/labkey/test/components/pipeline/PipelineTriggerWizard.java
+++ b/src/org/labkey/test/components/pipeline/PipelineTriggerWizard.java
@@ -16,6 +16,10 @@
 package org.labkey.test.components.pipeline;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.query.ContainerFilter;
+import org.labkey.remoteapi.query.Filter;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
@@ -24,11 +28,14 @@ import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.html.OptionSelect;
+import org.labkey.test.util.query.QueryApiHelper;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
+import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertTrue;
@@ -59,6 +66,18 @@ public class PipelineTriggerWizard extends WebDriverComponent<PipelineTriggerWiz
     {
         driver.beginAt(WebTestHelper.buildURL("pipeline", containerPath, "createPipelineTrigger", Map.of("pipelineTask", pipelineTask)));
         return new PipelineTriggerWizard(driver.getDriver());
+    }
+
+    public static void disableAllPipelineTriggers(Connection connection) throws IOException, CommandException
+    {
+        QueryApiHelper queryApiHelper = new QueryApiHelper(connection, "/", "pipeline", "TriggerConfigurations");
+        List<Map<String, Object>> triggers = queryApiHelper.selectRows(List.of("rowId", "enabled"),
+            List.of(new Filter("enabled", true)), List.of(), ContainerFilter.AllFolders).getRows();
+        if (!triggers.isEmpty())
+        {
+            triggers.forEach(trigger -> trigger.put("enabled", false));
+            queryApiHelper.updateRows(triggers);
+        }
     }
 
     @Override

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -1160,6 +1160,8 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
      */
     public String getCellPopoverText(int row, CharSequence columnIdentifier)
     {
+        dismissPopover(); // Other popovers can block the target cell
+        getWrapper().mouseOver(Locator.tag("td").findElement(getRow(row))); // Avoid passing over any header cells on the way to the target cell
         WebElement cellDiv = Locator.tagWithClass("div", "cellular-display").findElement(getCell(row, columnIdentifier));
         getWrapper().mouseOver(cellDiv);   // cause the tooltip to be present
         return Optional.ofNullable(WebDriverWrapper.waitFor(()-> Locators.popover.findElementOrNull(getDriver()), 1000))

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -1172,7 +1172,9 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
     public void dismissPopover()
     {
         Locators.popover.findOptionalElement(getDriver()).ifPresent(popover -> {
+            getWrapper().mouseOver(popover);
             getWrapper().mouseOut();
+            getWrapper().mouseOver(elementCache().getGridHeaderManager().getColumnHeader(0).getElement());
             getWrapper().shortWait().until(ExpectedConditions.invisibilityOf(popover));
         });
     }

--- a/src/org/labkey/test/components/ui/grids/FieldSelectionDialog.java
+++ b/src/org/labkey/test/components/ui/grids/FieldSelectionDialog.java
@@ -400,6 +400,7 @@ public class FieldSelectionDialog extends ModalDialog
                 continue;
             }
 
+            getWrapper().mouseOver(removeIcon);
             removeIcon.click();
         }
 

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -221,17 +221,17 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
     @Override
     public void doAndWaitForUpdate(Runnable func)
     {
-        waitForLoaded();
-        Optional<WebElement> optionalStatus = elementCache().selectionStatusContainerLoc.findOptionalElement(elementCache());
+        WebElement status = hasSelectColumn() ? Locators.selectionStatusContainerLoc.waitForElement(this, 5_000) : null;
 
         func.run();
 
-        optionalStatus.ifPresent(el -> {
-            getWrapper().shortWait().until(ExpectedConditions.stalenessOf(el));
-            elementCache().selectionStatusContainerLoc.waitForElement(this, 5_000);
-        });
+        if (status != null)
+        {
+            getWrapper().shortWait().until(ExpectedConditions.stalenessOf(status));
+            Locators.selectionStatusContainerLoc.waitForElement(this, 5_000);
+        }
 
-        waitForLoaded();
+        elementCache().waitForLoaded();
         clearElementCache();
     }
 
@@ -789,19 +789,35 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
         return (ElementCache) super.elementCache();
     }
 
+    protected static class Locators
+    {
+        static final Locator.XPathLocator selectionStatusContainerLoc = Locator.byClass("selection-status");
+    }
+
     protected class ElementCache extends ResponsiveGrid<QueryGrid>.ElementCache
     {
+
+        @Override
+        public Boolean isLoaded()
+        {
+            return isSelectionLoaded() && super.isLoaded();
+        }
+
+        private boolean isSelectionLoaded()
+        {
+            return Locators.selectionStatusContainerLoc.isDisplayed(this);
+        }
+
         final GridBar gridBar = new GridBar.GridBarFinder().findWhenNeeded(QueryGrid.this);
 
-        WebElement saveViewButton = Locator.button("Save").findWhenNeeded(getDriver());
+        final WebElement saveViewButton = Locator.button("Save").findWhenNeeded(getDriver());
 
         final BootstrapMenu viewMenu = new MultiMenu.MultiMenuFinder(getDriver()).withText("Views").findWhenNeeded(this);
 
-        final Locator.XPathLocator selectionStatusContainerLoc = Locator.tagWithClass("div", "selection-status");
-        final Locator selectAllBtnLoc = selectionStatusContainerLoc.append(Locator.tagWithClass("span", "selection-status__select-all")
-                .child(Locator.buttonContainingText("Select")));
-        final Locator clearBtnLoc = selectionStatusContainerLoc.append(Locator.byClass("selection-status__clear-all")
-                .child(Locator.tag("button")));
+        final Locator selectAllBtnLoc = Locators.selectionStatusContainerLoc.append(Locator.byClass("selection-status__select-all")
+            .childTag("button"));
+        final Locator clearBtnLoc = Locators.selectionStatusContainerLoc.append(Locator.byClass("selection-status__clear-all")
+            .childTag("button"));
 
         final WebElement filterStatusPanel = Locator.css("div.grid-panel__filter-status").findWhenNeeded(this);
 

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -221,18 +221,18 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
     @Override
     public void doAndWaitForUpdate(Runnable func)
     {
-        WebElement status = hasSelectColumn() ? Locators.selectionStatusContainerLoc.waitForElement(this, 5_000) : null;
-
-        func.run();
-
-        if (status != null)
+        super.doAndWaitForUpdate(() ->
         {
-            getWrapper().shortWait().until(ExpectedConditions.stalenessOf(status));
-            Locators.selectionStatusContainerLoc.waitForElement(this, 5_000);
-        }
+            WebElement status = hasSelectColumn() ? Locators.selectionStatusContainerLoc.waitForElement(this, 5_000) : null;
 
-        elementCache().waitForLoaded();
-        clearElementCache();
+            func.run();
+
+            if (status != null)
+            {
+                getWrapper().shortWait().until(ExpectedConditions.stalenessOf(status));
+                Locators.selectionStatusContainerLoc.waitForElement(this, 5_000);
+            }
+        });
     }
 
 
@@ -796,17 +796,6 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
 
     protected class ElementCache extends ResponsiveGrid<QueryGrid>.ElementCache
     {
-
-        @Override
-        public Boolean isLoaded()
-        {
-            return isSelectionLoaded() && super.isLoaded();
-        }
-
-        private boolean isSelectionLoaded()
-        {
-            return !hasSelectColumn() || Locators.selectionStatusContainerLoc.existsIn(this);
-        }
 
         final GridBar gridBar = new GridBar.GridBarFinder().findWhenNeeded(QueryGrid.this);
 

--- a/src/org/labkey/test/components/ui/grids/QueryGrid.java
+++ b/src/org/labkey/test/components/ui/grids/QueryGrid.java
@@ -805,7 +805,7 @@ public class QueryGrid extends ResponsiveGrid<QueryGrid>
 
         private boolean isSelectionLoaded()
         {
-            return Locators.selectionStatusContainerLoc.isDisplayed(this);
+            return !hasSelectColumn() || Locators.selectionStatusContainerLoc.existsIn(this);
         }
 
         final GridBar gridBar = new GridBar.GridBarFinder().findWhenNeeded(QueryGrid.this);

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -67,16 +67,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
 
     public Boolean isLoaded()
     {
-        return getComponentElement().isDisplayed() &&
-                !Locators.loadingGrid.existsIn(this) &&
-                !Locators.spinner.existsIn(this) &&
-            (Locator.tag("td").existsIn(this) ||
-                getGridEmptyMessage().isPresent());
-    }
-
-    protected void waitForLoaded()
-    {
-        WebDriverWrapper.waitFor(this::isLoaded, "Grid still loading", 30000);
+        return elementCache().isLoaded();
     }
 
     @Override
@@ -85,7 +76,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
         // Look at WebDriverWrapper.doAndWaitForElementToRefresh for an example.
         func.run();
 
-        waitForLoaded();
+        elementCache().waitForLoaded();
         clearElementCache();
     }
 
@@ -826,6 +817,20 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
         public ElementCache()
         {
             waitForLoaded();
+        }
+
+        protected void waitForLoaded()
+        {
+            WebDriverWrapper.waitFor(this::isLoaded, "Grid still loading", 30000);
+        }
+
+        public Boolean isLoaded()
+        {
+            return getComponentElement().isDisplayed() &&
+                !Locators.loadingGrid.existsIn(this) &&
+                !Locators.spinner.existsIn(this) &&
+                (Locator.tag("td").existsIn(this) ||
+                    getGridEmptyMessage().isPresent());
         }
 
         private Boolean hasSelectColumn = null;

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -824,7 +824,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
             WebDriverWrapper.waitFor(this::isLoaded, "Grid still loading", 30000);
         }
 
-        public Boolean isLoaded()
+        protected Boolean isLoaded()
         {
             return getComponentElement().isDisplayed() &&
                 !Locators.loadingGrid.existsIn(this) &&
@@ -843,7 +843,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
             return hasSelectColumn;
         }
 
-        ReactCheckBox selectAllCheckbox = new ReactCheckBox(Locator.xpath("//th/input[@type='checkbox']").findWhenNeeded(this))
+        final ReactCheckBox selectAllCheckbox = new ReactCheckBox(Locator.xpath("//th/input[@type='checkbox']").findWhenNeeded(this))
         {
             @Override
             public void toggle()

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -67,16 +67,27 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
 
     public Boolean isLoaded()
     {
-        return elementCache().isLoaded();
+        return getComponentElement().isDisplayed() &&
+                !Locators.loadingGrid.existsIn(this) &&
+                !Locators.spinner.existsIn(this) &&
+                (Locator.tag("td").existsIn(this) ||
+                        getGridEmptyMessage().isPresent());
+    }
+
+    protected void waitForLoaded()
+    {
+        WebDriverWrapper.waitFor(this::isLoaded, "Grid still loading", 30000);
     }
 
     @Override
     public void doAndWaitForUpdate(Runnable func)
     {
+        waitForLoaded();
+
         // Look at WebDriverWrapper.doAndWaitForElementToRefresh for an example.
         func.run();
 
-        elementCache().waitForLoaded();
+        waitForLoaded();
         clearElementCache();
     }
 
@@ -817,20 +828,6 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
         public ElementCache()
         {
             waitForLoaded();
-        }
-
-        protected void waitForLoaded()
-        {
-            WebDriverWrapper.waitFor(this::isLoaded, "Grid still loading", 30000);
-        }
-
-        protected Boolean isLoaded()
-        {
-            return getComponentElement().isDisplayed() &&
-                !Locators.loadingGrid.existsIn(this) &&
-                !Locators.spinner.existsIn(this) &&
-                (Locator.tag("td").existsIn(this) ||
-                    getGridEmptyMessage().isPresent());
         }
 
         private Boolean hasSelectColumn = null;

--- a/src/org/labkey/test/components/ui/lineage/LineageGraph.java
+++ b/src/org/labkey/test/components/ui/lineage/LineageGraph.java
@@ -1,6 +1,8 @@
 package org.labkey.test.components.ui.lineage;
 
 import org.labkey.test.Locator;
+import org.labkey.test.Locators;
+import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.react.Tabs;
@@ -46,6 +48,16 @@ public class LineageGraph extends WebDriverComponent<LineageGraph.ElementCache>
             webDriverWait.until(ExpectedConditions.visibilityOf(lineageGraph.getComponentElement()));
         }
         return lineageGraph;
+    }
+
+    @Override
+    protected void waitForReady()
+    {
+        WebDriverWrapper.waitFor(()->
+                        elementCache().visGraphContainer.isDisplayed() &&
+                        elementCache().nodeDetailContainer.isDisplayed() &&
+                        !Locators.loadingSpinner.existsIn(this),
+                "lineage graph did not load in time", 5_000);
     }
 
     public Map<String, String> getCurrentNodeData()
@@ -178,16 +190,16 @@ public class LineageGraph extends WebDriverComponent<LineageGraph.ElementCache>
         // container for the details of the currently-selected node
         final WebElement nodeDetailContainer = Locator.tagWithClass("div", "lineage-node-detail-container")
                 .findWhenNeeded(this).withTimeout(4000);
-        WebElement componentDetailImage = Locator.tagWithClass("i", "component-detail--child--img")
+        final WebElement componentDetailImage = Locator.tagWithClass("i", "component-detail--child--img")
                 .child(Locator.tag("img")).findWhenNeeded(nodeDetailContainer);
-        WebElement nodeDetailName = Locator.tagWithClass("h4", "lineage-name-data")
+        final WebElement nodeDetailName = Locator.tagWithClass("h4", "lineage-name-data")
                 .findWhenNeeded(nodeDetailContainer);
-        WebElement nodeDetailLinksContainer = Locator.tagWithClass("div", "lineage-node-detail")
+        final WebElement nodeDetailLinksContainer = Locator.tagWithClass("div", "lineage-node-detail")
                 .findWhenNeeded(nodeDetailContainer);
-        WebElement nodeOverviewLink = Locator.linkWithSpan("Overview").withClass("lineage-data-link--text")
+        final WebElement nodeOverviewLink = Locator.linkWithSpan("Overview").withClass("lineage-data-link--text")
                 .findWhenNeeded(nodeDetailLinksContainer);
-        Locator lineageLinkLoc = Locator.linkWithSpan("Lineage").withClass("lineage-data-link--text");
-        WebElement nodeLineageLink = lineageLinkLoc.findWhenNeeded(nodeDetailLinksContainer);
+        final Locator lineageLinkLoc = Locator.linkWithSpan("Lineage").withClass("lineage-data-link--text");
+        final WebElement nodeLineageLink = lineageLinkLoc.findWhenNeeded(nodeDetailLinksContainer);
         Tabs nodeDetailsTabs()
         {
             return new Tabs.TabsFinder(getDriver()).findWhenNeeded(nodeDetailContainer);
@@ -198,9 +210,9 @@ public class LineageGraph extends WebDriverComponent<LineageGraph.ElementCache>
             return new DetailTable.DetailTableFinder(getDriver()).waitFor(nodeDetailContainer);
         }
 
-        WebElement nodeDetails = Locator.tagWithClass("div", "lineage-node-detail")
+        final WebElement nodeDetails = Locator.tagWithClass("div", "lineage-node-detail")
                 .findWhenNeeded(nodeDetailContainer).withTimeout(3000);
-        WebElement nodeDetailsName = Locator.tagWithClass("div", "lineage-name-data")
+        final WebElement nodeDetailsName = Locator.tagWithClass("div", "lineage-name-data")
                 .findWhenNeeded(nodeDetails);
 
         NodeDetailGroup summaryList(String nodeLabel)

--- a/src/org/labkey/test/params/property/DomainProps.java
+++ b/src/org/labkey/test/params/property/DomainProps.java
@@ -36,10 +36,9 @@ public abstract class DomainProps
 
                 DomainResponse response = super.execute(connection, folderPath);
 
-                TestLogger.log("Successfully created domain, '%s':\n%s"
-                    .formatted(
-                        response.getDomain().getName(),
-                        response.getDomain().toJSONObject().toString(2)));
+                TestLogger.log().debug("Successfully created domain, '{}':\n{}",
+                        () -> response.getDomain().getName(),
+                        () -> response.getDomain().toJSONObject().toString(2));
 
                 return response;
             }

--- a/src/org/labkey/test/util/DataRegion.java
+++ b/src/org/labkey/test/util/DataRegion.java
@@ -37,6 +37,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
 
@@ -190,7 +191,7 @@ public abstract class DataRegion extends WebDriverComponent<DataRegion.ElementCa
     {
         if (_tableId == null)
         {
-            String id = _el.getAttribute("id");
+            String id = Objects.requireNonNull(_el.getAttribute("id"), "Table has no ID");
             if (id.endsWith("-form"))
                 _tableId = id.replace("-form", "");
             else
@@ -334,7 +335,7 @@ public abstract class DataRegion extends WebDriverComponent<DataRegion.ElementCa
         }
     }
 
-    public class ElementCache extends Component.ElementCache
+    public class ElementCache extends Component<DataRegion.ElementCache>.ElementCache
     {
         protected ElementCache()
         {
@@ -418,7 +419,7 @@ public abstract class DataRegion extends WebDriverComponent<DataRegion.ElementCa
 
     private abstract class BaseDataRegionApi
     {
-        final String regionJS = "LABKEY.DataRegions['" + getDataRegionName().replaceAll("'", "\\\\'") + "']";
+        final CachingSupplier<String> regionJS = new CachingSupplier<>(() -> "LABKEY.DataRegions['" + getDataRegionName().replaceAll("'", "\\\\'") + "']");
 
         public void executeScript(String methodWithArgs, Object... args)
         {
@@ -427,7 +428,7 @@ public abstract class DataRegion extends WebDriverComponent<DataRegion.ElementCa
 
         public <T> T executeScript(String methodWithArgs, Class<T> expectedResultType, Object... args)
         {
-            return getWrapper().executeScript((expectedResultType != null ? "return " : "") + regionJS + "." + methodWithArgs, expectedResultType, args);
+            return getWrapper().executeScript((expectedResultType != null ? "return " : "") + regionJS.get() + "." + methodWithArgs, expectedResultType, args);
         }
 
         public void callMethod(String apiMethodName, Object... args)
@@ -465,7 +466,7 @@ public abstract class DataRegion extends WebDriverComponent<DataRegion.ElementCa
         {
             MutableObject<T> result = new MutableObject<>();
             doAndWaitForUpdate(() -> result.setValue(super.executeScript(methodWithArgs, expectedResultType, args)));
-            return result.getValue();
+            return result.get();
         }
     }
 }


### PR DESCRIPTION
#### Rationale
- Some tests will leave file watchers enabled if they fail. These can show up as memory leaks to subsequent tests. We can disable all pipeline triggers via API to prevent this.
- Tooltips for the editable grid headers are very sensitive. When attempting to inspect error popovers, the mouse often passes over the header. Occasionally, this triggers a header tooltip which blocks the cell we actually want to inspect. We can move the mouse in a path that will not pass over the grid header to avoid this.
- The query metadata form can take more than two seconds to load. We can give it a little extra time.

#### Related Pull Requests
- N/A

#### Changes
- Disable pipeline triggers after failed tests
- Avoid mousing over editable grid headers
- Wait a little longer for DomainFormPanel to load