### PR TITLE
Drop LSID from provisioned dataclass tables

### DIFF
--- a/src/org/labkey/test/tests/DataClassTest.java
+++ b/src/org/labkey/test/tests/DataClassTest.java
@@ -419,7 +419,6 @@ public class DataClassTest extends BaseWebDriverTest
     private void verifyTableIndices(String prefix, List<String> indexSuffixes)
     {
         List<String> suffixes  = new ArrayList<>();
-        suffixes.add("lsid");
         suffixes.add("name");
         suffixes.add("rowid");
         suffixes.addAll(indexSuffixes);


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1988
- https://github.com/LabKey/platform/pull/7483
- https://github.com/LabKey/limsModules/pull/2034
- https://github.com/LabKey/testAutomation/pull/2965

#### Changes
- Update test to remove stale lsid index