### PR TITLE
Handle behavior change in `WebElement.isDisplayed`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ lookfirstSardineVersion=5.13
 
 jettyVersion=12.1.5
 
-seleniumVersion=4.40.0
+seleniumVersion=4.41.0
 
 mockserverNettyVersion=5.15.0
 

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -63,6 +63,7 @@ import org.labkey.test.util.TestLogger;
 import org.labkey.test.util.TextSearcher;
 import org.labkey.test.util.TextSearcher.TextTransformers;
 import org.labkey.test.util.Timer;
+import org.labkey.test.util.selenium.JavascriptExecutorWrapper;
 import org.labkey.test.util.selenium.ScrollUtils;
 import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.Alert;
@@ -539,11 +540,7 @@ public abstract class WebDriverWrapper implements WrapsDriver
      */
     public <T> T executeScript(@Language("JavaScript") String script, Class<T> expectedResultType, Object... arguments)
     {
-        Object o = executeScript(script, arguments);
-        if (o != null && !expectedResultType.isAssignableFrom(o.getClass()))
-            Assert.fail("Script return wrong type. Expected '" + expectedResultType.getSimpleName() + "'. Got: " + o.getClass().getName() + ". Result: " + o);
-
-        return (T) o;
+        return new JavascriptExecutorWrapper(getDriver()).executeScript(script, expectedResultType, arguments);
     }
 
     /**
@@ -552,20 +549,12 @@ public abstract class WebDriverWrapper implements WrapsDriver
      */
     public Object executeAsyncScript(@Language("JavaScript") String script, Object... arguments)
     {
-        script = "var callback = arguments[arguments.length - 1];\n" + // See WebDriver documentation for details on injected callback
-                "try {" +
-                script +
-                "} catch (error) { callback(error); }"; // ensure that the callback is invoked when an exception would otherwise prevent it
-        return ((JavascriptExecutor) getDriver()).executeAsyncScript(script, arguments);
+        return new JavascriptExecutorWrapper(getDriver()).executeAsyncScript(script, arguments);
     }
 
     public <T> T executeAsyncScript(@Language("JavaScript") String script, Class<T> expectedResultType, Object... arguments)
     {
-        Object o = executeAsyncScript(script, arguments);
-        if (o != null && !expectedResultType.isAssignableFrom(o.getClass()))
-            Assert.fail("Script return wrong type. Expected '" + expectedResultType.getSimpleName() + "'. Got: " + o.getClass().getName() + ". Result: " + o);
-
-        return (T) o;
+        return new JavascriptExecutorWrapper(getDriver()).executeAsyncScript(script, expectedResultType, arguments);
     }
 
     @LogMethod(quiet = true)

--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -75,7 +75,7 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
 
     public Boolean isLoaded()
     {
-        return getComponentElement().isDisplayed() &&
+        return WebElementUtils.checkVisibility(getComponentElement()) &&
                 !Locators.loadingGrid.existsIn(this) &&
                 !Locators.spinner.existsIn(this) &&
                 (Locator.tag("td").existsIn(this) ||

--- a/src/org/labkey/test/util/selenium/JavascriptExecutorWrapper.java
+++ b/src/org/labkey/test/util/selenium/JavascriptExecutorWrapper.java
@@ -10,23 +10,23 @@ import java.util.Set;
 
 public class JavascriptExecutorWrapper implements JavascriptExecutor
 {
-    final JavascriptExecutor _executor;
+    private final JavascriptExecutor _wrappedExecutor;
 
     public JavascriptExecutorWrapper(WebDriver driver)
     {
-        _executor = (JavascriptExecutor) driver;
+        _wrappedExecutor = (JavascriptExecutor) driver;
     }
 
     @Override
     public @Nullable Object executeScript(@Language("JavaScript") String script, @Nullable Object... args)
     {
-        return _executor.executeScript(script, args);
+        return _wrappedExecutor.executeScript(script, args);
     }
 
     @Override
     public @Nullable Object executeScript(ScriptKey key, @Nullable Object... args)
     {
-        return _executor.executeScript(key, args);
+        return _wrappedExecutor.executeScript(key, args);
     }
 
     /**
@@ -49,7 +49,7 @@ public class JavascriptExecutorWrapper implements JavascriptExecutor
                 "try {" +
                 script +
                 "} catch (error) { callback(error); }"; // ensure that the callback is invoked when an exception would otherwise prevent it
-        return _executor.executeAsyncScript(script, arguments);
+        return _wrappedExecutor.executeAsyncScript(script, arguments);
     }
 
     public <T> @Nullable T executeAsyncScript(@Language("JavaScript") String script, Class<T> expectedResultType, @Nullable Object... arguments)
@@ -68,18 +68,18 @@ public class JavascriptExecutorWrapper implements JavascriptExecutor
     @Override
     public Set<ScriptKey> getPinnedScripts()
     {
-        return _executor.getPinnedScripts();
+        return _wrappedExecutor.getPinnedScripts();
     }
 
     @Override
     public void unpin(ScriptKey key)
     {
-        _executor.unpin(key);
+        _wrappedExecutor.unpin(key);
     }
 
     @Override
     public ScriptKey pin(@Language("JavaScript") String script)
     {
-        return _executor.pin(script);
+        return _wrappedExecutor.pin(script);
     }
 }

--- a/src/org/labkey/test/util/selenium/JavascriptExecutorWrapper.java
+++ b/src/org/labkey/test/util/selenium/JavascriptExecutorWrapper.java
@@ -1,0 +1,85 @@
+package org.labkey.test.util.selenium;
+
+import org.intellij.lang.annotations.Language;
+import org.jetbrains.annotations.Nullable;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.ScriptKey;
+import org.openqa.selenium.WebDriver;
+
+import java.util.Set;
+
+public class JavascriptExecutorWrapper implements JavascriptExecutor
+{
+    final JavascriptExecutor _executor;
+
+    public JavascriptExecutorWrapper(WebDriver driver)
+    {
+        _executor = (JavascriptExecutor) driver;
+    }
+
+    @Override
+    public @Nullable Object executeScript(@Language("JavaScript") String script, @Nullable Object... args)
+    {
+        return _executor.executeScript(script, args);
+    }
+
+    @Override
+    public @Nullable Object executeScript(ScriptKey key, @Nullable Object... args)
+    {
+        return _executor.executeScript(key, args);
+    }
+
+    /**
+     * Wrapper for executing JavaScript through WebDriver and verifying return type.
+     * @param <T> See {@link JavascriptExecutor#executeScript(java.lang.String, java.lang.Object...)} for valid return types
+     */
+    public <T> @Nullable T executeScript(@Language("JavaScript") String script, Class<T> expectedResultType, @Nullable Object... arguments)
+    {
+        return verifyType(expectedResultType, executeScript(script, arguments));
+    }
+
+    /**
+     * Wrapper for synchronous execution of asynchronous JavaScript. This wrapper extracts the 'callback' from the argument list
+     * See {@link JavascriptExecutor#executeAsyncScript(java.lang.String, java.lang.Object...)} for details
+     */
+    @Override
+    public @Nullable Object executeAsyncScript(@Language("JavaScript") String script, @Nullable Object... arguments)
+    {
+        script = "var callback = arguments[arguments.length - 1];\n" + // See WebDriver documentation for details on injected callback
+                "try {" +
+                script +
+                "} catch (error) { callback(error); }"; // ensure that the callback is invoked when an exception would otherwise prevent it
+        return _executor.executeAsyncScript(script, arguments);
+    }
+
+    public <T> @Nullable T executeAsyncScript(@Language("JavaScript") String script, Class<T> expectedResultType, @Nullable Object... arguments)
+    {
+        return verifyType(expectedResultType, executeAsyncScript(script, arguments));
+    }
+
+    private <T> @Nullable T verifyType(Class<T> expectedResultType, @Nullable Object o)
+    {
+        if (o != null && !expectedResultType.isAssignableFrom(o.getClass()))
+            throw new IllegalStateException("Script return wrong type. Expected '" + expectedResultType.getName() + "'. Got: " + o.getClass().getName() + ". Result: " + o);
+
+        return (T) o;
+    }
+
+    @Override
+    public Set<ScriptKey> getPinnedScripts()
+    {
+        return _executor.getPinnedScripts();
+    }
+
+    @Override
+    public void unpin(ScriptKey key)
+    {
+        _executor.unpin(key);
+    }
+
+    @Override
+    public ScriptKey pin(@Language("JavaScript") String script)
+    {
+        return _executor.pin(script);
+    }
+}

--- a/src/org/labkey/test/util/selenium/WebDriverUtils.java
+++ b/src/org/labkey/test/util/selenium/WebDriverUtils.java
@@ -25,6 +25,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.WrapsElement;
 
+import java.util.Objects;
+
 public abstract class WebDriverUtils
 {
     /**
@@ -72,6 +74,17 @@ public abstract class WebDriverUtils
             return webDriver;
         else
             return null;
+    }
+
+    /**
+     * Extract a WebDriver instance from an arbitrarily wrapped object and the JavascriptExecutor tied to it.
+     *
+     * @param object Object that wraps a WebDriver. Typically, a Component, SearchContext, or WebElement
+     * @return JavascriptExecutor instance
+     */
+    public static JavascriptExecutorWrapper getJavascriptExecutor(Object object)
+    {
+        return Objects.requireNonNull(new JavascriptExecutorWrapper(extractWrappedDriver(object)), () -> "No WebDriver found in " + object.getClass());
     }
 
     /**

--- a/src/org/labkey/test/util/selenium/WebElementUtils.java
+++ b/src/org/labkey/test/util/selenium/WebElementUtils.java
@@ -1,13 +1,17 @@
 package org.labkey.test.util.selenium;
 
 import org.intellij.lang.annotations.Language;
+import org.labkey.test.selenium.LazyWebElement;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import static org.labkey.test.Locator.NBSP;
 
@@ -93,6 +97,29 @@ public abstract class WebElementUtils
      */
     public static String getTextContent(WebElement element)
     {
-        return element.getDomProperty("textContent").replace(NBSP, " ");
+        return Optional.ofNullable(element.getDomProperty("textContent")).map(s -> s.replace(NBSP, " ")).orElse(null);
+    }
+
+    /**
+     * Determines whether the specified element is visible. {@link WebElement#isDisplayed()} might return false if the
+     * element is out the viewport and scrolling is disabled due to a modal dialog.<br>
+     * TODO: Consider moving to {@link LazyWebElement#isDisplayed()}
+     *
+     * @param element element to inspect
+     * @return true if the element is visible, false otherwise
+     */
+    public static boolean checkVisibility(WebElement element)
+    {
+        try
+        {
+            return element.isDisplayed() ||
+                    Objects.requireNonNullElse(WebDriverUtils.getJavascriptExecutor(element)
+                            .executeScript("return arguments[0].checkVisibility();", Boolean.class, element),
+                            false);
+        }
+        catch (NoSuchElementException | StaleElementReferenceException e)
+        {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
#### Rationale
Starting with [Selenium 4.39.0](https://github.com/SeleniumHQ/selenium/commit/bd8fcaab9f3e28c9fb0ea8b4598d03b079e1f889), `WebElement.isDisplayed` is returning `false` for elements that are scrolled out of view while a modal dialog is preventing scrolling.
```
org.openqa.selenium.TimeoutException: Grid still loading <30.000s>
Build info: version: '4.40.0', revision: 'b3333f1'
System info: os.name: 'Linux', os.arch: 'amd64', os.version: '6.17.0-1007-aws', java.version: '25.0.2'
Driver info: driver.version: unknown
  at app//org.labkey.test.util.Timer.waitFor(Timer.java:105)
  at app//org.labkey.test.util.Timer.waitFor(Timer.java:112)
  at app//org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2386)
  at app//org.labkey.test.components.ui.grids.ResponsiveGrid.waitForLoaded(ResponsiveGrid.java:87)
  at app//org.labkey.test.components.ui.grids.ResponsiveGrid.doAndWaitForUpdate(ResponsiveGrid.java:93)
  at app//org.labkey.test.components.ui.grids.QueryGrid.doAndWaitForUpdate(QueryGrid.java:224)
  at app//org.labkey.test.components.inventory.freezer.FMCheckOutSampleDialog.clickCheckOutSample(FMCheckOutSampleDialog.java:150)
  at app//org.labkey.test.components.inventory.freezer.FMCheckOutSampleDialog.clickCheckOutSample(FMCheckOutSampleDialog.java:144)
  at app//org.labkey.test.tests.biologics.timeline.BiologicsSampleTimelineTest.testStorageTimelineEvents(BiologicsSampleTimelineTest.java:409)
```
The JavaScript [`checkVisibility`](https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility) method is a decent fallback. Using it more widely might have unexpected side-effects, so I'm just using it where this change is causing trouble (`ResponsiveGrid.waitForLoaded`).

#### Related Pull Requests
- N/A

#### Changes
- Handle behavior change in `WebElement.isDisplayed`
- Centralize JavascriptExecutor customization
- Upgrade Selenium to 4.41.0
