### PR TITLE
Update schema version in testAutomation/gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ seleniumVersion=4.45.0
 
 mockserverNettyVersion=5.15.0
 
-labkeySchemasTestVersion=26.3-SNAPSHOT
+labkeySchemasTestVersion=26.8-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ seleniumVersion=4.45.0
 
 mockserverNettyVersion=5.15.0
 
-labkeySchemasTestVersion=26.8-SNAPSHOT
+labkeySchemasTestVersion=26.7-SNAPSHOT


### PR DESCRIPTION
## Rationale
Update to the most recent ESR release for the LabKey APIs

## Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2266

## Changes
- Update schema to 26.7.
