### PR TITLE
Mutating SQL test

### DIFF
--- a/src/org/labkey/test/tests/SecurityTest.java
+++ b/src/org/labkey/test/tests/SecurityTest.java
@@ -100,7 +100,7 @@ public class SecurityTest extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject()
     {
-        ((SecurityTest)getCurrentTest()).doSetup();
+        ((SecurityTest) getCurrentTest()).doSetup();
     }
 
     protected void doSetup()
@@ -425,9 +425,9 @@ public class SecurityTest extends BaseWebDriverTest
         if (isPresent)
         {
             clickAndWait(userAccessLink);
-            
+
             // check for the expected number of group membership links (note: they may be hidden by expandos)
-            click(Locator.xpath("//tr[td/a[text()='" + getProjectName() + "']]//img" ));
+            click(Locator.xpath("//tr[td/a[text()='" + getProjectName() + "']]//img"));
             assertElementPresent(Locator.linkWithText(groupName), expectedCount);
             return;
         }
@@ -476,10 +476,10 @@ public class SecurityTest extends BaseWebDriverTest
         DataRegionTable table = new DataRegionTable("query", getDriver());
 
         table.getDataAsText(2, 2);
-        String createdBy      = table.getDataAsText(2, "Created By");
+        String createdBy = table.getDataAsText(2, "Created By");
         String impersonatedBy = table.getDataAsText(2, "Impersonated By");
-        String user           = table.getDataAsText(2, "User");
-        String comment        = table.getDataAsText(2, "Comment");
+        String user = table.getDataAsText(2, "User");
+        String comment = table.getDataAsText(2, "Comment");
 
         assertTrue("Incorrect display for deleted user -- expected '<nnnn>', found '" + user + "'", user.matches("<\\d{4,}>"));
         assertEquals("Incorrect log entry for deleted user",
@@ -504,7 +504,7 @@ public class SecurityTest extends BaseWebDriverTest
         _userHelper.deleteUsers(false, selfRegUserEmail);
 
         int getResponse = setAuthenticationParameter("SelfRegistration", true);
-        assertEquals("failed to set authentication param to enable self register via http get", 200, getResponse );
+        assertEquals("failed to set authentication param to enable self register via http get", 200, getResponse);
         signOut();
 
         // test: attempt login, check if register button appears, click register
@@ -550,5 +550,26 @@ public class SecurityTest extends BaseWebDriverTest
 
         // cleanup: sign admin back in
         signIn();
+    }
+
+    @LogMethod
+    @Test
+    public void invokeMutatingSqlAction()
+    {
+        // Ensure that GET request that invokes mutating SQL is flagged
+        String feature = "AllowMutatingSqlViaGet";
+        Connection conn = createDefaultConnection();
+        OptionalFeatureHelper.disableOptionalFeature(conn, feature);
+        beginAt(buildURL("test", "executeMutatingSql"));
+        assertTextPresent("MUTATING SQL executed as part of handling action: GET org.labkey.devtools.TestController$ExecuteMutatingSqlAction");
+        checkExpectedErrors(2);
+
+        // Turn on the deprecated feature flag and ensure that GET request can invoke mutating SQL
+        OptionalFeatureHelper.enableOptionalFeature(conn, feature);
+        beginAt(buildURL("test", "executeMutatingSql"));
+        assertTextPresent("UPDATE via GET was allowed!");
+
+        // Restore flag to original value
+        OptionalFeatureHelper.resetOptionalFeature(conn, feature);
     }
 }

--- a/src/org/labkey/test/tests/SecurityTest.java
+++ b/src/org/labkey/test/tests/SecurityTest.java
@@ -568,7 +568,7 @@ public class SecurityTest extends BaseWebDriverTest
 
             // Ensure that a GET request invoking mutating SQL is forbidden
             beginAt(getUrl);
-            assertTextPresent("MUTATING SQL executed as part of handling action: GET org.labkey.devtools.TestController$ExecuteMutatingSqlAction");
+            assertTextPresent("MUTATING SQL executed as part of handling action: GET org.labkey.devtools.TestController$ExecuteMutatingSqlGetAction");
             checkExpectedErrors(2);
 
             // Ensure that a POST request to a POST action can invoke mutating SQL

--- a/src/org/labkey/test/tests/SecurityTest.java
+++ b/src/org/labkey/test/tests/SecurityTest.java
@@ -64,6 +64,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.labkey.test.WebTestHelper.buildURL;
+import static org.labkey.test.WebTestHelper.getHttpResponse;
 import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
 import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
@@ -556,20 +557,34 @@ public class SecurityTest extends BaseWebDriverTest
     @Test
     public void invokeMutatingSqlAction()
     {
-        // Ensure that a GET request invoking mutating SQL is flagged
+        String getUrl = buildURL("test", "executeMutatingSqlGet");
+        String postUrl = buildURL("test", "executeMutatingSqlPost");
         String feature = "AllowMutatingSqlViaGet";
         Connection conn = createDefaultConnection();
-        OptionalFeatureHelper.disableOptionalFeature(conn, feature);
-        beginAt(buildURL("test", "executeMutatingSql"));
-        assertTextPresent("MUTATING SQL executed as part of handling action: GET org.labkey.devtools.TestController$ExecuteMutatingSqlAction");
-        checkExpectedErrors(2);
 
-        // Turn on the deprecated feature flag and ensure that GET request can invoke mutating SQL
-        OptionalFeatureHelper.enableOptionalFeature(conn, feature);
-        beginAt(buildURL("test", "executeMutatingSql"));
-        assertTextPresent("UPDATE via GET was allowed!");
+        try
+        {
+            OptionalFeatureHelper.disableOptionalFeature(conn, feature);
 
-        // Restore flag to original value
-        OptionalFeatureHelper.resetOptionalFeature(conn, feature);
+            // Ensure that a GET request invoking mutating SQL is forbidden
+            beginAt(getUrl);
+            assertTextPresent("MUTATING SQL executed as part of handling action: GET org.labkey.devtools.TestController$ExecuteMutatingSqlAction");
+            checkExpectedErrors(2);
+
+            // Ensure that a POST request to a POST action can invoke mutating SQL
+            SimpleHttpResponse response = getHttpResponse(postUrl, "POST");
+            assertTrue(response.getResponseBody().contains("UPDATE via POST was allowed!"));
+            assertEquals(HttpStatus.SC_OK, response.getResponseCode());
+
+            // Turn on the deprecated feature flag and ensure that a GET request can now invoke mutating SQL
+            OptionalFeatureHelper.enableOptionalFeature(conn, feature);
+            beginAt(getUrl);
+            assertTextPresent("UPDATE via GET was allowed!");
+        }
+        finally
+        {
+            // Restore flag to its original value
+            OptionalFeatureHelper.resetOptionalFeature(conn, feature);
+        }
     }
 }

--- a/src/org/labkey/test/tests/SecurityTest.java
+++ b/src/org/labkey/test/tests/SecurityTest.java
@@ -556,7 +556,7 @@ public class SecurityTest extends BaseWebDriverTest
     @Test
     public void invokeMutatingSqlAction()
     {
-        // Ensure that GET request that invokes mutating SQL is flagged
+        // Ensure that a GET request invoking mutating SQL is flagged
         String feature = "AllowMutatingSqlViaGet";
         Connection conn = createDefaultConnection();
         OptionalFeatureHelper.disableOptionalFeature(conn, feature);

--- a/src/org/labkey/test/util/DeferredErrorCollector.java
+++ b/src/org/labkey/test/util/DeferredErrorCollector.java
@@ -398,7 +398,7 @@ public class DeferredErrorCollector
         {
             if (allErrors.getLast().getScreenshotName() == null)
             {
-                withScreenshot("fallback").error("No screeshot taken for last deferred error(s). " +
+                withScreenshot("fallback").error("No screenshot taken for last deferred error(s). " +
                         "This screenshot may be relevant to previous failures. " +
                         "Please update test to take appropriate screenshots.");
             }


### PR DESCRIPTION
#### Rationale
Simple test that a GET request invoking mutating SQL is flagged and the deprecated feature flag allows it

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7791