### PR TITLE
VersionRange: accept null versions consistently

### DIFF
--- a/src/org/labkey/test/util/VersionRange.java
+++ b/src/org/labkey/test/util/VersionRange.java
@@ -23,7 +23,9 @@ public class VersionRange
 
     public static VersionRange versionRange(String earliestVersion, String latestVersion)
     {
-        return new VersionRange(new Version(earliestVersion), new Version(latestVersion));
+        Version earliest = earliestVersion == null ? null : new Version(earliestVersion);
+        Version latest = latestVersion == null ? null : new Version(latestVersion);
+        return new VersionRange(earliest, latest);
     }
 
     public boolean contains(Version version)


### PR DESCRIPTION
#### Rationale
This makes it possible to specify just a `@EarliestVersion` or a `@LatestVersion` without needing to specify both. Matches logic of `VersionRange.from(String version)` and `VersionRange.until(String version)`.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7210
- https://github.com/LabKey/limsModules/pull/1800
- https://github.com/LabKey/testAutomation/pull/2792
- https://github.com/LabKey/limsModules/pull/1803

#### Changes
- Support `null` values in `VersionRange.versionRange()`
