### PR TITLE
Fix navigation to audit log

### DIFF
--- a/src/org/labkey/test/util/AuditLogHelper.java
+++ b/src/org/labkey/test/util/AuditLogHelper.java
@@ -163,7 +163,7 @@ public class AuditLogHelper
 
     public DataRegionTable goToAuditEventView(String eventType)
     {
-        if (!_wrapper.isTextPresent("Audit Log"))
+        if (!StringUtils.trimToEmpty(_wrapper.getDriver().getCurrentUrl()).contains("audit-showAuditLog.view"))
         {
             ShowAdminPage.beginAt(_wrapper).clickAuditLog();
         }


### PR DESCRIPTION
#### Rationale
Checking for the text "Audit Log" isn't precise enough to determine what page the test is at.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7472

#### Changes
- Check URL to determine whether navigation is needed
