### PR TITLE
Fix Flakey Test Issues

### DIFF
--- a/src/org/labkey/test/util/AuditLogHelper.java
+++ b/src/org/labkey/test/util/AuditLogHelper.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.lang.Integer.parseInt;
 import static org.junit.Assert.assertEquals;
@@ -261,19 +262,24 @@ public class AuditLogHelper
 
     public void checkAuditEventValuesForTransactionId(String containerPath, AuditEvent auditEventName, Integer transactionId, List<Map<String, Object>> expectedValues) throws IOException, CommandException
     {
-        List<String> columnNames = expectedValues.get(0).keySet().stream().map(Object::toString).toList();
+        List<String> columnNames = expectedValues.getFirst().keySet().stream().map(Object::toString).toList();
         checkAuditEventValuesForTransactionId(containerPath, auditEventName, columnNames, transactionId, expectedValues);
     }
 
     public void checkAuditEventValuesForTransactionId(String containerPath, AuditEvent auditEventName, List<String> columnNames, Integer transactionId, List<Map<String, Object>> expectedValues) throws IOException, CommandException
     {
         List<Map<String, Object>> events = getAuditLogsForTransactionId(containerPath, auditEventName, columnNames, transactionId, ContainerFilter.CurrentAndSubfolders);
-        assertEquals("Unexpected number of events for transactionId " + transactionId, expectedValues.size(), events.size());
-        for (int i = 0; i < expectedValues.size(); i++)
-        {
-            for (String key : expectedValues.get(i).keySet())
-                assertEquals("Event " + i  + " value for " + key + " not as expected", expectedValues.get(i).get(key), events.get(i).get(key));
-        }
+
+        Set<String> keysOfInterest = expectedValues.getFirst().keySet();
+        List<Map<String, Object>> actualFiltered = events.stream()
+                .map(row -> row.entrySet().stream()
+                        .filter(e -> keysOfInterest.contains(e.getKey()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
+                .toList();
+
+        assertEquals("Lists do not contain the same entries",
+                new HashSet<>(actualFiltered), new HashSet<>(expectedValues));
+
     }
 
     public Map<String, Object> getTransactionAuditLogDetails(Integer transactionAuditId)

--- a/src/org/labkey/test/util/AuditLogHelper.java
+++ b/src/org/labkey/test/util/AuditLogHelper.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static java.lang.Integer.parseInt;
 import static org.junit.Assert.assertEquals;
@@ -270,16 +269,21 @@ public class AuditLogHelper
     {
         List<Map<String, Object>> events = getAuditLogsForTransactionId(containerPath, auditEventName, columnNames, transactionId, ContainerFilter.CurrentAndSubfolders);
 
-        Set<String> keysOfInterest = expectedValues.getFirst().keySet();
-        List<Map<String, Object>> actualFiltered = events.stream()
-                .map(row -> row.entrySet().stream()
-                        .filter(e -> keysOfInterest.contains(e.getKey()))
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
+        List<Map<String, Object>> unmatched = expectedValues.stream()
+                .filter(expectedRow -> {
+                    Set<String> keysOfInterest = expectedRow.keySet();
+                    return events.stream().noneMatch(actualRow -> {
+                        Map<String, Object> actualFiltered = actualRow.entrySet().stream()
+                                .filter(e -> keysOfInterest.contains(e.getKey()))
+                                .collect(HashMap::new,
+                                        (m, e) -> m.put(e.getKey(), e.getValue()),
+                                        HashMap::putAll);
+                        return actualFiltered.equals(expectedRow);
+                    });
+                })
                 .toList();
 
-        assertEquals("Lists do not contain the same entries",
-                new HashSet<>(actualFiltered), new HashSet<>(expectedValues));
-
+        assertTrue("Expected rows with no match in actual: " + unmatched, unmatched.isEmpty());
     }
 
     public Map<String, Object> getTransactionAuditLogDetails(Integer transactionAuditId)


### PR DESCRIPTION
## Rationale
Modify AuditLogHelper.checkAuditEventValuesForTransactionId to do a set comparison and not a list comparison.

## Related Pull Requests
- None.

## Changes
- AuditLogHelper.checkAuditEventValuesForTransactionId to do a set comparison and not a list comparison.
