### PR TITLE
Check for errors after saving query definition

### DIFF
--- a/src/org/labkey/test/pages/query/SourceQueryPage.java
+++ b/src/org/labkey/test/pages/query/SourceQueryPage.java
@@ -1,6 +1,7 @@
 package org.labkey.test.pages.query;
 
 import org.labkey.test.Locator;
+import org.labkey.test.Locators;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.pages.LabKeyPage;
@@ -8,6 +9,7 @@ import org.labkey.test.util.DataRegion;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.time.Duration;
@@ -88,7 +90,7 @@ public class SourceQueryPage extends LabKeyPage<SourceQueryPage.ElementCache>
 
     public SourceQueryPage clickSave()
     {
-        Ext4Helper.Locators.ext4Button("Save").findElement(getDriver()).click();
+        elementCache().saveButton.click();
         waitForElement(Locator.id("status").withText("Saved"), WAIT_FOR_JAVASCRIPT);
         waitForElementToDisappear(Locator.id("status").withText("Saved"), WAIT_FOR_JAVASCRIPT);
 
@@ -97,14 +99,22 @@ public class SourceQueryPage extends LabKeyPage<SourceQueryPage.ElementCache>
 
     public ExecuteQueryPage clickSaveAndFinish()
     {
-        clickAndWait(Ext4Helper.Locators.ext4Button("Save & Finish").findElement(getDriver()));
+        clickAndWait(elementCache().saveAndFinishButton);
+        assertNoLabKeyErrors();
         return new ExecuteQueryPage(getDriver());
     }
 
     public String clickSaveExpectingError()
     {
-        Ext4Helper.Locators.ext4Button("Save").findElement(getDriver()).click();
+        elementCache().saveButton.click();
         return waitForElement(Locator.tagWithId("div","status")).getText();
+    }
+
+    public String clickSaveAndFinishExpectingError()
+    {
+        clickAndWait(elementCache().saveAndFinishButton);
+        clearCache();
+        return waitForElement(Locators.labkeyError).getText();
     }
 
     @Override
@@ -115,5 +125,7 @@ public class SourceQueryPage extends LabKeyPage<SourceQueryPage.ElementCache>
 
     protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
+        private final WebElement saveButton = Ext4Helper.Locators.ext4Button("Save").findWhenNeeded(this);
+        private final WebElement saveAndFinishButton = Ext4Helper.Locators.ext4Button("Save & Finish").findWhenNeeded(this);
     }
 }

--- a/src/org/labkey/test/tests/PivotQueryTest.java
+++ b/src/org/labkey/test/tests/PivotQueryTest.java
@@ -228,7 +228,7 @@ public class PivotQueryTest extends ReportTest
         createQueryPage.setName(queryName);
         var sourceQueryPage = createQueryPage.clickCreate();
         sourceQueryPage.setSource(queryText);
-        sourceQueryPage.clickSaveAndFinish();
+        sourceQueryPage.clickSaveAndFinishExpectingError();
 
         // expect query error
         waitForText("Query 'Q1' has errors", "Error on line 3: Can not find pivot column:");


### PR DESCRIPTION
#### Rationale
Not detecting unexpected query errors can lead to hard to diagnose errors in subsequent tests.
```
java.lang.AssertionError: Did not find correct number of finished pipeline jobs. expected:<1> but was:<0>
  at org.junit.Assert.fail(Assert.java:89)
  at org.junit.Assert.failNotEquals(Assert.java:835)
  at org.junit.Assert.assertEquals(Assert.java:647)
  at org.labkey.test.LabKeySiteWrapper.waitForPipelineJobsToFinish(LabKeySiteWrapper.java:1641)
  at org.labkey.test.LabKeySiteWrapper.waitForPipelineJobsToComplete(LabKeySiteWrapper.java:1600)
  at org.labkey.test.LabKeySiteWrapper.waitForPipelineJobsToComplete(LabKeySiteWrapper.java:1587)
  at org.labkey.test.LabKeySiteWrapper.waitForPipelineJobsToComplete(LabKeySiteWrapper.java:1582)
  at org.labkey.test.tests.compliance.ComplianceQuerySnapshotTest.testPivotQueryETLToList(ComplianceQuerySnapshotTest.java:240)
```

#### Related Pull Requests
- N/A

#### Changes
- Check for errors after saving query definition
