### PR TITLE
Add parameter to set the logging level for TestLogger

### DIFF
--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -17,7 +17,6 @@ package org.labkey.test;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.labkey.serverapi.reader.Readers;
@@ -299,9 +298,9 @@ public abstract class TestProperties
         return getBooleanProperty("webtest.troubleshooting.stacktraces", false);
     }
 
-    public static Level getTestLogLevel()
+    public static String getTestLogLevel()
     {
-        return Level.toLevel(System.getProperty("webtest.log.level"), Level.INFO);
+        return System.getProperty("webtest.log.level");
     }
 
     public static boolean isPrimaryUserAppAdmin()

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -17,11 +17,13 @@ package org.labkey.test;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.labkey.serverapi.reader.Readers;
 import org.labkey.test.util.CachingSupplier;
 import org.labkey.test.util.CspLogUtil;
 import org.labkey.test.util.TestDataGenerator;
-import org.labkey.test.util.TestLogger;
 import org.labkey.test.util.Version;
 import org.openqa.selenium.Dimension;
 
@@ -42,19 +44,20 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public abstract class TestProperties
 {
+    private static final Logger LOG = LogManager.getLogger(TestProperties.class);
+
     static
     {
         final File propFile = new File(TestFileUtils.getTestRoot(), "test.properties");
         final File propFileTemplate = new File(TestFileUtils.getTestRoot(), "test.properties.template");
         if (!propFile.exists())
         {
-            TestLogger.log(String.format("'%s' does not exist. Creating default from '%s'", propFile.getName(), propFileTemplate.getName()));
+            LOG.info("'{}' does not exist. Creating default from '{}'", propFile.getName(), propFileTemplate.getName());
             try (Stream<String> propStream = Files.lines(propFileTemplate.toPath()))
             {
                 final Iterator<String> iterator = propStream.filter(line -> !line.startsWith("#!!")).iterator();
@@ -62,12 +65,12 @@ public abstract class TestProperties
             }
             catch (IOException e)
             {
-                TestLogger.error(e.getMessage());
+                LOG.error(e.getMessage(), e);
             }
         }
         try (Reader propReader = Readers.getReader(propFile))
         {
-            TestLogger.log("Loading properties from " + propFile.getName());
+            LOG.info("Loading properties from {}", propFile.getName());
             Properties properties = new Properties();
             properties.load(propReader);
             properties.putAll(System.getProperties());
@@ -75,8 +78,7 @@ public abstract class TestProperties
         }
         catch (IOException ioe)
         {
-            TestLogger.error("Failed to load " + propFile.getName() + " file. Running with hard-coded defaults");
-            ioe.printStackTrace(System.err);
+            LOG.error("Failed to load {} file. Running with hard-coded defaults", propFile.getName(), ioe);
         }
 
         final List<String> gradleProperties = List.of("labkeyVersion");
@@ -85,7 +87,7 @@ public abstract class TestProperties
         {
             try (Reader propReader = Readers.getReader(serverPropFile))
             {
-                TestLogger.log("Loading properties from " + serverPropFile.getName());
+                LOG.info("Loading properties from {}", serverPropFile.getName());
                 Properties properties = new Properties();
                 properties.load(propReader);
                 for (String key : gradleProperties)
@@ -98,8 +100,7 @@ public abstract class TestProperties
             }
             catch (IOException ioe)
             {
-                TestLogger.error("Failed to load " + serverPropFile.getName() + " file.");
-                ioe.printStackTrace(System.err);
+                LOG.error("Failed to load {} file.", serverPropFile.getName(), ioe);
             }
         }
 
@@ -298,9 +299,9 @@ public abstract class TestProperties
         return getBooleanProperty("webtest.troubleshooting.stacktraces", false);
     }
 
-    public static boolean isDebugLoggingEnabled()
+    public static Level getTestLogLevel()
     {
-        return getBooleanProperty("webtest.logging.debug", false);
+        return Level.toLevel(System.getProperty("webtest.log.level"), Level.INFO);
     }
 
     public static boolean isPrimaryUserAppAdmin()
@@ -432,7 +433,7 @@ public abstract class TestProperties
                         "Tried system properties failure.output.dir and java.io.tmpdir");
             }
 
-            TestLogger.log("Using " + dumpDir + " to store test output");
+            LOG.info("Using {} to store test output", dumpDir);
         }
         return dumpDir;
     }
@@ -475,7 +476,7 @@ public abstract class TestProperties
             }
             catch (NumberFormatException e)
             {
-                TestLogger.warn("Invalid value for property %s: '%s'".formatted(key, prop), e);
+                LOG.warn("Invalid value for property {}: '{}'", key, prop, e);
             }
         }
         return def;
@@ -499,7 +500,7 @@ public abstract class TestProperties
             }
             catch (NumberFormatException e)
             {
-                TestLogger.warn("Invalid value for property %s: '%s'".formatted(key, prop), e);
+                LOG.warn("Invalid value for property {}: '{}'", key, prop, e);
             }
         }
         return def;

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -355,6 +355,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
                     profile.setPreference("extensions.update.enabled", false);
                     profile.setPreference("dom.max_script_run_time", 0);
                     profile.setPreference("dom.max_chrome_script_run_time", 0);
+                    //profile.setPreference("dom.reporting.enabled", true); // Enable support for CSP report-to
 
                     // Prevent crawler from hanging on '_print=1' pages
                     profile.setPreference("print.always_print_silent", true);
@@ -1997,18 +1998,17 @@ public abstract class WebDriverWrapper implements WrapsDriver
     {
         try
         {
-            toBeStale.isEnabled();
             new WebDriverWait(getDriver(), timer.timeRemaining())
                     .withMessage("waiting for browser to navigate")
                     .until(ExpectedConditions.stalenessOf(toBeStale));
         }
-        catch (StaleElementReferenceException | NoSuchElementException | NullPointerException ignore)
-        {
-            // `ExpectedConditions.stalenessOf(toBeStale)` sometimes chokes when coming from a blank page (about:blank)
-        }
         catch (TimeoutException ex)
         {
             throw new TestTimeoutException(ex); // Triggers thread dump.
+        }
+        catch (WebDriverException | NullPointerException ignore)
+        {
+            // `ExpectedConditions.stalenessOf(toBeStale)` sometimes chokes when coming from a blank page (about:blank)
         }
 
         // WebDriver usually does this automatically, but not always.

--- a/src/org/labkey/test/aspects/MethodLoggingAspect.java
+++ b/src/org/labkey/test/aspects/MethodLoggingAspect.java
@@ -72,7 +72,7 @@ public class MethodLoggingAspect
 
         String argsString = getArgsString(loggedParameters);
 
-        if (logMethod.quiet())
+        if (logMethod.quiet() && !TestLogger.log().isDebugEnabled())
         {
             TestLogger.suppressLogging(true);
             quietMethods.add(method);
@@ -108,7 +108,7 @@ public class MethodLoggingAspect
 
         String argString = " done";
 
-        if (logMethod.quiet())
+        if (logMethod.quiet() && !TestLogger.log().isDebugEnabled())
         {
             quietMethods.pop();
             argString = quietMethodsArgStrings.pop();

--- a/src/org/labkey/test/util/TestLogger.java
+++ b/src/org/labkey/test/util/TestLogger.java
@@ -22,20 +22,15 @@ import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.labkey.test.TestProperties;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.labkey.test.TestProperties.getTestLogLevel;
+
 public class TestLogger
 {
-    private static final Logger LOG = LogManager.getLogger(TestLogger.class);
-    private static final Logger NO_OP;
-
-    static
-    {
-        Configurator.setLevel(LOG, TestProperties.getTestLogLevel());
-        NO_OP = LOG.isDebugEnabled() ? LOG : LogManager.getLogger("NoOpLogger");
-    }
+    private static final Logger LOG = Configurator.setLevel(LogManager.getLogger(TestLogger.class), getTestLogLevel());
+    private static final Logger NO_OP = LogManager.getLogger("NoOpLogger");
 
     private static final int indentStep = 2;
     private static final int MAX_INDENT = 20;

--- a/src/org/labkey/test/util/TestLogger.java
+++ b/src/org/labkey/test/util/TestLogger.java
@@ -19,15 +19,23 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.labkey.test.TestProperties;
 
 import java.util.concurrent.TimeUnit;
 
 public class TestLogger
 {
     private static final Logger LOG = LogManager.getLogger(TestLogger.class);
-    private static final Logger NO_OP = LogManager.getLogger("NoOpLogger");
+    private static final Logger NO_OP;
+
+    static
+    {
+        Configurator.setLevel(LOG, TestProperties.getTestLogLevel());
+        NO_OP = LOG.isDebugEnabled() ? LOG : LogManager.getLogger("NoOpLogger");
+    }
 
     private static final int indentStep = 2;
     private static final int MAX_INDENT = 20;

--- a/src/org/labkey/test/util/TestLogger.java
+++ b/src/org/labkey/test/util/TestLogger.java
@@ -16,6 +16,7 @@
 package org.labkey.test.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
@@ -29,8 +30,14 @@ import static org.labkey.test.TestProperties.getTestLogLevel;
 
 public class TestLogger
 {
-    private static final Logger LOG = Configurator.setLevel(LogManager.getLogger(TestLogger.class), getTestLogLevel());
+    private static final Logger LOG = LogManager.getLogger(TestLogger.class);
     private static final Logger NO_OP = LogManager.getLogger("NoOpLogger");
+
+    static
+    {
+        if (getTestLogLevel() != null)
+            Configurator.setLevel(LOG, Level.toLevel(getTestLogLevel()));
+    }
 
     private static final int indentStep = 2;
     private static final int MAX_INDENT = 20;

--- a/test.properties.template
+++ b/test.properties.template
@@ -64,6 +64,10 @@ test.credentials.file=
 webtest.timeout.multiplier=1.0
 ## Runs just the cleanup steps of the specified tests/suites
 cleanOnly=false
+## Set logging level for Selenium tests (default: INFO)
+#webtest.log.level=DEBUG
+## Set whether DeferredErrorCollector should fail immediately when errors are encountered (default: false)
+#webtest.checker.fatal=true
 
 
 #==============================================================================
@@ -131,7 +135,7 @@ labkey.contextpath=
 #==============================================================================
 # Server configuration properties
 #
-# These define certain Tomcat startup properties. Mostly only used by TeamCity
+# These inform tests of certain LabKey startup properties. Mostly only used by TeamCity
 #==============================================================================
 disableAssertions=false
 devMode=true


### PR DESCRIPTION
#### Rationale
While debugging a test failure, I realized that there isn't a way to configure our tests' log level without modifying the `log4j2.xml` config file. Fixing this introduced a circular dependency in the static initialization of `TestLogger` and `TestProperties`. I introduced a separate logger to `TestProperties` to avoid this (`WebTestHelper` has its own logger for a similar reason).

#### Related Pull Requests
- N/A

#### Changes
- Add parameter (`webtest.log.level`) to set the logging level for TestLogger
- Remove circular static initialization dependency between `TestLogger` and `TestProperties`
- Adjust `WebDriverWrapper.waitForPageToLoad` to work better on Chrome
