### PR TITLE
LabKeyErrorPageTest: update testServerConfigurationErrors

### DIFF
--- a/src/org/labkey/test/tests/LabkeyErrorPageTest.java
+++ b/src/org/labkey/test/tests/LabkeyErrorPageTest.java
@@ -102,7 +102,7 @@ public class LabkeyErrorPageTest extends BaseWebDriverTest
 
         checker().verifyEquals("Incorrect error heading message", "Oops! A server configuration error has occurred.",
                 errorPage.getErrorHeading());
-        checker().verifyEquals("Incorrect error sub-heading message", "The requested page cannot be found. You have a configuration problem.",
+        checker().verifyEquals("Incorrect error sub-heading message", "You have a configuration problem.",
                 errorPage.getSubErrorHeading());
         checker().verifyThat("Incorrect error image", errorPage.getErrorImage(), CoreMatchers.containsString(imageTitle));
         checker().verifyTrue("'Show Details' button should appear on configuration error page",


### PR DESCRIPTION
#### Rationale
I updated the error page to no longer imply that a page could not be found when a configuration error is encountered. This PR updates the test to account for that change.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2260
- https://github.com/LabKey/platform/pull/7759
- https://github.com/LabKey/testAutomation/pull/3049

#### Changes
- LabKeyErrorPageTest: update testServerConfigurationErrors to no longer expect "The requested page cannot be found"

#### Tasks 📍
- [x] Claude Code Review
- [x] TeamCity verification

