### PR TITLE
ContainerInfo: avoid illegal group reference

### DIFF
--- a/src/org/labkey/test/params/ContainerInfo.java
+++ b/src/org/labkey/test/params/ContainerInfo.java
@@ -8,6 +8,7 @@ import org.labkey.test.util.TestDataGenerator;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Matcher;
 
 import static org.labkey.test.util.TestDataGenerator.ALL_CHARS_PLACEHOLDER;
 import static org.labkey.test.util.TestDataGenerator.WIDE_PLACEHOLDER;
@@ -41,7 +42,8 @@ public class ContainerInfo
             if (name.startsWith("@"))
             {
                 // Folder name may not begin with '@'
-                name = name.replaceFirst("@", TestDataGenerator.randomString(1, "@", RANDOM_CHARSET));
+                String replacement = TestDataGenerator.randomString(1, "@", RANDOM_CHARSET);
+                name = name.replaceFirst("@", Matcher.quoteReplacement(replacement));
             }
             return name;
         }


### PR DESCRIPTION
#### Rationale
When initializing a `ContainerInfo.folder()` in the `RegistryUnidentifiedTest` the [tests encountered](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsPostgres/3903538?showLog=3903537_4302_3266.3462.4299&logFilter=debug&logView=flowAware) the following error:

```java
java.lang.ExceptionInInitializerError
  at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method)
  at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized(Unsafe.java:1169)
  at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.ensureClassInitialized(MethodHandleAccessorFactory.java:341)
  at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.newConstructorAccessor(MethodHandleAccessorFactory.java:104)
  at java.base/jdk.internal.reflect.ReflectionFactory.newConstructorAccessor(ReflectionFactory.java:138)
  at java.base/java.lang.reflect.Constructor.acquireConstructorAccessor(Constructor.java:546)
  at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:496)
  at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:483)
  at org.labkey.test.BaseWebDriverTest$1.starting(BaseWebDriverTest.java:453)
  at org.labkey.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:26)
  at org.labkey.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:27)
  at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
  at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
  at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
  at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: java.lang.IllegalArgumentException: Illegal group reference
  at java.base/java.util.regex.Matcher.appendExpandedReplacement(Matcher.java:1111)
  at java.base/java.util.regex.Matcher.appendReplacement(Matcher.java:1041)
  at java.base/java.util.regex.Matcher.replaceFirst(Matcher.java:1444)
  at java.base/java.lang.String.replaceFirst(String.java:3090)
  at org.labkey.test.params.ContainerInfo.getRandomName(ContainerInfo.java:44)
  at org.labkey.test.params.ContainerInfo.folder(ContainerInfo.java:54)
  at org.labkey.test.params.ContainerInfo.folder(ContainerInfo.java:64)
  at org.labkey.test.tests.biologics.registry.RegistryUnidentifiedTest.<clinit>(RegistryUnidentifiedTest.java:35)
  ... 15 more
```

This error only appears on TeamCity due to how random folder name generation is wired up. The fix is to quote the replacement string to avoid treating it like a regular expression.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2053
- https://github.com/LabKey/testAutomation/pull/2921

#### Changes
- Use `Matcher.quoteReplacement()` in edge case when generating a random folder name that starts with `"@"`
