### PR TITLE
Remove now-unused deprecated method

### DIFF
--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -4002,15 +4002,6 @@ public abstract class WebDriverWrapper implements WrapsDriver
     }
 
     /**
-     * @deprecated Use {@link WebElement#isSelected()}
-     */
-    @Deprecated (since = "22.9")
-    public boolean isChecked(WebElement checkBox)
-    {
-        return checkBox.isSelected();
-    }
-
-    /**
      * Try to select option by text or value.
      */
     private void selectOption(WebElement el, String text)

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -628,14 +628,6 @@ public class DataRegionTable extends DataRegion
         return rows;
     }
 
-    /**
-     * Strips the trailing Unicode word joiner character added by AJAXDetailsDisplayColumn for line wrapping purposes.
-     */
-    public static String stripWordJoiner(String value)
-    {
-        return value.replace("\u2060", "");
-    }
-
     public WebElement findRow(int index)
     {
         return elementCache().getDataRow(index);

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -628,6 +628,14 @@ public class DataRegionTable extends DataRegion
         return rows;
     }
 
+    /**
+     * Strips the trailing Unicode word joiner character added by AJAXDetailsDisplayColumn for line wrapping purposes.
+     */
+    public static String stripWordJoiner(String value)
+    {
+        return value.replace("\u2060", "");
+    }
+
     public WebElement findRow(int index)
     {
         return elementCache().getDataRow(index);


### PR DESCRIPTION
#### Rationale
We no longer have any uses of this deprecated method. Let's delete it.

#### Related Pull Requests
- https://github.com/LabKey/targetedms/pull/1208

#### Changes
- Remove WebDriverWrapper.isChecked()
