### PR TITLE
Update CASServerTest to verify renew=true

### DIFF
--- a/src/org/labkey/test/LabKeySiteWrapper.java
+++ b/src/org/labkey/test/LabKeySiteWrapper.java
@@ -156,12 +156,7 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
         }
         else
         {
-            log("Signing in as " + PasswordUtil.getUsername());
-            assertElementPresent(Locator.tagWithName("form", "login"));
-            setFormElement(Locator.name("email"), PasswordUtil.getUsername());
-            setFormElement(Locator.name("password"), PasswordUtil.getPassword());
-            acceptTermsOfUse(null, false);
-            clickButton("Sign In", 0);
+            fillSignInFormAndSubmit();
 
             // verify we're signed in now
             if (!waitFor(() ->
@@ -200,6 +195,16 @@ public abstract class LabKeySiteWrapper extends WebDriverWrapper
 
         _userHelper.saveCurrentDisplayName();
         WebTestHelper.saveSession(PasswordUtil.getUsername(), getDriver());
+    }
+
+    public void fillSignInFormAndSubmit()
+    {
+        log("Signing in as " + PasswordUtil.getUsername());
+        assertElementPresent(Locator.tagWithName("form", "login"));
+        setFormElement(Locator.name("email"), PasswordUtil.getUsername());
+        setFormElement(Locator.name("password"), PasswordUtil.getPassword());
+        acceptTermsOfUse(null, false);
+        clickButton("Sign In", 0);
     }
 
     /**

--- a/src/org/labkey/test/WebDriverWrapper.java
+++ b/src/org/labkey/test/WebDriverWrapper.java
@@ -1169,6 +1169,12 @@ public abstract class WebDriverWrapper implements WrapsDriver
         return createDefaultConnection();
     }
 
+    // Exempt the provided URL from controller-first URL warnings and exceptions
+    public void allowControllerFirstUrl(String url)
+    {
+        _controllerFirstUrls.add(url);
+    }
+
     public long beginAt(String url)
     {
         return beginAt(url, defaultWaitForPage);


### PR DESCRIPTION
#### Rationale
Extract just the login form submission part of sign in so `CASServerTest` can use it to verify re-auth. The full `simpleSignIn()` method expects the user to be signed in afterwards, which is not always the case with re-auth.

Provide a way to use "controller-first" URLs without logging (or throwing) complaints. CAS endpoints look like controller-first URLs, but we're not going to change them.

#### Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/565