### PR TITLE
GitHub Issue 875: Standard Assay Multi-File Transform Import Skips First Data Row

### DIFF
--- a/src/org/labkey/test/tests/GpatAssayTest.java
+++ b/src/org/labkey/test/tests/GpatAssayTest.java
@@ -262,7 +262,7 @@ public class GpatAssayTest extends BaseWebDriverTest
     // GitHub Issue #875: Optionally add transform scripts in GPAT assay design to test code path with and without transform script
     private void randomlyAddTransformScript(ReactAssayDesignerPage assayDesignerPage)
     {
-        boolean shouldAddTransformScript = TestDataGenerator.randomBoolean();
+        boolean shouldAddTransformScript = TestDataGenerator.randomBoolean("whether to add transform script in assay design");
         if (shouldAddTransformScript)
             assayDesignerPage.addTransformScript(RTRANSFORM_SCRIPT_FILE_NOOP);
     }

--- a/src/org/labkey/test/tests/GpatAssayTest.java
+++ b/src/org/labkey/test/tests/GpatAssayTest.java
@@ -41,6 +41,7 @@ import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
+import org.labkey.test.util.RReportHelper;
 import org.labkey.test.util.TestDataGenerator;
 import org.labkey.test.util.core.webdav.WebDavUploadHelper;
 import org.openqa.selenium.WebElement;
@@ -72,11 +73,13 @@ public class GpatAssayTest extends BaseWebDriverTest
     private static final String ASSAY_NAME_FNA = "FASTA Assay";
     private static final String ASSAY_NAME_FNA_MULTIPLE = "FASTA Assay - Multiple file upload";
     private static final String ASSAY_NAME_FNA_MULTIPLE_SINGLE_INPUT = "FASTA Assay - Multiple file single input upload";
+    private static final File RTRANSFORM_SCRIPT_FILE_NOOP = TestFileUtils.getSampleData("qc/noopTransform.R");
 
     @BeforeClass
     public static void doSetup()
     {
         GpatAssayTest init = getCurrentTest();
+        new RReportHelper(init).ensureRConfig();
         init._containerHelper.createProject(init.getProjectName(), "Assay");
         init.goToProjectHome();
     }
@@ -256,6 +259,14 @@ public class GpatAssayTest extends BaseWebDriverTest
         clickButton("Save and Finish", defaultWaitForPage);
     }
 
+    // GitHub Issue #875: Optionally add transform scripts in GPAT assay design to test code path with and without transform script
+    private void randomlyAddTransformScript(ReactAssayDesignerPage assayDesignerPage)
+    {
+        boolean shouldAddTransformScript = true;//TestDataGenerator.randomBoolean();
+        if (shouldAddTransformScript)
+            assayDesignerPage.addTransformScript(RTRANSFORM_SCRIPT_FILE_NOOP);
+    }
+
     @LogMethod
     private ReactAssayDesignerPage startCreateGpatAssay(File dataFile, @LoggedParam String assayName)
     {
@@ -265,9 +276,9 @@ public class GpatAssayTest extends BaseWebDriverTest
         _fileBrowserHelper.importFile(dataFile.getName(), "Create New Standard Assay Design");
 
         ReactAssayDesignerPage assayDesignerPage = new ReactAssayDesignerPage(getDriver());
-
         if (assayName != null)
             assayDesignerPage.setName(assayName);
+        randomlyAddTransformScript(assayDesignerPage);
         return assayDesignerPage;
     }
 

--- a/src/org/labkey/test/tests/GpatAssayTest.java
+++ b/src/org/labkey/test/tests/GpatAssayTest.java
@@ -262,7 +262,7 @@ public class GpatAssayTest extends BaseWebDriverTest
     // GitHub Issue #875: Optionally add transform scripts in GPAT assay design to test code path with and without transform script
     private void randomlyAddTransformScript(ReactAssayDesignerPage assayDesignerPage)
     {
-        boolean shouldAddTransformScript = true;//TestDataGenerator.randomBoolean();
+        boolean shouldAddTransformScript = TestDataGenerator.randomBoolean();
         if (shouldAddTransformScript)
             assayDesignerPage.addTransformScript(RTRANSFORM_SCRIPT_FILE_NOOP);
     }

--- a/src/org/labkey/test/util/TestDataGenerator.java
+++ b/src/org/labkey/test/util/TestDataGenerator.java
@@ -799,7 +799,15 @@ public class TestDataGenerator
 
     public static boolean randomBoolean()
     {
-        return ThreadLocalRandom.current().nextBoolean();
+        return randomBoolean(null);
+    }
+
+    public static boolean randomBoolean(@Nullable String message)
+    {
+        boolean value = ThreadLocalRandom.current().nextBoolean();
+        if (message != null)
+            TestLogger.log("Generated random boolean value for %s: %s".formatted(message, value));
+        return value;
     }
 
     private @NotNull List<String> getFieldsForFile()


### PR DESCRIPTION
#### Rationale
[#875](https://github.com/LabKey/internal-issues/issues/875) Luminex Multi-File Transform Import Skips First Data Row

See related PR for rationale. This PR updates the Standard assay test case to fuzz whether or not a no-op R transform script is added to the assay design so that we test both code paths for an assay import (with and without transform script).

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7456
- https://github.com/LabKey/commonAssays/pull/986

#### Changes
- GpatAssayTest to randomlyAddTransformScript for testing GitHub Issue 875
