### PR TITLE
Make CSP error logging validation more robust

### DIFF
--- a/src/org/labkey/test/tests/wiki/WikiCspTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiCspTest.java
@@ -21,7 +21,9 @@ import java.util.List;
 @BaseWebDriverTest.ClassTimeout(minutes = 2)
 public class WikiCspTest extends BaseWebDriverTest
 {
-    private static final String PROJECT_NAME = TRICKY_CHARACTERS_FOR_PROJECT_NAMES + "WikiCspTest";
+    // Add something unique to make sure log de-duping doesn't suppress the logging. Otherwise, running the test multiple
+    // times against the same server won't actually log the CSP error after the first hit
+    private static final String PROJECT_NAME = TRICKY_CHARACTERS_FOR_PROJECT_NAMES + "WikiCspTest" + System.currentTimeMillis();
     private static final String WIKI_PAGE_TITLE = "TOC_with_inline";
     private static final String WIKI_PAGE_BODY =
         // Issue 52483: HTML substitution patterns can throw errors during wiki validation
@@ -76,13 +78,18 @@ public class WikiCspTest extends BaseWebDriverTest
 
         waitForText("Click me");
 
-        try
+        waitFor(() ->
         {
-            CspLogUtil.checkNewCspWarnings(getArtifactCollector());
-        }
-        catch (CspLogUtil.CspWarningDetectedException ignore) {}
-
-        goToAdminConsole().goToSettingsSection();
+            try
+            {
+                CspLogUtil.checkNewCspWarnings(getArtifactCollector());
+                return false;
+            }
+            catch (CspLogUtil.CspWarningDetectedException ignore)
+            {
+                return true;
+            }
+        }, "Should have triggered a CSP error", WAIT_FOR_PAGE);
 
         SiteValidationPage validationPage = goToAdminConsole().clickSiteValidation();
         validationPage.setAllValidators(false);

--- a/src/org/labkey/test/tests/wiki/WikiCspTest.java
+++ b/src/org/labkey/test/tests/wiki/WikiCspTest.java
@@ -13,6 +13,7 @@ import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.labkey.test.util.CspLogUtil;
 import org.labkey.test.util.TextSearcher;
 import org.labkey.test.util.WikiHelper;
+import org.labkey.test.util.core.admin.CspConfigHelper;
 
 import java.util.Arrays;
 import java.util.List;
@@ -21,9 +22,7 @@ import java.util.List;
 @BaseWebDriverTest.ClassTimeout(minutes = 2)
 public class WikiCspTest extends BaseWebDriverTest
 {
-    // Add something unique to make sure log de-duping doesn't suppress the logging. Otherwise, running the test multiple
-    // times against the same server won't actually log the CSP error after the first hit
-    private static final String PROJECT_NAME = TRICKY_CHARACTERS_FOR_PROJECT_NAMES + "WikiCspTest" + System.currentTimeMillis();
+    private static final String PROJECT_NAME = TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
     private static final String WIKI_PAGE_TITLE = "TOC_with_inline";
     private static final String WIKI_PAGE_BODY =
         // Issue 52483: HTML substitution patterns can throw errors during wiki validation
@@ -55,6 +54,17 @@ public class WikiCspTest extends BaseWebDriverTest
         _containerHelper.createProject(PROJECT_NAME, null);
         _containerHelper.enableModules(Arrays.asList("Wiki"));
         goToProjectHome();
+        CspConfigHelper.debugCspWarnings();  // Ensure that CSP violation logs aren't suppressed by de-duping efforts
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest)
+    {
+        super.doCleanup(afterTest);
+        if (afterTest)
+        {
+            CspConfigHelper.infoCspWarnings();
+        }
     }
 
     @Override

--- a/src/org/labkey/test/util/core/admin/CspConfigHelper.java
+++ b/src/org/labkey/test/util/core/admin/CspConfigHelper.java
@@ -75,6 +75,11 @@ public class CspConfigHelper
         Log4jUtils.setLogLevel("org.labkey.core.admin.AdminController.ContentSecurityPolicyReportAction", ManagerPage.LoggingLevel.DEBUG);
     }
 
+    public static void infoCspWarnings()
+    {
+        Log4jUtils.setLogLevel("org.labkey.core.admin.AdminController.ContentSecurityPolicyReportAction", ManagerPage.LoggingLevel.INFO);
+    }
+
     public static class AllowedHost
     {
         private final Directive _directive;


### PR DESCRIPTION
#### Rationale
WikiCspTest has been failing in a feature branch because the error is logged a little later than expected.

https://teamcity.labkey.org/buildConfiguration/LabKey_2511Release_Community_ModuleSuites_WikiSqlserver/3826615

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7373

#### Changes
- Ensure unique container path to avoid log de-duplication
- Wait for the CSP error to log before proceeding
- Make sure the error gets logged
