### PR TITLE
Make `Component.waitForReady` cooperate with refinding components

### DIFF
--- a/src/org/labkey/test/components/Component.java
+++ b/src/org/labkey/test/components/Component.java
@@ -73,7 +73,12 @@ public abstract class Component<EC extends Component.ElementCache> implements Se
 
             _elementCache = Objects.requireNonNull(newElementCache());
             waitForReady();
-            Objects.requireNonNull(_elementCache, "waitForReady() cleared the element cache");
+            if (_elementCache == null)
+            {
+                // waitForReady triggered a cache clear -- either explicitly or due to a refind.
+                // It succeeded, so it should be safe to get a fresh `newElementCache`
+                _elementCache = Objects.requireNonNull(newElementCache());
+            }
         }
         return _elementCache;
     }


### PR DESCRIPTION
#### Rationale
A component found with `refindWhenNeeded` will automatically clear its cache after refinding. This can interfere with elementCache construction.
```
java.lang.NullPointerException: waitForReady() cleared the element cache
  at java.base/java.util.Objects.requireNonNull(Objects.java:235)
  at org.labkey.test.components.Component.elementCache(Component.java:76)
  at org.labkey.test.components.ui.notifications.ServerNotificationItem.getMessage(ServerNotificationItem.java:83)
  at org.labkey.test.tests.samplemanagement.samples.FMSampleFileImportTest.testCreateStorageWithLabels(FMSampleFileImportTest.java:2592)
```
If this `requireNonNull` gets triggered, `waitForReady` was successful or a component refind was successful. Either way, it should be safe to build a fresh element cache.


#### Related Pull Requests
- #2600

#### Changes
- Make `Component.waitForReady` cooperate with refinding components