### PR TITLE
Issue #980: Deprecate the UI for deriving samples in LKS

### DIFF
--- a/src/org/labkey/test/tests/SampleTypeLimitsTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLimitsTest.java
@@ -62,6 +62,7 @@ public class SampleTypeLimitsTest extends BaseWebDriverTest
 {
     private static final String PROJECT_NAME = "SampleTypeLimitsTest";
     private static final String SAMPLE_TYPE_NAME = "10000Samples"; // Testing with 10,000 samples because as per the product the lookup is converted into text field only when the samples exceed 10,000 samples
+    private Boolean previousDeriveSamplesSetting = null;
 
     @Override
     public List<String> getAssociatedModules()
@@ -116,6 +117,14 @@ public class SampleTypeLimitsTest extends BaseWebDriverTest
         {
             fail(e.getMessage());
         }
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest)
+    {
+        super.doCleanup(afterTest);
+        if (previousDeriveSamplesSetting != null)
+            OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", previousDeriveSamplesSetting);
     }
 
     @Test
@@ -197,7 +206,7 @@ public class SampleTypeLimitsTest extends BaseWebDriverTest
     public void testDeriveSamplesLookupFields() throws IOException, CommandException
     {
         goToProjectHome();
-        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
+        previousDeriveSamplesSetting = OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
 
         log("Create sample type with lookup field to " + SAMPLE_TYPE_NAME);
         String sampleTypeName = "SampleTypeWithLookup";

--- a/src/org/labkey/test/tests/SampleTypeLimitsTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLimitsTest.java
@@ -62,7 +62,6 @@ public class SampleTypeLimitsTest extends BaseWebDriverTest
 {
     private static final String PROJECT_NAME = "SampleTypeLimitsTest";
     private static final String SAMPLE_TYPE_NAME = "10000Samples"; // Testing with 10,000 samples because as per the product the lookup is converted into text field only when the samples exceed 10,000 samples
-    private Boolean previousDeriveSamplesSetting = null;
 
     @Override
     public List<String> getAssociatedModules()
@@ -123,8 +122,7 @@ public class SampleTypeLimitsTest extends BaseWebDriverTest
     protected void doCleanup(boolean afterTest)
     {
         super.doCleanup(afterTest);
-        if (previousDeriveSamplesSetting != null)
-            OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", previousDeriveSamplesSetting);
+        OptionalFeatureHelper.resetOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp");
     }
 
     @Test
@@ -206,7 +204,7 @@ public class SampleTypeLimitsTest extends BaseWebDriverTest
     public void testDeriveSamplesLookupFields() throws IOException, CommandException
     {
         goToProjectHome();
-        previousDeriveSamplesSetting = OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
+        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
 
         log("Create sample type with lookup field to " + SAMPLE_TYPE_NAME);
         String sampleTypeName = "SampleTypeWithLookup";

--- a/src/org/labkey/test/tests/SampleTypeLimitsTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLimitsTest.java
@@ -36,6 +36,7 @@ import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.params.list.ListDefinition;
 import org.labkey.test.params.list.VarListDefinition;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
 import org.labkey.test.util.TestDataGenerator;
@@ -196,6 +197,7 @@ public class SampleTypeLimitsTest extends BaseWebDriverTest
     public void testDeriveSamplesLookupFields() throws IOException, CommandException
     {
         goToProjectHome();
+        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
 
         log("Create sample type with lookup field to " + SAMPLE_TYPE_NAME);
         String sampleTypeName = "SampleTypeWithLookup";

--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -38,6 +38,7 @@ import org.labkey.test.params.FieldKey;
 import org.labkey.test.params.experiment.DataClassDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
 import org.labkey.test.util.TestDataGenerator;
@@ -86,7 +87,7 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
     {
         SampleTypeLineageTest init = getCurrentTest();
 
-        // Comment out this line (after you run once) it will make iterating on  tests much easier.
+        // Comment out this line (after you run once) it will make iterating on tests much easier.
         init.doSetup();
     }
 
@@ -101,6 +102,7 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         portalHelper.addWebPart("Sample Types");
 
         portalHelper.exitAdminMode();
+        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
     }
 
     @Override
@@ -604,6 +606,8 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
     @Test
     public void testDeriveSampleByUI() throws CommandException, IOException
     {
+        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
+
         String sampleTypeName= "LineageUI_01";
         String namePrefix = "SampleUI-";
         int newSampleIndex = 6;

--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -70,8 +70,6 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
     private static final String PROJECT_NAME = "SampleType_Lineage_Test_Project";
     private static final String SUB_FOLDER_NAME = "SubFolder_A";
 
-    private Boolean previousDeriveSamplesSetting = null;
-
     @Override
     public List<String> getAssociatedModules()
     {
@@ -103,15 +101,15 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         portalHelper.addWebPart("Sample Types");
 
         portalHelper.exitAdminMode();
-        previousDeriveSamplesSetting = OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
+        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
     }
 
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
         super.doCleanup(afterTest);
-        if (previousDeriveSamplesSetting != null)
-            OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", previousDeriveSamplesSetting);
+
+        OptionalFeatureHelper.resetOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp");
     }
 
     /**

--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -110,6 +110,8 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
         super.doCleanup(afterTest);
+        if (previousDeriveSamplesSetting != null)
+            OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", previousDeriveSamplesSetting);
     }
 
     /**

--- a/src/org/labkey/test/tests/SampleTypeLineageTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLineageTest.java
@@ -70,6 +70,8 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
     private static final String PROJECT_NAME = "SampleType_Lineage_Test_Project";
     private static final String SUB_FOLDER_NAME = "SubFolder_A";
 
+    private Boolean previousDeriveSamplesSetting = null;
+
     @Override
     public List<String> getAssociatedModules()
     {
@@ -87,7 +89,6 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
     {
         SampleTypeLineageTest init = getCurrentTest();
 
-        // Comment out this line (after you run once) it will make iterating on tests much easier.
         init.doSetup();
     }
 
@@ -102,17 +103,13 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
         portalHelper.addWebPart("Sample Types");
 
         portalHelper.exitAdminMode();
-        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
+        previousDeriveSamplesSetting = OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
     }
 
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
         super.doCleanup(afterTest);
-
-        // If you are debugging tests change this function to do nothing.
-        // It can make re-running faster but you need to valid the integrity of the test data on your own.
-//        log("Do nothing.");
     }
 
     /**
@@ -606,8 +603,6 @@ public class SampleTypeLineageTest extends BaseWebDriverTest
     @Test
     public void testDeriveSampleByUI() throws CommandException, IOException
     {
-        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
-
         String sampleTypeName= "LineageUI_01";
         String namePrefix = "SampleUI-";
         int newSampleIndex = 6;

--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -74,8 +74,6 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
 
     protected DateTimeFormatter _dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     protected String now = LocalDateTime.now().format(_dateTimeFormatter);
-    private Boolean previousDeriveSamplesSetting = null;
-
 
     @BeforeClass
     public static void setupProject() throws IOException
@@ -108,7 +106,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         new PortalHelper(getDriver()).addBodyWebPart("Datasets");
 
         createSampleTypes();
-        previousDeriveSamplesSetting = OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
+        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
 
     }
 
@@ -888,7 +886,6 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         _containerHelper.deleteProject(DATE_BASED_STUDY, false);
         _containerHelper.deleteProject(SAMPLE_TYPE_PROJECT + " Study 1", false);
         _containerHelper.deleteProject(SAMPLE_TYPE_PROJECT + " Study 2", false);
-        if (previousDeriveSamplesSetting != null)
-            OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", previousDeriveSamplesSetting);
+        OptionalFeatureHelper.resetOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp");
     }
 }

--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -74,6 +74,8 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
 
     protected DateTimeFormatter _dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     protected String now = LocalDateTime.now().format(_dateTimeFormatter);
+    private Boolean previousDeriveSamplesSetting = null;
+
 
     @BeforeClass
     public static void setupProject() throws IOException
@@ -106,9 +108,11 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         new PortalHelper(getDriver()).addBodyWebPart("Datasets");
 
         createSampleTypes();
-        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
+        previousDeriveSamplesSetting = OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
 
     }
+
+
 
     private void createSampleTypes()
     {
@@ -884,5 +888,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         _containerHelper.deleteProject(DATE_BASED_STUDY, false);
         _containerHelper.deleteProject(SAMPLE_TYPE_PROJECT + " Study 1", false);
         _containerHelper.deleteProject(SAMPLE_TYPE_PROJECT + " Study 2", false);
+        if (previousDeriveSamplesSetting != null)
+            OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", previousDeriveSamplesSetting);
     }
 }

--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -40,6 +40,7 @@ import org.labkey.test.pages.study.ManageVisitPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
 import org.labkey.test.util.StudyHelper;
@@ -105,6 +106,8 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         new PortalHelper(getDriver()).addBodyWebPart("Datasets");
 
         createSampleTypes();
+        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
+
     }
 
     private void createSampleTypes()

--- a/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
+++ b/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
@@ -113,6 +113,8 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
 
     protected final AuditLogHelper _auditLogHelper = new AuditLogHelper(this);
 
+    private Boolean previousDeriveSamplesSetting = null;
+
     @Override
     public List<String> getAssociatedModules()
     {
@@ -131,6 +133,14 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
     {
         SampleTypeNameExpressionTest test = getCurrentTest();
         test.doSetup();
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest)
+    {
+        super.doCleanup(afterTest);
+        if (previousDeriveSamplesSetting != null)
+            OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", previousDeriveSamplesSetting);
     }
 
     private void addDataRow(TestDataGenerator dataGenerator, String name, int intVal)
@@ -197,7 +207,7 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
 
         // Just want to get an updated view of the sample types.
         refresh();
-        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
+        previousDeriveSamplesSetting = OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
     }
 
     @Before

--- a/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
+++ b/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
@@ -113,8 +113,6 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
 
     protected final AuditLogHelper _auditLogHelper = new AuditLogHelper(this);
 
-    private Boolean previousDeriveSamplesSetting = null;
-
     @Override
     public List<String> getAssociatedModules()
     {
@@ -139,8 +137,7 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
     protected void doCleanup(boolean afterTest)
     {
         super.doCleanup(afterTest);
-        if (previousDeriveSamplesSetting != null)
-            OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", previousDeriveSamplesSetting);
+        OptionalFeatureHelper.resetOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp");
     }
 
     private void addDataRow(TestDataGenerator dataGenerator, String name, int intVal)
@@ -207,7 +204,7 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
 
         // Just want to get an updated view of the sample types.
         refresh();
-        previousDeriveSamplesSetting = OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
+        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
     }
 
     @Before

--- a/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
+++ b/src/org/labkey/test/tests/SampleTypeNameExpressionTest.java
@@ -39,6 +39,7 @@ import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.AuditLogHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.EscapeUtil;
+import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
 import org.labkey.test.util.TestDataGenerator;
@@ -196,7 +197,7 @@ public class SampleTypeNameExpressionTest extends BaseWebDriverTest
 
         // Just want to get an updated view of the sample types.
         refresh();
-
+        OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "deriveSamplesNotInApp", true);
     }
 
     @Before


### PR DESCRIPTION
#### Rationale
Issue [980](https://github.com/LabKey/internal-issues/issues/980): The derivation UI in our apps is far superior to the one in LKS, so we will be removing the LKS interface in 26.11 after deprecating it in 26.7.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7764

#### Changes
- update tests that use the deprecated UI to enable the feature first

