### PR TITLE
Upgrade test for "limit unsuccessful logins" settings

### DIFF
--- a/src/org/labkey/test/pages/compliance/ComplianceLoginSettingsPage.java
+++ b/src/org/labkey/test/pages/compliance/ComplianceLoginSettingsPage.java
@@ -35,6 +35,11 @@ public class ComplianceLoginSettingsPage extends BaseComplianceSettingsPage<Comp
         shortWait().until(wd -> !elementCache().loginAttemptCountCombo.isEnabled());
     }
 
+    public boolean isLoginLimitEnabled()
+    {
+        return elementCache().enableLoginChk.isSelected();
+    }
+
     public void setLoginAttemptCount(String count)
     {
         setFormElement(elementCache().loginAttemptCountInput, count);
@@ -43,6 +48,21 @@ public class ComplianceLoginSettingsPage extends BaseComplianceSettingsPage<Comp
     public void selectLoginAttemptCount(String count)
     {
         elementCache().loginAttemptCountCombo.selectComboBoxItem(count);
+    }
+
+    public String getLoginAttemptCount()
+    {
+        return getFormElement(elementCache().loginAttemptCountInput);
+    }
+
+    public String getLoginAttemptPeriod()
+    {
+        return getFormElement(elementCache().loginAttemptPeriodInput);
+    }
+
+    public String getLoginAttemptRecoveryTime()
+    {
+        return getFormElement(elementCache().loginAttemptRecoveryTimeInput);
     }
 
     public void selectLoginAttemptPeriod(String period)

--- a/src/org/labkey/test/tests/upgrade/BaseUpgradeTest.java
+++ b/src/org/labkey/test/tests/upgrade/BaseUpgradeTest.java
@@ -50,13 +50,23 @@ public abstract class BaseUpgradeTest extends BaseWebDriverTest
     {
         BaseUpgradeTest currentTest = BaseWebDriverTest.getCurrentTest();
 
+        Class<?> testClass = currentTest.getClass();
+        String earliestVersion = Optional.ofNullable(testClass.getAnnotation(EarliestVersion.class))
+                .map(EarliestVersion::value).orElse(null);
+        String latestVersion = Optional.ofNullable(testClass.getAnnotation(LatestVersion.class))
+                .map(LatestVersion::value).orElse(null);
+
+        Assume.assumeTrue("Test class not valid when upgrading from version: " + setupVersion,
+                VersionRange.versionRange(earliestVersion, latestVersion).contains(setupVersion)
+        );
+
         if (isUpgradeSetupPhase)
         {
             currentTest.doSetup();
         }
         else
         {
-            TestLogger.info("Skipping setup for %s. Verifying upgrade.". formatted(currentTest.getClass().getSimpleName()));
+            TestLogger.info("Skipping setup for %s. Verifying upgrade.". formatted(testClass.getSimpleName()));
         }
     }
 
@@ -100,19 +110,19 @@ public abstract class BaseUpgradeTest extends BaseWebDriverTest
      * Specifies the earliest version of the test class that performed the required setup for the annotated method.
      */
     @Retention(RetentionPolicy.RUNTIME)
-    @Target({ElementType.METHOD})
+    @Target({ElementType.METHOD, ElementType.TYPE})
     protected @interface EarliestVersion
     {
         String value();
     }
 
     /**
-     * Annotates test methods that should only run when upgrading from particular LabKey versions, as specified in
-     * {@code webtest.upgradePreviousVersion}.<br>
-     * Specifies the latest version of the test class that performed the required setup for the annotated method.
+     * Annotates test methods or classes that should only run when upgrading from particular LabKey versions, as
+     * specified in {@code webtest.upgradePreviousVersion}.<br>
+     * Specifies the latest version of the test class that performed the required setup for the annotated method or class.
      */
     @Retention(RetentionPolicy.RUNTIME)
-    @Target({ElementType.METHOD})
+    @Target({ElementType.METHOD, ElementType.TYPE})
     protected @interface LatestVersion {
         String value();
     }

--- a/src/org/labkey/test/util/VersionRange.java
+++ b/src/org/labkey/test/util/VersionRange.java
@@ -14,15 +14,13 @@ public class VersionRange
      *
      * @param earliestVersion The earliest version in the range (inclusive). If null, there is no lower bound.
      * @param latestVersion The latest version in the range (inclusive). If null, there is no upper bound.
-     * @throws IllegalArgumentException if both versions are null, or if earliestVersion is after latestVersion.
+     * @throws IllegalArgumentException if earliestVersion is after latestVersion.
      */
     public VersionRange(Version earliestVersion, Version latestVersion)
     {
         this.earliestVersion = earliestVersion;
         this.latestVersion = latestVersion;
 
-        if (earliestVersion == null && latestVersion == null)
-            throw new IllegalArgumentException("Version range requires at least one version");
         if (earliestVersion != null && latestVersion != null && earliestVersion.compareTo(latestVersion) > 0)
             throw new IllegalArgumentException("%s is after %s".formatted(earliestVersion, latestVersion));
 


### PR DESCRIPTION
#### Rationale
Add upgrade test setup for moving login limit settings out of compliance module. `ComplianceLoginSettingsPage` needs some getters to verify the settings.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7645

#### Changes
- Upgrade test for "limit unsuccessful logins" settings
- Update `BaseUpgradeTest` annotations to work at the class level
