### PR TITLE
Backport to 26.3: PackageLockJsonTest allow "npm:" alias transitive dependencies (#2995)

### DIFF
--- a/src/org/labkey/test/tests/PackageLockJsonTest.java
+++ b/src/org/labkey/test/tests/PackageLockJsonTest.java
@@ -28,8 +28,7 @@ import java.util.Set;
 public class PackageLockJsonTest
 {
     private static final Set<String> ALLOWED_DEPENDENCY_HOSTS = Set.of("registry.npmjs.org", "labkey.jfrog.io");
-    // Allow-list of '@isaacs/cliui' dependencies
-    private static final Set<String> ALLOWED_NONSTANDARD_VERSIONS = Set.of("npm:string-width@^4.2.0", "npm:strip-ansi@^6.0.1", "npm:wrap-ansi@^7.0.0");
+    private static final File SERVER_MODULES_DIR = new File(TestFileUtils.getLabKeyRoot(), "server/modules");
 
     private final List<String> errors = new ArrayList<>();
     private final File moduleDir;
@@ -44,11 +43,10 @@ public class PackageLockJsonTest
     {
         List<File> allModules = new ArrayList<>();
 
-        File modulesDir = new File(TestFileUtils.getLabKeyRoot(), "server/modules");
-        File[] files = modulesDir.listFiles();
+        File[] files = SERVER_MODULES_DIR.listFiles();
         if (files == null)
         {
-            throw new RuntimeException("No files found in modules directory: " + modulesDir.getAbsolutePath());
+            throw new RuntimeException("No files found in modules directory: " + SERVER_MODULES_DIR.getAbsolutePath());
         }
         for (File file : files)
         {
@@ -96,17 +94,19 @@ public class PackageLockJsonTest
             }
         }
 
-        Assert.assertTrue("Bad sources: " + errors, errors.isEmpty());
+        Assert.assertTrue("Untrusted package sources:\n" + String.join("\n", errors), errors.isEmpty());
     }
 
     /// Verify that a package reference in a package-lock.json file only resolves to known hosts and has a valid version
     /// Also checks sub-dependencies
     private void verifyPackage(String packageName, JSONObject packageJson, File packageLockFile)
     {
+        String relPath = SERVER_MODULES_DIR.toPath().relativize(packageLockFile.toPath()).toString();
+
         String resolved = packageJson.optString("resolved");
         if (resolved.isBlank())
         {
-            TestLogger.debug("Resolved field is blank for package " + packageName + " in " + packageLockFile.getAbsolutePath());
+            TestLogger.debug("Resolved field is blank for package " + packageName + " in " + relPath);
         }
         else
         {
@@ -116,14 +116,14 @@ public class PackageLockJsonTest
                 String host = resolvedURL.getHost();
                 if (!ALLOWED_DEPENDENCY_HOSTS.contains(host))
                 {
-                    String message = "Package " + packageName + " resolved to unrecognized host [" + host + "] in " + packageLockFile.getAbsolutePath();
+                    String message = "Package " + packageName + " resolved to unrecognized host [" + host + "] in " + relPath;
                     errors.add(message);
                     TestLogger.error(message);
                 }
             }
             catch (URISyntaxException e)
             {
-                String message = "Package " + packageName + " resolved to an invalid location [" + resolved + "] in " + packageLockFile.getAbsolutePath();
+                String message = "Package " + packageName + " resolved to an invalid location [" + resolved + "] in " + relPath;
                 errors.add(message);
                 TestLogger.error(message);
             }
@@ -132,7 +132,7 @@ public class PackageLockJsonTest
         String version = packageJson.optString("version");
         if (version.isBlank() || !CharUtils.isAsciiNumeric(version.charAt(0)))
         {
-            String message = "Package " + packageName + " has bad version [" + version + "] in " + packageLockFile.getAbsolutePath();
+            String message = "Package " + packageName + " has bad version [" + version + "] in " + relPath;
             errors.add(message);
             TestLogger.error(message);
         }
@@ -148,9 +148,9 @@ public class PackageLockJsonTest
             else
             {
                 String tVer = transitiveDeps.optString(tDep);
-                if (tVer == null || tVer.contains(":") && !ALLOWED_NONSTANDARD_VERSIONS.contains(tVer)) // URL, file, or workspace dependency
+                if (tVer == null || tVer.replaceAll("^npm:", "").contains(":")) // URL, file, or workspace dependency
                 {
-                    String message = "Package " + packageName + " has bad transitive dependency [" + tVer + "] in " + packageLockFile.getAbsolutePath();
+                    String message = "Package " + packageName + " has bad transitive dependency [" + tVer + "] in " + relPath;
                     errors.add(message);
                     TestLogger.error(message);
                 }


### PR DESCRIPTION
## Rationale

Cherry-pick of #2995 to release26.3-SNAPSHOT. Packages that declare npm-aliased dependencies (e.g. `npm:react-is@^18.3.1`) are legitimate registry references, but the pre-#2995 version of the test flags them as untrusted sources.

## Related Pull Requests

- https://github.com/LabKey/testAutomation/pull/2995

## Changes

- Allow transitive dependency version specs with an `npm:` alias prefix instead of the hard-coded allow-list; still flags URL, file, git, and workspace specs.
- Error messages report lock-file paths relative to `server/modules`.