### PR TITLE
GitHub Issue 73: Field editor Advanced Settings to allow for non-unique single-field index

### DIFF
--- a/src/org/labkey/test/components/domain/AdvancedSettingsDialog.java
+++ b/src/org/labkey/test/components/domain/AdvancedSettingsDialog.java
@@ -170,16 +170,10 @@ public class AdvancedSettingsDialog extends ModalDialog
         return this;
     }
 
-    public boolean isUniqueConstraint()
+    public AdvancedSettingsDialog setSingleFieldIndex(String type)
     {
-        return elementCache().uniqueConstraint.get();
-    }
-
-    public AdvancedSettingsDialog setUniqueConstraint(boolean checked)
-    {
-        elementCache().uniqueConstraint.set(checked);
-        getWrapper().waitFor(()-> elementCache().uniqueConstraint.get().equals(checked),
-                "uniqueConstraint checkbox was not set as expected", 1000);
+        if (type == null) type = "None";
+        elementCache().indexSelect.selectByVisibleText(type);
         return this;
     }
 
@@ -256,8 +250,8 @@ public class AdvancedSettingsDialog extends ModalDialog
                 Locator.input("domainpropertiesrow-recommendedVariable").findWhenNeeded(this));
         public Checkbox enableMissingValues = new Checkbox(
                 Locator.input("domainpropertiesrow-mvEnabled").findWhenNeeded(this));
-        public Checkbox uniqueConstraint = new Checkbox(
-                Locator.input("domainpropertiesrow-uniqueConstraint").findWhenNeeded(this));
+        public Select indexSelect = SelectWrapper.Select(Locator.tagWithAttribute("select", "name", "domainpropertiesrow-singleFieldConstraint"))
+                .findWhenNeeded(this);
     }
 
 }

--- a/src/org/labkey/test/components/domain/AdvancedSettingsDialog.java
+++ b/src/org/labkey/test/components/domain/AdvancedSettingsDialog.java
@@ -170,10 +170,10 @@ public class AdvancedSettingsDialog extends ModalDialog
         return this;
     }
 
-    public AdvancedSettingsDialog setSingleFieldIndex(String type)
+    public AdvancedSettingsDialog setSingleFieldIndex(SingleFieldIndexType type)
     {
-        if (type == null) type = "No Index";
-        elementCache().indexSelect.selectByVisibleText(type);
+        if (type == null) type = SingleFieldIndexType.NO_INDEX;
+        elementCache().indexSelect.selectByVisibleText(type.getText());
         return this;
     }
 
@@ -206,6 +206,25 @@ public class AdvancedSettingsDialog extends ModalDialog
     {
         dismiss("Cancel");
         return _row;
+    }
+
+    public enum SingleFieldIndexType
+    {
+        NO_INDEX("No Index"),
+        INDEX("Index"),
+        UNIQUE_INDEX("Index and require unique values");
+
+        private final String _text;
+
+        SingleFieldIndexType(String text)
+        {
+            _text = text;
+        }
+
+        public String getText()
+        {
+            return _text;
+        }
     }
 
     @Override

--- a/src/org/labkey/test/components/domain/AdvancedSettingsDialog.java
+++ b/src/org/labkey/test/components/domain/AdvancedSettingsDialog.java
@@ -172,7 +172,7 @@ public class AdvancedSettingsDialog extends ModalDialog
 
     public AdvancedSettingsDialog setSingleFieldIndex(String type)
     {
-        if (type == null) type = "None";
+        if (type == null) type = "No Index";
         elementCache().indexSelect.selectByVisibleText(type);
         return this;
     }

--- a/src/org/labkey/test/tests/DataClassTest.java
+++ b/src/org/labkey/test/tests/DataClassTest.java
@@ -24,6 +24,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
+import org.labkey.test.components.domain.AdvancedSettingsDialog;
 import org.labkey.test.components.domain.BaseDomainDesigner;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.core.admin.BaseSettingsPage.DATE_FORMAT;
@@ -49,6 +50,7 @@ import static org.labkey.test.util.DataRegionTable.DataRegion;
 public class DataClassTest extends BaseWebDriverTest
 {
     private static final String PROJECT_NAME = "DataClassTestProject";
+    boolean IS_POSTGRES = WebTestHelper.getDatabaseType() == WebTestHelper.DatabaseType.PostgreSQL;
 
     @Override
     public List<String> getAssociatedModules()
@@ -275,10 +277,10 @@ public class DataClassTest extends BaseWebDriverTest
         createPage.clickSave();
 
         viewRawTableMetadata(dataClassName);
-        verifyTableIndices("unique_constraint_test_", List.of("field_name1", "fieldname_2"));
+        verifyTableIndices("unique_constraint_test_", List.of("field_Name1", "fieldName_2"));
         assertTextNotPresent("unique_constraint_test_fieldname_3");
-        verifyTableIndexNonUnique("unique_constraint_test_", "field_name1", true);
-        verifyTableIndexNonUnique("unique_constraint_test_", "fieldname_2", false);
+        verifyTableIndexNonUnique("unique_constraint_test_", "field_Name1", true);
+        verifyTableIndexNonUnique("unique_constraint_test_", "fieldName_2", false);
 
         log("Remove a field unique constraint and add a new one");
         goToProjectHome();
@@ -292,10 +294,10 @@ public class DataClassTest extends BaseWebDriverTest
                 .apply();
         updatePage.clickSave();
         viewRawTableMetadata(dataClassName);
-        verifyTableIndices("unique_constraint_test_", List.of("fieldname_2", "fieldname_3"));
+        verifyTableIndices("unique_constraint_test_", List.of("fieldName_2", "FieldName_3"));
         assertTextNotPresent("unique_constraint_test_field_name1");
-        verifyTableIndexNonUnique("unique_constraint_test_", "fieldname_2", false);
-        verifyTableIndexNonUnique("unique_constraint_test_", "fieldname_3", true);
+        verifyTableIndexNonUnique("unique_constraint_test_", "fieldName_2", false);
+        verifyTableIndexNonUnique("unique_constraint_test_", "FieldName_3", true);
     }
 
     @Test
@@ -413,7 +415,11 @@ public class DataClassTest extends BaseWebDriverTest
 
     private void verifyTableIndexNonUnique(String prefix, String suffix, boolean isUnique)
     {
-        Locator locator = Locator.xpath("//td[contains(text(), '" + prefix + suffix + "')]/preceding-sibling::td[2][text()='" + !isUnique + "']");
+        String boolDisplay = isUnique ? "0" : "1";
+        if (IS_POSTGRES) boolDisplay = isUnique ? "false" : "true";
+        String fieldKey = prefix + suffix;
+        if (IS_POSTGRES) fieldKey = fieldKey.toLowerCase();
+        Locator locator = Locator.xpath("//td[contains(text(), '" + fieldKey + "')]/preceding-sibling::td[2][text()='" + boolDisplay + "']");
         checker().verifyTrue("Non_Unique value not as expected in metadata for locator: " + locator, locator.existsIn(getDriver()));
     }
 

--- a/src/org/labkey/test/tests/DataClassTest.java
+++ b/src/org/labkey/test/tests/DataClassTest.java
@@ -262,12 +262,12 @@ public class DataClassTest extends BaseWebDriverTest
         DomainFormPanel domainFormPanel = createPage.getDomainEditor();
         domainFormPanel.manuallyDefineFields(fieldName1)
                 .setType(FieldDefinition.ColumnType.Integer)
-                .expand().clickAdvancedSettings().setSingleFieldIndex("Unique").apply();
+                .expand().clickAdvancedSettings().setSingleFieldIndex("Index and require unique values").apply();
         log("Add another field with a non-unique constraint");
         String fieldName2 = "fieldName_2";
         domainFormPanel.addField(fieldName2)
                 .setType(FieldDefinition.ColumnType.DateAndTime)
-                .expand().clickAdvancedSettings().setSingleFieldIndex("Non-Unique").apply();
+                .expand().clickAdvancedSettings().setSingleFieldIndex("Index").apply();
         log("Add another field which does not have a unique constraint");
         String fieldName3 = "FieldName@3";
         domainFormPanel.addField(fieldName3)
@@ -288,7 +288,7 @@ public class DataClassTest extends BaseWebDriverTest
                 .expand().clickAdvancedSettings().setSingleFieldIndex(null)
                 .apply();
         domainFormPanel.getField(fieldName3)
-                .expand().clickAdvancedSettings().setSingleFieldIndex("Unique")
+                .expand().clickAdvancedSettings().setSingleFieldIndex("Index and require unique values")
                 .apply();
         updatePage.clickSave();
         viewRawTableMetadata(dataClassName);

--- a/src/org/labkey/test/tests/DataClassTest.java
+++ b/src/org/labkey/test/tests/DataClassTest.java
@@ -262,12 +262,12 @@ public class DataClassTest extends BaseWebDriverTest
         DomainFormPanel domainFormPanel = createPage.getDomainEditor();
         domainFormPanel.manuallyDefineFields(fieldName1)
                 .setType(FieldDefinition.ColumnType.Integer)
-                .expand().clickAdvancedSettings().setUniqueConstraint(true).apply();
-        log("Add another field with a unique constraint");
+                .expand().clickAdvancedSettings().setSingleFieldIndex("Unique").apply();
+        log("Add another field with a non-unique constraint");
         String fieldName2 = "fieldName_2";
         domainFormPanel.addField(fieldName2)
                 .setType(FieldDefinition.ColumnType.DateAndTime)
-                .expand().clickAdvancedSettings().setUniqueConstraint(true).apply();
+                .expand().clickAdvancedSettings().setSingleFieldIndex("Non-Unique").apply();
         log("Add another field which does not have a unique constraint");
         String fieldName3 = "FieldName@3";
         domainFormPanel.addField(fieldName3)
@@ -276,21 +276,26 @@ public class DataClassTest extends BaseWebDriverTest
 
         viewRawTableMetadata(dataClassName);
         verifyTableIndices("unique_constraint_test_", List.of("field_name1", "fieldname_2"));
+        assertTextNotPresent("unique_constraint_test_fieldname_3");
+        verifyTableIndexNonUnique("unique_constraint_test_", "field_name1", true);
+        verifyTableIndexNonUnique("unique_constraint_test_", "fieldname_2", false);
 
         log("Remove a field unique constraint and add a new one");
         goToProjectHome();
         CreateDataClassPage updatePage = goToDataClass(dataClassName);
         domainFormPanel = updatePage.getDomainEditor();
-        domainFormPanel.getField(fieldName2)
-                .expand().clickAdvancedSettings().setUniqueConstraint(false)
+        domainFormPanel.getField(fieldName1)
+                .expand().clickAdvancedSettings().setSingleFieldIndex(null)
                 .apply();
         domainFormPanel.getField(fieldName3)
-                .expand().clickAdvancedSettings().setUniqueConstraint(true)
+                .expand().clickAdvancedSettings().setSingleFieldIndex("Unique")
                 .apply();
         updatePage.clickSave();
         viewRawTableMetadata(dataClassName);
-        verifyTableIndices("unique_constraint_test_", List.of("field_name1", "fieldname_3"));
-        assertTextNotPresent("unique_constraint_test_fieldname_2");
+        verifyTableIndices("unique_constraint_test_", List.of("fieldname_2", "fieldname_3"));
+        assertTextNotPresent("unique_constraint_test_field_name1");
+        verifyTableIndexNonUnique("unique_constraint_test_", "fieldname_2", false);
+        verifyTableIndexNonUnique("unique_constraint_test_", "fieldname_3", true);
     }
 
     @Test
@@ -404,6 +409,12 @@ public class DataClassTest extends BaseWebDriverTest
 
         for (String suffix : suffixes)
             assertTextPresentCaseInsensitive(prefix + suffix);
+    }
+
+    private void verifyTableIndexNonUnique(String prefix, String suffix, boolean isUnique)
+    {
+        Locator locator = Locator.xpath("//td[contains(text(), '" + prefix + suffix + "')]/preceding-sibling::td[2][text()='" + !isUnique + "']");
+        checker().verifyTrue("Non_Unique value not as expected in metadata for locator: " + locator, locator.existsIn(getDriver()));
     }
 
     private CreateDataClassPage goToCreateNewDataClass()

--- a/src/org/labkey/test/tests/DataClassTest.java
+++ b/src/org/labkey/test/tests/DataClassTest.java
@@ -262,12 +262,12 @@ public class DataClassTest extends BaseWebDriverTest
         DomainFormPanel domainFormPanel = createPage.getDomainEditor();
         domainFormPanel.manuallyDefineFields(fieldName1)
                 .setType(FieldDefinition.ColumnType.Integer)
-                .expand().clickAdvancedSettings().setSingleFieldIndex("Index and require unique values").apply();
+                .expand().clickAdvancedSettings().setSingleFieldIndex(AdvancedSettingsDialog.SingleFieldIndexType.UNIQUE_INDEX).apply();
         log("Add another field with a non-unique constraint");
         String fieldName2 = "fieldName_2";
         domainFormPanel.addField(fieldName2)
                 .setType(FieldDefinition.ColumnType.DateAndTime)
-                .expand().clickAdvancedSettings().setSingleFieldIndex("Index").apply();
+                .expand().clickAdvancedSettings().setSingleFieldIndex(AdvancedSettingsDialog.SingleFieldIndexType.INDEX).apply();
         log("Add another field which does not have a unique constraint");
         String fieldName3 = "FieldName@3";
         domainFormPanel.addField(fieldName3)
@@ -288,7 +288,7 @@ public class DataClassTest extends BaseWebDriverTest
                 .expand().clickAdvancedSettings().setSingleFieldIndex(null)
                 .apply();
         domainFormPanel.getField(fieldName3)
-                .expand().clickAdvancedSettings().setSingleFieldIndex("Index and require unique values")
+                .expand().clickAdvancedSettings().setSingleFieldIndex(AdvancedSettingsDialog.SingleFieldIndexType.UNIQUE_INDEX)
                 .apply();
         updatePage.clickSave();
         viewRawTableMetadata(dataClassName);

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -1830,12 +1830,12 @@ public class SampleTypeTest extends BaseWebDriverTest
         DomainFormPanel domainFormPanel = createPage.getFieldsPanel();
         domainFormPanel.manuallyDefineFields(fieldName1)
                 .setType(ColumnType.Integer)
-                .expand().clickAdvancedSettings().setSingleFieldIndex("Non-Unique").apply();
+                .expand().clickAdvancedSettings().setSingleFieldIndex("Index").apply();
         log("Add another field with a unique constraint");
         String fieldName2 = "fieldName_2";
         domainFormPanel.addField(fieldName2)
                 .setType(ColumnType.DateAndTime)
-                .expand().clickAdvancedSettings().setSingleFieldIndex("Unique").apply();
+                .expand().clickAdvancedSettings().setSingleFieldIndex("Index and require unique values").apply();
         log("Add another field which does not have a unique constraint");
         String fieldName3 = "FieldName@3";
         domainFormPanel.addField(fieldName3)
@@ -1853,10 +1853,10 @@ public class SampleTypeTest extends BaseWebDriverTest
         UpdateSampleTypePage updatePage = sampleHelper.goToEditSampleType(sampleTypeName);
         domainFormPanel = updatePage.getFieldsPanel();
         domainFormPanel.getField(fieldName2)
-                .expand().clickAdvancedSettings().setSingleFieldIndex("Non-Unique")
+                .expand().clickAdvancedSettings().setSingleFieldIndex("Index")
                 .apply();
         domainFormPanel.getField(fieldName3)
-                .expand().clickAdvancedSettings().setSingleFieldIndex("Unique")
+                .expand().clickAdvancedSettings().setSingleFieldIndex("Index and require unique values")
                 .apply();
         updatePage.clickSave();
         viewRawTableMetadata(sampleTypeName);

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -1825,17 +1825,17 @@ public class SampleTypeTest extends BaseWebDriverTest
                 .goToCreateNewSampleType()
                 .setName(sampleTypeName);
 
-        log("Add a field with a unique constraint");
+        log("Add a field with a non-unique constraint");
         String fieldName1 = "field Name1";
         DomainFormPanel domainFormPanel = createPage.getFieldsPanel();
         domainFormPanel.manuallyDefineFields(fieldName1)
                 .setType(ColumnType.Integer)
-                .expand().clickAdvancedSettings().setUniqueConstraint(true).apply();
+                .expand().clickAdvancedSettings().setSingleFieldIndex("Non-Unique").apply();
         log("Add another field with a unique constraint");
         String fieldName2 = "fieldName_2";
         domainFormPanel.addField(fieldName2)
                 .setType(ColumnType.DateAndTime)
-                .expand().clickAdvancedSettings().setUniqueConstraint(true).apply();
+                .expand().clickAdvancedSettings().setSingleFieldIndex("Unique").apply();
         log("Add another field which does not have a unique constraint");
         String fieldName3 = "FieldName@3";
         domainFormPanel.addField(fieldName3)
@@ -1844,21 +1844,26 @@ public class SampleTypeTest extends BaseWebDriverTest
 
         viewRawTableMetadata(sampleTypeName);
         verifyTableIndices("unique_constraint_test_", List.of("field_name1", "fieldname_2"));
+        assertTextNotPresent("unique_constraint_test_fieldname_3");
+        verifyTableIndexNonUnique("unique_constraint_test_", "field_name1", false);
+        verifyTableIndexNonUnique("unique_constraint_test_", "fieldname_2", true);
 
         log("Remove a field unique constraint and add a new one");
         goToProjectHome();
         UpdateSampleTypePage updatePage = sampleHelper.goToEditSampleType(sampleTypeName);
         domainFormPanel = updatePage.getFieldsPanel();
         domainFormPanel.getField(fieldName2)
-                .expand().clickAdvancedSettings().setUniqueConstraint(false)
+                .expand().clickAdvancedSettings().setSingleFieldIndex("Non-Unique")
                 .apply();
         domainFormPanel.getField(fieldName3)
-                .expand().clickAdvancedSettings().setUniqueConstraint(true)
+                .expand().clickAdvancedSettings().setSingleFieldIndex("Unique")
                 .apply();
         updatePage.clickSave();
         viewRawTableMetadata(sampleTypeName);
         verifyTableIndices("unique_constraint_test_", List.of("field_name1", "fieldname_3"));
-        assertTextNotPresent("unique_constraint_test_fieldname_2");
+        verifyTableIndexNonUnique("unique_constraint_test_", "field_name1", false);
+        verifyTableIndexNonUnique("unique_constraint_test_", "fieldname_2", false);
+        verifyTableIndexNonUnique("unique_constraint_test_", "fieldname_3", true);
     }
 
     @Test
@@ -2018,6 +2023,12 @@ public class SampleTypeTest extends BaseWebDriverTest
 
         for (String suffix : suffixes)
             assertTextPresentCaseInsensitive(prefix + suffix);
+    }
+
+    private void verifyTableIndexNonUnique(String prefix, String suffix, boolean isUnique)
+    {
+        Locator locator = Locator.xpath("//td[contains(text(), '" + prefix + suffix + "')]/preceding-sibling::td[2][text()='" + !isUnique + "']");
+        checker().verifyTrue("Non_Unique value not as expected in metadata for locator: " + locator, locator.existsIn(getDriver()));
     }
 
     private void setFileAttachment(int index, File attachment)

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -38,6 +38,7 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.components.assay.AssayConstants;
+import org.labkey.test.components.domain.AdvancedSettingsDialog;
 import org.labkey.test.components.domain.BaseDomainDesigner;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.ext4.Window;
@@ -105,6 +106,7 @@ public class SampleTypeTest extends BaseWebDriverTest
     private static final String LOWER_CASE_SAMPLE_TYPE = CASE_INSENSITIVE_SAMPLE_TYPE.toLowerCase();
     private static final String UPPER_CASE_SAMPLE_TYPE = CASE_INSENSITIVE_SAMPLE_TYPE.toUpperCase();
     private static final TestUser USER_FOR_FILTERTEST = new TestUser("filter_user@sampletypetest.test");
+    boolean IS_POSTGRES = WebTestHelper.getDatabaseType() == WebTestHelper.DatabaseType.PostgreSQL;
 
     @Override
     public List<String> getAssociatedModules()
@@ -1843,10 +1845,10 @@ public class SampleTypeTest extends BaseWebDriverTest
         createPage.clickSave();
 
         viewRawTableMetadata(sampleTypeName);
-        verifyTableIndices("unique_constraint_test_", List.of("field_name1", "fieldname_2"));
+        verifyTableIndices("unique_constraint_test_", List.of("field_Name1", "fieldName_2"));
         assertTextNotPresent("unique_constraint_test_fieldname_3");
-        verifyTableIndexNonUnique("unique_constraint_test_", "field_name1", false);
-        verifyTableIndexNonUnique("unique_constraint_test_", "fieldname_2", true);
+        verifyTableIndexNonUnique("unique_constraint_test_", "field_Name1", false);
+        verifyTableIndexNonUnique("unique_constraint_test_", "fieldName_2", true);
 
         log("Remove a field unique constraint and add a new one");
         goToProjectHome();
@@ -1860,10 +1862,10 @@ public class SampleTypeTest extends BaseWebDriverTest
                 .apply();
         updatePage.clickSave();
         viewRawTableMetadata(sampleTypeName);
-        verifyTableIndices("unique_constraint_test_", List.of("field_name1", "fieldname_3"));
-        verifyTableIndexNonUnique("unique_constraint_test_", "field_name1", false);
-        verifyTableIndexNonUnique("unique_constraint_test_", "fieldname_2", false);
-        verifyTableIndexNonUnique("unique_constraint_test_", "fieldname_3", true);
+        verifyTableIndices("unique_constraint_test_", List.of("field_name1", "FieldName_3"));
+        verifyTableIndexNonUnique("unique_constraint_test_", "field_Name1", false);
+        verifyTableIndexNonUnique("unique_constraint_test_", "fieldName_2", false);
+        verifyTableIndexNonUnique("unique_constraint_test_", "FieldName_3", true);
     }
 
     @Test
@@ -2027,7 +2029,11 @@ public class SampleTypeTest extends BaseWebDriverTest
 
     private void verifyTableIndexNonUnique(String prefix, String suffix, boolean isUnique)
     {
-        Locator locator = Locator.xpath("//td[contains(text(), '" + prefix + suffix + "')]/preceding-sibling::td[2][text()='" + !isUnique + "']");
+        String boolDisplay = isUnique ? "0" : "1";
+        if (IS_POSTGRES) boolDisplay = isUnique ? "false" : "true";
+        String fieldKey = prefix + suffix;
+        if (IS_POSTGRES) fieldKey = fieldKey.toLowerCase();
+        Locator locator = Locator.xpath("//td[contains(text(), '" + fieldKey + "')]/preceding-sibling::td[2][text()='" + boolDisplay + "']");
         checker().verifyTrue("Non_Unique value not as expected in metadata for locator: " + locator, locator.existsIn(getDriver()));
     }
 

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -1830,12 +1830,12 @@ public class SampleTypeTest extends BaseWebDriverTest
         DomainFormPanel domainFormPanel = createPage.getFieldsPanel();
         domainFormPanel.manuallyDefineFields(fieldName1)
                 .setType(ColumnType.Integer)
-                .expand().clickAdvancedSettings().setSingleFieldIndex("Index").apply();
+                .expand().clickAdvancedSettings().setSingleFieldIndex(AdvancedSettingsDialog.SingleFieldIndexType.INDEX).apply();
         log("Add another field with a unique constraint");
         String fieldName2 = "fieldName_2";
         domainFormPanel.addField(fieldName2)
                 .setType(ColumnType.DateAndTime)
-                .expand().clickAdvancedSettings().setSingleFieldIndex("Index and require unique values").apply();
+                .expand().clickAdvancedSettings().setSingleFieldIndex(AdvancedSettingsDialog.SingleFieldIndexType.UNIQUE_INDEX).apply();
         log("Add another field which does not have a unique constraint");
         String fieldName3 = "FieldName@3";
         domainFormPanel.addField(fieldName3)
@@ -1853,10 +1853,10 @@ public class SampleTypeTest extends BaseWebDriverTest
         UpdateSampleTypePage updatePage = sampleHelper.goToEditSampleType(sampleTypeName);
         domainFormPanel = updatePage.getFieldsPanel();
         domainFormPanel.getField(fieldName2)
-                .expand().clickAdvancedSettings().setSingleFieldIndex("Index")
+                .expand().clickAdvancedSettings().setSingleFieldIndex(AdvancedSettingsDialog.SingleFieldIndexType.INDEX)
                 .apply();
         domainFormPanel.getField(fieldName3)
-                .expand().clickAdvancedSettings().setSingleFieldIndex("Index and require unique values")
+                .expand().clickAdvancedSettings().setSingleFieldIndex(AdvancedSettingsDialog.SingleFieldIndexType.UNIQUE_INDEX)
                 .apply();
         updatePage.clickSave();
         viewRawTableMetadata(sampleTypeName);

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -1589,45 +1589,56 @@ public class ListTest extends BaseWebDriverTest
         viewRawTableMetadata(listName);
         verifyTableIndices("unique_constraint_list_", Collections.emptyList());
 
-        // set two fields to have unique constraints
+        // set fields to have constraints
         EditListDefinitionPage listDefinitionPage = _listHelper.goToEditDesign(listName);
         listDefinitionPage.getFieldsPanel()
-                .getField(fieldName1).expand().clickAdvancedSettings().setUniqueConstraint(true)
+                .getField(fieldName1).expand().clickAdvancedSettings().setSingleFieldIndex("Unique")
                 .apply();
         listDefinitionPage.getFieldsPanel()
-                .getField(fieldName2).expand().clickAdvancedSettings().setUniqueConstraint(true)
+                .getField(fieldName2).expand().clickAdvancedSettings().setSingleFieldIndex("Unique")
+                .apply();
+        // set one field to have non-unique constraint
+        listDefinitionPage.getFieldsPanel()
+                .getField(fieldName3).expand().clickAdvancedSettings().setSingleFieldIndex("Non-Unique")
                 .apply();
         listDefinitionPage.clickSave();
 
         AuditLogHelper.DetailedAuditEventRow expectedDomainEvent = new AuditLogHelper.DetailedAuditEventRow(null, listName, null,
                 "The descriptor of domain " + listName + " was updated.",
-                "", null, null, "Indices:  > [field Name1, unique: true, fieldName_2, unique: true]");
+                "", null, null, "Indices:  > [FieldName@3, unique: false, field Name1, unique: true, fieldName_2, unique: true]");
         boolean pass = _auditLogHelper.validateLastDomainAuditEvents(listName, getProjectName(), expectedDomainEvent, Collections.emptyMap());
         checker().verifyTrue("Domain audit comment not as expected after updating field unique constraint", pass);
 
         viewRawTableMetadata(listName);
-        verifyTableIndices("unique_constraint_list_", List.of("field_name1", "fieldname_2"));
-        assertTextNotPresent("unique_constraint_list_fieldname_3");
+        verifyTableIndices("unique_constraint_list_", List.of("field_name1", "fieldname_2", "fieldname_3"));
+        verifyTableIndexNonUnique("unique_constraint_list_", "field_name1", true);
+        verifyTableIndexNonUnique("unique_constraint_list_", "fieldname_2", true);
+        verifyTableIndexNonUnique("unique_constraint_list_", "fieldname_3", false);
 
-        // remove a field unique constraint and add a new one
+        // remove a field unique constraint, change a field from unique -> non-unique, and change one from non-unique -> unique
         listDefinitionPage = _listHelper.goToEditDesign(listName);
         listDefinitionPage.getFieldsPanel()
-                .getField(fieldName2).expand().clickAdvancedSettings().setUniqueConstraint(false)
+                .getField(fieldName1).expand().clickAdvancedSettings().setSingleFieldIndex(null)
                 .apply();
         listDefinitionPage.getFieldsPanel()
-                .getField(fieldName3).expand().clickAdvancedSettings().setUniqueConstraint(true)
+                .getField(fieldName2).expand().clickAdvancedSettings().setSingleFieldIndex("Non-Unique")
+                .apply();
+        listDefinitionPage.getFieldsPanel()
+                .getField(fieldName3).expand().clickAdvancedSettings().setSingleFieldIndex("Unique")
                 .apply();
         listDefinitionPage.clickSave();
 
         expectedDomainEvent = new AuditLogHelper.DetailedAuditEventRow(null, listName, null,
                 "The descriptor of domain " + listName + " was updated.",
-                "", null, null, "Indices: [field name1, unique: true, fieldname_2, unique: true] > [FieldName@3, unique: true, field Name1, unique: true]");
+                "", null, null, "Indices: [field name1, unique: true, fieldname@3, unique: false, fieldname_2, unique: true] > [FieldName@3, unique: true, fieldName_2, unique: false]");
         pass = _auditLogHelper.validateLastDomainAuditEvents(listName, getProjectName(), expectedDomainEvent, Collections.emptyMap());
         checker().verifyTrue("Domain audit comment not as expected after updating field unique constraint", pass);
 
         viewRawTableMetadata(listName);
-        verifyTableIndices("unique_constraint_list_", List.of("field_name1", "fieldname_3"));
-        assertTextNotPresent("unique_constraint_list_fieldname_2");
+        verifyTableIndices("unique_constraint_list_", List.of("fieldname_2", "fieldname_3"));
+        assertTextNotPresent("unique_constraint_list_field_name1");
+        verifyTableIndexNonUnique("unique_constraint_list_", "fieldname_2", false);
+        verifyTableIndexNonUnique("unique_constraint_list_", "fieldname_3", true);
     }
 
     @Test // Issue 52247
@@ -1696,6 +1707,12 @@ public class ListTest extends BaseWebDriverTest
 
         for (String suffix : suffixes)
             assertTextPresentCaseInsensitive(prefix + suffix);
+    }
+
+    private void verifyTableIndexNonUnique(String prefix, String suffix, boolean isUnique)
+    {
+        Locator locator = Locator.xpath("//td[contains(text(), '" + prefix + suffix + "')]/preceding-sibling::td[2][text()='" + !isUnique + "']");
+        checker().verifyTrue("Non_Unique value not as expected in metadata for locator: " + locator, locator.existsIn(getDriver()));
     }
 
     /**

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -38,6 +38,7 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Data;
 import org.labkey.test.categories.Hosting;
 import org.labkey.test.components.CustomizeView;
+import org.labkey.test.components.domain.AdvancedSettingsDialog;
 import org.labkey.test.components.domain.BaseDomainDesigner;
 import org.labkey.test.components.domain.ConditionalFormatDialog;
 import org.labkey.test.components.domain.DomainFieldRow;
@@ -101,6 +102,7 @@ public class ListTest extends BaseWebDriverTest
     protected final static String LIST_NAME_HTML_KEY = "A_HtmlKey_" + DOMAIN_TRICKY_CHARACTERS;
     protected final static ColumnType LIST_KEY_TYPE = ColumnType.String;
     protected final static String LIST_KEY_NAME = "Key";
+    boolean IS_POSTGRES = WebTestHelper.getDatabaseType() == WebTestHelper.DatabaseType.PostgreSQL;
 
     protected final static String LIST_KEY_NAME2 = "Color \"`~!@#$%^&*()_-+={}[]|\\:;<>,.?/";
     protected final static String LIST_KEY_NAME2_BULK = "\"Color \"\"`~!@#$%^&*()_-+={}[]|\\:;<>,.?/\"";
@@ -1610,10 +1612,10 @@ public class ListTest extends BaseWebDriverTest
         checker().verifyTrue("Domain audit comment not as expected after updating field unique constraint", pass);
 
         viewRawTableMetadata(listName);
-        verifyTableIndices("unique_constraint_list_", List.of("field_name1", "fieldname_2", "fieldname_3"));
-        verifyTableIndexNonUnique("unique_constraint_list_", "field_name1", true);
-        verifyTableIndexNonUnique("unique_constraint_list_", "fieldname_2", true);
-        verifyTableIndexNonUnique("unique_constraint_list_", "fieldname_3", false);
+        verifyTableIndices("unique_constraint_list_", List.of("field_Name1", "fieldName_2", "FieldName_3"));
+        verifyTableIndexNonUnique("unique_constraint_list_", "field_Name1", true);
+        verifyTableIndexNonUnique("unique_constraint_list_", "fieldName_2", true);
+        verifyTableIndexNonUnique("unique_constraint_list_", "FieldName_3", false);
 
         // remove a field unique constraint, change a field from unique -> non-unique, and change one from non-unique -> unique
         listDefinitionPage = _listHelper.goToEditDesign(listName);
@@ -1628,17 +1630,19 @@ public class ListTest extends BaseWebDriverTest
                 .apply();
         listDefinitionPage.clickSave();
 
+        String expectedDataChanges = "Indices: [field name1, unique: true, fieldname@3, unique: false, fieldname_2, unique: true] > [FieldName@3, unique: true, fieldName_2, unique: false]";
+        if (!IS_POSTGRES) expectedDataChanges = "Indices: [FieldName@3, unique: false, field Name1, unique: true, fieldName_2, unique: true] > [FieldName@3, unique: true, fieldName_2, unique: false]";
         expectedDomainEvent = new AuditLogHelper.DetailedAuditEventRow(null, listName, null,
                 "The descriptor of domain " + listName + " was updated.",
-                "", null, null, "Indices: [field name1, unique: true, fieldname@3, unique: false, fieldname_2, unique: true] > [FieldName@3, unique: true, fieldName_2, unique: false]");
+                "", null, null, expectedDataChanges);
         pass = _auditLogHelper.validateLastDomainAuditEvents(listName, getProjectName(), expectedDomainEvent, Collections.emptyMap());
         checker().verifyTrue("Domain audit comment not as expected after updating field unique constraint", pass);
 
         viewRawTableMetadata(listName);
-        verifyTableIndices("unique_constraint_list_", List.of("fieldname_2", "fieldname_3"));
+        verifyTableIndices("unique_constraint_list_", List.of("fieldName_2", "FieldName_3"));
         assertTextNotPresent("unique_constraint_list_field_name1");
-        verifyTableIndexNonUnique("unique_constraint_list_", "fieldname_2", false);
-        verifyTableIndexNonUnique("unique_constraint_list_", "fieldname_3", true);
+        verifyTableIndexNonUnique("unique_constraint_list_", "fieldName_2", false);
+        verifyTableIndexNonUnique("unique_constraint_list_", "FieldName_3", true);
     }
 
     @Test // Issue 52247
@@ -1711,7 +1715,11 @@ public class ListTest extends BaseWebDriverTest
 
     private void verifyTableIndexNonUnique(String prefix, String suffix, boolean isUnique)
     {
-        Locator locator = Locator.xpath("//td[contains(text(), '" + prefix + suffix + "')]/preceding-sibling::td[2][text()='" + !isUnique + "']");
+        String boolDisplay = isUnique ? "0" : "1";
+        if (IS_POSTGRES) boolDisplay = isUnique ? "false" : "true";
+        String fieldKey = prefix + suffix;
+        if (IS_POSTGRES) fieldKey = fieldKey.toLowerCase();
+        Locator locator = Locator.xpath("//td[contains(text(), '" + fieldKey + "')]/preceding-sibling::td[2][text()='" + boolDisplay + "']");
         checker().verifyTrue("Non_Unique value not as expected in metadata for locator: " + locator, locator.existsIn(getDriver()));
     }
 

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -1592,14 +1592,14 @@ public class ListTest extends BaseWebDriverTest
         // set fields to have constraints
         EditListDefinitionPage listDefinitionPage = _listHelper.goToEditDesign(listName);
         listDefinitionPage.getFieldsPanel()
-                .getField(fieldName1).expand().clickAdvancedSettings().setSingleFieldIndex("Index and require unique values")
+                .getField(fieldName1).expand().clickAdvancedSettings().setSingleFieldIndex(AdvancedSettingsDialog.SingleFieldIndexType.UNIQUE_INDEX)
                 .apply();
         listDefinitionPage.getFieldsPanel()
-                .getField(fieldName2).expand().clickAdvancedSettings().setSingleFieldIndex("Index and require unique values")
+                .getField(fieldName2).expand().clickAdvancedSettings().setSingleFieldIndex(AdvancedSettingsDialog.SingleFieldIndexType.UNIQUE_INDEX)
                 .apply();
         // set one field to have non-unique constraint
         listDefinitionPage.getFieldsPanel()
-                .getField(fieldName3).expand().clickAdvancedSettings().setSingleFieldIndex("Index")
+                .getField(fieldName3).expand().clickAdvancedSettings().setSingleFieldIndex(AdvancedSettingsDialog.SingleFieldIndexType.INDEX)
                 .apply();
         listDefinitionPage.clickSave();
 
@@ -1621,10 +1621,10 @@ public class ListTest extends BaseWebDriverTest
                 .getField(fieldName1).expand().clickAdvancedSettings().setSingleFieldIndex(null)
                 .apply();
         listDefinitionPage.getFieldsPanel()
-                .getField(fieldName2).expand().clickAdvancedSettings().setSingleFieldIndex("Index")
+                .getField(fieldName2).expand().clickAdvancedSettings().setSingleFieldIndex(AdvancedSettingsDialog.SingleFieldIndexType.INDEX)
                 .apply();
         listDefinitionPage.getFieldsPanel()
-                .getField(fieldName3).expand().clickAdvancedSettings().setSingleFieldIndex("Index and require unique values")
+                .getField(fieldName3).expand().clickAdvancedSettings().setSingleFieldIndex(AdvancedSettingsDialog.SingleFieldIndexType.UNIQUE_INDEX)
                 .apply();
         listDefinitionPage.clickSave();
 

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -1592,14 +1592,14 @@ public class ListTest extends BaseWebDriverTest
         // set fields to have constraints
         EditListDefinitionPage listDefinitionPage = _listHelper.goToEditDesign(listName);
         listDefinitionPage.getFieldsPanel()
-                .getField(fieldName1).expand().clickAdvancedSettings().setSingleFieldIndex("Unique")
+                .getField(fieldName1).expand().clickAdvancedSettings().setSingleFieldIndex("Index and require unique values")
                 .apply();
         listDefinitionPage.getFieldsPanel()
-                .getField(fieldName2).expand().clickAdvancedSettings().setSingleFieldIndex("Unique")
+                .getField(fieldName2).expand().clickAdvancedSettings().setSingleFieldIndex("Index and require unique values")
                 .apply();
         // set one field to have non-unique constraint
         listDefinitionPage.getFieldsPanel()
-                .getField(fieldName3).expand().clickAdvancedSettings().setSingleFieldIndex("Non-Unique")
+                .getField(fieldName3).expand().clickAdvancedSettings().setSingleFieldIndex("Index")
                 .apply();
         listDefinitionPage.clickSave();
 
@@ -1621,10 +1621,10 @@ public class ListTest extends BaseWebDriverTest
                 .getField(fieldName1).expand().clickAdvancedSettings().setSingleFieldIndex(null)
                 .apply();
         listDefinitionPage.getFieldsPanel()
-                .getField(fieldName2).expand().clickAdvancedSettings().setSingleFieldIndex("Non-Unique")
+                .getField(fieldName2).expand().clickAdvancedSettings().setSingleFieldIndex("Index")
                 .apply();
         listDefinitionPage.getFieldsPanel()
-                .getField(fieldName3).expand().clickAdvancedSettings().setSingleFieldIndex("Unique")
+                .getField(fieldName3).expand().clickAdvancedSettings().setSingleFieldIndex("Index and require unique values")
                 .apply();
         listDefinitionPage.clickSave();
 


### PR DESCRIPTION
#### Rationale
[#73](https://github.com/LabKey/internal-issues/issues/73) Make it easy to add indices on lookup fields (LabKey Issue: 53827)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1915
- https://github.com/LabKey/platform/pull/7295
- https://github.com/LabKey/limsModules/pull/1879
- https://github.com/LabKey/testAutomation/pull/2827
- https://github.com/LabKey/premiumModules/pull/442

#### Changes
- Selenium test updates to check non-unique index for fields via the schema browser table viewer
