### PR TITLE
GitHub Issue 919: Add to Storage > Search for Samples removal of "More Filters" button and related code

### DIFF
--- a/src/org/labkey/test/components/ui/grids/GridFilterModal.java
+++ b/src/org/labkey/test/components/ui/grids/GridFilterModal.java
@@ -26,7 +26,7 @@ public class GridFilterModal extends ModalDialog
 
     public GridFilterModal(WebDriver driver, UpdatingComponent linkedComponent)
     {
-        super(new ModalDialogFinder(driver));
+        super(new ModalDialogFinder(driver).withTitle("Filter"));
         _linkedComponent = linkedComponent;
     }
 

--- a/src/org/labkey/test/components/ui/grids/GridFilterModal.java
+++ b/src/org/labkey/test/components/ui/grids/GridFilterModal.java
@@ -26,7 +26,12 @@ public class GridFilterModal extends ModalDialog
 
     public GridFilterModal(WebDriver driver, UpdatingComponent linkedComponent)
     {
-        super(new ModalDialogFinder(driver).withTitle("Filter"));
+        this(driver, linkedComponent, "Filter");
+    }
+
+    public GridFilterModal(WebDriver driver, UpdatingComponent linkedComponent, String titlePrefix)
+    {
+        super(new ModalDialogFinder(driver).withTitle(titlePrefix));
         _linkedComponent = linkedComponent;
     }
 

--- a/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
+++ b/src/org/labkey/test/components/ui/search/EntityFieldFilterModal.java
@@ -19,7 +19,7 @@ public class EntityFieldFilterModal extends GridFilterModal
 {
     public EntityFieldFilterModal(WebDriver driver, UpdatingComponent linkedComponent)
     {
-        super(driver, linkedComponent);
+        super(driver, linkedComponent, "Select");
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
[#919](https://github.com/LabKey/internal-issues/issues/919) Add to Storage > Search for Samples "More Filter" button and panel are no longer relevant

See ui-premium Pr for rationale

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/919
- https://github.com/LabKey/labkey-ui-components/pull/1965
- https://github.com/LabKey/limsModules/pull/2070
- https://github.com/LabKey/testAutomation/pull/2925

#### Changes
- GridFilterModal finder update to include title prefix
