### PR TITLE
Archive HDRL module

### DIFF
--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -216,7 +216,6 @@ public class Crawler
             new ControllerActionId("biologics", "begin"),
             new ControllerActionId("datafinder", "begin"),
             new ControllerActionId("ehr_compliancedb", "requirementDetails"),
-            new ControllerActionId("hdrl", "begin"),
             new ControllerActionId("onprc_billingpublic", "begin"),
             new ControllerActionId("reagent", "begin")
         );


### PR DESCRIPTION
#### Rationale
HDRL module has been archived, so no need for the exclusion