### PR TITLE
test setRequired()

### DIFF
--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -1396,6 +1396,45 @@ public class ListTest extends BaseWebDriverTest
         assertTextBefore(newFieldName, origFieldName);
     }
 
+
+    @Test
+    public void requiredFieldsTest()
+    {
+        log("Test changing required property of field");
+        String listName = "requiredColList";
+        String fieldA = "c$a";
+        String fieldB = "c_b";
+
+        _listHelper.createList(PROJECT_VERIFY, listName, "key",
+                new FieldDefinition(fieldA, ColumnType.String).setDescription("first column").setRequired(false),
+                new FieldDefinition(fieldB, ColumnType.String).setDescription("second column").setRequired(false)
+        );
+
+        // insert a row with a NULL value and NON-NULL value
+        Map<String, String> row = new HashMap<>();
+        row.put(fieldA, "not null");
+        row.put(fieldB, "");
+        _listHelper.insertNewRow(row, false);
+
+        // fieldA can be set to required==true
+        EditListDefinitionPage listDefinitionPage = _listHelper.goToEditDesign(listName);
+        listDefinitionPage.getFieldsPanel()
+                .getField(fieldA)
+                .setRequiredField(true);
+        listDefinitionPage.clickSave();
+
+        // fieldB can not be set to required==true
+        listDefinitionPage = _listHelper.goToEditDesign(listName);
+        listDefinitionPage.getFieldsPanel()
+                .getField(fieldB)
+                .setRequiredField(true);
+        List<String> errors = listDefinitionPage.clickSaveExpectingErrors();
+        assertEquals(2, errors.size());
+        assertEquals("The property \"" + fieldB + "\" cannot be required when it contains rows with blank values.", errors.get(0));
+        assertEquals("Please correct errors in " + listName + " before saving.", errors.get(1));
+    }
+
+
     @Test
     public void exportPhiFileColumn() throws Exception
     {

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -1415,6 +1415,9 @@ public class ListTest extends BaseWebDriverTest
         row.put(fieldA, "not null");
         row.put(fieldB, "");
         _listHelper.insertNewRow(row, false);
+        row.put(fieldA, "still not null");
+        row.put(fieldB, "also not null");
+        _listHelper.insertNewRow(row, false);
 
         // fieldA can be set to required==true
         EditListDefinitionPage listDefinitionPage = _listHelper.goToEditDesign(listName);
@@ -1432,6 +1435,10 @@ public class ListTest extends BaseWebDriverTest
         assertEquals(2, errors.size());
         assertEquals("The property \"" + fieldB + "\" cannot be required when it contains rows with blank values.", errors.get(0));
         assertEquals("Please correct errors in " + listName + " before saving.", errors.get(1));
+
+        goToProjectHome();
+        clickAndWait(Locator.linkWithText(listName));
+        _listHelper.deleteList();
     }
 
 


### PR DESCRIPTION
#### Rationale
Test that field (non-MVTC) can't be set to required if null is present

regression test for change in https://github.com/LabKey/platform/pull/7549

#### Related Pull Requests
[- <!-- list of links to related pull requests (replace this comment) -->](https://github.com/LabKey/platform/pull/7549)

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
