### PR TITLE
Updating SampleFinder Test Component

### DIFF
--- a/src/org/labkey/test/components/ui/search/SampleFinder.java
+++ b/src/org/labkey/test/components/ui/search/SampleFinder.java
@@ -109,9 +109,9 @@ public class SampleFinder extends WebDriverComponent<SampleFinder.ElementCache>
         elementCache().findFilterCard(queryName).clickRemove();
     }
 
-    public EntityFieldFilterModal editSearchCard()
+    public EntityFieldFilterModal editSearchCard(String queryName)
     {
-        return elementCache().findFilterCards().getFirst().clickEdit();
+        return elementCache().findFilterCard(queryName).clickEdit();
     }
 
     /**

--- a/src/org/labkey/test/components/ui/search/SampleFinder.java
+++ b/src/org/labkey/test/components/ui/search/SampleFinder.java
@@ -109,6 +109,11 @@ public class SampleFinder extends WebDriverComponent<SampleFinder.ElementCache>
         elementCache().findFilterCard(queryName).clickRemove();
     }
 
+    public EntityFieldFilterModal editSearchCard()
+    {
+        return elementCache().findFilterCards().getFirst().clickEdit();
+    }
+
     /**
      * Reset the sample finder to its initial state, with no search criteria
      */


### PR DESCRIPTION
#### Rationale
SampleFinder FilterCard test component had an edit method, but it wasn't exposed. This adds a editSearchCard() in SampleFinder and is at the same level as the removeSearchCard() method.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1963

#### Changes
- Add editSearchCard()
