### PR TITLE
Update BaseUpgradeTest to use local enlistment version

### DIFF
--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.SystemUtils;
 import org.labkey.serverapi.reader.Readers;
 import org.labkey.test.util.CspLogUtil;
 import org.labkey.test.util.TestLogger;
+import org.labkey.test.util.Version;
 import org.openqa.selenium.Dimension;
 
 import java.io.File;
@@ -73,6 +74,31 @@ public abstract class TestProperties
             TestLogger.error("Failed to load " + propFile.getName() + " file. Running with hard-coded defaults");
             ioe.printStackTrace(System.err);
         }
+
+        final List<String> gradleProperties = List.of("labkeyVersion");
+        final File serverPropFile = new File(TestFileUtils.getLabKeyRoot(), "gradle.properties");
+        if (serverPropFile.exists())
+        {
+            try (Reader propReader = Readers.getReader(serverPropFile))
+            {
+                TestLogger.log("Loading properties from " + serverPropFile.getName());
+                Properties properties = new Properties();
+                properties.load(propReader);
+                for (String key : gradleProperties)
+                {
+                    if (properties.containsKey(key))
+                    {
+                        System.setProperty(key, properties.getProperty(key));
+                    }
+                }
+            }
+            catch (IOException ioe)
+            {
+                TestLogger.error("Failed to load " + serverPropFile.getName() + " file.");
+                ioe.printStackTrace(System.err);
+            }
+        }
+
     }
 
     private static ZoneId browserZoneId = null;
@@ -81,6 +107,19 @@ public abstract class TestProperties
     {
         /* Force static block to run */
         CspLogUtil.init();
+    }
+
+    /// Get the local enlistment version, stripping everything past the minor version.
+    /// - `"25.11.0"` -> `"25.11"`
+    /// - `"25.11-SNAPSHOT"` -> `"25.11"`
+    /// @return Enlistment Version or `null` if unable to determine
+    public static Version getProductVersion()
+    {
+        Version version = new Version(System.getProperty("labkeyVersion", "1"));
+        if (version.size() >= 2)
+            return version.trim(2);
+        else
+            return null;
     }
 
     public static boolean isTestCleanupSkipped()

--- a/src/org/labkey/test/tests/upgrade/BaseUpgradeTest.java
+++ b/src/org/labkey/test/tests/upgrade/BaseUpgradeTest.java
@@ -36,7 +36,7 @@ public abstract class BaseUpgradeTest extends BaseWebDriverTest
 
     protected static final boolean isUpgradeSetupPhase = TestProperties.getBooleanProperty("webtest.upgradeSetup", true);
     protected static final Version previousVersion = Optional.ofNullable(trimToNull(System.getProperty("webtest.upgradePreviousVersion")))
-        .map(Version::new).orElse(null);
+        .map(Version::new).orElse(TestProperties.getProductVersion());
 
     @Override
     protected boolean skipCleanup(boolean afterTest)
@@ -114,7 +114,7 @@ public abstract class BaseUpgradeTest extends BaseWebDriverTest
                 @Override
                 public void evaluate() throws Throwable
                 {
-                    Assume.assumeTrue("Test doesn't support upgrading from version: " + previousVersion,
+                    Assume.assumeTrue("Test not valid when upgrading from version: " + previousVersion,
                         VersionRange.versionRange(earliestVersion, latestVersion).contains(previousVersion)
                     );
                     base.evaluate();

--- a/src/org/labkey/test/util/Version.java
+++ b/src/org/labkey/test/util/Version.java
@@ -15,14 +15,22 @@ public class Version implements Comparable<Version>
 {
     private final List<Integer> _version;
 
-    public Version(Integer... version)
+    private Version(List<Integer> version)
     {
         _version = validate(version);
     }
 
+    public Version(Integer... version)
+    {
+        this(List.of(version));
+    }
+
     public Version(String version)
     {
-        this(Arrays.stream(version.split("\\.")).map(Integer::parseInt).toArray(Integer[]::new));
+        this(Arrays.stream(version
+                .split("-", 2)[0] // Remove snapshot suffix
+                .split("\\.")) // Split the version into major, minor, patch, etc. parts
+                .map(Integer::parseInt).toList());
     }
 
     public Version(Double version)
@@ -30,9 +38,9 @@ public class Version implements Comparable<Version>
         this(version.toString());
     }
 
-    private static List<Integer> validate(Integer... versionParts)
+    private static List<Integer> validate(List<Integer> versionParts)
     {
-        List<Integer> partList = List.of(versionParts);
+        List<Integer> partList = List.copyOf(versionParts);
         if (partList.isEmpty())
         {
             throw new IllegalArgumentException("Version must have at least one part");
@@ -45,6 +53,19 @@ public class Version implements Comparable<Version>
             }
         }
         return partList;
+    }
+
+    public Version trim(int maxParts)
+    {
+        if (maxParts == _version.size())
+            return this;
+        else
+            return new Version(_version.subList(0, maxParts));
+    }
+
+    public int size()
+    {
+        return _version.size();
     }
 
     @Override

--- a/src/org/labkey/test/util/VersionRange.java
+++ b/src/org/labkey/test/util/VersionRange.java
@@ -23,7 +23,9 @@ public class VersionRange
 
     public static VersionRange versionRange(String earliestVersion, String latestVersion)
     {
-        return new VersionRange(new Version(earliestVersion), new Version(latestVersion));
+        Version earliest = earliestVersion == null ? null : new Version(earliestVersion);
+        Version latest = latestVersion == null ? null : new Version(latestVersion);
+        return new VersionRange(earliest, latest);
     }
 
     public boolean contains(Version version)


### PR DESCRIPTION
#### Rationale
When running upgrade tests locally, it can be useful to check the enlistment version in order to control which tests are run.

#### Related Pull Requests
- N/A

#### Changes
- Update BaseUpgradeTest to use local enlistment version
