### PR TITLE
Add support for sample creation actions in workflow jobs

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -1745,7 +1745,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         return errorMessage;
     }
 
-    private ProductKey getProductConfiguration() throws IOException, CommandException
+    protected ProductKey getProductConfiguration() throws IOException, CommandException
     {
         SimpleGetCommand command = new SimpleGetCommand("admin", "productFeature");
         var resp = command.execute(createDefaultConnection(), "/");

--- a/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
+++ b/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
@@ -36,8 +36,7 @@ public class EntityFieldFilterModal extends GridFilterModal
     public EntityFieldFilterModal selectQuery(String queryName)
     {
         WebElement queryItem = elementCache().findQueryOption(queryName);
-        getWrapper().doAndWaitForElementToRefresh(queryItem::click,
-                () -> elementCache().listItemLoc.findElement(elementCache().fieldsSelectionPanel), getWrapper().shortWait());
+        queryItem.click();
 
         getWrapper().shortWait().until(ExpectedConditions.invisibilityOfElementLocated(BootstrapLocators.loadingSpinner));
 

--- a/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
+++ b/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
@@ -10,6 +10,8 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.List;
 
+import static org.labkey.test.WebDriverWrapper.sleep;
+
 /**
  * Wraps 'labkey-ui-component' defined in <code>internal/components/search/EntityFieldFilterModal.tsx</code>
  */
@@ -37,6 +39,12 @@ public class EntityFieldFilterModal extends GridFilterModal
     {
         WebElement queryItem = elementCache().findQueryOption(queryName);
         queryItem.click();
+        sleep(500); // wait for the fields to be displayed or updated.
+        // The wait below does not consistently work. It works for the first rendering of the modal, but
+        // if the modal is opened with a query already selected, selecting another query does not cause
+        // staleness of the field panel elements, only an update of the contents.
+//        getWrapper().doAndWaitForElementToRefresh(queryItem::click,
+//                () -> elementCache().listItemLoc.findElement(elementCache().fieldsSelectionPanel), getWrapper().shortWait());
 
         getWrapper().shortWait().until(ExpectedConditions.invisibilityOfElementLocated(BootstrapLocators.loadingSpinner));
 


### PR DESCRIPTION
#### Rationale
We are expanding our workflow capabilities by adding more action types. This PR and its relatives are adding the ability to perform sample derivation, aliquot, and pooling actions from a Job task.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/906
- https://github.com/LabKey/labkey-ui-components/pull/1951
- https://github.com/LabKey/limsModules/pull/2033

#### Changes
- make `setProductConfiguration` protected instead of private
