### PR TITLE
Back porting test fix

### DIFF
--- a/src/org/labkey/test/tests/AbstractKnitrReportTest.java
+++ b/src/org/labkey/test/tests/AbstractKnitrReportTest.java
@@ -175,7 +175,7 @@ public abstract class AbstractKnitrReportTest extends BaseWebDriverTest
                                             Locator.tag("img").withAttribute("alt", "plot of chunk blood-pressure-scatter")), // new
                                     Locator.tag("pre").containing("## \"1\",249318596,\"2008-05-17\",86,36,129,76,64"),
                                     Locator.tag("pre").withText("## knitr says hello to HTML!"),
-                                    Locator.tag("pre").startsWith("## Error").containing(": non-numeric argument to binary operator"),
+                                    Locator.tag("pre").startsWith("## Error").containing("non-numeric argument to binary operator"),
                                     Locator.tag("p").startsWith("Well, everything seems to be working. Let's ask R what is the value of \u03C0? Of course it is 3.141"),
                                     nonceCheckSuccessLoc // Inline script should run
         };


### PR DESCRIPTION
#### Rationale
Back porting a test fix to 25.7 to keep the noise down.

#### Related Pull Requests
- None.

#### Changes
- Update expected string.