### PR TITLE
Dismiss popover for responsive grid

### DIFF
--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -328,6 +328,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
         WebElement menu = Locator.css("ul.grid-header-cell__dropdown-menu.open").findWhenNeeded(getDriver());
         WebElement menuItem = Locator.css("li > a").containing(menuText).findWhenNeeded(menu);
         waitFor(menuItem::isDisplayed, 1000);
+        dismissPopover();
         if (waitForUpdate)
             doAndWaitForUpdate(menuItem::click);
         else
@@ -800,6 +801,17 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
         return msg;
     }
 
+    public void dismissPopover()
+    {
+        getWrapper().mouseOut();
+        Locators.popover.findOptionalElement(getDriver()).ifPresent(popover -> {
+            getWrapper().mouseOver(popover);
+            getWrapper().mouseOut();
+            getWrapper().mouseOver(elementCache().getGridHeaderManager().getColumnHeader(0).getElement());
+            getWrapper().shortWait().until(ExpectedConditions.invisibilityOf(popover));
+        });
+    }
+
     public List<FieldReference> getHeaders()
     {
         return Collections.unmodifiableList(elementCache().findHeaders());
@@ -971,6 +983,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
         static final Locator emptyGrid = Locator.css("tbody tr.grid-empty");
         static final Locator spinner = Locator.byClass("fa-spinner");
         static final Locator headerCells = Locator.tagWithClass("th", "grid-header-cell");
+        static final Locator popover = Locator.byClass("popover");
         static public Locator.XPathLocator headerCellBody(String label)
         {
             return Locator.tagWithClass("div", "grid-header-cell__body")


### PR DESCRIPTION
#### Rationale
Fix for test [SMSampleDeleteSimpleTest.testSimpleDeleteFromGrid](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_SampleManagerEPostgres/3825717?buildTab=tests&status=failed&name=SMSampleDeleteSimpleTest.testSimpleDeleteFromGrid)
Element  is not clickable at point (85,597) because another element obscures it.

#### Changes
- Added dismissPopover() method to ResponsiveGrid class
