### PR TITLE
Close empty project menu before retrying open

### DIFF
--- a/src/org/labkey/test/components/core/ProjectMenu.java
+++ b/src/org/labkey/test/components/core/ProjectMenu.java
@@ -89,6 +89,8 @@ public class ProjectMenu extends WebDriverComponent<ProjectMenu.ElementCache>
             openMenu.run();
             if (!Locator.tagWithClass("div", "folder-nav").existsIn(this))
             {
+                // Menu opened but the folder list didn't load
+                close();
                 openMenu.run(); // retry
             }
         }


### PR DESCRIPTION
#### Rationale
The previous attempt to fix the non-opening project menu wasn't quite right. It needs to close the menu before attempting to reopen it, otherwise the retry just closes it.

#### Related Pull Requests
- #2828 

#### Changes
- Close empty project menu before retrying open
