### PR TITLE
Account for sample types that may have been defined in other tests

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
@@ -566,8 +566,12 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         List<FieldDefinition> testFields = SampleTypeAPIHelper.sampleTypeTestFields(false);
         SampleTypeDefinition testSampleType = new SampleTypeDefinition(projectSampleType).setFields(testFields);
         SampleTypeAPIHelper.createEmptySampleType(getProjectName(), testSampleType);
-
         goToProjectHome();
+        PortalHelper portalHelper = new PortalHelper(this);
+        portalHelper.addWebPart("Sample Types");
+        DataRegionTable table = DataRegionTable.DataRegion(getDriver()).withName("SampleSet").waitFor();
+        List<String> exportedNames = table.getColumnDataAsText("Name");
+
         ExportFolderPage exportPage = goToFolderManagement()
                 .goToExportTab();
         exportPage.includeSubfolders(true);
@@ -576,11 +580,11 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         goToProjectHome(importProject);
         importFolderFromZip(exportedFolderFile, false, 1);
         goToProjectFolder(importProject, subfolder);
-        PortalHelper portalHelper = new PortalHelper(this);
+        portalHelper = new PortalHelper(this);
         portalHelper.addWebPart("Sample Types");
-        DataRegionTable table = DataRegionTable.DataRegion(getDriver()).withName("SampleSet").waitFor();
+        table = DataRegionTable.DataRegion(getDriver()).withName("SampleSet").waitFor();
         List<String> typeNames = table.getColumnDataAsText("Name");
-        checker().verifyEquals("Type names not as expected", List.of(projectSampleType), typeNames);
+        checker().verifyEquals("Type names not as expected", exportedNames, typeNames);
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
New test added did not properly account for possibly other sample types from previous tests.

Test is now passing: https://teamcity.labkey.org/buildConfiguration/bt7/3930620?buildTab=tests

#### Related Pull Requests
- #2933 

#### Changes
- Update test to capture full set of sample types before export.
