### PR TITLE
GitHub Issue 778: Track selection loading state on DataRegion so we can disable buttons and prevent another click

### DIFF
--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -279,6 +279,20 @@ public class DataRegionTable extends DataRegion
     }
 
     /**
+     * Assert that a Data Region has expected selection text (e.g. "Selected 100,000 of 1,234,567")
+     * @param selectedRows number of selected rows
+     * @param totalRows total number of rows in data behind the dataregion
+     */
+    public void assertSelectionText(int selectedRows, int totalRows)
+    {
+        String expected = "Selected " + String.format("%,d", selectedRows) + " of " + String.format("%,d", totalRows) + " rows.";
+        String fullSelectionText = Locator.tagWithAttribute("div", "data-msgpart", "selection")
+                .findElement(this).getText();
+
+        assertTrue("Expected text to start with: " + expected + " Full text: " + fullSelectionText, fullSelectionText.startsWith(expected));
+    }
+
+    /**
      * @deprecated Renamed. Use {@link #getRowIndex(CharSequence, String)}
      */
     @Deprecated


### PR DESCRIPTION
#### Rationale
See related PR for rationale.
[#778](https://github.com/LabKey/internal-issues/issues/778) No result when trying to select 100,000 rows when a filter is applied

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7335

#### Changes
- DataRegion.assertSelectionText