### PR TITLE
GitHub #503: Add option to open URL links in a new tab in the domain designer UI (LabKey Issue: 54178)

### DIFF
--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -1651,7 +1651,7 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
                 .refindWhenNeeded(this), getDriver());
         public final Input urlInput = new Input(Locator.tagWithAttributeContaining("input", "id", "domainpropertiesrow-URL-")
                 .refindWhenNeeded(this), getDriver());
-        protected final Locator urlTargetCheckboxLoc = Locator.input("domainpropertiesrow-URLTarget");
+        protected final Locator urlTargetCheckboxLoc = Locator.input("domainpropertiesrow-isTargetBlank");
         public final Checkbox urlTargetCheckbox = new Checkbox(urlTargetCheckboxLoc.refindWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT));
 
         // numeric field options

--- a/src/org/labkey/test/components/domain/DomainFieldRow.java
+++ b/src/org/labkey/test/components/domain/DomainFieldRow.java
@@ -373,6 +373,19 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
         return this;
     }
 
+    public boolean isUrlOpenNewTab()
+    {
+        expand();
+        return elementCache().urlTargetCheckbox.get();
+    }
+
+    public DomainFieldRow setUrlOpenNewTab(boolean checked)
+    {
+        expand();
+        elementCache().urlTargetCheckbox.set(checked);
+        return this;
+    }
+
     //
     // numeric field options.
 
@@ -1638,6 +1651,8 @@ public class DomainFieldRow extends WebDriverComponent<DomainFieldRow.ElementCac
                 .refindWhenNeeded(this), getDriver());
         public final Input urlInput = new Input(Locator.tagWithAttributeContaining("input", "id", "domainpropertiesrow-URL-")
                 .refindWhenNeeded(this), getDriver());
+        protected final Locator urlTargetCheckboxLoc = Locator.input("domainpropertiesrow-URLTarget");
+        public final Checkbox urlTargetCheckbox = new Checkbox(urlTargetCheckboxLoc.refindWhenNeeded(this).withTimeout(WAIT_FOR_JAVASCRIPT));
 
         // numeric field options
         public final Select defaultScaleTypeSelect = SelectWrapper.Select(Locator.name("domainpropertiesrow-defaultScale"))

--- a/src/org/labkey/test/components/domain/DomainFormPanel.java
+++ b/src/org/labkey/test/components/domain/DomainFormPanel.java
@@ -178,6 +178,8 @@ public class DomainFormPanel extends DomainPanel<DomainFormPanel.ElementCache, D
             fieldRow.setCharCount(fieldDefinition.getScale());
         if (fieldDefinition.getURL() != null)
             fieldRow.setUrl(fieldDefinition.getURL());
+        if (fieldDefinition.isURLOpenNewTab())
+            fieldRow.setUrlOpenNewTab(fieldDefinition.isURLOpenNewTab());
         if (fieldDefinition.getImportAliases() != null)
             fieldRow.setImportAliases(fieldDefinition.getImportAliases());
         if (fieldDefinition.getRequired())

--- a/src/org/labkey/test/params/FieldDefinition.java
+++ b/src/org/labkey/test/params/FieldDefinition.java
@@ -278,6 +278,18 @@ public class FieldDefinition extends PropertyDescriptor
         return this;
     }
 
+    public boolean isURLOpenNewTab()
+    {
+        Object val = getFieldProperty("URLTarget");
+        return "_blank".equals(val);
+    }
+
+    public FieldDefinition setURLOpenNewTab(boolean openNewTab)
+    {
+        setFieldProperty("URLTarget", openNewTab ? "_blank" : null);
+        return this;
+    }
+
     public String getImportAliases()
     {
         return (String) getFieldProperty("importAliases");

--- a/src/org/labkey/test/tests/ContainerContextTest.java
+++ b/src/org/labkey/test/tests/ContainerContextTest.java
@@ -142,7 +142,8 @@ public class ContainerContextTest extends BaseWebDriverTest
         log("** Creating lookup target list in sub-folder");
         List<FieldDefinition> lookupTargetCols = List.of(
             new FieldDefinition("LookupName", FieldDefinition.ColumnType.String).setDescription("Lookup Name"),
-            new FieldDefinition("LookupAge", FieldDefinition.ColumnType.Integer).setDescription("Lookup Age").setURL("fake/action.view?key=${Key}")
+            new FieldDefinition("LookupAge", FieldDefinition.ColumnType.Integer).setDescription("Lookup Age")
+                    .setURL("fake/action.view?key=${Key}").setURLOpenNewTab(true)
         );
         String lookupTargetListName = SUB_FOLDER_A + "-LookupTarget-List";
         TestDataGenerator subfolderDgen = new IntListDefinition(lookupTargetListName, LIST_KEY_NAME).setFields(lookupTargetCols)
@@ -202,6 +203,8 @@ public class ContainerContextTest extends BaseWebDriverTest
         href = getAttribute(Locator.linkWithText("200"), "href");
         assertTrue("Expected ListLookup/LookupAge link to go to " + getProjectName() + "/" + SUB_FOLDER_A + " container, href=" + href,
                 href.contains(getProjectName() + "/" + SUB_FOLDER_A) && href.contains("fake") && href.contains("action.view?key=2"));
+
+        assertEquals("Expected LookupAge link target to be _blank", "_blank", getAttribute(Locator.linkWithText("200"), "target"));
     }
 
     // Issue 15751: Pipeline job list generates URLs without correct container

--- a/src/org/labkey/test/tests/DomainDesignerTest.java
+++ b/src/org/labkey/test/tests/DomainDesignerTest.java
@@ -1676,6 +1676,11 @@ public class DomainDesignerTest extends BaseWebDriverTest
             verifyExpectedFieldProperties(createdField, exportedField);
         }
 
+        // verify URL settings for the boolean field
+        DomainFieldRow boolFieldRow = domainDesignerPage.fieldsPanel().getField("booleanField");
+        checker().verifyEquals("URL value not retained after import/export", "fake/list-def.url", boolFieldRow.getUrl());
+        checker().verifyEquals("URL open in new tab value not retained after import/export", true, boolFieldRow.isUrlOpenNewTab());
+
         // now create a list with the set of created Keys
         String roundTripList = "roundTripListNameCreatedFromJsonFields";
         EditListDefinitionPage listDefPage = _listHelper.beginCreateList(getProjectName(), roundTripList);
@@ -1746,6 +1751,11 @@ public class DomainDesignerTest extends BaseWebDriverTest
                     roundTrippedFields.get(i).getName(), is(uiFields.get(i)));
         }
         assertThat(exportedFields.keySet(), is(roundTrippedFields.keySet()));
+
+        // verify URL settings for the boolean field
+        DomainFieldRow boolFieldRow = sampleTypeDesignerPage.fieldsPanel().getField("booleanField");
+        checker().verifyEquals("URL value not retained after import/export", "fake/list-def.url", boolFieldRow.getUrl());
+        checker().verifyEquals("URL open in new tab value not retained after import/export", true, boolFieldRow.isUrlOpenNewTab());
     }
 
     @Test
@@ -1793,7 +1803,8 @@ public class DomainDesignerTest extends BaseWebDriverTest
         fields.add(new FieldDefinition("booleanField", FieldDefinition.ColumnType.Boolean)
                 .setLabel("Boolean Field")
                 .setRequired(true)
-                .setURL("fake/list-def.url"));
+                .setURL("fake/list-def.url")
+                .setURLOpenNewTab(true));
         fields.add(new FieldDefinition("attachmentField", FieldDefinition.ColumnType.Attachment)
                 .setHidden(true));
         fields.add(new FieldDefinition("decimalField", FieldDefinition.ColumnType.Decimal).

--- a/src/org/labkey/test/tests/LinkedSchemaTest.java
+++ b/src/org/labkey/test/tests/LinkedSchemaTest.java
@@ -292,6 +292,7 @@ public class LinkedSchemaTest extends BaseWebDriverTest
             "          <column columnName=\"R\">\n" +
             "            <columnTitle>A_People template Query R</columnTitle>\n" +
             "            <url>fake/a_template_metadata.view</url>\n" +
+            "            <urlTarget>_blank</urlTarget>\n" +
             "          </column>\n" +
             "        </columns>\n" +
             "    </table>\n" +
@@ -668,8 +669,8 @@ public class LinkedSchemaTest extends BaseWebDriverTest
                 .addField(new FieldDefinition("Name", FieldDefinition.ColumnType.String).setLabel("Name").setDescription("Name"))
                 .addField(new FieldDefinition("Age", FieldDefinition.ColumnType.Integer).setLabel("Age").setDescription("Age"))
                 .addField(new FieldDefinition("Crazy", FieldDefinition.ColumnType.Boolean).setLabel("Crazy").setDescription("Crazy?"))
-                .addField(new FieldDefinition("P", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " P").setURL("fake/" + LIST_DEF_URL))
-                .addField(new FieldDefinition("Q", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " Q").setURL("fake/" + LIST_DEF_URL))
+                .addField(new FieldDefinition("P", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " P").setURL("fake/" + LIST_DEF_URL).setURLOpenNewTab(false))
+                .addField(new FieldDefinition("Q", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " Q").setURL("fake/" + LIST_DEF_URL).setURLOpenNewTab(true))
                 .addField(new FieldDefinition("R", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " R").setURL("fake/" + LIST_DEF_URL))
                 .addField(new FieldDefinition("S", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " S").setURL("fake/" + LIST_DEF_URL))
                 .addField(new FieldDefinition("T", FieldDefinition.ColumnType.String).setLabel(LIST_DEF_TITLE + " T").setURL("fake/" + LIST_DEF_URL))
@@ -736,7 +737,9 @@ public class LinkedSchemaTest extends BaseWebDriverTest
         assertEquals("Expected to filter table to only Adam", "Adam", table.getDataAsText(0, A_PEOPLE_METADATA_TITLE));
         log("** Verify table metadata overrides when simplemodule is not active in TargetFolder");
         assertHrefContains(table, "A_People db_metadata List P", "a_db_metadata.view");
+        assertEquals("P link target not as expected", "", table.getLinkAttribute(0, table.getColumnIndexStrict("A_People db_metadata List P"), "target"));
         assertHrefContains(table, "A_People db_metadata List Q", "a_db_metadata.view");
+        assertEquals("Q link target not as expected", "_blank", table.getLinkAttribute(0, table.getColumnIndexStrict("A_People db_metadata List Q"), "target"));
         assertHrefContains(table, "A_People db_metadata List R", "a_db_metadata.view");
         assertHrefContains(table, "A_People db_metadata List S", "a_db_metadata.view");
         assertHrefContains(table, "A_People template List T", "a_template_metadata.view");
@@ -779,7 +782,9 @@ public class LinkedSchemaTest extends BaseWebDriverTest
         impersonate(READER_USER);
         assertHrefContains(table, "A_People db_metadata Query P", "a_db_metadata.view");
         assertHrefContains(table, "A_People file_metadata Query Q", "a_template_file_metadata.view");
+        assertEquals("Q link target not as expected", "_blank", table.getLinkAttribute(0, table.getColumnIndexStrict("A_People file_metadata Query Q"), "target"));
         assertHrefContains(table, "A_People template Query R", "a_template_metadata.view");
+        assertEquals("R link target not as expected", "_blank", table.getLinkAttribute(0, table.getColumnIndexStrict("A_People template Query R"), "target"));
         // Columns S-Z have their URL removed by the linked schema.
         assertHrefNotPresent(table, "file_metadata Query S");
         assertHrefNotPresent(table, "file_metadata Query T");

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -765,7 +765,7 @@ public class DataRegionTable extends DataRegion
 
     private String _getHref(int row, int column)
     {
-        return link(row, column).getAttribute("href");
+        return getLinkAttribute(row, column, "href");
     }
 
     public String getHref(int row, CharSequence columnIdentifier)
@@ -790,6 +790,11 @@ public class DataRegionTable extends DataRegion
     public boolean hasHref(int row, CharSequence columnIdentifier)
     {
         return hasHref(row, getColumnIndexStrict(columnIdentifier));
+    }
+
+    public String getLinkAttribute(int row, int column, String attr)
+    {
+        return link(row, column).getAttribute(attr);
     }
 
     public WebElement getFlag(int row, CharSequence columnIdentifier)


### PR DESCRIPTION
#### Rationale
[#503](https://github.com/LabKey/internal-issues/issues/503) LKSM: Add option to open URL links in a new tab in the domain designer UI (LabKey Issue: 54178)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1919
- https://github.com/LabKey/platform/pull/7304
- https://github.com/LabKey/limsModules/pull/1887
- https://github.com/LabKey/commonAssays/pull/974
- https://github.com/LabKey/testAutomation/pull/2831

#### Changes
- Selenium test updates to check for link/href target when set via field editor or XML metadata
