### PR TITLE
Provide warnings for unknown fields for cross sample type import

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -1721,23 +1721,28 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
 
     public String getConversionErrorMessage(Object value, String fieldName, Class<?> targetClass)
     {
-        return getConversionErrorMessage(value, fieldName, targetClass, true);
+        return getConversionErrorMessage(value, fieldName, targetClass, true, false);
     }
 
     // Note: Keep in sync with ConvertHelper.getStandardConversionErrorMessage()
     // Example: "Could not convert value '2.34' (Double) for Boolean field 'Medical History.Dep Diagnosed in Last 18 Months'"
-    public String getConversionErrorMessage(Object value, String fieldName, Class<?> targetClass, boolean useUSDateParsing)
+    public String getConversionErrorMessage(Object value, String fieldName, Class<?> targetClass, boolean useUSDateParsing, boolean removeSingleQuotes)
     {
+        String errorMessage;
         String fieldType = targetClass.getSimpleName();
 
         // Issue 50768: Need a better error message if date value is not in the expected format.
         if (fieldType.equalsIgnoreCase("date") || fieldType.equalsIgnoreCase("datetime") || fieldType.equalsIgnoreCase("timestamp"))
         {
             String parsingMode = useUSDateParsing ? "U.S. date parsing (MDY)" : "Non-U.S. date parsing (DMY)";
-            return value + " is not a valid " + fieldType + " for " + fieldName + " using " + parsingMode;
+            errorMessage = "'" + value + "' is not a valid " + fieldType + " for " + fieldName + " using " + parsingMode;
+        }
+        else
+        {
+            errorMessage = "Could not convert value '" + value + "' (" + value.getClass().getSimpleName() + ") for " + fieldType + " field '" + fieldName + "'";
         }
 
-        return "Could not convert value " + value + " (" + value.getClass().getSimpleName() + ") for " + fieldType + " field " + fieldName;
+        return removeSingleQuotes ? errorMessage.replace("'", "") : errorMessage;
     }
 
     private ProductKey getProductConfiguration() throws IOException, CommandException

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -1734,10 +1734,10 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         if (fieldType.equalsIgnoreCase("date") || fieldType.equalsIgnoreCase("datetime") || fieldType.equalsIgnoreCase("timestamp"))
         {
             String parsingMode = useUSDateParsing ? "U.S. date parsing (MDY)" : "Non-U.S. date parsing (DMY)";
-            return "'" + value + "' is not a valid " + fieldType + " for " + fieldName + " using " + parsingMode;
+            return value + " is not a valid " + fieldType + " for " + fieldName + " using " + parsingMode;
         }
 
-        return "Could not convert value '" + value + "' (" + value.getClass().getSimpleName() + ") for " + fieldType + " field '" + fieldName + "'" ;
+        return "Could not convert value " + value + " (" + value.getClass().getSimpleName() + ") for " + fieldType + " field " + fieldName;
     }
 
     private ProductKey getProductConfiguration() throws IOException, CommandException

--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -1726,23 +1726,24 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
 
     // Note: Keep in sync with ConvertHelper.getStandardConversionErrorMessage()
     // Example: "Could not convert value '2.34' (Double) for Boolean field 'Medical History.Dep Diagnosed in Last 18 Months'"
-    public String getConversionErrorMessage(Object value, String fieldName, Class<?> targetClass, boolean useUSDateParsing, boolean removeSingleQuotes)
+    public String getConversionErrorMessage(Object value, String fieldName, Class<?> targetClass, boolean useUSDateParsing, boolean withoutSingleQuotes)
     {
         String errorMessage;
         String fieldType = targetClass.getSimpleName();
+        String quote = withoutSingleQuotes ? "" : "'";
 
         // Issue 50768: Need a better error message if date value is not in the expected format.
         if (fieldType.equalsIgnoreCase("date") || fieldType.equalsIgnoreCase("datetime") || fieldType.equalsIgnoreCase("timestamp"))
         {
             String parsingMode = useUSDateParsing ? "U.S. date parsing (MDY)" : "Non-U.S. date parsing (DMY)";
-            errorMessage = "'" + value + "' is not a valid " + fieldType + " for " + fieldName + " using " + parsingMode;
+            errorMessage = quote + value + quote + " is not a valid " + fieldType + " for " + fieldName + " using " + parsingMode;
         }
         else
         {
-            errorMessage = "Could not convert value '" + value + "' (" + value.getClass().getSimpleName() + ") for " + fieldType + " field '" + fieldName + "'";
+            errorMessage = "Could not convert value " + quote + value + quote + " (" + value.getClass().getSimpleName() + ") for " + fieldType + " field " + quote + fieldName + quote;
         }
 
-        return removeSingleQuotes ? errorMessage.replace("'", "") : errorMessage;
+        return errorMessage;
     }
 
     private ProductKey getProductConfiguration() throws IOException, CommandException

--- a/src/org/labkey/test/tests/InlineImagesListTest.java
+++ b/src/org/labkey/test/tests/InlineImagesListTest.java
@@ -372,7 +372,7 @@ public class InlineImagesListTest extends BaseWebDriverTest
         importFilePathError(listImportPage, "1", PDF_FILE.getName());
         importFilePathError(listImportPage, "5", PDF_FILE.getName());
 
-        String attachmentError = "Can't upload '%s' to field %s with type Attachment.";
+        String attachmentError = "Cannot upload '%s' to Attachment type field '%s'.";
         String attachmentPdfError = String.format(attachmentError, PDF_FILE.getName(), LIST_ATTACHMENT01_NAME);
         String attachmentAbsentError = String.format(attachmentError, "Absent.txt", LIST_ATTACHMENT01_NAME);
         verifyQueryAPI("lists", LIST_NAME, Map.of(LIST_KEY_NAME, 5, LIST_ATTACHMENT01_NAME, PDF_FILE.getName()), true, "Row 1: " + attachmentPdfError);
@@ -397,7 +397,7 @@ public class InlineImagesListTest extends BaseWebDriverTest
         listImportPage.submitExpectingError();
         try
         {
-            String expectedError = "Row 1: Can't upload '" + attachmentValue + "' to field " + LIST_ATTACHMENT01_NAME + " with type Attachment.";
+            String expectedError = "Row 1: Cannot upload '" + attachmentValue + "' to Attachment type field '" + LIST_ATTACHMENT01_NAME + "'.";
             checker().withScreenshot("import_error").verifyTrue("Invalid attachment error not as expected", isElementPresent(Locator.tagWithClass("div", "labkey-error").withText(expectedError)));
         }
         catch(NoSuchElementException nse)

--- a/src/org/labkey/test/tests/SampleTypeTest.java
+++ b/src/org/labkey/test/tests/SampleTypeTest.java
@@ -1883,11 +1883,11 @@ public class SampleTypeTest extends BaseWebDriverTest
 
         log("verify error when inserting a row with an amount but no unit");
         sampleHelper.insertRow(Map.of("Name", "AU-ERR-1", "StoredAmount", "0.0"));
-        assertTextPresent("No Units value provided for Amount 0.0.");
+        assertTextPresent("No 'Units' value provided for Amount '0.0'.");
         clickButton("Cancel");
         log("verify error when inserting a row with a unit but no amount");
         sampleHelper.insertRow(Map.of("Name", "AU-ERR-2", "Units", "mL"));
-        assertTextPresent("No Amount value provided for Units mL.");
+        assertTextPresent("No 'Amount' value provided for Units 'mL'.");
         clickButton("Cancel");
 
         log("verify error when inserting a row with incompatible units");
@@ -1962,11 +1962,11 @@ public class SampleTypeTest extends BaseWebDriverTest
         log("verify that inserting a row with an amount or unit requires both fields to be filled in");
         // insert row with amount but not unit (error expected)
         sampleHelper.insertRow(Map.of("Name", "AU-ERR-1", "StoredAmount", "5.0"));
-        assertTextPresent("No Units value provided for Amount 5.0.");
+        assertTextPresent("No 'Units' value provided for Amount '5.0'.");
         clickButton("Cancel");
         // insert row with unit but not amount (error expected)
         sampleHelper.insertRow(Map.of("Name", "AU-ERR-2", "Units", "mg"));
-        assertTextPresent("No Amount value provided for Units mg.");
+        assertTextPresent("No 'Amount' value provided for Units 'mg'.");
         clickButton("Cancel");
         // insert row with both amount and unit (success)
         sampleHelper.insertRow(Map.of("Name", "AU-SUCCESS-1", "StoredAmount", "5.0", "Units", "mg"));
@@ -1975,11 +1975,11 @@ public class SampleTypeTest extends BaseWebDriverTest
         log("verify that updating a row with an amount or unit requires both fields to be filled in");
         // update row with amount but not unit (error expected)
         sampleHelper.updateRow(0, Map.of("Units", ""));
-        assertTextPresent("No Units value provided for Amount 5.0.");
+        assertTextPresent("No 'Units' value provided for Amount '5.0'.");
         clickButton("Cancel");
         // update row with unit but not amount (error expected)
         sampleHelper.updateRow(0, Map.of("StoredAmount", ""));
-        assertTextPresent("No Amount value provided for Units mg.");
+        assertTextPresent("No 'Amount' value provided for Units 'mg'.");
         clickButton("Cancel");
         // update row with both amount and unit (success)
         sampleHelper.updateRow(0, Map.of("StoredAmount", "10.0123", "Units", "g"));
@@ -1988,11 +1988,11 @@ public class SampleTypeTest extends BaseWebDriverTest
         log("verify that bulk import with an amount or unit requires both fields to be filled in");
         // bulk import with amount but not unit (error expected)
         sampleHelper.bulkImportExpectingError(List.of(Map.of("Name", "AU-BULK-ERR-1", "StoredAmount", "0")), SampleTypeHelper.IMPORT_OPTION);
-        assertTextPresent("A Units value must be provided when Amounts are provided");
+        assertTextPresent("A 'Units' value must be provided when 'Amounts' are provided");
         clickButton("Cancel");
         // bulk import with unit but not amount (error expected)
         sampleHelper.bulkImportExpectingError(List.of(Map.of("Name", "AU-BULK-ERR-2", "Units", "mL")), SampleTypeHelper.IMPORT_OPTION);
-        assertTextPresent("An Amount value must be provided when Units are provided.");
+        assertTextPresent("An 'Amount' value must be provided when 'Units' are provided.");
         clickButton("Cancel");
         // bulk import with both amount and unit (success expected)
         sampleHelper.bulkImport(List.of(Map.of("Name", "AU-BULK-SUCCESS-1", "StoredAmount", "0", "Units", "L")));


### PR DESCRIPTION
#### Rationale
For awhile now, we have shown warnings about file import / update column headers above the file preview grid. For single sample type and single source type file imports, we show warnings about unknown fields, system fields, sample/aliquot only fields, etc. This PR does the same type of warnings check for fields in the cross sample type import case.

It also updates the display of some error messages on the source and sample file import case to use bold instead of single quotes to highlight the value / field in the error message.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1930
- https://github.com/LabKey/labkey-ui-premium/pull/889
- https://github.com/LabKey/limsModules/pull/1958
- https://github.com/LabKey/platform/pull/7370
- https://github.com/LabKey/testAutomation/pull/2862

#### Changes
- Test fixes for change from quoted values to bold in error messages
