### PR TITLE
PuppeteerHelper: use localhost

### DIFF
--- a/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
+++ b/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
@@ -20,7 +20,6 @@ import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.puppeteer.PuppeteerSettings;
 import org.labkey.remoteapi.puppeteer.PuppeteerStatus;
-import org.labkey.test.WebTestHelper;
 
 import java.io.IOException;
 

--- a/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
+++ b/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
@@ -37,7 +37,9 @@ public class PuppeteerHelper
 
     public static String getRemoteServiceURL()
     {
-        return WebTestHelper.getTargetServer() + ":3031";
+        // Note: We are explicitly using localhost here instead of WebTestHelper.getTargetServer() because on TC it will
+        // use the hostname of the server, which is running Puppeteer with http, so API requests to it will be rejected.
+        return "localhost:3031";
     }
 
     public static PuppeteerStatus getStatus(Connection connection) throws IOException, CommandException

--- a/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
+++ b/src/org/labkey/test/util/puppeteer/PuppeteerHelper.java
@@ -39,7 +39,7 @@ public class PuppeteerHelper
     {
         // Note: We are explicitly using localhost here instead of WebTestHelper.getTargetServer() because on TC it will
         // use the hostname of the server, which is running Puppeteer with http, so API requests to it will be rejected.
-        return "localhost:3031";
+        return "http://localhost:3031";
     }
 
     public static PuppeteerStatus getStatus(Connection connection) throws IOException, CommandException


### PR DESCRIPTION
#### Rationale
My changes in https://github.com/LabKey/limsModules/pull/2260 make it so insecure requests to non-loopback hosts are refused for by the puppeteer service. This PR updates the PuppeteerHelper to use localhost so the API requests don't get denied.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2260
- https://github.com/LabKey/testAutomation/pull/3073

#### Changes
- PuppeteerHelper: use localhost

#### Tasks 📍
- [x] Claude Code Review
- [x] TeamCity verification
