### PR TITLE
Log orphaned attachments action for tests

### DIFF
--- a/src/org/labkey/test/tests/BasicTest.java
+++ b/src/org/labkey/test/tests/BasicTest.java
@@ -29,6 +29,7 @@ import org.labkey.test.categories.Git;
 import org.labkey.test.categories.Hosting;
 import org.labkey.test.categories.Smoke;
 import org.labkey.test.pages.core.admin.ShowAdminPage;
+import org.labkey.test.util.AttachmentHelper;
 import org.labkey.test.util.Order;
 
 import java.util.List;
@@ -60,6 +61,14 @@ public class BasicTest extends BaseWebDriverTest
         // Check for unrecognized scripts on the orphaned scripts page (only available in dev mode)
         beginAt(WebTestHelper.buildURL("admin-sql", "orphanedScripts"));
         assertTextNotPresent("WARNING:");
+    }
+
+    @Test
+    public void testOrphanedAttachments()
+    {
+        int orphanCount = AttachmentHelper.logOrphanedAttachments();
+        if (orphanCount > 0)
+            log("Orphaned attachments: " + orphanCount);
     }
 
     @Test

--- a/src/org/labkey/test/tests/BasicTest.java
+++ b/src/org/labkey/test/tests/BasicTest.java
@@ -64,14 +64,6 @@ public class BasicTest extends BaseWebDriverTest
     }
 
     @Test
-    public void testOrphanedAttachments()
-    {
-        int orphanCount = AttachmentHelper.logOrphanedAttachments();
-        if (orphanCount > 0)
-            log("Orphaned attachments: " + orphanCount);
-    }
-
-    @Test
     public void testStartupLogging()
     {
         ShowAdminPage adminPage = goToAdminConsole();

--- a/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
+++ b/src/org/labkey/test/tests/DatabaseDiagnosticsTest.java
@@ -31,6 +31,7 @@ import org.labkey.test.categories.Git;
 import org.labkey.test.io.Grep;
 import org.labkey.test.pages.core.admin.SiteValidationPage;
 import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
+import org.labkey.test.util.AttachmentHelper;
 import org.labkey.test.util.Maps;
 import org.labkey.test.util.Order;
 import org.labkey.test.util.PasswordUtil;
@@ -133,6 +134,14 @@ public class DatabaseDiagnosticsTest extends BaseWebDriverTest
         WebElement exceptionCount = waitForElement(Locator.id("exceptionCount"));
         if (!"no exceptions".equals(exceptionCount.getText()))
             getArtifactCollector().dumpPageSnapshot("exceptions", null);
+    }
+
+    @Test
+    public void testOrphanedAttachments()
+    {
+        int orphanCount = AttachmentHelper.logOrphanedAttachments();
+        if (orphanCount > 0)
+            log("Orphaned attachments: " + orphanCount);
     }
 
     @Override

--- a/src/org/labkey/test/util/AttachmentHelper.java
+++ b/src/org/labkey/test/util/AttachmentHelper.java
@@ -1,0 +1,29 @@
+package org.labkey.test.util;
+
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.SimpleGetCommand;
+import org.labkey.test.WebTestHelper;
+
+import java.io.IOException;
+
+public class AttachmentHelper
+{
+    /**
+     * Tells LabKey to log the first 20 orphaned attachments it detects at the ERROR level. Returns the total number of
+     * orphaned attachments detected. Must be a root admin (site or app) to call this.
+     */
+    public static int logOrphanedAttachments()
+    {
+        SimpleGetCommand command = new SimpleGetCommand("admin", "logOrphanedAttachments");
+        try
+        {
+            CommandResponse response = command.execute(WebTestHelper.getRemoteApiConnection(), "/");
+            return response.getProperty("count");
+        }
+        catch (IOException | CommandException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/org/labkey/test/util/Crawler.java
+++ b/src/org/labkey/test/util/Crawler.java
@@ -194,7 +194,6 @@ public class Crawler
             new ControllerActionId("login", "setPassword"),
             new ControllerActionId("ms2", "showList"),
             new ControllerActionId("ms2", "showParamsFile"),
-            new ControllerActionId("nlp", "runPipeline"),
             new ControllerActionId("pipeline-analysis", "analyze"), // Doesn't navigate
             new ControllerActionId("project", "togglePageAdminMode"),
             // Tested directly in XTandemTest


### PR DESCRIPTION
#### Rationale
`AttachmentHelper.logOrphanedAttachments()` gives the tests a way to proactively check for orphaned attachments

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7556