### PR TITLE
26.3 fb increase time out

### DIFF
--- a/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
+++ b/src/org/labkey/test/tests/assay/UploadLargeExcelAssayTest.java
@@ -103,7 +103,7 @@ public class UploadLargeExcelAssayTest extends BaseWebDriverTest
 
         // wait for import complete
         var assayJobsPage1 = new AssayUploadJobsPage(getDriver());
-        var pipelineDetailsPage1 = assayJobsPage1.clickJobStatus("200k", 3 * WebDriverWrapper.WAIT_FOR_PAGE);
+        var pipelineDetailsPage1 = assayJobsPage1.clickJobStatus("200k", 6 * WebDriverWrapper.WAIT_FOR_PAGE);
         pipelineDetailsPage1.waitForComplete(12 * WebDriverWrapper.WAIT_FOR_PAGE);
 
         // export assay1 data to excel


### PR DESCRIPTION
#### Rationale
Importing a large xlsx assay result is taking longer to upload in MSSQL than before. On a local run it took about 5 minutes. On TeamCity the increase is just a bit over 3 1/2 minutes.

#### Related Pull Requests
- None

#### Changes
- Increase timeout for pipeline job.
