### PR TITLE
Issue 54218: Escape special characters in form field names

### DIFF
--- a/src/org/labkey/test/pages/assay/AssayImportPage.java
+++ b/src/org/labkey/test/pages/assay/AssayImportPage.java
@@ -95,6 +95,15 @@ public class AssayImportPage extends LabKeyPage<AssayImportPage.Elements>
         return this;
     }
 
+    public @Nullable String getFieldValue(String fieldName)
+    {
+        var input = Locator.input(getTableViewFormFieldName(fieldName));
+        if (isElementPresent(input))
+            return getFormElement(input);
+
+        return null;
+    }
+
     /**
      * Retrieves the file name for a field if it has been previously uploaded. In this case the server
      * will display a file name with an icon and a "[remove]" link. If a value has not been previously uploaded,
@@ -114,11 +123,17 @@ public class AssayImportPage extends LabKeyPage<AssayImportPage.Elements>
             return StringUtils.trimToNull(text.replace("[remove]", ""));
         }
 
-        var fileInput = Locator.input(getTableViewFormFieldName(fieldName));
-        if (isElementPresent(fileInput))
-            return getFormElement(fileInput);
+        return getFieldValue(fieldName);
+    }
 
-        return null;
+    public AssayImportPage removeFileValue(String fieldName)
+    {
+        var removeFileLink = Locator.tagWithClass("div", "lk-remove-file")
+                .withAttribute("data-fieldname", fieldName)
+                .child(Locator.tagWithText("a", "remove"));
+
+        removeFileLink.findElement(getDriver()).click();
+        return this;
     }
 
     /* button actions */

--- a/src/org/labkey/test/pages/assay/AssayImportPage.java
+++ b/src/org/labkey/test/pages/assay/AssayImportPage.java
@@ -29,6 +29,8 @@ import org.openqa.selenium.WebElement;
 
 import java.io.File;
 
+import static org.labkey.test.util.EscapeUtil.getTableViewFormFieldName;
+
 public class AssayImportPage extends LabKeyPage<AssayImportPage.Elements>
 {
     public AssayImportPage(WebDriver driver)
@@ -38,28 +40,28 @@ public class AssayImportPage extends LabKeyPage<AssayImportPage.Elements>
 
     public AssayImportPage setNamedInputText(String name, String text)
     {
-        WebElement input = Locator.input(name).findElement(getDriver());
+        WebElement input = Locator.input(getTableViewFormFieldName(name)).findElement(getDriver());
         new Input(input, getDriver()).set(text);
         return this;
     }
 
     public AssayImportPage selectNamedFieldOption(String name, String text)
     {
-        WebElement input = Locator.xpath("//select[@name='" + name +"']").findElement(getDriver());
+        WebElement input = Locator.tagWithName("select", getTableViewFormFieldName(name)).findElement(getDriver());
         new OptionSelect(input).set(text);
         return this;
     }
 
     public AssayImportPage setNamedTextAreaValue(String name, String text)
     {
-        WebElement input = Locator.textarea(name).findElement(getDriver());
+        WebElement input = Locator.textarea(getTableViewFormFieldName(name)).findElement(getDriver());
         setFormElement(input, text);
         return this;
     }
 
     public AssayImportPage setFileField(String name, File file)
     {
-        setFormElement(Locator.input(name), file);
+        setFormElement(Locator.input(getTableViewFormFieldName(name)), file);
         return this;
     }
 
@@ -112,7 +114,7 @@ public class AssayImportPage extends LabKeyPage<AssayImportPage.Elements>
             return StringUtils.trimToNull(text.replace("[remove]", ""));
         }
 
-        var fileInput = Locator.input(fieldName);
+        var fileInput = Locator.input(getTableViewFormFieldName(fieldName));
         if (isElementPresent(fileInput))
             return getFormElement(fileInput);
 

--- a/src/org/labkey/test/tests/AttachmentFieldTest.java
+++ b/src/org/labkey/test/tests/AttachmentFieldTest.java
@@ -148,7 +148,6 @@ public class AttachmentFieldTest extends BaseWebDriverTest
         clickAndWait(Locator.tagWithText("a", "S1"));
         clickAndWait(Locator.tagWithClass("a", "labkey-text-link").withText("edit"));
         waitForElement(Locator.tagContainingText("div", "jpg_sample.jpg (unavailable)"));
-        assertElementNotPresent(Locator.tagWithAttributeContaining("img", "src", "/_icons/image.png"));
     }
 
     @Test

--- a/src/org/labkey/test/util/EscapeUtil.java
+++ b/src/org/labkey/test/util/EscapeUtil.java
@@ -266,6 +266,11 @@ public class EscapeUtil
         return getFormFieldName(columnName, FORM_FIELD_PREFIX);
     }
 
+    public static String getTableViewFormFieldName(String columnName)
+    {
+        return getFormFieldName(columnName, null);
+    }
+
     /**
      * Escapes special characters in a column name to be used as a form field name.
      * See associated {@link org.labkey.api.query.QueryUpdateForm#getFormFieldName}


### PR DESCRIPTION
#### Rationale
Test updates associated with changes in https://github.com/LabKey/platform/pull/7193.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7193

#### Changes
- Introduce `EscapeUtil.getTableViewFormFieldName()` for use in tests that need to interact with form fields where the name has escaped special characters.
