### PR TITLE
Fix intermittent R report timeouts

### DIFF
--- a/src/org/labkey/test/pages/reports/ScriptReportPage.java
+++ b/src/org/labkey/test/pages/reports/ScriptReportPage.java
@@ -214,7 +214,7 @@ public class ScriptReportPage extends LabKeyPage<ScriptReportPage.ElementCache>
         scrollToTop(); // Clicking report tab can scroll such that the cursor hovers over and opens the project menu
         waitAndClick(Ext4Helper.Locators.tab("Report"));
         // Report view should appear quickly
-        shortWait().until(ExpectedConditions.visibilityOfElementLocated(Locator.tagWithClass("div", "reportView")));
+        longWait().until(ExpectedConditions.visibilityOfElementLocated(Locator.tagWithClass("div", "reportView")));
         // Actual report might take a while to load
         _ext4Helper.waitForMaskToDisappear(BaseWebDriverTest.WAIT_FOR_PAGE);
     }

--- a/src/org/labkey/test/tests/AbstractKnitrReportTest.java
+++ b/src/org/labkey/test/tests/AbstractKnitrReportTest.java
@@ -234,7 +234,7 @@ public abstract class AbstractKnitrReportTest extends BaseWebDriverTest
         clickProject(getProjectName());
         _ext4Helper.waitForMaskToDisappear();
         waitAndClickAndWait(Locator.linkWithText("kable"));
-        _ext4Helper.waitForMaskToDisappear(3 * BaseWebDriverTest.WAIT_FOR_JAVASCRIPT);
+        _ext4Helper.waitForMaskToDisappear(60_000);
         waitForElement(Locator.id("mtcars_table"));
     }
 


### PR DESCRIPTION
#### Rationale
The report in `AbstractKnitrReportTest.moduleReportDependencies` takes 25-35 seconds to load. It usually passes on the Linux agents but exceeds the 30 second timeout pretty regularly on Windows agents.
```
org.openqa.selenium.TimeoutException: Expected condition failed: waiting for element to disappear: xpath=//div[contains(concat(' ',normalize-space(@class),' '), ' x4-mask ')][not(ancestor-or-self::*[contains(@style,'display: none') or contains(@style,'visibility: hidden') or contains(@class, 'x-hide-display') or contains(@class, 'x4-hide-offsets') or contains(@class, 'x-hide-offsets')] or (@type = 'hidden'))]
(tried for 30 seconds with 500 milliseconds interval)
  at app//org.openqa.selenium.support.ui.FluentWait.timeoutException(FluentWait.java:278)
  at app//org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:233)
  at app//org.labkey.test.Locator.waitForElementToDisappear(Locator.java:583)
  at app//org.labkey.test.Locator.waitForElementToDisappear(Locator.java:578)
  at app//org.labkey.test.WebDriverWrapper.waitForElementToDisappear_aroundBody24(WebDriverWrapper.java:2628)
  at app//org.labkey.test.WebDriverWrapper$AjcClosure25.run(WebDriverWrapper.java:1)
  at app//org.aspectj.runtime.reflect.JoinPointImpl.proceed(JoinPointImpl.java:164)
  at app//org.labkey.test.aspects.StaleElementRetryAspect.beforeLoggedMethod(StaleElementRetryAspect.java:40)
  at app//org.labkey.test.WebDriverWrapper.waitForElementToDisappear(WebDriverWrapper.java:2626)
  at app//org.labkey.test.util.Ext4Helper.waitForMaskToDisappear(Ext4Helper.java:682)
  at app//org.labkey.test.tests.AbstractKnitrReportTest.moduleReportDependencies(AbstractKnitrReportTest.java:237)
  at app//org.labkey.test.tests.KnitrReportTest.testModuleReportDependencies(KnitrReportTest.java:98)
```

Other reports tend to time out on Windows also:
```
org.openqa.selenium.TimeoutException: Expected condition failed: waiting for visibility of element found by css=div.reportView
(tried for 10 seconds with 500 milliseconds interval)
  at app//org.openqa.selenium.support.ui.WebDriverWait.timeoutException(WebDriverWait.java:85)
  at app//org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:233)
  at app//org.labkey.test.pages.reports.ScriptReportPage._clickReportTab(ScriptReportPage.java:232)
  at app//org.labkey.test.pages.reports.ScriptReportPage.clickReportTab(ScriptReportPage.java:213)
  at app//org.labkey.test.util.RReportHelper.clickReportTab(RReportHelper.java:474)
  at app//org.labkey.test.util.RReportHelper.executeScript(RReportHelper.java:136)
  at app//org.labkey.test.util.RReportHelper.executeScript(RReportHelper.java:122)
  at app//org.labkey.test.tests.RlabkeyTest.doRLabkeyTest(RlabkeyTest.java:307)
  at app//org.labkey.test.tests.RlabkeyTest.testRlabkeyWebDavApi(RlabkeyTest.java:259)
  at java.base@25.0.1/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
```

#### Related Pull Requests
- N/A

#### Changes
- Increase timeout for R reports

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Claude Code Review
- [ ] TeamCity verification
-->
