### PR TITLE
Increase timeout for the query metadata form

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -47,7 +47,7 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
     @Override
     protected void waitForReady()
     {
-        waitFor(() -> !BootstrapLocators.loadingSpinner.existsIn(this), "Loading spinner still present", 2_000);
+        waitFor(() -> !BootstrapLocators.loadingSpinner.existsIn(this), "Loading spinner still present", 10_000);
     }
 
     public static List<AdvancedFieldSetting> advancedSettingsFromFieldDefinition(FieldDefinition def)


### PR DESCRIPTION
#### Rationale
Some Biologics tests started failing with https://github.com/LabKey/platform/pull/7163. Unable to reproduce locally. Increasing timeout to reduce TeamCity noise.
```
org.openqa.selenium.TimeoutException: Loading spinner still present <2.000s>
  at app//org.labkey.test.util.Timer.waitFor(Timer.java:105)
  at app//org.labkey.test.util.Timer.waitFor(Timer.java:112)
  at app//org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2389)
  at app//org.labkey.test.components.domain.DomainFormPanel.waitForReady(DomainFormPanel.java:50)
  at app//org.labkey.test.components.Component.elementCache(Component.java:75)
  at app//org.labkey.test.components.domain.DomainPanel.isExpanded(DomainPanel.java:83)
  at app//org.labkey.test.components.domain.DomainPanel.setExpanded(DomainPanel.java:63)
  at app//org.labkey.test.components.domain.DomainPanel.expand(DomainPanel.java:53)
  at app//org.labkey.test.pages.query.QueryMetadataEditorPage.fieldsPanel(QueryMetadataEditorPage.java:60)
  at app//org.labkey.test.tests.biologics.BiologicsTest.testCreateDataClassAndConfirmNonEditNameFieldSettings(BiologicsTest.java:3007)
```

#### Related Pull Requests
- N/A

#### Changes
- Increase timeout for the query metadata form
