### PR TITLE
GitHub Issue 717: Reserve fields from ExpDataTable in DataClassDomainKind

### DIFF
--- a/src/org/labkey/test/tests/DataClassTest.java
+++ b/src/org/labkey/test/tests/DataClassTest.java
@@ -164,6 +164,13 @@ public class DataClassTest extends BaseWebDriverTest
                 "'name' is a reserved field name in 'Reserved Field Names Test'.",
                 "Please correct errors in Reserved Field Names Test before saving."),
                 createPage.clickSaveExpectingErrors());
+        domainFormPanel.removeAllFields(false);
+
+        domainFormPanel.manuallyDefineFields("protocol");
+        assertEquals("Data class reserved field name error", Arrays.asList(
+                        "'protocol' is a reserved field name in 'Reserved Field Names Test'.",
+                        "Please correct errors in Reserved Field Names Test before saving."),
+                createPage.clickSaveExpectingErrors());
 
         createPage.clickCancel();
     }

--- a/src/org/labkey/test/tests/DataClassTest.java
+++ b/src/org/labkey/test/tests/DataClassTest.java
@@ -171,6 +171,13 @@ public class DataClassTest extends BaseWebDriverTest
                         "'protocol' is a reserved field name in 'Reserved Field Names Test'.",
                         "Please correct errors in Reserved Field Names Test before saving."),
                 createPage.clickSaveExpectingErrors());
+        domainFormPanel.removeAllFields(false);
+
+        domainFormPanel.manuallyDefineFields("Name Expression");
+        assertEquals("Data class reserved field name error", Arrays.asList(
+                        "'Name Expression' is a reserved field name in 'Reserved Field Names Test'.",
+                        "Please correct errors in Reserved Field Names Test before saving."),
+                createPage.clickSaveExpectingErrors());
 
         createPage.clickCancel();
     }


### PR DESCRIPTION
#### Rationale
Issue [717](https://github.com/LabKey/internal-issues/issues/717) The data class domain kind does not reserve fields from the ExpDataTable, in contrast to the corresponding domain kind and table for samples. 

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7311

#### Changes
- Update test for data class reserved fields to include one from `ExpDataTable`.
