### PR TITLE
Fix PortTab helper.

### DIFF
--- a/src/org/labkey/test/components/labkey/PortalTab.java
+++ b/src/org/labkey/test/components/labkey/PortalTab.java
@@ -222,7 +222,7 @@ public class PortalTab extends WebDriverComponent<PortalTab.ElementCache>
         }
 
         static public Locator.XPathLocator container = Locator.tagWithClass("ul", "lk-nav-tabs");
-        static public Locator.XPathLocator tabItem = Locator.xpath("//li[@role='presentation']");
+        static public Locator.XPathLocator tabItem = Locator.xpath("//li");
         static public Locator.XPathLocator subContainerTabSelect = Locator.tagWithAttribute("select", "title", "subContainerTabs");
 
         static public Locator.XPathLocator tabList = container.append(tabItem);


### PR DESCRIPTION
#### Rationale
Remove the role attribute from the locator.

#### Related Pull Requests
- [Improve accessibility - remove inappropriate role="presentation" on tabs](https://github.com/LabKey/platform/pull/7534)

#### Changes
- Remove the role attribute from the locator.
