### PR TITLE
QueryChartDialog: Add locators and methods for legend position

### DIFF
--- a/src/org/labkey/test/components/react/QueryChartDialog.java
+++ b/src/org/labkey/test/components/react/QueryChartDialog.java
@@ -143,6 +143,34 @@ public class QueryChartDialog extends ModalDialog
         elementCache().fieldOptionIconByLabel(label).click();
     }
 
+    public QueryChartDialog setLegendPos(String legendPos)
+    {
+
+        if ("bottom".equals(legendPos))
+            elementCache().legendBottomRadio.check();
+        else if ("right".equals(legendPos))
+            elementCache().legendRightRadio.check();
+        else
+            throw new IllegalArgumentException("Invalid legend value: " + legendPos);
+
+        return this;
+    }
+
+    public String getLegendPos()
+    {
+        if (elementCache().legendBottomRadio.isChecked())
+            return "bottom";
+        else if (elementCache().legendRightRadio.isChecked())
+            return "right";
+
+        throw new IllegalStateException("Unexpected legend position");
+    }
+
+    public boolean isLegendPosVisible()
+    {
+        return elementCache().legendBottomRadio.isDisplayed() && elementCache().legendRightRadio.isDisplayed();
+    }
+
     /**
      * Set the axis scale to 'linear' or 'log' for the given axis
      * @param label the axis label
@@ -717,6 +745,8 @@ public class QueryChartDialog extends ModalDialog
         public RadioButton scaleLogRadio = RadioButton.RadioButton(Locator.radioButtonByNameAndValue("scaleTrans", "log")).refindWhenNeeded(fieldOptionPopover);
         public RadioButton scaleAutomaticRadio = RadioButton.RadioButton(Locator.radioButtonByNameAndValue("scaleType", "automatic")).refindWhenNeeded(fieldOptionPopover);
         public RadioButton scaleManualRadio = RadioButton.RadioButton(Locator.radioButtonByNameAndValue("scaleType", "manual")).refindWhenNeeded(fieldOptionPopover);
+        public RadioButton legendRightRadio = RadioButton.RadioButton(Locator.radioButtonByNameAndValue("legendPos", "right")).refindWhenNeeded(settingsPanel);
+        public RadioButton legendBottomRadio = RadioButton.RadioButton(Locator.radioButtonByNameAndValue("legendPos", "bottom")).refindWhenNeeded(settingsPanel);
         public Input scaleRangeMinInput = Input(Locator.input("scaleMin"), getDriver()).refindWhenNeeded(fieldOptionPopover);
         public Input scaleRangeMaxInput = Input(Locator.input("scaleMax"), getDriver()).refindWhenNeeded(fieldOptionPopover);
         public Input yLabelInput = Input(Locator.input("y-label"), getDriver()).refindWhenNeeded(fieldOptionPopover);


### PR DESCRIPTION
#### Rationale
This PR updates QueryChartDialog so we can add tests for charts with bottom legends

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1904
- https://github.com/LabKey/platform/pull/7245
- https://github.com/LabKey/limsModules/pull/1842
- https://github.com/LabKey/testAutomation/pull/2811

#### Changes
- QueryChartDialog: Add locators and methods for legend position
