### PR TITLE
Fix for SMProCustomizeIdentifyingFieldsTest.testEditingIdentifyingFields and SMProFMUITest.testCreationAndManagementForStorageDesigner

### DIFF
--- a/src/org/labkey/test/components/ui/grids/FieldSelectionDialog.java
+++ b/src/org/labkey/test/components/ui/grids/FieldSelectionDialog.java
@@ -522,49 +522,67 @@ public class FieldSelectionDialog extends ModalDialog
      */
     public FieldSelectionDialog repositionField(FieldKey fieldToMove, FieldKey targetField, boolean beforeTarget)
     {
-        WebElement elementToMove = elementCache().findSelectedField(fieldToMove);
-        WebElement elementTarget = elementCache().findSelectedField(targetField);
+        List<String> order = selectedFieldKeys();
+        int from = indexOfFieldKey(order, fieldToMove);
+        int target = indexOfFieldKey(order, targetField);
+        int to = beforeTarget ? (from < target ? target - 1 : target) : (from < target ? target : target + 1);
 
-        int yBefore =  elementToMove.getRect().getY();
+        keyboardReorder(elementCache().findDragHandle(fieldToMove), to - from);
 
-        int offset;
-
-        if(beforeTarget)
-        {
-            if(elementTarget.getRect().getY() < elementToMove.getRect().getY())
-            {
-                // If the target is above the field being moved.
-                offset = -1 * elementTarget.getSize().getHeight();
-            }
-            else
-            {
-                // If the target is below the field being moved.
-                offset = -1 * elementTarget.getSize().getHeight() / 2;
-            }
-        }
-        else
-        {
-            offset = elementTarget.getSize().getHeight() / 2 + 10;
-        }
-
-        WebElement dragHandle = Locator.tagWithAttribute("div", "role", "button").findWhenNeeded(elementToMove);
-        getWrapper().mouseOver(dragHandle);
-        new Actions(getDriver())
-                .clickAndHold(dragHandle)
-                .moveToElement(elementTarget)
-                .moveByOffset(2, offset)
-                .release()
-                .perform();
-
-        // Maybe I don't need to wait?
-        WebDriverWrapper.sleep(1_000);
-
-        int yAfter =  elementToMove.getRect().getY();
-
-        WebDriverWrapper.waitFor(()-> yAfter != yBefore, "I don't think I repositioned the field in the list.",
-                1_000);
+        WebDriverWrapper.waitFor(() -> {
+            List<String> now = selectedFieldKeys();
+            return indexOfFieldKey(now, fieldToMove) - indexOfFieldKey(now, targetField) == (beforeTarget ? -1 : 1);
+        }, "Field '" + fieldToMove + "' was not repositioned as expected", 5_000);
 
         return this;
+    }
+
+    /**
+     * Reorder a row via the keyboard controls: focus the handle, Space to lift, one Arrow per
+     * step, Space to drop. (Mouse drag is unreliable with the library's sensor.)
+     *
+     * @param dragHandle The row's drag handle.
+     * @param steps Positions to move; negative moves up, positive moves down.
+     */
+    private void keyboardReorder(WebElement dragHandle, int steps)
+    {
+        getWrapper().scrollIntoView(dragHandle);
+        getWrapper().executeScript("arguments[0].focus();", dragHandle);
+
+        Actions drag = new Actions(getDriver()).sendKeys(Keys.SPACE).pause(Duration.ofMillis(400)); // lift
+        Keys arrow = steps < 0 ? Keys.ARROW_UP : Keys.ARROW_DOWN;
+        for (int i = 0; i < Math.abs(steps); i++)
+            drag.sendKeys(arrow).pause(Duration.ofMillis(300));
+        drag.sendKeys(Keys.SPACE).perform(); // drop
+    }
+
+    /**
+     * Get the 'data-fieldkey' values of the selected fields, in display order.
+     *
+     * @return The encoded field keys.
+     */
+    private List<String> selectedFieldKeys()
+    {
+        return elementCache().getListItemElements(elementCache().selectedFieldsPanel).stream()
+                .map(el -> el.getDomAttribute("data-fieldkey"))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Get the index of a field in the given list, matched case-insensitively (as findFieldRow locates rows).
+     *
+     * @param fieldKeys Encoded field keys, in display order.
+     * @param fieldKey Field to locate.
+     * @return The index, or -1 if not present.
+     */
+    private static int indexOfFieldKey(List<String> fieldKeys, FieldKey fieldKey)
+    {
+        for (int i = 0; i < fieldKeys.size(); i++)
+        {
+            if (fieldKey.toString().equalsIgnoreCase(fieldKeys.get(i)))
+                return i;
+        }
+        return -1;
     }
 
     /**
@@ -660,6 +678,11 @@ public class FieldSelectionDialog extends ModalDialog
         protected WebElement findSelectedField(FieldKey fieldKey)
         {
             return findFieldRow(fieldKey, selectedFieldsPanel);
+        }
+
+        protected WebElement findDragHandle(FieldKey fieldKey)
+        {
+            return Locator.tagWithAttribute("div", "role", "button").findElement(findSelectedField(fieldKey));
         }
 
         protected WebElement findAvailableField(FieldKey fieldKey)

--- a/src/org/labkey/test/components/ui/navigation/ProductMenu.java
+++ b/src/org/labkey/test/components/ui/navigation/ProductMenu.java
@@ -267,7 +267,7 @@ public class ProductMenu extends WebDriverComponent<ProductMenu.ElementCache>
     protected class ElementCache extends Component<?>.ElementCache
     {
         private final WebElement toggle = Locator.byClass("product-menu-button").findWhenNeeded(this);
-        private final WebElement menuContent = Locator.tagWithClass("div", "product-menu-content").findWhenNeeded(this);
+        private final WebElement menuContent = Locator.tagWithClass("div", "product-menu-content").refindWhenNeeded(this);
         private final WebElement folderColumn = Locator.tagWithClass("div", "col-folders").findWhenNeeded(menuContent);
         private final WebElement sectionContent = Locator.tagWithClass("div", "sections-content").findWhenNeeded(menuContent);
 


### PR DESCRIPTION
## Rationale
Fixes two flaky UI-test helpers. Each makes a helper resilient to the app's async React re-rendering rather than relying on timing/mouse gestures.

## Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

## Changes
- ProductMenu.menuContent now refindWhenNeeded to self-heal on menu re-render, fixing intermittent StaleElementReferenceException.
- FieldSelectionDialog.repositionField reorder via keyboard controls instead of the unreliable mouse drag.
<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->