### PR TITLE
Improve cache clearing/GC/heap dump behavior

### DIFF
--- a/src/org/labkey/remoteapi/admin/ClearCachesCommand.java
+++ b/src/org/labkey/remoteapi/admin/ClearCachesCommand.java
@@ -23,9 +23,9 @@ public class ClearCachesCommand extends PostCommand<CommandResponse>
     {
         Map<String, Object> params = new HashMap<>();
         if (_clearCaches)
-            params.put("clearCaches", "1");
+            params.put("clearCaches", true);
         if (_gc)
-            params.put("gc", "1");
+            params.put("gc", true);
         return params;
     }
 }

--- a/src/org/labkey/remoteapi/admin/ClearCachesCommand.java
+++ b/src/org/labkey/remoteapi/admin/ClearCachesCommand.java
@@ -1,0 +1,31 @@
+package org.labkey.remoteapi.admin;
+
+import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.PostCommand;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ClearCachesCommand extends PostCommand<CommandResponse>
+{
+    private final boolean _clearCaches;
+    private final boolean _gc;
+
+    public ClearCachesCommand(boolean clearCaches, boolean gc)
+    {
+        super("admin", "clearCaches");
+        _clearCaches = clearCaches;
+        _gc = gc;
+    }
+
+    @Override
+    protected Map<String, Object> createParameterMap()
+    {
+        Map<String, Object> params = new HashMap<>();
+        if (_clearCaches)
+            params.put("clearCaches", "1");
+        if (_gc)
+            params.put("gc", "1");
+        return params;
+    }
+}

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -44,6 +44,7 @@ import org.labkey.junit.rules.TestWatcher;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.admin.ClearCachesCommand;
 import org.labkey.remoteapi.SimpleGetCommand;
 import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
@@ -99,7 +100,6 @@ import org.labkey.test.util.TestLogger;
 import org.labkey.test.util.UIPermissionsHelper;
 import org.labkey.test.util.core.webdav.WebDavUploadHelper;
 import org.labkey.test.util.ext4cmp.Ext4FieldRef;
-import org.labkey.test.util.query.QueryUtils;
 import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.ElementClickInterceptedException;
@@ -1389,6 +1389,22 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         return SingletonWebDriver.getInstance().getDownloadDir();
     }
 
+    /**
+     * Clears all server caches and runs garbage collection via the admin ClearCachesAction.
+     * Leaves the browser on the MemTracker page.
+     */
+    protected void clearCaches()
+    {
+        try
+        {
+            new ClearCachesCommand(true, true).execute(createDefaultConnection(), "/");
+        }
+        catch (IOException | CommandException e)
+        {
+            throw new RuntimeException("Failed to clear caches", e);
+        }
+    }
+
     protected void checkLeaks()
     {
         if (isLeakCheckSkipped())
@@ -1415,7 +1431,8 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
                 }
             }
             msSinceTestStart = System.currentTimeMillis() - previousLeakCheck;
-            beginAt(WebTestHelper.buildURL("admin", "memTracker", Map.of("gc", 1, "clearCaches", 1)), 120000);
+            clearCaches();
+            beginAt(WebTestHelper.buildURL("admin", "memTracker"));
             if (!isTextPresent("In-Use Objects"))
                 throw new IllegalStateException("Asserts must be enabled to track memory leaks; add -ea to your server VM params and restart or add -DmemCheck=false to your test VM params.");
             leakCount = getImageWithAltTextCount("expand/collapse");
@@ -2377,12 +2394,6 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     public void validateQueries(boolean validateSubfolders)
     {
         validateQueries(validateSubfolders, 120000);
-    }
-
-    @Deprecated
-    public void deleteAllRows(String projectName, String schema, String table) throws IOException, CommandException
-    {
-        QueryUtils.truncateTable(projectName, schema, table);
     }
 
     // This class makes it easier to start a specimen import early in a test and wait for completion later.

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1174,6 +1174,7 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
 
         // Use dumpHeapAction rather that touching file so that we can get file name and publish artifact.
         beginAt(WebTestHelper.buildURL("admin", "dumpHeap"));
+        clickButton("OK");
         String dumpMsg = Locators.bodyPanel().childTag("div").findElement(getDriver()).getText();
         String filePrefix = "Heap dumped to ";
         int prefixIndex = dumpMsg.indexOf(filePrefix);

--- a/src/org/labkey/test/tests/filecontent/FilesQueryTest.java
+++ b/src/org/labkey/test/tests/filecontent/FilesQueryTest.java
@@ -173,7 +173,7 @@ public class FilesQueryTest extends BaseWebDriverTest
     private void ensureFilesUpToDate()
     {
         log("Clear cache so that exp.files will do a sync immediately");
-        beginAt(WebTestHelper.buildURL("admin", "caches", Map.of("clearCaches", "1")), 120000);
+        clearCaches();
         goToProjectHome();
     }
 

--- a/src/org/labkey/test/tests/perf/SchemaBrowserPerfTest.java
+++ b/src/org/labkey/test/tests/perf/SchemaBrowserPerfTest.java
@@ -88,7 +88,7 @@ public class SchemaBrowserPerfTest extends PerformanceTest
         long[] emptyCacheOpenStudyTimes = new long[5];
         // run tests
         for (int x = 0 ; x < 5; x++) {
-            beginAt(WebTestHelper.buildURL("admin", "caches", Map.of("clearCaches", 1)), 120000);
+            clearCaches();
             goToHome();
             clickProject(getProjectName());
             goToSchemaBrowser();
@@ -103,7 +103,7 @@ public class SchemaBrowserPerfTest extends PerformanceTest
     private long[] studyBaselineFullCache() {
         long[] fullCacheOpenStudyTimes = new long[5];
         // prepare cache
-        beginAt(WebTestHelper.buildURL("admin", "caches", Map.of("clearCaches", 1)), 120000);
+        clearCaches();
         goToHome();
         clickProject(getProjectName());
         goToSchemaBrowser();
@@ -125,7 +125,7 @@ public class SchemaBrowserPerfTest extends PerformanceTest
     private long[] studyDataBaselineFullCache() {
         long[] emptyCacheOpenStudyDataTimes = new long[5];
         // prepare cache
-        beginAt(WebTestHelper.buildURL("admin", "caches", Map.of("clearCaches", 1)), 120000);
+        clearCaches();
         goToHome();
         clickProject(getProjectName());
         goToSchemaBrowser();


### PR DESCRIPTION
#### Rationale
Cache clearing is switching to an API call.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7655

#### Changes
- New utility method to clear caches using `ClearCachesCommand`
- Eliminate deprecated method