### PR TITLE
Update table index check for dataclass tables

### DIFF
--- a/src/org/labkey/test/tests/DataClassTest.java
+++ b/src/org/labkey/test/tests/DataClassTest.java
@@ -420,7 +420,8 @@ public class DataClassTest extends BaseWebDriverTest
     {
         List<String> suffixes  = new ArrayList<>();
         suffixes.add("lsid");
-        suffixes.add("name_classid");
+        suffixes.add("name");
+        suffixes.add("rowid");
         suffixes.addAll(indexSuffixes);
 
         for (String suffix : suffixes)


### PR DESCRIPTION
#### Rationale
Dataclass provisioned now has a rowId column and no longer has classId column

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7439
- https://github.com/LabKey/limsModules/pull/1997
- https://github.com/LabKey/testAutomation/pull/2891
- https://github.com/LabKey/limsModules/pull/2003

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
