### PR TITLE
Fix for SMEditableGridTest.testDragFillReadOnlyColumn

### DIFF
--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -1040,6 +1040,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
                 // WebDriver doesn't calculate correct location to click the cell selection handle
                 .moveToElement(elementToDrag, 0, 7)
                 .clickAndHold()
+                .pause(Duration.ofMillis(200))
                 .moveToElement(destinationCell)
                 // Extra wiggle to get it to stick
                 .moveByOffset(0, -size.getHeight())


### PR DESCRIPTION
#### Rationale
The beginDrag method for the UI component has a 150 ms timer to distinguish between a drag and a click. I've added a 200 ms wait to the drag action in the test to account for this.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
