### PR TITLE
Upgrade Selenium to 4.45.0 and Jetty to 12.1.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,9 +8,9 @@ awaitilityVersion=4.3.0
 
 lookfirstSardineVersion=5.13
 
-jettyVersion=12.1.7
+jettyVersion=12.1.10
 
-seleniumVersion=4.44.0
+seleniumVersion=4.45.0
 
 mockserverNettyVersion=5.15.0
 


### PR DESCRIPTION
## Rationale

Routine test-dependency upgrade per the JAR dependency upgrade schedule.

## Related Pull Requests

- LabKey/platform#7812 (ActiveMQ 5.19.8)
- LabKey/premiumModules#647 (Snowflake JDBC 4.3.1)

## Changes

- Bump `seleniumVersion` from 4.44.0 to 4.45.0 in `gradle.properties`
- Bump `jettyVersion` from 12.1.7 to 12.1.10 in `gradle.properties`