### PR TITLE
Fix crawler and redirect test failures

### DIFF
--- a/src/org/labkey/test/tests/assay/AssayTransformMissingParentDirTest.java
+++ b/src/org/labkey/test/tests/assay/AssayTransformMissingParentDirTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * Issue 54156: Regression test to ensure a reasonable error message is shown when an assay design references
@@ -40,10 +41,9 @@ public class AssayTransformMissingParentDirTest extends AbstractAssayTransformTe
         TestFileUtils.writeFile(transformFile, transformContent);
 
         // Create a General assay and add the transform by absolute path (not upload)
-        var protocolResponse = new GeneralAssayDesign(assayName).createAssay(getProjectName(), createDefaultConnection());
+        var protocolResponse = new GeneralAssayDesign(assayName).setBatchFields(List.of(), false).createAssay(getProjectName(), createDefaultConnection());
         var assayDesignerPage = ReactAssayDesignerPage.beginAt(this, getProjectName(), protocolResponse.getProtocolId(),
-                "general", getURL().toString());
-        assayDesignerPage.goToBatchFields().removeAllFields(true);
+                "general", "");
         // add by path so the absolute path is stored; this allows reproducing the missing parent dir scenario
         assayDesignerPage.addTransformScript(transformFile);
         assayDesignerPage.clickSave();
@@ -78,7 +78,6 @@ public class AssayTransformMissingParentDirTest extends AbstractAssayTransformTe
                 1\tP1\timport after parent deleted
                 """;
 
-        clickAndWait(Locator.linkWithText(assayName));
         new AssayRunsPage(getDriver()).getTable().clickHeaderButtonAndWait("Import Data");
         var importPage = new AssayImportPage(getDriver());
         importPage.setNamedInputText("Name", "missingParentImport");

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -861,6 +861,11 @@ public class ListTest extends BaseWebDriverTest
 
         customizeURLTest();
         crossContainerLookupTest();
+
+        // Prevent crawler errors after the list is deleted
+        // A Query WebPart for a missing query contains links that will 404
+        goToProjectHome();
+        new PortalHelper(this).removeAllWebParts();
     }
 
     /* Issue 23487: add regression coverage for batch insert into list with multiple errors
@@ -1128,8 +1133,10 @@ public class ListTest extends BaseWebDriverTest
         clickProject(PROJECT_VERIFY);
 
         PortalHelper portalHelper = new PortalHelper(this);
-        portalHelper.addQueryWebPart(null, "lists", LIST_NAME_COLORS, null);
-        portalHelper.addQueryWebPart(null, "lists", LIST_NAME_COLORS, null);
+        portalHelper.doInAdminMode(ph -> {
+            portalHelper.addQueryWebPart(null, "lists", LIST_NAME_COLORS, null);
+            portalHelper.addQueryWebPart(null, "lists", LIST_NAME_COLORS, null);
+        });
 
         log("Test that the right filters are present for each type");
         DataRegionTable region = new DataRegionTable("qwp3", getDriver());


### PR DESCRIPTION
#### Rationale
<details><summary>AssayTransformMissingParentDirTest</summary>
<p>

```
org.openqa.selenium.NoSuchElementException: Unable to find element: link=missingParentDirAssay
[...]
  at app//org.labkey.test.WebDriverWrapper.clickAndWait(WebDriverWrapper.java:2906)
  at app//org.labkey.test.tests.assay.AssayTransformMissingParentDirTest.testMissingParentDirectoryRegression(AssayTransformMissingParentDirTest.java:81)
```

</p>
</details> 
This failure is caused by the test using the current URL (as the test begins) as the 'returnUrl' for the assay designer. The test doesn't control what happened before it and shouldn't assume it starts on a particular page. When it is on an unexpected page, the assay designer won't navigate where the test expects when saving. Omitting the returnUrl causes the save to navigate to the assay runs page (where the test wants to be anyway).

<details><summary>ListTest</summary>
<p>

```
java.lang.AssertionError: ListVerifyProject/study-reports-participantCrosstab.view?schemaName=lists&queryName=A_Colors_%2B-%20_.%3A%26()%2F%E2%98%83%C3%85%C3%A4&viewName=&dataRegionName=qwp2&redirectUrl=%2FListVerifyProject%2Fproject-begin.view&reportType=ReportService.CrossTab
produced response code 404
Originating page: http://localhost:8111/ListVerifyProject/project-begin.view
Target Page: ListVerifyProject/study-reports-participantCrosstab.view?schemaName=lists&queryName=A_Colors_%2B-%20_.%3A%26()%2F%E2%98%83%C3%85%C3%A4&viewName=&dataRegionName=qwp2&redirectUrl=%2FListVerifyProject%2Fproject-begin.view&reportType=ReportService.CrossTab
  at org.junit.Assert.fail(Assert.java:89)
  at org.labkey.test.util.Crawler.crawlLink(Crawler.java:1056)
  at org.labkey.test.util.Crawler.crawl(Crawler.java:869)
  at org.labkey.test.util.Crawler.crawlAllLinks(Crawler.java:832)
```

</p>
</details> 
`ListTest.filterTest` adds some query webparts pointing to a list that is later deleted. When the crawler comes along it finds links that 404 within those webparts. The webparts are functioning as intended, the test should just remove them when it is done.


#### Related Pull Requests
- N/A

#### Changes
- Fix ListTest crawler failure
- Fix returnUrl error in AssayTransformMissingParentDirTest
