### PR TITLE
GitHub Issue #1061: Error loading assay import page when Participant/Visit resolver field is set to 'fixed value' default

### DIFF
--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -30,13 +30,16 @@ import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.PlateGrid;
 import org.labkey.test.components.assay.AssayConstants;
+import org.labkey.test.components.domain.AdvancedFieldSetting;
 import org.labkey.test.components.labkey.LabKeyAlert;
+import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.admin.PermissionsPage;
 import org.labkey.test.pages.assay.RunQCPage;
 import org.labkey.test.pages.assay.plate.PlateDesignerPage;
 import org.labkey.test.pages.assay.plate.PlateTemplateListPage;
 import org.labkey.test.pages.query.NewQueryPage;
 import org.labkey.test.pages.query.SourceQueryPage;
+import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.tests.AbstractAssayTest;
 import org.labkey.test.util.AssayImportOptions;
 import org.labkey.test.util.AssayImporter;
@@ -234,7 +237,6 @@ public class NabAssayTest extends AbstractAssayTest
 
         clickProject(TEST_ASSAY_PRJ_NAB);
         clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));
-
         _assayHelper.clickEditAssayDesign()
                 .setPlateTemplate(PLATE_TEMPLATE_NAME)
                 .clickFinish();
@@ -259,6 +261,15 @@ public class NabAssayTest extends AbstractAssayTest
         clickAndWait(Locator.linkWithText("Assay List"));
         clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));
 
+        log("GitHub Issue #1061: set ParticipantVisitResolver field as fixed value for default value setting");
+        clickProject(TEST_ASSAY_PRJ_NAB);
+        clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));
+        ReactAssayDesignerPage assayDesignerPage = _assayHelper.clickEditAssayDesign();
+        assayDesignerPage.goToBatchFields()
+                .getField(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME)
+                .setAdvancedSettings(List.of(AdvancedFieldSetting.defaultType(FieldDefinition.DefaultType.FIXED_NON_EDITABLE)));
+        assayDesignerPage.clickFinish();
+
         log("Uploading NAb Runs");
         new AssayImporter(this, new AssayImportOptions.ImportOptionsBuilder().
                         assayId("ptid + visit").
@@ -275,6 +286,15 @@ public class NabAssayTest extends AbstractAssayTest
                         methods(new String[]{"Dilution", "Dilution", "Dilution", "Dilution", "Dilution"}).
                         runFile(TEST_ASSAY_NAB_FILE1).
                         build()).doImport();
+
+        log("GitHub Issue #1061: revert ParticipantVisitResolver field default value setting");
+        clickProject(TEST_ASSAY_PRJ_NAB);
+        clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));
+        assayDesignerPage = _assayHelper.clickEditAssayDesign();
+        assayDesignerPage.goToBatchFields()
+                .getField(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME)
+                .setAdvancedSettings(List.of(AdvancedFieldSetting.defaultType(FieldDefinition.DefaultType.LAST_ENTERED)));
+        assayDesignerPage.clickFinish();
 
         // verify that we catch an invalid date prior to upload
         new AssayImporter(this, new AssayImportOptions.ImportOptionsBuilder().

--- a/src/org/labkey/test/tests/nab/NabAssayTest.java
+++ b/src/org/labkey/test/tests/nab/NabAssayTest.java
@@ -255,12 +255,6 @@ public class NabAssayTest extends AbstractAssayTest
         assertTextPresent(PLATE_TEMPLATE_NAME);
         assertTextNotPresent("NAb: 5 specimens in duplicate");
 
-        navigateToFolder(TEST_ASSAY_PRJ_NAB, TEST_ASSAY_FLDR_NAB);
-        portalHelper.addWebPart("Assay List");
-
-        clickAndWait(Locator.linkWithText("Assay List"));
-        clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));
-
         log("GitHub Issue #1061: set ParticipantVisitResolver field as fixed value for default value setting");
         clickProject(TEST_ASSAY_PRJ_NAB);
         clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));
@@ -269,6 +263,11 @@ public class NabAssayTest extends AbstractAssayTest
                 .getField(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME)
                 .setAdvancedSettings(List.of(AdvancedFieldSetting.defaultType(FieldDefinition.DefaultType.FIXED_NON_EDITABLE)));
         assayDesignerPage.clickFinish();
+
+        navigateToFolder(TEST_ASSAY_PRJ_NAB, TEST_ASSAY_FLDR_NAB);
+        portalHelper.addWebPart("Assay List");
+        clickAndWait(Locator.linkWithText("Assay List"));
+        clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));
 
         log("Uploading NAb Runs");
         new AssayImporter(this, new AssayImportOptions.ImportOptionsBuilder().
@@ -295,6 +294,9 @@ public class NabAssayTest extends AbstractAssayTest
                 .getField(AssayConstants.PARTICIPANT_VISIT_RESOLVER_FIELD_NAME)
                 .setAdvancedSettings(List.of(AdvancedFieldSetting.defaultType(FieldDefinition.DefaultType.LAST_ENTERED)));
         assayDesignerPage.clickFinish();
+        navigateToFolder(TEST_ASSAY_PRJ_NAB, TEST_ASSAY_FLDR_NAB);
+        clickAndWait(Locator.linkWithText("Assay List"));
+        clickAndWait(Locator.linkWithText(TEST_ASSAY_NAB));
 
         // verify that we catch an invalid date prior to upload
         new AssayImporter(this, new AssayImportOptions.ImportOptionsBuilder().


### PR DESCRIPTION
#### Rationale
[#1061](https://github.com/LabKey/internal-issues/issues/1061) Error loading import page when NAb assay participant/resolver field is set to 'fixed value' default

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7592

#### Changes
- Update NabAssayTest case for setting default value type of ParticipantVisitResolver
