### PR TITLE
Fix ClassCastException from ErrorTest

### DIFF
--- a/src/org/labkey/test/Runner.java
+++ b/src/org/labkey/test/Runner.java
@@ -555,7 +555,14 @@ public class Runner extends TestSuite
             }
             else if (test.countTestCases() > 0)
             {
-                flattenSuiteInto(suite, (TestSuite) test);
+                if (test instanceof TestSuite)
+                {
+                    flattenSuiteInto(suite, (TestSuite) test);
+                }
+                else
+                {
+                    suite.addTest(test);
+                }
                 foundServerSideTest = true;
             }
         }


### PR DESCRIPTION
#### Rationale
If our test runner hits errors when determining the set of tests to run, we inject a stub test (`ErrorTest`) into the suite to surface the error on TeamCity. This stub test doesn't work with the [recent change](https://github.com/LabKey/testAutomation/pull/2973) to fix logging on TeamCity.
```
java.lang.ClassCastException: class org.labkey.test.Runner$ErrorTest cannot be cast to class junit.framework.TestSuite (org.labkey.test.Runner$ErrorTest and junit.framework.TestSuite are in unnamed module of loader 'app')
  at org.labkey.test.Runner.addTests(Runner.java:558)
  at org.labkey.test.Runner.getSuite(Runner.java:423)
  at org.labkey.test.Runner.suite(Runner.java:1028)
  at org.labkey.test.Runner.suite(Runner.java:875)
```

#### Related Pull Requests
- #2973 

#### Changes
- Fix ClassCastException from ErrorTest
