### PR TITLE
Leave browser windows open after test failures

### DIFF
--- a/src/org/labkey/test/BaseWebDriverTest.java
+++ b/src/org/labkey/test/BaseWebDriverTest.java
@@ -44,9 +44,9 @@ import org.labkey.junit.rules.TestWatcher;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.admin.ClearCachesCommand;
 import org.labkey.remoteapi.SimpleGetCommand;
 import org.labkey.remoteapi.SimplePostCommand;
+import org.labkey.remoteapi.admin.ClearCachesCommand;
 import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.labkey.remoteapi.query.ContainerFilter;
 import org.labkey.remoteapi.query.Filter;
@@ -2929,16 +2929,40 @@ public abstract class BaseWebDriverTest extends LabKeySiteWrapper implements Cle
             }
             finally
             {
-                clear();
+                clear(closeOldBrowser);
             }
         }
 
         private void clear()
         {
-            if (getDriverService() != null && getDriverService().isRunning())
+            clear(true);
+        }
+
+        private void clear(boolean closedOldBrowser)
+        {
+            if (getDriverService() != null && getDriverService().isRunning() && !shouldLeaveDriverServiceRunning(closedOldBrowser))
                 getDriverService().stop();
             // Don't clear _downloadDir. Cleanup steps might still need it after tearDown
             _driverAndService = new ImmutablePair<>(null, null);
+        }
+
+        /**
+         * Starting with Geckodriver v0.37.0, shutting down the driver service also shuts down the browser.
+         * We need to leave the FirefoxDriverService running after test failures to allow manual inspection of the
+         * browser state.
+         * We can remove this if they add a 'detach' flag to Geckodriver, similar to the one in Chromedriver.
+         * https://github.com/mozilla/geckodriver/issues/2247
+         * https://bugzilla.mozilla.org/show_bug.cgi?id=2046321
+         *
+         * @param closedOldBrowser Indicates that WebDriver was closed
+         * @return true if the DriverService should be left running
+         */
+        private boolean shouldLeaveDriverServiceRunning(boolean closedOldBrowser)
+        {
+            return !closedOldBrowser // Don't leave DriverService running if browser was closed
+                    && BrowserType.FIREFOX.matchesDriver(getWebDriver())
+                    && TestProperties.allowZombieGeckodriver()
+                    && !TestProperties.isTestRunningOnTeamCity();
         }
     }
 

--- a/src/org/labkey/test/TestProperties.java
+++ b/src/org/labkey/test/TestProperties.java
@@ -183,6 +183,11 @@ public abstract class TestProperties
         return !getBooleanProperty("selenium.reuseWebDriver", false);
     }
 
+    public static boolean allowZombieGeckodriver()
+    {
+        return getBooleanProperty("webtest.allowZombieGeckodriver", false);
+    }
+
     public static boolean isViewCheckSkipped()
     {
         return !getBooleanProperty("viewCheck", true);

--- a/test.properties.template
+++ b/test.properties.template
@@ -68,6 +68,9 @@ cleanOnly=false
 #webtest.log.level=DEBUG
 ## Set whether DeferredErrorCollector should fail immediately when errors are encountered (default: false)
 #webtest.checker.fatal=true
+## Set to leave Geckodriver running after test failures (https://github.com/mozilla/geckodriver/issues/2247)
+## Note: requires you to manually kill 'geckodriver' processes (`killall geckodriver`)
+#webtest.allowZombieGeckodriver=true
 
 
 #==============================================================================


### PR DESCRIPTION
#### Rationale
Starting with Geckodriver v0.37.0, shutting down the driver service also shuts down the browser.
We need to leave the FirefoxDriverService running after test failures to allow manual inspection of the browser state.
I'm putting this behavior behind a flag because it will also leave a lot of zombie 'geckodriver' processes that will need to be cleanup up manually.

 * https://github.com/mozilla/geckodriver/issues/2247
 * https://bugzilla.mozilla.org/show_bug.cgi?id=2046321

#### Related Pull Requests
- N/A

#### Changes
- Leave geckodriver running after test failures

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Claude Code Review
- [ ] TeamCity verification
-->
