### PR TITLE
Update tests that relied on obsolete actions.

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -24,9 +24,9 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hc.core5.http.HttpStatus;
 import org.awaitility.Awaitility;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Assume;
 import org.junit.AssumptionViolatedException;
 import org.junit.ClassRule;
@@ -1686,20 +1686,17 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
     protected void setSelectedFields(String containerPath, String schema, String query, String viewName, String[] fields)
     {
         pushLocation();
-        beginAt(WebTestHelper.buildURL("query", containerPath, "internalNewView"));
-        setFormElement(Locator.name("ff_schemaName"), schema);
-        setFormElement(Locator.name("ff_queryName"), query);
+        beginAt(WebTestHelper.buildURL("query", containerPath, "executeQuery", Map.of("schemaName", "query", "queryName", "CustomViews")));
+        DataRegionTable drt = new DataRegionTable("query", getDriver());
+        drt.clickInsertNewRow();
+        waitForElement(Locator.name("quf_Schema"));
+        setFormElement(Locator.name("quf_Schema"), schema);
+        setFormElement(Locator.name("quf_QueryName"), query);
         if (viewName != null)
-            setFormElement(Locator.name("ff_viewName"), viewName);
-        clickButton("Create");
-        StringBuilder strFields = new StringBuilder(fields[0]);
-        for (int i = 1; i < fields.length; i ++)
-        {
-            strFields.append("&");
-            strFields.append(fields[i]);
-        }
-        setFormElement(Locator.name("ff_columnList"), strFields.toString());
-        clickButton("Save");
+            setFormElement(Locator.name("quf_Name"), viewName);
+        setFormElement(Locator.name("quf_Columns"), String.join("&", fields));
+        setFormElement(Locator.name("quf_Flags"), "0");
+        clickButton("Submit");
         popLocation();
     }
 

--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -1688,15 +1688,14 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
         pushLocation();
         beginAt(WebTestHelper.buildURL("query", containerPath, "executeQuery", Map.of("schemaName", "query", "queryName", "CustomViews")));
         DataRegionTable drt = new DataRegionTable("query", getDriver());
-        drt.clickInsertNewRow();
-        waitForElement(Locator.name("quf_Schema"));
-        setFormElement(Locator.name("quf_Schema"), schema);
-        setFormElement(Locator.name("quf_QueryName"), query);
+        var queryRowPage = drt.clickInsertNewRow();
+        queryRowPage.setField("Schema", schema);
+        queryRowPage.setField("QueryName", query);
         if (viewName != null)
-            setFormElement(Locator.name("quf_Name"), viewName);
-        setFormElement(Locator.name("quf_Columns"), String.join("&", fields));
-        setFormElement(Locator.name("quf_Flags"), "0");
-        clickButton("Submit");
+            queryRowPage.setField("Name", viewName);
+        queryRowPage.setField("Columns", String.join("&", fields));
+        queryRowPage.setField("Flags", "0");
+        queryRowPage.submit();
         popLocation();
     }
 

--- a/src/org/labkey/test/tests/TimeChartImportTest.java
+++ b/src/org/labkey/test/tests/TimeChartImportTest.java
@@ -311,11 +311,6 @@ public class TimeChartImportTest extends StudyBaseTest
 
         log("Verify masked ptids in publish study reportInfo");
         clickFolder(publishFolderName);
-        for (TimeChartInfo chartInfo : VISIT_CHARTS)
-        {
-            clickTab("Clinical and Assay Data");
-            waitAndClickAndWait(Locator.linkWithText(chartInfo.getName()));
-        }
 
         // verify the report descriptor XML does not contain the masked ptid
         goToSchemaBrowser();
@@ -325,7 +320,6 @@ public class TimeChartImportTest extends StudyBaseTest
         customizeView.applyCustomView();
 
         drt = new DataRegionTable("query", getDriver());
-        drt.setPageSize(100);
         int xmlIdx = drt.getColumnIndex("DescriptorXML");
 
         for (int row=0; row < drt.getDataRowCount(); row++)

--- a/src/org/labkey/test/tests/TimeChartImportTest.java
+++ b/src/org/labkey/test/tests/TimeChartImportTest.java
@@ -325,6 +325,7 @@ public class TimeChartImportTest extends StudyBaseTest
         customizeView.applyCustomView();
 
         drt = new DataRegionTable("query", getDriver());
+        drt.setPageSize(100);
         int xmlIdx = drt.getColumnIndex("DescriptorXML");
 
         for (int row=0; row < drt.getDataRowCount(); row++)

--- a/src/org/labkey/test/tests/TimeChartImportTest.java
+++ b/src/org/labkey/test/tests/TimeChartImportTest.java
@@ -23,10 +23,10 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Charting;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Reports;
+import org.labkey.test.components.CustomizeView;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.PortalHelper;
@@ -35,7 +35,6 @@ import org.labkey.test.util.WikiHelper;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * This test imports a folder archive that has 2 subfolders (a date based study and a visit based study) which have been
@@ -316,13 +315,24 @@ public class TimeChartImportTest extends StudyBaseTest
         {
             clickTab("Clinical and Assay Data");
             waitAndClickAndWait(Locator.linkWithText(chartInfo.getName()));
-            beginAt(WebTestHelper.buildURL("reports",
-                getProjectName() + "/" + VISIT_STUDY_FOLDER_NAME + "/" + publishFolderName,
-                "reportInfo", Map.of("reportId", getUrlParam("reportId"))));
-            waitForText("Report Debug Information");
+        }
+
+        // verify the report descriptor XML does not contain the masked ptid
+        goToSchemaBrowser();
+        DataRegionTable drt = viewQueryData("core", "Reports");
+        CustomizeView customizeView = drt.openCustomizeGrid();
+        customizeView.addColumn("DescriptorXML");
+        customizeView.applyCustomView();
+
+        drt = new DataRegionTable("query", getDriver());
+        int xmlIdx = drt.getColumnIndex("DescriptorXML");
+
+        for (int row=0; row < drt.getDataRowCount(); row++)
+        {
+            String descriptor = drt.getDataAsText(row, xmlIdx);
             for (String origMouseId : origMouseIds)
             {
-                assertTextNotPresent(origMouseId);
+                Assert.assertFalse("Unexpected masked ptid in report descriptor : " + descriptor, descriptor.contains(origMouseId));
             }
         }
     }


### PR DESCRIPTION
#### Rationale
A recent PR removed some internal actions like `query.internalNewView` and `reports.reportInfo`. I've updated those tests to rely on alternate ways to accomplish the same actions.