### PR TITLE
Set headless flag earlier in test initialization

### DIFF
--- a/src/org/labkey/test/Runner.java
+++ b/src/org/labkey/test/Runner.java
@@ -94,6 +94,14 @@ import static org.labkey.test.WebTestHelper.logToServer;
 
 public class Runner extends TestSuite
 {
+    static
+    {
+        // Prevent `java.awt.HeadlessException` on Windows on TeamCity
+        String headless = "java.awt.headless";
+        if (System.getProperty(headless) == null)
+            System.setProperty(headless, "false");
+    }
+
     private static final Logger LOG = LogManager.getLogger(Runner.class);
 
     private static final int DEFAULT_MAX_TEST_FAILURES = 10;
@@ -220,7 +228,6 @@ public class Runner extends TestSuite
     @Override
     public synchronized void runTest(final Test test, final TestResult testResult)
     {
-        System.setProperty("java.awt.headless", "false"); // Prevent `java.awt.HeadlessException` on Windows on TeamCity
         long startTimeMs = System.currentTimeMillis();
         if (_cleanOnly)
         {


### PR DESCRIPTION
#### Rationale
Forgot to check the test results from my previous "fix". AWT locks in headless mode at some point early so we need to set the flag as early as we can.

#### Related Pull Requests
- #2814 

#### Changes
- Set headless flag earlier in test initialization
