### PR TITLE
Update the version of LabKey API for tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ seleniumVersion=4.45.0
 
 mockserverNettyVersion=5.15.0
 
-labkeySchemasTestVersion=26.3-SNAPSHOT
+labkeySchemasTestVersion=26.7-SNAPSHOT


### PR DESCRIPTION
## Rationale
Update the LabKey API the tests use to the latest ESR build.

## Related Pull Requests
- None

## Changes
- Change schema version to 26.7
