### PR TITLE
Fix for SampleTypeNameExpressionTest

### DIFF
--- a/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
@@ -436,7 +436,8 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
 
         public final WebElement helpTarget(String divLabelText)
         {
-            return Locator.xpath(String.format("//div[text()='%s']//div[@class='overlay-trigger']", divLabelText)).findWhenNeeded(this);
+            String element = getThis().getClass().getSimpleName().contains("SampleType")? "div" : "span";
+            return Locator.xpath(String.format("//%s[text()='%s']//div[@class='overlay-trigger']", element, divLabelText)).findWhenNeeded(this);
         }
 
         // Tool tips exist on the page, outside the scope of the domainDesigner, so scope the search accordingly.

--- a/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
+++ b/src/org/labkey/test/components/ui/domainproperties/EntityTypeDesigner.java
@@ -436,7 +436,7 @@ public abstract class EntityTypeDesigner<T extends EntityTypeDesigner<T>> extend
 
         public final WebElement helpTarget(String divLabelText)
         {
-            return Locator.xpath(String.format("//span[text()='%s']//div[@class='overlay-trigger']", divLabelText)).findWhenNeeded(this);
+            return Locator.xpath(String.format("//div[text()='%s']//div[@class='overlay-trigger']", divLabelText)).findWhenNeeded(this);
         }
 
         // Tool tips exist on the page, outside the scope of the domainDesigner, so scope the search accordingly.


### PR DESCRIPTION
#### Rationale
[SampleTypeNameExpressionTest.testNameExpressionPreview, SampleTypeNameExpressionTest.testErrorsAndWarnings](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyPostgres_2/3969885?buildTab=tests&status=failed&name=expression) failed with message "Unable to find element: xpath=//span[text()='Naming ']//div[@class='overlay-trigger']". Element xpath changed.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Changed xpath
