### PR TITLE
Add support for moving workflow jobs

### DIFF
--- a/src/org/labkey/remoteapi/admin/SaveAuditSettingsCommand.java
+++ b/src/org/labkey/remoteapi/admin/SaveAuditSettingsCommand.java
@@ -1,0 +1,37 @@
+package org.labkey.remoteapi.admin;
+
+import org.json.JSONObject;
+import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.PostCommand;
+
+public class SaveAuditSettingsCommand extends PostCommand<CommandResponse>
+{
+    private static final String ACTION_NAME = "saveAuditSettings";
+    private static final String CONTROLLER_NAME = "audit";
+    private boolean _requireUserComments = false;
+
+    public SaveAuditSettingsCommand(boolean requireUserComments)
+    {
+        super(CONTROLLER_NAME, ACTION_NAME);
+        _requireUserComments = requireUserComments;
+    }
+
+    public boolean isRequireUserComments()
+    {
+        return _requireUserComments;
+    }
+
+    public void setRequireUserComments(boolean requireUserComments)
+    {
+        this._requireUserComments = requireUserComments;
+    }
+
+    @Override
+    public JSONObject getJsonObject()
+    {
+        JSONObject json = new JSONObject();
+        json.put("requireUserComments", isRequireUserComments());
+
+        return json;
+    }
+}

--- a/src/org/labkey/test/util/APIAssayHelper.java
+++ b/src/org/labkey/test/util/APIAssayHelper.java
@@ -82,15 +82,22 @@ public class APIAssayHelper extends AbstractAssayHelper
         return irc.execute(_test.createDefaultConnection(), projectPath);
     }
 
-    @LogMethod(quiet = true)
     public ImportRunResponse importAssay(int assayID, String runName, List<Map<String, Object>> dataRows, String projectPath,
                                          Map<String, Object> runProperties, Map<String, Object> batchProperties, String errorMsg) throws CommandException, IOException
+    {
+        return importAssay(assayID, runName, dataRows, projectPath, runProperties, batchProperties, errorMsg, null);
+    }
+
+    @LogMethod(quiet = true)
+    public ImportRunResponse importAssay(int assayID, String runName, List<Map<String, Object>> dataRows, String projectPath,
+                                         Map<String, Object> runProperties, Map<String, Object> batchProperties, String errorMsg, @Nullable Integer workflowTaskId) throws CommandException, IOException
     {
         ImportRunCommand  irc = new ImportRunCommand(assayID, dataRows);
         irc.setName(runName);
         irc.setProperties(runProperties);
         irc.setBatchProperties(batchProperties);
         irc.setTimeout(180000); // Wait 3 minutes for assay import
+        irc.setWorkflowTaskId(workflowTaskId);
         if (errorMsg != null)
         {
             try
@@ -121,7 +128,7 @@ public class APIAssayHelper extends AbstractAssayHelper
     public ImportRunResponse importAssay(int assayID, String runName, List<Map<String, Object>> dataRows, String projectPath,
                                          Map<String, Object> runProperties, Map<String, Object> batchProperties) throws CommandException, IOException
     {
-        return importAssay(assayID, runName, dataRows, projectPath, runProperties, batchProperties, null);
+        return importAssay(assayID, runName, dataRows, projectPath, runProperties, batchProperties, null, null);
     }
 
     @LogMethod(quiet = true)

--- a/src/org/labkey/test/util/AuditLogHelper.java
+++ b/src/org/labkey/test/util/AuditLogHelper.java
@@ -6,7 +6,6 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
-import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.query.ContainerFilter;
@@ -155,8 +154,6 @@ public class AuditLogHelper
         }
         return (Integer) rows.get(0).get(rowId);
     }
-
-
 
     public DataRegionTable beginAtAuditEventView(String auditTable, Integer rowIdCutoff)
     {

--- a/src/org/labkey/test/util/AuditLogHelper.java
+++ b/src/org/labkey/test/util/AuditLogHelper.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.query.ContainerFilter;
@@ -154,6 +155,8 @@ public class AuditLogHelper
         }
         return (Integer) rows.get(0).get(rowId);
     }
+
+
 
     public DataRegionTable beginAtAuditEventView(String auditTable, Integer rowIdCutoff)
     {


### PR DESCRIPTION
#### Rationale
Users want to move jobs around as they work to reorganize their data when the organization or its usage of the Workflow feature set expands.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1859

#### Changes
- Add `SaveAuditSettingsCommand` to set the `requireUserComments` property via API
- Add additional argument to `importAssay` to specify the job task to associate the run with
