### PR TITLE
Use the project when removing members for a project group

### DIFF
--- a/src/org/labkey/test/tests/UserPermissionsTest.java
+++ b/src/org/labkey/test/tests/UserPermissionsTest.java
@@ -272,7 +272,7 @@ public class UserPermissionsTest extends BaseWebDriverTest
 
         log("Remove user from group and verify logs");
         goToProjectHome();
-        permissionsHelper.removeUserFromGroup(GAMMA_SUBMITTER_GROUP_NAME, GAMMA_SUBMITTER_USER);
+        permissionsHelper.removeUserFromGroup(GAMMA_SUBMITTER_GROUP_NAME, GAMMA_SUBMITTER_USER, getProjectName());
         verifyAuditLog("User: " + GAMMA_SUBMITTER_USER + " was deleted from Group: " + GAMMA_SUBMITTER_GROUP_NAME);
     }
 

--- a/src/org/labkey/test/util/ApiPermissionsHelper.java
+++ b/src/org/labkey/test/util/ApiPermissionsHelper.java
@@ -658,12 +658,12 @@ public class ApiPermissionsHelper extends PermissionsHelper
     }
 
     @Override
-    public void removeUserFromGroup(String groupName, String userName)
+    public void removeUserFromGroup(String groupName, String userName, String projectPath)
     {
         Integer groupId = getGroupId(groupName);
         if (groupId == null)
             throw new IllegalArgumentException("Attempting to remove members from non-existent site group: " + groupName);
-        removeMembersFromGroup(groupId, userName);
+        removeMembersFromGroup(groupId, projectPath, userName);
     }
 
     @Override
@@ -675,7 +675,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
         removeMembersFromGroup(groupId, userName);
     }
 
-    private void removeMembersFromGroup(Integer groupId, String... members)
+    private void removeMembersFromGroup(Integer groupId, String projectPath, String... members)
     {
         BulkUpdateGroupCommand command = new BulkUpdateGroupCommand(groupId);
         command.setCreateGroup(false);
@@ -685,7 +685,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
         try
         {
             Connection connection = getConnection();
-            command.execute(connection, "/");
+            command.execute(connection, projectPath);
         }
         catch (IOException | CommandException e)
         {

--- a/src/org/labkey/test/util/ApiPermissionsHelper.java
+++ b/src/org/labkey/test/util/ApiPermissionsHelper.java
@@ -672,7 +672,7 @@ public class ApiPermissionsHelper extends PermissionsHelper
         Integer groupId = getSiteGroupId(groupName);
         if (groupId == null)
             throw new IllegalArgumentException("Attempting to remove members from non-existent group: " + groupName);
-        removeMembersFromGroup(groupId, userName);
+        removeMembersFromGroup(groupId, "/", userName);
     }
 
     private void removeMembersFromGroup(Integer groupId, String projectPath, String... members)

--- a/src/org/labkey/test/util/PermissionsHelper.java
+++ b/src/org/labkey/test/util/PermissionsHelper.java
@@ -175,7 +175,7 @@ public abstract class PermissionsHelper
     @LogMethod(quiet = true)
     public abstract void deleteGroup(@LoggedParam String groupName, boolean failIfNotFound);
 
-    public abstract void removeUserFromGroup(String groupName, String userName);
+    public abstract void removeUserFromGroup(String groupName, String userName, String projectName);
     public abstract void removeUserFromSiteGroup(String groupName, String userName);
 
     public abstract boolean doesGroupExist(String groupName, String projectName);

--- a/src/org/labkey/test/util/UIPermissionsHelper.java
+++ b/src/org/labkey/test/util/UIPermissionsHelper.java
@@ -316,11 +316,11 @@ public class UIPermissionsHelper extends PermissionsHelper
     @Override
     public void removeUserFromSiteGroup(String groupName, String userEmail)
     {
-        removeUserFromGroup(groupName, userEmail);
+        removeUserFromGroup(groupName, userEmail, "/");
     }
 
     @Override
-    public void removeUserFromGroup(String groupName, String userEmail)
+    public void removeUserFromGroup(String groupName, String userEmail, String projectPath)
     {
         if (!_driver.isTextPresent("Group " + groupName))
             selectGroup(groupName);


### PR DESCRIPTION
## Rationale
Recent improvements to the APIs for adding or removing members from a project group mean that we should use the project as the target URL when making those changes.

## Changes
- Pass in the correct project group when making changes

## Tasks 📍
- [x] Claude Code Review
-  ~Manual Testing~
- [x] Test Automation
