### PR TITLE
Prevent `java.awt.HeadlessException` on Windows on TeamCity

### DIFF
--- a/src/org/labkey/test/Runner.java
+++ b/src/org/labkey/test/Runner.java
@@ -220,6 +220,7 @@ public class Runner extends TestSuite
     @Override
     public synchronized void runTest(final Test test, final TestResult testResult)
     {
+        System.setProperty("java.awt.headless", "false"); // Prevent `java.awt.HeadlessException` on Windows on TeamCity
         long startTimeMs = System.currentTimeMillis();
         if (_cleanOnly)
         {


### PR DESCRIPTION
#### Rationale
On Java 25, tests running on Windows agents are complaining that the application needs desktop access.
```
java.awt.HeadlessException:
The application does not have desktop access,
but this program performed an operation which requires it.
  at java.desktop/sun.awt.HeadlessToolkit.getSystemClipboard(HeadlessToolkit.java:216)
  at org.labkey.test.WebDriverWrapper.setClipboardContent(WebDriverWrapper.java:3607)
  at org.labkey.test.WebDriverWrapper.actionPaste(WebDriverWrapper.java:3570)
  at org.labkey.test.WebDriverWrapper.actionPaste(WebDriverWrapper.java:3597)
  at org.labkey.test.components.core.login.SetPasswordForm.pastePassword(SetPasswordForm.java:149)
  at org.labkey.test.components.core.login.SetPasswordForm.assertPasswordGuidance(SetPasswordForm.java:110)
  at org.labkey.test.components.core.login.SetPasswordForm.verifyPasswordStrengthGauge(SetPasswordForm.java:95)
  at org.labkey.test.LabKeySiteWrapper.checkForUpgrade(LabKeySiteWrapper.java:671)
  at org.labkey.test.LabKeySiteWrapper.signIn(LabKeySiteWrapper.java:355)
  at org.labkey.test.BaseWebDriverTest.doPreamble(BaseWebDriverTest.java:656)
  at org.labkey.test.BaseWebDriverTest$1.starting(BaseWebDriverTest.java:471)
```
We can "lie" and tell it that the environment is not headless by setting the `java.awt.headless` system property.

#### Related Pull Requests
- N/A

#### Changes
- Prevent `java.awt.HeadlessException` on Windows on TeamCity
