### PR TITLE
Remove MVTC experimental flag

### DIFF
--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -1746,7 +1746,6 @@ public class ListTest extends BaseWebDriverTest
     @Test
     public void testMultiChoiceValues() throws IOException, CommandException
     {
-        OptionalFeatureHelper.enableOptionalFeature(getCurrentTest().createDefaultConnection(), "multiChoiceDataType");
         Assume.assumeTrue("Multi-choice text fields are only supported on PostgreSQL", WebTestHelper.getDatabaseType() == WebTestHelper.DatabaseType.PostgreSQL);
         // Setup a list with an auto-increment key and a multi-value text choice field.
         String encodedListName = TestDataGenerator.randomDomainName("multiChoiceList", DomainUtils.DomainKind.IntList);

--- a/src/org/labkey/test/tests/list/ListTest.java
+++ b/src/org/labkey/test/tests/list/ListTest.java
@@ -65,7 +65,6 @@ import org.labkey.test.util.DomainUtils;
 import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.Maps;
-import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.TestDataGenerator;
 import org.labkey.test.util.TextSearcher;


### PR DESCRIPTION
#### Rationale
`multiChoiceDataType` experimental flag is no longer present.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7622
- https://github.com/LabKey/limsModules/pull/2146
- https://github.com/LabKey/testAutomation/pull/2966

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
