### PR TITLE
Add SimpleFormCommand and backport upgrade test conditions 

### DIFF
--- a/src/org/labkey/remoteapi/SimpleFormCommand.java
+++ b/src/org/labkey/remoteapi/SimpleFormCommand.java
@@ -1,0 +1,43 @@
+package org.labkey.remoteapi;
+
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class SimpleFormCommand extends Command<CommandResponse, HttpUriRequest>
+{
+    private final Map<String, String> _formData;
+
+    public SimpleFormCommand(String controller, String action, Map<String, String> formData)
+    {
+        super(controller, action);
+        _formData = formData;
+    }
+
+    public CommandResponse execute(Connection connection) throws IOException, CommandException
+    {
+        return execute(connection, null);
+    }
+
+    @Override
+    protected HttpUriRequest createRequest(URI uri)
+    {
+        HttpPost post = new HttpPost(uri);
+
+        List<NameValuePair> args = new ArrayList<>();
+        for (Map.Entry<String, String> reportVal : _formData.entrySet())
+        {
+            args.add(new BasicNameValuePair(reportVal.getKey(), reportVal.getValue()));
+        }
+        post.setEntity(new UrlEncodedFormEntity(args));
+        return post;
+    }
+}

--- a/src/org/labkey/test/tests/upgrade/BaseUpgradeTest.java
+++ b/src/org/labkey/test/tests/upgrade/BaseUpgradeTest.java
@@ -35,8 +35,9 @@ public abstract class BaseUpgradeTest extends BaseWebDriverTest
 {
 
     protected static final boolean isUpgradeSetupPhase = TestProperties.getBooleanProperty("webtest.upgradeSetup", true);
-    protected static final Version previousVersion = Optional.ofNullable(trimToNull(System.getProperty("webtest.upgradePreviousVersion")))
-        .map(Version::new).orElse(TestProperties.getProductVersion());
+    protected static final Version setupVersion = isUpgradeSetupPhase ? TestProperties.getProductVersion() :
+        Optional.ofNullable(trimToNull(System.getProperty("webtest.upgradePreviousVersion"))).map(Version::new)
+            .orElse(TestProperties.getProductVersion());
 
     @Override
     protected boolean skipCleanup(boolean afterTest)
@@ -68,6 +69,29 @@ public abstract class BaseUpgradeTest extends BaseWebDriverTest
     public List<String> getAssociatedModules()
     {
         return Arrays.asList();
+    }
+
+    /**
+     * Checks if the setup for the current test was performed in a version prior to the specified version.
+     *
+     * @param version The version to check against.
+     * @return {@code true} if the setup version is earlier than the specified version.
+     */
+    protected boolean wasSetupBefore(String version)
+    {
+        return !wasSetupWithin(version, null);
+    }
+
+    /**
+     * Checks if the setup for the current test was performed within the specified version range (inclusive).
+     *
+     * @param earliestVersion The earliest version in the range (inclusive).
+     * @param latestVersion The latest version in the range (inclusive).
+     * @return {@code true} if the setup version is within the specified range.
+     */
+    protected boolean wasSetupWithin(String earliestVersion, String latestVersion)
+    {
+        return VersionRange.versionRange(earliestVersion, latestVersion).contains(setupVersion);
     }
 
     /**
@@ -104,7 +128,7 @@ public abstract class BaseUpgradeTest extends BaseWebDriverTest
             String latestVersion = Optional.ofNullable(description.getAnnotation(LatestVersion.class))
                 .map(LatestVersion::value).orElse(null);
 
-            if (isUpgradeSetupPhase || previousVersion == null || (earliestVersion == null && latestVersion == null))
+            if (isUpgradeSetupPhase || setupVersion == null || (earliestVersion == null && latestVersion == null))
             {
                 return base; // Run the test normally
             }
@@ -114,8 +138,8 @@ public abstract class BaseUpgradeTest extends BaseWebDriverTest
                 @Override
                 public void evaluate() throws Throwable
                 {
-                    Assume.assumeTrue("Test not valid when upgrading from version: " + previousVersion,
-                        VersionRange.versionRange(earliestVersion, latestVersion).contains(previousVersion)
+                    Assume.assumeTrue("Test not valid when upgrading from version: " + setupVersion,
+                        VersionRange.versionRange(earliestVersion, latestVersion).contains(setupVersion)
                     );
                     base.evaluate();
                 }

--- a/src/org/labkey/test/util/VersionRange.java
+++ b/src/org/labkey/test/util/VersionRange.java
@@ -1,26 +1,62 @@
 package org.labkey.test.util;
 
+/**
+ * Represents a range of LabKey versions.
+ * Used for checking if a specific version falls within an inclusive range.
+ */
 public class VersionRange
 {
-    private final Version eariestVersion;
+    private final Version earliestVersion;
     private final Version latestVersion;
 
-    public VersionRange(Version eariestVersion, Version latestVersion)
+    /**
+     * Constructs a version range.
+     *
+     * @param earliestVersion The earliest version in the range (inclusive). If null, there is no lower bound.
+     * @param latestVersion The latest version in the range (inclusive). If null, there is no upper bound.
+     * @throws IllegalArgumentException if both versions are null, or if earliestVersion is after latestVersion.
+     */
+    public VersionRange(Version earliestVersion, Version latestVersion)
     {
-        this.eariestVersion = eariestVersion;
+        this.earliestVersion = earliestVersion;
         this.latestVersion = latestVersion;
+
+        if (earliestVersion == null && latestVersion == null)
+            throw new IllegalArgumentException("Version range requires at least one version");
+        if (earliestVersion != null && latestVersion != null && earliestVersion.compareTo(latestVersion) > 0)
+            throw new IllegalArgumentException("%s is after %s".formatted(earliestVersion, latestVersion));
+
     }
 
+    /**
+     * Creates a version range starting from the specified version with no upper bound.
+     *
+     * @param version The earliest version (inclusive).
+     * @return A new {@link VersionRange}.
+     */
     public static VersionRange from(String version)
     {
         return new VersionRange(new Version(version), null);
     }
 
+    /**
+     * Creates a version range ending at the specified version with no lower bound.
+     *
+     * @param version The latest version (inclusive).
+     * @return A new {@link VersionRange}.
+     */
     public static VersionRange until(String version)
     {
         return new VersionRange(null, new Version(version));
     }
 
+    /**
+     * Creates a version range with specified bounds.
+     *
+     * @param earliestVersion The earliest version (inclusive). If null, there is no lower bound.
+     * @param latestVersion The latest version (inclusive). If null, there is no upper bound.
+     * @return A new {@link VersionRange}.
+     */
     public static VersionRange versionRange(String earliestVersion, String latestVersion)
     {
         Version earliest = earliestVersion == null ? null : new Version(earliestVersion);
@@ -28,9 +64,15 @@ public class VersionRange
         return new VersionRange(earliest, latest);
     }
 
+    /**
+     * Checks if the specified version is within this range (inclusive).
+     *
+     * @param version The version to check.
+     * @return {@code true} if the version is within the range.
+     */
     public boolean contains(Version version)
     {
-        return (eariestVersion == null || eariestVersion.compareTo(version) <= 0) &&
+        return (earliestVersion == null || earliestVersion.compareTo(version) <= 0) &&
             (latestVersion == null || latestVersion.compareTo(version) >= 0);
     }
 }


### PR DESCRIPTION
#### Rationale
Backporting some upgrade test improvements to help with Mixture batch upgrade test.

We've lacked a simple method for tests to POST to LabKey form views (ones that don't accept JSON or URL parameters) for quite some time.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1903

#### Changes
- Backport #2834 
- Add SimpleFormCommand
