### PR TITLE
Test fixes for Rserve support

### DIFF
--- a/data/api/rlabkey-api-query.xml
+++ b/data/api/rlabkey-api-query.xml
@@ -629,10 +629,10 @@
         <url>
             <![CDATA[
                 library(Rlabkey)
-                makeFilter(
+                print(makeFilter(
                     c("foo/Reagent", "CONTAINS", "this or that"),
                     c("Temp_C", "GREATER_THAN", "12"),
-                    c("SystolicBloodPressure", "MISSING", ""))
+                    c("SystolicBloodPressure", "MISSING", "")))
             ]]>
         </url>
         <response>
@@ -647,10 +647,10 @@
         <url>
             <![CDATA[
                 library(Rlabkey)
-                makeFilter(
+                print(makeFilter(
                     c("foo/Reagent", "CONTAINS", "this or that"),
                     c("Temp_C", "GREATER_THAN", "12"),
-                    c("SystolicBloodPressure", "MISSING", ""), asList=TRUE)
+                    c("SystolicBloodPressure", "MISSING", ""), asList=TRUE))
             ]]>
         </url>
         <response>


### PR DESCRIPTION
#### Rationale
This fixes some recent test failures for some new tests added as part of this change : https://github.com/LabKey/labkey-api-r/pull/122.

Once `Rlabkey 3.4.5` becomes available from CRAN, some of the tests will be fixed but we also need to call `print` in the script source for the output to be available through Rserve. This is one of the differences between running R locally or through Rserve.
