### PR TITLE
Expand "See Audit Log Events" test

### DIFF
--- a/src/org/labkey/test/tests/AbstractAssayTest.java
+++ b/src/org/labkey/test/tests/AbstractAssayTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import static org.labkey.test.params.FieldDefinition.DOMAIN_TRICKY_CHARACTERS;
 import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+import static org.labkey.test.util.PermissionsHelper.SEE_AUDIT_LOG_SITE_ROLE;
 
 /**
  * @deprecated TODO: Move shared functionality to a Helper class
@@ -209,8 +210,8 @@ public abstract class AbstractAssayTest extends BaseWebDriverTest
 
         //add a PI user to that group
         permissionsHelper.addUserToProjGroup(TEST_ASSAY_USR_PI1, getProjectName(), TEST_ASSAY_GRP_PIS);
-        // give the PI user "CanSeeAuditLog" permission
-        permissionsHelper.setSiteRoleUserPermissions(TEST_ASSAY_USR_PI1, "See Audit Log Events");
+        // give the PI user site "CanSeeAuditLog" permission
+        permissionsHelper.setSiteRoleUserPermissions(TEST_ASSAY_USR_PI1, SEE_AUDIT_LOG_SITE_ROLE);
 
         //add a lab tech user to the Users group
         permissionsHelper.addUserToProjGroup(TEST_ASSAY_USR_TECH1, getProjectName(), TEST_ASSAY_GRP_USERS);

--- a/src/org/labkey/test/tests/AuditLogTest.java
+++ b/src/org/labkey/test/tests/AuditLogTest.java
@@ -70,6 +70,8 @@ import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
 import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
 import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.SEE_AUDIT_LOG_FOLDER_ROLE;
+import static org.labkey.test.util.PermissionsHelper.SEE_AUDIT_LOG_SITE_ROLE;
 
 @Category({Daily.class, Hosting.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 9)
@@ -392,16 +394,16 @@ public class AuditLogTest extends BaseWebDriverTest
         // Grant the "See Audit Log Events" folder role to our audit user in the project and verify we see audit
         // information in this project but not /Home. We pass the fully qualified classnames in the next few calls to
         // disambiguate the root role from the folder role.
-        permissionsHelper.addMemberToRole(AUDIT_TEST_USER, "org.labkey.api.security.roles.CanSeeAuditLogFolderRole", PermissionsHelper.MemberType.user, getProjectName());
+        permissionsHelper.addMemberToRole(AUDIT_TEST_USER, SEE_AUDIT_LOG_FOLDER_ROLE, PermissionsHelper.MemberType.user, getProjectName());
         impersonate(AUDIT_TEST_USER);
         verifyAuditQueries(true, getProjectName());
         verifyAuditQueries(false, "Home");
         stopImpersonating();
-        permissionsHelper.removeUserRoleAssignment(AUDIT_TEST_USER, "org.labkey.api.security.roles.CanSeeAuditLogFolderRole", getProjectName());
+        permissionsHelper.removeUserRoleAssignment(AUDIT_TEST_USER, SEE_AUDIT_LOG_FOLDER_ROLE, getProjectName());
 
         // Grant the "See Audit Log Events" root role to our audit user and verify we see audit information in this
         // project and in /Home
-        permissionsHelper.setSiteRoleUserPermissions(AUDIT_TEST_USER, "org.labkey.api.security.roles.CanSeeAuditLogRole");
+        permissionsHelper.setSiteRoleUserPermissions(AUDIT_TEST_USER, SEE_AUDIT_LOG_SITE_ROLE);
         impersonate(AUDIT_TEST_USER);
         verifyAuditQueries(true, getProjectName());
         ExecuteQueryPage.beginAt(this, "Home", "auditLog", "SearchAuditEvent");

--- a/src/org/labkey/test/tests/AuditLogTest.java
+++ b/src/org/labkey/test/tests/AuditLogTest.java
@@ -47,6 +47,7 @@ import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Log4jUtils;
 import org.labkey.test.util.PermissionsHelper;
 import org.labkey.test.util.PortalHelper;
+import org.labkey.test.util.SearchHelper;
 import org.labkey.test.util.UIUserHelper;
 
 import java.io.BufferedReader;
@@ -64,11 +65,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.labkey.test.util.PasswordUtil.getUsername;
 import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
 import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
 import static org.labkey.test.util.PermissionsHelper.PROJECT_ADMIN_ROLE;
-import static org.labkey.test.util.PasswordUtil.getUsername;
 
 @Category({Daily.class, Hosting.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 9)
@@ -79,21 +80,18 @@ public class AuditLogTest extends BaseWebDriverTest
     public static final String QUERY_UPDATE_EVENT = "Query update events";
     public static final String PROJECT_AUDIT_EVENT = "Project and Folder events";
     public static final String ASSAY_AUDIT_EVENT = "Link to Study events";
+    public static final String COMMENT_COLUMN = "Comment";
 
     private static final String AUDIT_TEST_USER = "audit_user1@auditlog.test";
     private static final String AUDIT_TEST_USER2 = "audit_user2@auditlog.test";
     private static final String AUDIT_TEST_USER3 = "audit_user3@auditlog.test";
-
     private static final String AUDIT_SECURITY_GROUP = "Testers";
-
     private static final String AUDIT_TEST_PROJECT = "AuditVerifyTest";
     private static final String AUDIT_DETAILED_TEST_PROJECT = "AuditDetailedLogTest";
     private static final String AUDIT_TEST_SUBFOLDER = "AuditVerifyTest_Subfolder";
     private static final String AUDIT_PROPERTY_EVENTS_PROJECT = "AuditDomainPropertyEvents";
-
-    final String DOMAIN_PROPERTY_LOG_NAME = "Domain property events";
-
-    public static final String COMMENT_COLUMN = "Comment";
+    private static final String DOMAIN_PROPERTY_LOG_NAME = "Domain property events";
+    private static final String SEARCH_TERM = "doesn't matter";
 
     private final ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
     private final AuditLogHelper _auditLogHelper = new AuditLogHelper(this);
@@ -377,19 +375,37 @@ public class AuditLogTest extends BaseWebDriverTest
         createUserWithPermissions(AUDIT_TEST_USER, AUDIT_TEST_PROJECT, EDITOR_ROLE);
         createUserWithPermissions(AUDIT_TEST_USER2, AUDIT_TEST_PROJECT, PROJECT_ADMIN_ROLE);
 
+        // Do a search to ensure an audit entry in /home
+        clickProject("Home");
+        new SearchHelper(this).searchFor(SEARCH_TERM);
+        goToProjectHome();
+
         // signed in as an admin so we should see rows here
-        verifyAuditQueries(true);
+        verifyAuditQueries(true, getProjectName());
 
         // signed in as an editor should not show any rows for audit query links
         impersonate(AUDIT_TEST_USER);
-        verifyAuditQueries(false);
+        verifyAuditQueries(false, getProjectName());
+        verifyAuditQueries(false, "Home");
         stopImpersonating();
 
-        // now grant CanSeeAuditLog permission to our audit user and verify
-        // we see audit information
-        permissionsHelper.setSiteRoleUserPermissions(AUDIT_TEST_USER, "See Audit Log Events");
+        // Grant the "See Audit Log Events" folder role to our audit user in the project and verify we see audit
+        // information in this project but not /Home. We pass the fully qualified classnames in the next few calls to
+        // disambiguate the root role from the folder role.
+        permissionsHelper.addMemberToRole(AUDIT_TEST_USER, "org.labkey.api.security.roles.CanSeeAuditLogFolderRole", PermissionsHelper.MemberType.user, getProjectName());
         impersonate(AUDIT_TEST_USER);
-        verifyAuditQueries(true);
+        verifyAuditQueries(true, getProjectName());
+        verifyAuditQueries(false, "Home");
+        stopImpersonating();
+        permissionsHelper.removeUserRoleAssignment(AUDIT_TEST_USER, "org.labkey.api.security.roles.CanSeeAuditLogFolderRole", getProjectName());
+
+        // Grant the "See Audit Log Events" root role to our audit user and verify we see audit information in this
+        // project and in /Home
+        permissionsHelper.setSiteRoleUserPermissions(AUDIT_TEST_USER, "org.labkey.api.security.roles.CanSeeAuditLogRole");
+        impersonate(AUDIT_TEST_USER);
+        verifyAuditQueries(true, getProjectName());
+        ExecuteQueryPage.beginAt(this, "Home", "auditLog", "SearchAuditEvent");
+        verifyAuditQueryEvent(this, "Query", SEARCH_TERM, 1);
 
         // cleanup
         stopImpersonating();
@@ -482,7 +498,7 @@ public class AuditLogTest extends BaseWebDriverTest
             //then create model (which has detailed audit log level)
             InsertRowsCommand insertCmd2 = new InsertRowsCommand("vehicle", "models");
             rowMap = new HashMap<>();
-            rowMap.put("manufacturerId", resp1.getRows().get(0).get("rowid"));
+            rowMap.put("manufacturerId", resp1.getRows().getFirst().get("rowid"));
             rowMap.put("name", "Soul");
             insertCmd2.addRow(rowMap);
             insertCmd2.execute(cn, AUDIT_DETAILED_TEST_PROJECT);
@@ -535,17 +551,17 @@ public class AuditLogTest extends BaseWebDriverTest
         verifyAuditQueryEvent(this, "List", "Child List", 1, canSeeChild(v));
     }
 
-    protected void verifyAuditQueries(boolean canSeeAuditLog)
+    protected void verifyAuditQueries(boolean canSeeAuditLog, String containerPath)
     {
-        ExecuteQueryPage.beginAt(this, getProjectName(), "auditLog", "ContainerAuditEvent");
+        ExecuteQueryPage.beginAt(this, containerPath, "auditLog", "ContainerAuditEvent");
         if (canSeeAuditLog)
             verifyAuditQueryEvent(this, COMMENT_COLUMN, AUDIT_TEST_PROJECT + " was created", 1);
         else
             assertTextPresent("No data to show.");
 
-        ExecuteQueryPage.beginAt(this, getProjectName(), "auditLog", "GroupAuditEvent");
+        ExecuteQueryPage.beginAt(this, containerPath, "auditLog", "GroupAuditEvent");
         if (canSeeAuditLog)
-            verifyAuditQueryEvent(this, COMMENT_COLUMN, "The user " + AUDIT_TEST_USER + " was assigned to the security role Editor.", 1);
+            verifyAuditQueryEvent(this, COMMENT_COLUMN, "The user " + AUDIT_TEST_USER + " was assigned to the security role Editor.", 4);
         else
             assertTextPresent("No data to show.");
     }

--- a/src/org/labkey/test/util/PermissionsHelper.java
+++ b/src/org/labkey/test/util/PermissionsHelper.java
@@ -51,7 +51,7 @@ public abstract class PermissionsHelper
     public static final String SEE_AUDIT_LOG_SITE_ROLE = "org.labkey.api.security.roles.CanSeeAuditLogRole";
     public static final String SEE_AUDIT_LOG_FOLDER_ROLE = "org.labkey.api.security.roles.CanSeeAuditLogFolderRole";
 
-    // Should "See Audit Log" roles be added here?
+    // TODO: Should "See Audit Log" roles be added here?
     public static final Set<String> AUDIT_LOG_VIEWER_ROLES = Set.of(SITE_ADMIN_ROLE, APP_ADMIN_ROLE, PROJECT_ADMIN_ROLE, FOLDER_ADMIN_ROLE);
 
     public static boolean canSeeAuditLogs(String roleName)

--- a/src/org/labkey/test/util/PermissionsHelper.java
+++ b/src/org/labkey/test/util/PermissionsHelper.java
@@ -47,6 +47,11 @@ public abstract class PermissionsHelper
     public static final String AUTHOR_ROLE = "Author";
     public static final String SUBMITTER_ROLE = "Submitter";
 
+    // These two roles have the same friendly name; disambiguate using their fully qualified class names
+    public static final String SEE_AUDIT_LOG_SITE_ROLE = "org.labkey.api.security.roles.CanSeeAuditLogRole";
+    public static final String SEE_AUDIT_LOG_FOLDER_ROLE = "org.labkey.api.security.roles.CanSeeAuditLogFolderRole";
+
+    // Should "See Audit Log" roles be added here?
     public static final Set<String> AUDIT_LOG_VIEWER_ROLES = Set.of(SITE_ADMIN_ROLE, APP_ADMIN_ROLE, PROJECT_ADMIN_ROLE, FOLDER_ADMIN_ROLE);
 
     public static boolean canSeeAuditLogs(String roleName)


### PR DESCRIPTION
#### Rationale
Backport of #2899 

Add and use constants in tests to disambiguate between site and folder role