### PR TITLE
Scroll the domain designer save button into view

### DIFF
--- a/src/org/labkey/test/components/domain/BaseDomainDesigner.java
+++ b/src/org/labkey/test/components/domain/BaseDomainDesigner.java
@@ -4,6 +4,7 @@ import org.labkey.test.BootstrapLocators;
 import org.labkey.test.Locator;
 import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
+import org.labkey.test.util.selenium.ScrollUtils;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -66,7 +67,8 @@ public abstract class BaseDomainDesigner<EC extends BaseDomainDesigner.ElementCa
      */
     public Object clickSave()
     {
-        getWrapper().clickAndWait(elementCache().saveButton);
+        // Selenium sometimes doesn't think the save button needs to be scrolled into view but the click does nothing.
+        getWrapper().clickAndWait(ScrollUtils.scrollIntoView(elementCache().saveButton));
         return null;
     }
 

--- a/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
@@ -122,6 +122,10 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
     {
         expandPropertiesPanel();
         elementCache().nameExpressionInput.set(nameExpression);
+        if (nameExpression.contains("${genId}"))
+        {
+            var _ = WebDriverWrapper.waitFor(this::isGenIdVisible, 2_000);
+        }
         return getThis();
     }
 

--- a/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
@@ -124,7 +124,9 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
         elementCache().nameExpressionInput.set(nameExpression);
         if (nameExpression.contains("${genId}"))
         {
-            var _ = WebDriverWrapper.waitFor(this::isGenIdVisible, 2_000);
+            // Wait for genId banner to avoid interfering with subsequent steps by shifting the page layout
+            // Non-fatal to let specific tests check for this
+            var _ = WebDriverWrapper.waitFor(this::isGenIdVisible, 1_000);
         }
         return getThis();
     }


### PR DESCRIPTION
#### Rationale
This test failure happens when there is just a pixel of the save button visible. For some reason Selenium doesn't scroll it into view and the click does nothing.

<img width="552" height="194" alt="image" src="https://github.com/user-attachments/assets/752579ff-3636-445d-a274-9ebc0ca5ba4d" />

```
org.labkey.test.TestTimeoutException: org.openqa.selenium.TimeoutException: Expected condition failed: waiting for browser to navigate (tried for 59 second(s) with 500 milliseconds interval)
[...]
  at app//org.labkey.test.WebDriverWrapper.waitForPageToLoad(WebDriverWrapper.java:2011)
  at app//org.labkey.test.WebDriverWrapper.doAndMaybeWaitForPageToLoad(WebDriverWrapper.java:2137)
  at app//org.labkey.test.WebDriverWrapper.doAndWaitForPageToLoad(WebDriverWrapper.java:2106)
  at app//org.labkey.test.WebDriverWrapper.clickAndWait(WebDriverWrapper.java:2961)
  at app//org.labkey.test.WebDriverWrapper.clickAndWait(WebDriverWrapper.java:2956)
  at app//org.labkey.test.components.domain.BaseDomainDesigner.clickSave(BaseDomainDesigner.java:69)
  at app//org.labkey.test.components.domain.DomainDesigner.clickSave(DomainDesigner.java:35)
  at app//org.labkey.test.tests.SampleTypeRenameTest.testSampleTypeFieldRename(SampleTypeRenameTest.java:118)
```

This test fails reliably for me if the component waits for the `genId` banner to appear. Adding a non-fatal wait to account for the page layout shift.

#### Related Pull Requests
- N/A

#### Changes
- Scroll the domain designer save button into view
- Wait for `genId` counter to appear
