### PR TITLE
FIx EditableGridTest failures

### DIFF
--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -215,6 +215,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
             throw new NoSuchElementException("there is no selection column for grid");
 
         var checkBoxes = Locator.tag("tr").child("td")
+                .child(Locator.byClass("table-cell-content"))
                 .child(Locator.tagWithAttribute("input", "type", "checkbox"))
                 .findElements(elementCache().table);
         getWrapper().scrollIntoView(checkBoxes.get(start)); // Make sure the header isn't in the way

--- a/src/org/labkey/test/tests/component/EditableGridTest.java
+++ b/src/org/labkey/test/tests/component/EditableGridTest.java
@@ -459,12 +459,13 @@ public class EditableGridTest extends BaseWebDriverTest
         Tests the scenario where a row is selected, then another, and another are shift-selected
         expects the range-bump to redefine the selected range
      */
-    @Test public void testShiftSelect_bumpSelect()
+    @Test public void testShiftSelectMultipleTimes()
     {
         EditableGrid testGrid = goToEditableGrid(PASTING_SAMPLE_TYPE);
         testGrid.addRows(15);
 
         Locator boxes = Locator.tag("tr").child("td")
+                .child(Locator.byClass("table-cell-content"))
                 .child(Locator.tagWithAttribute("input", "type", "checkbox"));
         var checkBoxes = boxes.findElements(testGrid);
         scrollIntoView(checkBoxes.get(2), false);


### PR DESCRIPTION
#### Rationale
My recent PR for improved column widths changed how we render table cells, which broke the locators used by `EdtiableGridTest` and `EditableGrid`.

#### Related Pull Requests
- n/a

#### Changes
- Fix locators for Editable Grid checkboxes
- Rename `testShiftSelect_bumpSelect` to `testShiftSelectMultipleTimes`
