### PR TITLE
Fix for SMEditableGridTest.testDragFillReadOnlyColumn

### DIFF
--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -1023,7 +1023,16 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
     {
         dismissPopover();
         Locator.XPathLocator selectionHandleLoc = Locator.byClass("cell-selection-handle");
-        WebElement selectionHandle = selectionHandleLoc.findElement(startCell);
+
+        WebElement selectionHandle = selectionHandleLoc.waitForElement(startCell, 2_000);
+        dragToCell(selectionHandle, endCell);
+
+        // Wait and check after drag
+        if (WebDriverWrapper.waitFor(() -> !selectionHandleLoc.findElements(endCell).isEmpty(), 2_000))
+            return;
+
+        // Retry if failed
+        selectionHandle = selectionHandleLoc.waitForElement(startCell, 2_000);
         dragToCell(selectionHandle, endCell);
         selectionHandleLoc.waitForElement(endCell, 5_000);
     }
@@ -1045,7 +1054,7 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
                 // WebDriver doesn't calculate correct location to click the cell selection handle
                 .moveToElement(elementToDrag, 0, 7)
                 .clickAndHold()
-                .pause(Duration.ofMillis(200))
+                .pause(Duration.ofMillis(500))
                 .moveToElement(destinationCell)
                 // Extra wiggle to get it to stick
                 .moveByOffset(0, -size.getHeight())

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -1023,18 +1023,22 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
     {
         dismissPopover();
         Locator.XPathLocator selectionHandleLoc = Locator.byClass("cell-selection-handle");
-
-        WebElement selectionHandle = selectionHandleLoc.waitForElement(startCell, 2_000);
+        // Get the value from the start cell
+        String fillValue = getCellValue(startCell);
+        WebElement selectionHandle = selectionHandleLoc.waitForElement(getComponentElement(), 2_000);
         dragToCell(selectionHandle, endCell);
 
-        // Wait and check after drag
-        if (WebDriverWrapper.waitFor(() -> !selectionHandleLoc.findElements(endCell).isEmpty(), 2_000))
-            return;
-
-        // Retry if failed
-        selectionHandle = selectionHandleLoc.waitForElement(startCell, 2_000);
-        dragToCell(selectionHandle, endCell);
-        selectionHandleLoc.waitForElement(endCell, 5_000);
+        // Wait until endCell actually receives the fill value.
+        if (!WebDriverWrapper.waitFor(() -> fillValue.equals(getCellValue(endCell)), 3_000))
+        {
+            // Fill didn't complete on the first attempt — the drag likely extended the selection
+            // without triggering the fill. Re-click startCell to restore selection, then retry the drag.
+            startCell.click();
+            selectionHandle = selectionHandleLoc.waitForElement(getComponentElement(), 2_000);
+            dragToCell(selectionHandle, endCell);
+            WebDriverWrapper.waitFor(() -> fillValue.equals(getCellValue(endCell)),
+                    "Drag fill did not populate end cell with value: " + fillValue, 5_000);
+        }
     }
 
     public void selectCellRange(WebElement startCell, WebElement endCell)

--- a/src/org/labkey/test/components/ui/grids/EditableGrid.java
+++ b/src/org/labkey/test/components/ui/grids/EditableGrid.java
@@ -1019,6 +1019,38 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         return getWrapper().getClipboardContent();
     }
 
+    /**
+     * Select a cell range and drag-fill from the end of that selection to {@code dragEnd}.
+     * Because this overload owns the {@link #selectCellRange} step, it can fully restore state
+     * and retry if the first drag extended the selection without applying the fill.
+     *
+     * @param selectStart first cell of the selection (passed to {@link #selectCellRange})
+     * @param selectEnd   last cell of the selection; also the source of the fill value
+     * @param dragEnd     destination cell for the fill drag
+     */
+    public void dragFill(WebElement selectStart, WebElement selectEnd, WebElement dragEnd)
+    {
+        Locator.XPathLocator selectionHandleLoc = Locator.byClass("cell-selection-handle");
+        selectCellRange(selectStart, selectEnd);
+        String fillValue = getCellValue(selectEnd);
+        WebElement selectionHandle = selectionHandleLoc.waitForElement(getComponentElement(), 2_000);
+        dragToCell(selectionHandle, dragEnd);
+        if (!WebDriverWrapper.waitFor(() -> fillValue.equals(getCellValue(dragEnd)), 3_000))
+        {
+            // Fill didn't complete — the drag likely extended the selection without triggering the fill.
+            selectCellRange(selectStart, selectEnd);
+            selectionHandle = selectionHandleLoc.waitForElement(getComponentElement(), 2_000);
+            dragToCell(selectionHandle, dragEnd);
+            WebDriverWrapper.waitFor(() -> fillValue.equals(getCellValue(dragEnd)),
+                    "Drag fill did not populate end cell with value: " + fillValue, 5_000);
+        }
+    }
+
+    /**
+     * Drag-fill from {@code startCell} (which must already be selected / part of the current
+     * selection) to {@code endCell}.  Prefer {@link #dragFill(WebElement, WebElement, WebElement)}
+     * when the selection range is known — that overload can retry reliably.
+     */
     public void dragFill(WebElement startCell, WebElement endCell)
     {
         dismissPopover();
@@ -1027,18 +1059,10 @@ public class EditableGrid extends WebDriverComponent<EditableGrid.ElementCache>
         String fillValue = getCellValue(startCell);
         WebElement selectionHandle = selectionHandleLoc.waitForElement(getComponentElement(), 2_000);
         dragToCell(selectionHandle, endCell);
-
-        // Wait until endCell actually receives the fill value.
-        if (!WebDriverWrapper.waitFor(() -> fillValue.equals(getCellValue(endCell)), 3_000))
-        {
-            // Fill didn't complete on the first attempt — the drag likely extended the selection
-            // without triggering the fill. Re-click startCell to restore selection, then retry the drag.
-            startCell.click();
-            selectionHandle = selectionHandleLoc.waitForElement(getComponentElement(), 2_000);
-            dragToCell(selectionHandle, endCell);
-            WebDriverWrapper.waitFor(() -> fillValue.equals(getCellValue(endCell)),
-                    "Drag fill did not populate end cell with value: " + fillValue, 5_000);
-        }
+        // Handle appearing in endCell alone is insufficient — the selection can expand
+        // (handle moves) without fill values being applied. Wait for the actual value.
+        WebDriverWrapper.waitFor(() -> fillValue.equals(getCellValue(endCell)),
+                "Drag fill did not populate end cell with value: " + fillValue, 5_000);
     }
 
     public void selectCellRange(WebElement startCell, WebElement endCell)

--- a/src/org/labkey/test/tests/MultiValueTextChoiceSampleTypeTest.java
+++ b/src/org/labkey/test/tests/MultiValueTextChoiceSampleTypeTest.java
@@ -149,7 +149,7 @@ public class MultiValueTextChoiceSampleTypeTest extends BaseWebDriverTest implem
         updateSampleTypePage.getFieldsPanel()
                 .getField(multiValueTextChoiceFieldName)
                 .expand()
-                .setAllowMultipleSelections(false);
+                .setAllowMultipleSelections(false, true);
         updateSampleTypePage.clickSave();
 
         // Check that impossible to choose multiple values.


### PR DESCRIPTION
#### Rationale
Test [SMEditableGridTest.testDragFillReadOnlyColumn](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_SampleManagerPostgres/3933361?buildTab=tests&name=dragFill) failing with the error "Drag is initializing in the wrong column".

#### Related Pull Requests
- [https://github.com/LabKey/limsModules/pull/2158](https://github.com/LabKey/limsModules/pull/2158)

#### Changes
- Added retry after dragToCell
