### PR TITLE
Add test to check package-lock.json files for suspicious dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
 }
 
 import org.labkey.gradle.task.RunTestSuite
+import org.labkey.gradle.task.RunUiTest
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 import org.labkey.gradle.util.PomFileHelper
@@ -169,6 +170,10 @@ project.tasks.register("convertHarToStressXml", JavaExec) {
                 throw new IllegalArgumentException("Specify input file for " + task.name + ". -PharInFile=<file>")
             }
         }
+}
+
+project.tasks.register("testPackageLockJson", RunUiTest) {
+    include "org/labkey/test/tests/PackageLockJsonTest.class"
 }
 
 project.tasks.named("uiTests").configure {

--- a/src/org/labkey/test/tests/PackageLockJsonTest.java
+++ b/src/org/labkey/test/tests/PackageLockJsonTest.java
@@ -1,9 +1,11 @@
 package org.labkey.test.tests;
 
+import org.apache.commons.lang3.CharUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.serverapi.reader.Readers;
@@ -14,7 +16,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,18 +28,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 @Category({})
 public class PackageLockJsonTest
 {
     private static final Set<String> ALLOWED_SOURCES = Set.of("registry.npmjs.org", "labkey.jfrog.io");
-    private static final Pattern STARTS_WITH_ALPHA = Pattern.compile("^[a-zA-Z]");
     private final Map<String, AtomicInteger> depCounts = new HashMap<>();
-    private final List<String> badSources = new ArrayList<>();
+    private final List<String> errors = new ArrayList<>();
 
-    @Test
+    @Test @Ignore("package-lock check seems sufficient")
     public void packageJsonTest() throws Exception
     {
         Path modulesDir = new File(TestFileUtils.getLabKeyRoot(), "server/modules").toPath();
@@ -49,7 +50,7 @@ public class PackageLockJsonTest
                 .filter(packageJsonMatcher::matches)
                 .forEach(this::scanPackageJson);
         }
-        Assert.assertTrue("Bad sources: " + String.join("\n", badSources), badSources.isEmpty());
+        Assert.assertTrue("Bad sources: " + String.join("\n", errors), errors.isEmpty());
     }
 
     public void scanPackageJson(Path packageJson)
@@ -65,9 +66,9 @@ public class PackageLockJsonTest
             {
                 dependencies.keySet().forEach(key -> {
                     String val = dependencies.getString(key);
-                    if (STARTS_WITH_ALPHA.matcher(val).matches())
+                    if (val.contains(":")) // URL, file, or workspace dependency
                     {
-                        badSources.add(key + " = " + val + " - " + packageJson);
+                        errors.add(key + " = " + val + " - " + packageJson);
                     }
                 });
             }
@@ -75,9 +76,9 @@ public class PackageLockJsonTest
             {
                 devDependencies.keySet().forEach(key -> {
                     String val = devDependencies.getString(key);
-                    if (STARTS_WITH_ALPHA.matcher(val).matches())
+                    if (val.contains(":")) // URL, file, or workspace dependency
                     {
-                        badSources.add(key + " = " + val + " - " + packageJson);
+                        errors.add(key + " = " + val + " - " + packageJson);
                     }
                 });
             }
@@ -113,7 +114,7 @@ public class PackageLockJsonTest
             }
         }
         TestLogger.log("Package lock JSON dependencies:" + depCounts);
-        Assert.assertTrue("Bad sources: " + badSources, badSources.isEmpty());
+        Assert.assertTrue("Bad sources: " + errors, errors.isEmpty());
     }
 
     private void testModuleContainer(File moduleContainer) throws Exception
@@ -157,21 +158,57 @@ public class PackageLockJsonTest
                 if (!packageName.isBlank())
                 {
                     JSONObject packageJson = packages.getJSONObject(packageName);
-                    String resolved = packageJson.optString("resolved");
-                    if (resolved.isBlank())
-                    {
-                        TestLogger.warn("Resolved field is blank for package " + packageName + " in " + packageLock.getAbsolutePath());
-                        continue;
-                    }
-                    URL resolvedURL = new URL(resolved);
-                    String host = resolvedURL.getHost();
-                    if (!ALLOWED_SOURCES.contains(host))
-                    {
-                        String message = "Package " + packageName + " resolved to unrecognized host " + host + " in " + packageLock.getAbsolutePath();
-                        badSources.add(message);
-                        TestLogger.error(message);
-                    }
-                    depCounts.computeIfAbsent(host, k -> new AtomicInteger()).incrementAndGet();
+                    verifyPackage(packageName, packageJson, packageLock);
+                }
+            }
+        }
+    }
+
+    private void verifyPackage(String packageName, JSONObject packageJson, File packageLock) throws URISyntaxException
+    {
+        String resolved = packageJson.optString("resolved");
+        if (resolved.isBlank())
+        {
+            TestLogger.debug("Resolved field is blank for package " + packageName + " in " + packageLock.getAbsolutePath());
+
+        }
+        else
+        {
+            URI resolvedURL = new URI(resolved);
+            String host = resolvedURL.getHost();
+            if (!ALLOWED_SOURCES.contains(host))
+            {
+                String message = "Package " + packageName + " resolved to unrecognized host " + host + " in " + packageLock.getAbsolutePath();
+                errors.add(message);
+                TestLogger.error(message);
+            }
+            depCounts.computeIfAbsent(host, k -> new AtomicInteger()).incrementAndGet();
+        }
+
+        String version = packageJson.optString("version");
+        if (version.isBlank() || !CharUtils.isAsciiNumeric(version.charAt(0)))
+        {
+            String message = "Package " + packageName + " has bad version [" + version + "] in " + packageLock.getAbsolutePath();
+            errors.add(message);
+            TestLogger.error(message);
+        }
+
+        JSONObject transitiveDeps = packageJson.optJSONObject("dependencies", new JSONObject());
+        for (String tDep : transitiveDeps.keySet())
+        {
+            JSONObject packageJsonDep = transitiveDeps.optJSONObject(tDep);
+            if (packageJsonDep != null)
+            {
+                verifyPackage(tDep, packageJsonDep, packageLock);
+            }
+            else
+            {
+                String tVer = transitiveDeps.optString(tDep);
+                if (tVer == null || tVer.contains(":") && !tVer.startsWith("npm:")) // URL, file, or workspace dependency
+                {
+                    String message = "Package " + packageName + " has bad transitive dependency [" + tVer + "] in " + packageLock.getAbsolutePath();
+                    errors.add(message);
+                    TestLogger.error(message);
                 }
             }
         }

--- a/src/org/labkey/test/tests/PackageLockJsonTest.java
+++ b/src/org/labkey/test/tests/PackageLockJsonTest.java
@@ -5,98 +5,49 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.labkey.serverapi.reader.Readers;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.util.TestLogger;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
 
 @Category({})
+@RunWith(Parameterized.class)
 public class PackageLockJsonTest
 {
     private static final Set<String> ALLOWED_SOURCES = Set.of("registry.npmjs.org", "labkey.jfrog.io");
+    // Allow-list of '@isaacs/cliui' dependencies
+    private static final Set<String> ALLOWED_NONSTANDARD_VERSIONS = Set.of("npm:string-width@^4.2.0", "npm:strip-ansi@^6.0.1", "npm:wrap-ansi@^7.0.0");
     private final Map<String, AtomicInteger> depCounts = new HashMap<>();
     private final List<String> errors = new ArrayList<>();
 
-    @Test @Ignore("package-lock check seems sufficient")
-    public void packageJsonTest() throws Exception
-    {
-        Path modulesDir = new File(TestFileUtils.getLabKeyRoot(), "server/modules").toPath();
-        PathMatcher packageJsonMatcher = FileSystems.getDefault().getPathMatcher("glob:**/package.json");
+    private final File moduleDir;
 
-        try (Stream<Path> paths = Files.walk(modulesDir))
-        {
-            paths
-                .filter(path -> !path.toString().contains("/.gradle/"))
-                .filter(packageJsonMatcher::matches)
-                .forEach(this::scanPackageJson);
-        }
-        Assert.assertTrue("Bad sources: " + String.join("\n", errors), errors.isEmpty());
+    public PackageLockJsonTest(File moduleDir, String name)
+    {
+        this.moduleDir = moduleDir;
     }
 
-    public void scanPackageJson(Path packageJson)
-    {
-        TestLogger.log("Scanning " + packageJson);
+    @Parameterized.Parameters(name = "{1}")
+    public static Collection<Object[]> data() {
+        List<File> allModules = new ArrayList<>();
 
-        try (InputStream is = Files.newInputStream(packageJson))
-        {
-            JSONObject jsonObject = new JSONObject(new JSONTokener(is));
-            JSONObject dependencies = jsonObject.optJSONObject("dependencies");
-            JSONObject devDependencies = jsonObject.optJSONObject("devDependencies");
-            if (dependencies != null)
-            {
-                dependencies.keySet().forEach(key -> {
-                    String val = dependencies.getString(key);
-                    if (val.contains(":")) // URL, file, or workspace dependency
-                    {
-                        errors.add(key + " = " + val + " - " + packageJson);
-                    }
-                });
-            }
-            if (devDependencies != null)
-            {
-                devDependencies.keySet().forEach(key -> {
-                    String val = devDependencies.getString(key);
-                    if (val.contains(":")) // URL, file, or workspace dependency
-                    {
-                        errors.add(key + " = " + val + " - " + packageJson);
-                    }
-                });
-            }
-        }
-        catch (JSONException ex)
-        {
-            TestLogger.log("  JSONException: " + ex.getMessage());
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException("Error reading " + packageJson, e);
-        }
-
-    }
-
-    @Test
-    public void testPackageLockJson() throws Exception
-    {
         File modulesDir = new File(TestFileUtils.getLabKeyRoot(), "server/modules");
         File[] files = modulesDir.listFiles();
         if (files == null)
@@ -108,58 +59,55 @@ public class PackageLockJsonTest
             if (file.isDirectory())
             {
                 if (new File(file, "module.properties").exists())
-                    testModule(file);
+                {
+                    allModules.add(file);
+                }
                 else
-                    testModuleContainer(file);
+                {
+                    allModules.addAll(Arrays.stream(Objects.requireNonNull(file.listFiles(), () -> "No files found in " + file.getAbsolutePath()))
+                        .filter(f -> f.isDirectory() && new File(f, "module.properties").isFile()).toList());
+                }
             }
         }
-        TestLogger.log("Package lock JSON dependencies:" + depCounts);
-        Assert.assertTrue("Bad sources: " + errors, errors.isEmpty());
+
+        return allModules.stream().filter(file -> new File(file, "package-lock.json").exists())
+            .map(f -> new Object[]{f, f.getName()}).toList();
     }
 
-    private void testModuleContainer(File moduleContainer) throws Exception
+    @Test
+    public void testPackageLock() throws Exception
     {
-        File[] modules = moduleContainer.listFiles();
-        if (modules == null)
-        {
-            throw new RuntimeException("No files found in modules directory: " + moduleContainer.getAbsolutePath());
-        }
-        for (File module : modules)
-        {
-            if (module.isDirectory() && new File(module, "module.properties").isFile())
-            {
-                testModule(module);
-            }
-        }
+        testModule(moduleDir);
+        Assert.assertTrue("Bad sources: " + errors, errors.isEmpty());
     }
 
     private void testModule(File module) throws Exception
     {
         File packageLock = new File(module, "package-lock.json");
-        if (packageLock.isFile())
-        {
-            TestLogger.log("Testing module: " + module.getAbsolutePath());
+        Assert.assertTrue("No package-lock.json found in module: " + module.getAbsolutePath(), packageLock.isFile()); // Should be unfailable
 
-            JSONObject packages;
-            try (Reader reader = Readers.getReader(packageLock))
+        TestLogger.log("Testing module: " + module.getAbsolutePath());
+
+        JSONObject packages;
+        try (Reader reader = Readers.getReader(packageLock))
+        {
+            JSONObject jsonObject = new JSONObject(new JSONTokener(reader));
+            packages = jsonObject.optJSONObject("packages");
+            if (packages == null)
+                packages = jsonObject.getJSONObject("dependencies"); // old lockfile version
+        }
+        catch (JSONException e)
+        {
+            TestLogger.error("Testing module: " + module.getName() + " failed to parse package-lock.json: " + e.getMessage());
+            return;
+        }
+
+        for (String packageName : packages.keySet())
+        {
+            if (!packageName.isBlank())
             {
-                JSONObject jsonObject = new JSONObject(new JSONTokener(reader));
-                packages = jsonObject.optJSONObject("packages");
-                if (packages == null)
-                    packages = jsonObject.getJSONObject("dependencies"); // old lockfile version
-            }
-            catch (JSONException e)
-            {
-                TestLogger.error("Testing module: " + module.getName() + " failed to parse package-lock.json: " + e.getMessage());
-                return;
-            }
-            for (String packageName : packages.keySet())
-            {
-                if (!packageName.isBlank())
-                {
-                    JSONObject packageJson = packages.getJSONObject(packageName);
-                    verifyPackage(packageName, packageJson, packageLock);
-                }
+                JSONObject packageJson = packages.getJSONObject(packageName);
+                verifyPackage(packageName, packageJson, packageLock);
             }
         }
     }
@@ -182,7 +130,7 @@ public class PackageLockJsonTest
                 errors.add(message);
                 TestLogger.error(message);
             }
-            depCounts.computeIfAbsent(host, k -> new AtomicInteger()).incrementAndGet();
+            depCounts.computeIfAbsent(host, _ -> new AtomicInteger()).incrementAndGet();
         }
 
         String version = packageJson.optString("version");
@@ -199,12 +147,12 @@ public class PackageLockJsonTest
             JSONObject packageJsonDep = transitiveDeps.optJSONObject(tDep);
             if (packageJsonDep != null)
             {
-                verifyPackage(tDep, packageJsonDep, packageLock);
+                verifyPackage(tDep, packageJsonDep, packageLock); // belt and suspenders
             }
             else
             {
                 String tVer = transitiveDeps.optString(tDep);
-                if (tVer == null || tVer.contains(":") && !tVer.startsWith("npm:")) // URL, file, or workspace dependency
+                if (tVer == null || tVer.contains(":") && !ALLOWED_NONSTANDARD_VERSIONS.contains(tVer)) // URL, file, or workspace dependency
                 {
                     String message = "Package " + packageName + " has bad transitive dependency [" + tVer + "] in " + packageLock.getAbsolutePath();
                     errors.add(message);

--- a/src/org/labkey/test/tests/PackageLockJsonTest.java
+++ b/src/org/labkey/test/tests/PackageLockJsonTest.java
@@ -11,24 +11,90 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.util.TestLogger;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.Reader;
 import java.net.URL;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 @Category({})
 public class PackageLockJsonTest
 {
     private static final Set<String> ALLOWED_SOURCES = Set.of("registry.npmjs.org", "labkey.jfrog.io");
+    private static final Pattern STARTS_WITH_ALPHA = Pattern.compile("^[a-zA-Z]");
     private final Map<String, AtomicInteger> depCounts = new HashMap<>();
     private final List<String> badSources = new ArrayList<>();
 
     @Test
-    public void test() throws Exception
+    public void packageJsonTest() throws Exception
+    {
+        Path modulesDir = new File(TestFileUtils.getLabKeyRoot(), "server/modules").toPath();
+        PathMatcher packageJsonMatcher = FileSystems.getDefault().getPathMatcher("glob:**/package.json");
+
+        try (Stream<Path> paths = Files.walk(modulesDir))
+        {
+            paths
+                .filter(path -> !path.toString().contains("/.gradle/"))
+                .filter(packageJsonMatcher::matches)
+                .forEach(this::scanPackageJson);
+        }
+        Assert.assertTrue("Bad sources: " + String.join("\n", badSources), badSources.isEmpty());
+    }
+
+    public void scanPackageJson(Path packageJson)
+    {
+        TestLogger.log("Scanning " + packageJson);
+
+        try (InputStream is = Files.newInputStream(packageJson))
+        {
+            JSONObject jsonObject = new JSONObject(new JSONTokener(is));
+            JSONObject dependencies = jsonObject.optJSONObject("dependencies");
+            JSONObject devDependencies = jsonObject.optJSONObject("devDependencies");
+            if (dependencies != null)
+            {
+                dependencies.keySet().forEach(key -> {
+                    String val = dependencies.getString(key);
+                    if (STARTS_WITH_ALPHA.matcher(val).matches())
+                    {
+                        badSources.add(key + " = " + val + " - " + packageJson);
+                    }
+                });
+            }
+            if (devDependencies != null)
+            {
+                devDependencies.keySet().forEach(key -> {
+                    String val = devDependencies.getString(key);
+                    if (STARTS_WITH_ALPHA.matcher(val).matches())
+                    {
+                        badSources.add(key + " = " + val + " - " + packageJson);
+                    }
+                });
+            }
+        }
+        catch (JSONException ex)
+        {
+            TestLogger.log("  JSONException: " + ex.getMessage());
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Error reading " + packageJson, e);
+        }
+
+    }
+
+    @Test
+    public void testPackageLockJson() throws Exception
     {
         File modulesDir = new File(TestFileUtils.getLabKeyRoot(), "server/modules");
         File[] files = modulesDir.listFiles();

--- a/src/org/labkey/test/tests/PackageLockJsonTest.java
+++ b/src/org/labkey/test/tests/PackageLockJsonTest.java
@@ -1,7 +1,6 @@
 package org.labkey.test.tests;
 
 import org.apache.commons.lang3.CharUtils;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.Assert;
@@ -20,12 +19,9 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 
 @Category({})
 @RunWith(Parameterized.class)
@@ -35,7 +31,6 @@ public class PackageLockJsonTest
     // Allow-list of '@isaacs/cliui' dependencies
     private static final Set<String> ALLOWED_NONSTANDARD_VERSIONS = Set.of("npm:string-width@^4.2.0", "npm:strip-ansi@^6.0.1", "npm:wrap-ansi@^7.0.0");
 
-    private final Map<String, AtomicInteger> depCounts = new HashMap<>();
     private final List<String> errors = new ArrayList<>();
     private final File moduleDir;
 
@@ -78,16 +73,10 @@ public class PackageLockJsonTest
     @Test
     public void testPackageLock() throws Exception
     {
-        testModule(moduleDir);
-        Assert.assertTrue("Bad sources: " + errors, errors.isEmpty());
-    }
+        File packageLock = new File(moduleDir, "package-lock.json");
+        Assert.assertTrue("No package-lock.json found in module: " + moduleDir.getAbsolutePath(), packageLock.isFile());
 
-    private void testModule(File module) throws Exception
-    {
-        File packageLock = new File(module, "package-lock.json");
-        Assert.assertTrue("No package-lock.json found in module: " + module.getAbsolutePath(), packageLock.isFile()); // Should be unfailable
-
-        TestLogger.log("Testing module: " + module.getAbsolutePath());
+        TestLogger.log("Testing module: " + moduleDir.getAbsolutePath());
 
         JSONObject packages;
         try (Reader reader = Readers.getReader(packageLock))
@@ -96,11 +85,6 @@ public class PackageLockJsonTest
             packages = jsonObject.optJSONObject("packages");
             if (packages == null)
                 packages = jsonObject.getJSONObject("dependencies"); // old lockfile version
-        }
-        catch (JSONException e)
-        {
-            TestLogger.error("Testing module: " + module.getName() + " failed to parse package-lock.json: " + e.getMessage());
-            return;
         }
 
         for (String packageName : packages.keySet())
@@ -111,9 +95,13 @@ public class PackageLockJsonTest
                 verifyPackage(packageName, packageJson, packageLock);
             }
         }
+
+        Assert.assertTrue("Bad sources: " + errors, errors.isEmpty());
     }
 
-    private void verifyPackage(String packageName, JSONObject packageJson, File packageLockFile) throws URISyntaxException
+    /// Verify that a package reference in a package-lock.json file only resolves to known hosts and has a valid version
+    /// Also checks sub-dependencies
+    private void verifyPackage(String packageName, JSONObject packageJson, File packageLockFile)
     {
         String resolved = packageJson.optString("resolved");
         if (resolved.isBlank())
@@ -122,15 +110,23 @@ public class PackageLockJsonTest
         }
         else
         {
-            URI resolvedURL = new URI(resolved);
-            String host = resolvedURL.getHost();
-            if (!ALLOWED_SOURCES.contains(host))
+            try
             {
-                String message = "Package " + packageName + " resolved to unrecognized host " + host + " in " + packageLockFile.getAbsolutePath();
+                URI resolvedURL = new URI(resolved);
+                String host = resolvedURL.getHost();
+                if (!ALLOWED_SOURCES.contains(host))
+                {
+                    String message = "Package " + packageName + " resolved to unrecognized host [" + host + "] in " + packageLockFile.getAbsolutePath();
+                    errors.add(message);
+                    TestLogger.error(message);
+                }
+            }
+            catch (URISyntaxException e)
+            {
+                String message = "Package " + packageName + " resolved to an invalid location [" + resolved + "] in " + packageLockFile.getAbsolutePath();
                 errors.add(message);
                 TestLogger.error(message);
             }
-            depCounts.computeIfAbsent(host, _ -> new AtomicInteger()).incrementAndGet();
         }
 
         String version = packageJson.optString("version");

--- a/src/org/labkey/test/tests/PackageLockJsonTest.java
+++ b/src/org/labkey/test/tests/PackageLockJsonTest.java
@@ -27,7 +27,7 @@ import java.util.Set;
 @RunWith(Parameterized.class)
 public class PackageLockJsonTest
 {
-    private static final Set<String> ALLOWED_SOURCES = Set.of("registry.npmjs.org", "labkey.jfrog.io");
+    private static final Set<String> ALLOWED_DEPENDENCY_HOSTS = Set.of("registry.npmjs.org", "labkey.jfrog.io");
     // Allow-list of '@isaacs/cliui' dependencies
     private static final Set<String> ALLOWED_NONSTANDARD_VERSIONS = Set.of("npm:string-width@^4.2.0", "npm:strip-ansi@^6.0.1", "npm:wrap-ansi@^7.0.0");
 
@@ -114,7 +114,7 @@ public class PackageLockJsonTest
             {
                 URI resolvedURL = new URI(resolved);
                 String host = resolvedURL.getHost();
-                if (!ALLOWED_SOURCES.contains(host))
+                if (!ALLOWED_DEPENDENCY_HOSTS.contains(host))
                 {
                     String message = "Package " + packageName + " resolved to unrecognized host [" + host + "] in " + packageLockFile.getAbsolutePath();
                     errors.add(message);

--- a/src/org/labkey/test/tests/PackageLockJsonTest.java
+++ b/src/org/labkey/test/tests/PackageLockJsonTest.java
@@ -34,9 +34,9 @@ public class PackageLockJsonTest
     private static final Set<String> ALLOWED_SOURCES = Set.of("registry.npmjs.org", "labkey.jfrog.io");
     // Allow-list of '@isaacs/cliui' dependencies
     private static final Set<String> ALLOWED_NONSTANDARD_VERSIONS = Set.of("npm:string-width@^4.2.0", "npm:strip-ansi@^6.0.1", "npm:wrap-ansi@^7.0.0");
+
     private final Map<String, AtomicInteger> depCounts = new HashMap<>();
     private final List<String> errors = new ArrayList<>();
-
     private final File moduleDir;
 
     public PackageLockJsonTest(File moduleDir, String name)
@@ -112,13 +112,12 @@ public class PackageLockJsonTest
         }
     }
 
-    private void verifyPackage(String packageName, JSONObject packageJson, File packageLock) throws URISyntaxException
+    private void verifyPackage(String packageName, JSONObject packageJson, File packageLockFile) throws URISyntaxException
     {
         String resolved = packageJson.optString("resolved");
         if (resolved.isBlank())
         {
-            TestLogger.debug("Resolved field is blank for package " + packageName + " in " + packageLock.getAbsolutePath());
-
+            TestLogger.debug("Resolved field is blank for package " + packageName + " in " + packageLockFile.getAbsolutePath());
         }
         else
         {
@@ -126,7 +125,7 @@ public class PackageLockJsonTest
             String host = resolvedURL.getHost();
             if (!ALLOWED_SOURCES.contains(host))
             {
-                String message = "Package " + packageName + " resolved to unrecognized host " + host + " in " + packageLock.getAbsolutePath();
+                String message = "Package " + packageName + " resolved to unrecognized host " + host + " in " + packageLockFile.getAbsolutePath();
                 errors.add(message);
                 TestLogger.error(message);
             }
@@ -136,7 +135,7 @@ public class PackageLockJsonTest
         String version = packageJson.optString("version");
         if (version.isBlank() || !CharUtils.isAsciiNumeric(version.charAt(0)))
         {
-            String message = "Package " + packageName + " has bad version [" + version + "] in " + packageLock.getAbsolutePath();
+            String message = "Package " + packageName + " has bad version [" + version + "] in " + packageLockFile.getAbsolutePath();
             errors.add(message);
             TestLogger.error(message);
         }
@@ -147,14 +146,14 @@ public class PackageLockJsonTest
             JSONObject packageJsonDep = transitiveDeps.optJSONObject(tDep);
             if (packageJsonDep != null)
             {
-                verifyPackage(tDep, packageJsonDep, packageLock); // belt and suspenders
+                verifyPackage(tDep, packageJsonDep, packageLockFile); // belt and suspenders
             }
             else
             {
                 String tVer = transitiveDeps.optString(tDep);
                 if (tVer == null || tVer.contains(":") && !ALLOWED_NONSTANDARD_VERSIONS.contains(tVer)) // URL, file, or workspace dependency
                 {
-                    String message = "Package " + packageName + " has bad transitive dependency [" + tVer + "] in " + packageLock.getAbsolutePath();
+                    String message = "Package " + packageName + " has bad transitive dependency [" + tVer + "] in " + packageLockFile.getAbsolutePath();
                     errors.add(message);
                     TestLogger.error(message);
                 }

--- a/src/org/labkey/test/tests/PackageLockJsonTest.java
+++ b/src/org/labkey/test/tests/PackageLockJsonTest.java
@@ -1,0 +1,113 @@
+package org.labkey.test.tests;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.serverapi.reader.Readers;
+import org.labkey.test.TestFileUtils;
+import org.labkey.test.util.TestLogger;
+
+import java.io.File;
+import java.io.Reader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Category({})
+public class PackageLockJsonTest
+{
+    private static final Set<String> ALLOWED_SOURCES = Set.of("registry.npmjs.org", "labkey.jfrog.io");
+    private final Map<String, AtomicInteger> depCounts = new HashMap<>();
+    private final List<String> badSources = new ArrayList<>();
+
+    @Test
+    public void test() throws Exception
+    {
+        File modulesDir = new File(TestFileUtils.getLabKeyRoot(), "server/modules");
+        File[] files = modulesDir.listFiles();
+        if (files == null)
+        {
+            throw new RuntimeException("No files found in modules directory: " + modulesDir.getAbsolutePath());
+        }
+        for (File file : files)
+        {
+            if (file.isDirectory())
+            {
+                if (new File(file, "module.properties").exists())
+                    testModule(file);
+                else
+                    testModuleContainer(file);
+            }
+        }
+        TestLogger.log("Package lock JSON dependencies:" + depCounts);
+        Assert.assertTrue("Bad sources: " + badSources, badSources.isEmpty());
+    }
+
+    private void testModuleContainer(File moduleContainer) throws Exception
+    {
+        File[] modules = moduleContainer.listFiles();
+        if (modules == null)
+        {
+            throw new RuntimeException("No files found in modules directory: " + moduleContainer.getAbsolutePath());
+        }
+        for (File module : modules)
+        {
+            if (module.isDirectory() && new File(module, "module.properties").isFile())
+            {
+                testModule(module);
+            }
+        }
+    }
+
+    private void testModule(File module) throws Exception
+    {
+        File packageLock = new File(module, "package-lock.json");
+        if (packageLock.isFile())
+        {
+            TestLogger.log("Testing module: " + module.getAbsolutePath());
+
+            JSONObject packages;
+            try (Reader reader = Readers.getReader(packageLock))
+            {
+                JSONObject jsonObject = new JSONObject(new JSONTokener(reader));
+                packages = jsonObject.optJSONObject("packages");
+                if (packages == null)
+                    packages = jsonObject.getJSONObject("dependencies"); // old lockfile version
+            }
+            catch (JSONException e)
+            {
+                TestLogger.error("Testing module: " + module.getName() + " failed to parse package-lock.json: " + e.getMessage());
+                return;
+            }
+            for (String packageName : packages.keySet())
+            {
+                if (!packageName.isBlank())
+                {
+                    JSONObject packageJson = packages.getJSONObject(packageName);
+                    String resolved = packageJson.optString("resolved");
+                    if (resolved.isBlank())
+                    {
+                        TestLogger.warn("Resolved field is blank for package " + packageName + " in " + packageLock.getAbsolutePath());
+                        continue;
+                    }
+                    URL resolvedURL = new URL(resolved);
+                    String host = resolvedURL.getHost();
+                    if (!ALLOWED_SOURCES.contains(host))
+                    {
+                        String message = "Package " + packageName + " resolved to unrecognized host " + host + " in " + packageLock.getAbsolutePath();
+                        badSources.add(message);
+                        TestLogger.error(message);
+                    }
+                    depCounts.computeIfAbsent(host, k -> new AtomicInteger()).incrementAndGet();
+                }
+            }
+        }
+    }
+}

--- a/src/org/labkey/test/tests/PackageLockJsonTest.java
+++ b/src/org/labkey/test/tests/PackageLockJsonTest.java
@@ -45,7 +45,8 @@ public class PackageLockJsonTest
     }
 
     @Parameterized.Parameters(name = "{1}")
-    public static Collection<Object[]> data() {
+    public static Collection<Object[]> data()
+    {
         List<File> allModules = new ArrayList<>();
 
         File modulesDir = new File(TestFileUtils.getLabKeyRoot(), "server/modules");


### PR DESCRIPTION
#### Rationale
By requiring all NPM dependencies to come from registry.npmjs.org or labkey.jfrog.io, we can reduce the risk of downloading malicious code.

#### Related Pull Requests
- N/A

#### Changes
- Add test to check package-lock.json files for suspicious dependencies
