### PR TITLE
Update expected error message for knitr report

### DIFF
--- a/src/org/labkey/test/tests/AbstractKnitrReportTest.java
+++ b/src/org/labkey/test/tests/AbstractKnitrReportTest.java
@@ -175,7 +175,7 @@ public abstract class AbstractKnitrReportTest extends BaseWebDriverTest
                                             Locator.tag("img").withAttribute("alt", "plot of chunk blood-pressure-scatter")), // new
                                     Locator.tag("pre").containing("## \"1\",249318596,\"2008-05-17\",86,36,129,76,64"),
                                     Locator.tag("pre").withText("## knitr says hello to HTML!"),
-                                    Locator.tag("pre").startsWith("## Error").containing(": non-numeric argument to binary operator"),
+                                    Locator.tag("pre").startsWith("## Error").containing("non-numeric argument to binary operator"),
                                     Locator.tag("p").startsWith("Well, everything seems to be working. Let's ask R what is the value of \u03C0? Of course it is 3.141"),
                                     nonceCheckSuccessLoc // Inline script should run
         };


### PR DESCRIPTION
#### Rationale
A recent update to one of the knitr dependencies pulled in by our `rserve-service` docker container slightly changed the format for the error message we check for.
<img width="359" height="42" alt="image" src="https://github.com/user-attachments/assets/daabb75a-d6cd-4f98-a9fe-9808a81942aa" />

```
org.openqa.selenium.NoSuchElementException: Expected condition failed: waiting for xpath=//pre[starts-with(normalize-space(), '## Error')][contains(normalize-space(), ': non-numeric argument to binary operator')]
within: [[FirefoxDriver: firefox on linux (a6104892-fd56-46c6-9334-216a6d2da3e7)] -> css selector: div.reportView > div.labkey-knitr] (tried for 60 second(s) with 100 milliseconds interval)
  at app//org.labkey.test.Locator.waitForElement(Locator.java:570)
  at app//org.labkey.test.Locator.waitForElement(Locator.java:546)
  at app//org.labkey.test.Locator.waitForElement(Locator.java:539)
  at app//org.labkey.test.util.RReportHelper.assertKnitrReportContents(RReportHelper.java:552)
  at app//org.labkey.test.tests.AbstractKnitrReportTest.createAndVerifyKnitrReport(AbstractKnitrReportTest.java:148)
  at app//org.labkey.test.tests.AbstractKnitrReportTest.createAndVerifyKnitrReport(AbstractKnitrReportTest.java:137)
  at app//org.labkey.test.tests.AbstractKnitrReportTest.htmlFormat(AbstractKnitrReportTest.java:189)
  at app//org.labkey.test.tests.rserve.RemoteRKnitrTest.testKnitrHTMLFormat(RemoteRKnitrTest.java:23)
```

#### Related Pull Requests
- N/A

#### Changes
- Update expected error message for knitr report
