### PR TITLE
Move getExpectedAuditDataChange method to AuditLogHelper.

### DIFF
--- a/src/org/labkey/test/util/AuditLogHelper.java
+++ b/src/org/labkey/test/util/AuditLogHelper.java
@@ -293,6 +293,17 @@ public class AuditLogHelper
         return new JSONObject(detailJSON).toMap();
     }
 
+    public static String getExpectedAuditDataChange(String field, Object oldValue, Object newValue)
+    {
+        String dataChangeString = field + ": ";
+        if (oldValue != null)
+            dataChangeString += oldValue;
+        if (newValue != null)
+            dataChangeString +=  " > " + newValue;
+        return dataChangeString;
+    }
+
+
     public void checkLastTransactionAuditLogDetails(String containerPath, Map<TransactionDetail, Object> expectedDetails)
     {
         Integer transactionAuditId = getLastTransactionId(containerPath);


### PR DESCRIPTION
#### Rationale
Issue [839](https://github.com/LabKey/internal-issues/issues/839)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1975

#### Changes
- Add utility method for constructing string of expected audit log diff values.
