### PR TITLE
Selenium test for GitHub Issue 915: Bulk edit doesn't completely remove attachments for sources

### DIFF
--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -16,6 +16,7 @@ import org.labkey.test.components.html.Input;
 import org.labkey.test.components.react.FilteringReactSelect;
 import org.labkey.test.components.react.ReactDateTimePicker;
 import org.labkey.test.components.react.ToggleButton;
+import org.labkey.test.components.ui.files.AttachmentCard;
 import org.labkey.test.components.ui.files.FileAttachmentContainer;
 import org.labkey.test.components.ui.files.FileUploadField;
 import org.labkey.test.params.FieldDefinition;
@@ -291,6 +292,24 @@ public class EntityBulkUpdateDialog extends ModalDialog
     public EntityBulkUpdateDialog removeFile(CharSequence fieldIdentifier)
     {
         getFileField(fieldIdentifier).removeFile();
+        return this;
+    }
+
+    /**
+     * Removes an existing attachment displayed as an {@link AttachmentCard} in the bulk update dialog.
+     * This is used when the rows being edited already have an attachment — the existing file is shown
+     * as an AttachmentCard with a dropdown menu containing "Remove attachment".
+     *
+     * @param fieldIdentifier Identifier for the field; name ({@link String}) or fieldKey ({@link FieldKey})
+     * @return this component
+     */
+    public EntityBulkUpdateDialog removeExistingAttachment(CharSequence fieldIdentifier)
+    {
+        var row = getFileField(fieldIdentifier);
+        // setEditableState(fieldIdentifier, true);
+        // WebElement row = elementCache().formRow(fieldIdentifier);
+        AttachmentCard card = new AttachmentCard.FileAttachmentCardFinder(getDriver()).waitFor(row);
+        card.clickRemove();
         return this;
     }
 

--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -306,8 +306,6 @@ public class EntityBulkUpdateDialog extends ModalDialog
     public EntityBulkUpdateDialog removeExistingAttachment(CharSequence fieldIdentifier)
     {
         var row = getFileField(fieldIdentifier);
-        // setEditableState(fieldIdentifier, true);
-        // WebElement row = elementCache().formRow(fieldIdentifier);
         AttachmentCard card = new AttachmentCard.FileAttachmentCardFinder(getDriver()).waitFor(row);
         card.clickRemove();
         return this;


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7543
- https://github.com/LabKey/limsModules/pull/2092
- https://github.com/LabKey/testAutomation/pull/2934

#### Changes
- Add test utils to properly remove existing saved attachment from bulk update form