### PR TITLE
GitHub Kanban #1946: issues encoding of summary text resolution

### DIFF
--- a/src/org/labkey/test/tests/issues/IssuesTest.java
+++ b/src/org/labkey/test/tests/issues/IssuesTest.java
@@ -750,6 +750,32 @@ public class IssuesTest extends BaseWebDriverTest
         assertTextPresent(String.format("Issue %s marked as duplicate of this issue.", issueIdB), "Duplicates");
     }
 
+    // GitHub Kanban #1946: verify encoding of resolution submitted on resolve
+    @Test
+    public void testResolutionEncodingInChangeSummary()
+    {
+        final String markerId = "testResolutionEncodingInChangeSummary";
+        // The Resolution dropdown won't accept arbitrary text, so we inject the payload into the <select> via JS below.
+        final String testResolution = "testRes<img src=\"x\" id=\"" + markerId + "\">";
+
+        DetailsPage detailsPage = _issuesHelper.addIssue("Resolution Encoding issue", NAME);
+
+        ResolvePage resolvePage = detailsPage.clickResolve();
+        // Force an arbitrary (un-allow-listed) resolution value onto the Resolution select and submit it
+        executeScript(
+                "var sel = document.getElementsByName('Resolution')[0];" +
+                "var opt = document.createElement('option');" +
+                "opt.value = arguments[0]; opt.text = arguments[0]; opt.selected = true;" +
+                "sel.add(opt); sel.value = arguments[0];",
+                testResolution);
+        detailsPage = resolvePage.save();
+
+        // verify that the resolution value is encoded in the summary text
+        assertElementNotPresent("Resolution was not HTML-encoded in the change-summary comment (stored XSS)",
+                Locator.id(markerId));
+        assertTextPresent(testResolution);
+    }
+
     @Test
     public void moveIssueTest()
     {


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/kanban/issues/1946
Test case for encoding updates with issues resolution summary text
