### PR TITLE
Try to address issue with customizing grid view in LKS.

### DIFF
--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -390,10 +390,17 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
 
         // Expand all nodes necessary to reveal the desired node.
         WebElement fieldRow = expandPivots(fieldKey);
-        // Just click the checkbox, don't need to click the row.
-        WebElement checkbox = Locator.css("input[type=button]").findElement(fieldRow);
+        WebElement checkbox = Locator.css("input[type=button]").refindWhenNeeded(fieldRow);
+
+        // In some situations calling Checkbox(checkbox).check() doesn't always check the checkbox. Verify that it has
+        // been checked, and if not try again.
         ScrollUtils.scrollIntoView(checkbox);
         new Checkbox(checkbox).check();
+        if (!new Checkbox(checkbox).isChecked())
+        {
+            new Checkbox(checkbox).check();
+        }
+
         itemXPath(type, fieldKey).waitForElement(this, 2_000);
     }
 

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -390,6 +390,7 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
 
         // Expand all nodes necessary to reveal the desired node.
         WebElement fieldRow = expandPivots(fieldKey);
+        // Just click the checkbox, don't need to click the row.
         WebElement checkbox = Locator.css("input[type=button]").findElement(fieldRow);
         ScrollUtils.scrollIntoView(checkbox);
         new Checkbox(checkbox).check();

--- a/src/org/labkey/test/components/CustomizeView.java
+++ b/src/org/labkey/test/components/CustomizeView.java
@@ -391,8 +391,6 @@ public class CustomizeView extends WebDriverComponent<CustomizeView.Elements>
         // Expand all nodes necessary to reveal the desired node.
         WebElement fieldRow = expandPivots(fieldKey);
         WebElement checkbox = Locator.css("input[type=button]").findElement(fieldRow);
-        WebElement rowLabel = Locator.byClass("x4-tree-node-text").findElement(fieldRow);
-        rowLabel.click();
         ScrollUtils.scrollIntoView(checkbox);
         new Checkbox(checkbox).check();
         itemXPath(type, fieldKey).waitForElement(this, 2_000);

--- a/src/org/labkey/test/components/ui/notifications/ServerNotificationMenu.java
+++ b/src/org/labkey/test/components/ui/notifications/ServerNotificationMenu.java
@@ -198,7 +198,7 @@ public class ServerNotificationMenu extends WebDriverComponent<ServerNotificatio
 
         // Find the container again, don't return listContainer WebElement previously found. If the list was slow to
         // update with the most recent notification the old reference will be stale.
-        return notificationsContainerLocator.waitForElement(elementCache().menuContent, 1_000);
+        return notificationsContainerLocator.refindWhenNeeded((elementCache().menuContent));
     }
 
     /**


### PR DESCRIPTION
#### Rationale
Some LKSM test have failed when trying to customize a grid view in LKS. Specifically if a field name is very long, there is a problem trying to scroll the label into view and click it.
It doesn't look like we need to click this label, clicking the checkbox associated with the label is enough. 

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1853

#### Changes
- Remove the code that finds and clicks the row label in CustomizeView.addItem.
