### PR TITLE
Make uiTests task work with Gradle 9.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'maven-publish'
 }
 
-import org.labkey.gradle.task.RunUiTest
+import org.labkey.gradle.task.RunTestSuite
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.PomFileHelper
@@ -177,8 +177,8 @@ project.tasks.named("uiTests").configure {
 project.parent.parent.tasks.named("ijConfigure").configure {
     dependsOn(initPropertiesTask)
 }
-project.tasks.withType(RunUiTest).configureEach { it ->
-    scanForTestClasses = true
+project.tasks.withType(RunTestSuite).configureEach { it ->
+    scanForTestClasses = true // Required for Gradle 9.3
 }
 
 if (project.hasProperty('doPublishing'))

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'maven-publish'
 }
 
+import org.labkey.gradle.task.RunUiTest
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.PomFileHelper
@@ -170,8 +171,15 @@ project.tasks.register("convertHarToStressXml", JavaExec) {
         }
 }
 
-project.tasks.uiTests.dependsOn(initPropertiesTask)
-project.parent.parent.tasks.ijConfigure.dependsOn(initPropertiesTask)
+project.tasks.named("uiTests").configure {
+    dependsOn(initPropertiesTask)
+}
+project.parent.parent.tasks.named("ijConfigure").configure {
+    dependsOn(initPropertiesTask)
+}
+project.tasks.withType(RunUiTest).configureEach { it ->
+    scanForTestClasses = true
+}
 
 if (project.hasProperty('doPublishing'))
 {

--- a/src/org/labkey/test/Runner.java
+++ b/src/org/labkey/test/Runner.java
@@ -41,9 +41,11 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Ignore;
 import org.junit.runner.Description;
+import org.junit.runner.RunWith;
 import org.junit.runner.manipulation.Filter;
 import org.junit.runner.manipulation.Filterable;
 import org.junit.runner.manipulation.NoTestsRemainException;
+import org.junit.runners.AllTests;
 import org.labkey.junit.runner.WebTestProperties;
 import org.labkey.serverapi.reader.Readers;
 import org.labkey.serverapi.writer.PrintWriters;
@@ -92,6 +94,7 @@ import java.util.stream.Collectors;
 
 import static org.labkey.test.WebTestHelper.logToServer;
 
+@RunWith(AllTests.class)
 public class Runner extends TestSuite
 {
     static


### PR DESCRIPTION
#### Rationale
Something in Gradle 9.3 changed how it detects JUnit tests. Gradle only recognizes test classes that meet [certain criteria](https://docs.gradle.org/current/userguide/java_testing.html#sec:test_detection). Adding a `RunWith` annotation to our test runner is the most straightforward.
Additionally `scanForTestClasses` needs to be enabled, though this seems to be a direct contradiction of the Gradle documentation.
```
Execution failed for task ':server:testAutomation:ciTestsPostgres18'. org.gradle.api.internal.exceptions.MarkedVerificationException: There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration. If this is not a misconfiguration, this error can be disabled by setting the 'failOnNoDiscoveredTests' property to false.
```

#### Related Pull Requests
- https://github.com/LabKey/server/pull/1261

#### Changes
- Make uiTests task work with Gradle 9.3
- Use lazy task configuration
