### PR TITLE
Account for the AssayID column being present.

### DIFF
--- a/src/org/labkey/test/tests/InlineImagesAssayTest.java
+++ b/src/org/labkey/test/tests/InlineImagesAssayTest.java
@@ -207,7 +207,7 @@ public class InlineImagesAssayTest extends BaseWebDriverTest
             log("Validate that the 'File' (last) column is as expected.");
             assertEquals("Values in 'File' column not exported as expected [" + exportedFile.getName() + "]",
                     Arrays.asList("Batch File Field", "assaydata" + File.separator + XLS_FILE.getName(), "assaydata" + File.separator + XLS_FILE.getName(), "assaydata" + File.separator + XLS_FILE.getName()),
-                    ExcelHelper.getColumnData(workbook.getSheetAt(workbook.getActiveSheetIndex()), 7));
+                    ExcelHelper.getColumnData(workbook.getSheetAt(workbook.getActiveSheetIndex()), 8));
         }
 
         log("Remove the 'File' (last) column from the batch and see that things still work.");

--- a/src/org/labkey/test/tests/TextChoiceTest.java
+++ b/src/org/labkey/test/tests/TextChoiceTest.java
@@ -248,6 +248,7 @@ public abstract class TextChoiceTest extends BaseWebDriverTest
 
             Map<String, String> expectedData = Map.of(RESULT_SAMPLE_FIELD, entry.getKey(),
                     RESULT_TC_FIELD, entry.getValue(),
+                    "Run/Name", ASSAY_RUN_ID,
                     String.format("Run/Batch/%s", BATCH_TC_FIELD), BATCH_VALUE,
                     String.format("Run/%s", RUN_TC_FIELD), expectedRunValue);
 


### PR DESCRIPTION
#### Rationale
AssayID column is now shown by default.

#### Related Pull Requests
- None.

#### Changes
- Added "Run/Name" column to TextChoice test.
- Change column index of expected data.
