### PR TITLE
Change the xpath used to find tabs.

### DIFF
--- a/src/org/labkey/test/components/labkey/PortalTab.java
+++ b/src/org/labkey/test/components/labkey/PortalTab.java
@@ -222,7 +222,7 @@ public class PortalTab extends WebDriverComponent<PortalTab.ElementCache>
         }
 
         static public Locator.XPathLocator container = Locator.tagWithClass("ul", "lk-nav-tabs");
-        static public Locator.XPathLocator tabItem = Locator.xpath("//li");
+        static public Locator.XPathLocator tabItem = Locator.xpath("/li");
         static public Locator.XPathLocator subContainerTabSelect = Locator.tagWithAttribute("select", "title", "subContainerTabs");
 
         static public Locator.XPathLocator tabList = container.append(tabItem);

--- a/src/org/labkey/test/util/PortalHelper.java
+++ b/src/org/labkey/test/util/PortalHelper.java
@@ -87,7 +87,7 @@ public class PortalHelper extends WebDriverWrapper
             throw new IllegalArgumentException("Can't move folder tabs vertically.");
 
         String tabId = tabText.replace(" ", "") + "Tab";
-        Locator.XPathLocator tabList = Locator.xpath("//ul[contains(@class, 'lk-nav-tabs-admin')]//li[@role='presentation']");
+        Locator.XPathLocator tabList = Locator.xpath("//ul[contains(@class, 'lk-nav-tabs-admin')]/li");
         Locator.XPathLocator tabLink = Locator.xpath("//a[@id=" + Locator.xq(tabId) + "]");
 
         int tabCount = getElementCount(tabList) - 1;


### PR DESCRIPTION
#### Rationale
Fix the portal tab helpers again. Find the tabs, and not dropdown menu items on the tabs. 

[Daily Postgres in 26.3](https://teamcity.labkey.org/buildConfiguration/LabKey_263Release_Community_DailyPostgres2/3918588?buildTab=dependencies&type=snapshot&mode=list) was run in this branch and had no failures related to the tab issue.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2929

#### Changes
- Update the xpath used to find the **li** elements that represent the tabs.
