### PR TITLE
Handle paths, not just file names, when extracting zips in test code

### DIFF
--- a/src/org/labkey/test/TestFileUtils.java
+++ b/src/org/labkey/test/TestFileUtils.java
@@ -564,7 +564,7 @@ public abstract class TestFileUtils
 
             while (null != (entry = zis.getNextEntry()))
             {
-                File destFile = FileUtil.appendName(unzipDir, entry.getName());
+                File destFile = FileUtil.appendPath(unzipDir, org.labkey.api.util.Path.parse(entry.getName()));
 
                 if (!destFile.getCanonicalPath().startsWith(unzipDir.getCanonicalPath() + File.separator)) {
                     throw new IOException("Zip entry is outside of the target dir: " + entry.getName());


### PR DESCRIPTION
#### Rationale
We need to handle paths when extracting from a zip file, not just simple file names

#### Changes
- Accept paths too