### PR TITLE
Fix DataRegion Locators for "Experiment Runs" webpart

### DIFF
--- a/src/org/labkey/test/params/assay/AssayDesign.java
+++ b/src/org/labkey/test/params/assay/AssayDesign.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 
 public abstract class AssayDesign<T extends AssayDesign<T>>
 {
+    final String _name;
     final String _providerName;
     final List<Consumer<Protocol>> _transformers = new ArrayList<>();
 
@@ -39,6 +40,7 @@ public abstract class AssayDesign<T extends AssayDesign<T>>
     {
         _providerName = providerName;
         _transformers.add(p -> p.setName(name));
+        _name = name;
     }
 
     public static AssayDesign<?> of(String providerName, String name)
@@ -76,15 +78,15 @@ public abstract class AssayDesign<T extends AssayDesign<T>>
 
     public Protocol createAssay(String containerPath, Connection connection) throws IOException, CommandException
     {
-        TestLogger.info(String.format("Creating %s assay in '%s'", _providerName, containerPath));
+        TestLogger.info("Creating %s assay '%s' in '%s'".formatted(_providerName, _name, containerPath));
 
         GetProtocolCommand getProtocolCommand = new GetProtocolCommand(_providerName);
         ProtocolResponse getProtocolResponse = getProtocolCommand.execute(connection, containerPath);
 
         Protocol protocol = updateProtocol(containerPath, connection, getProtocolResponse.getProtocol());
 
-        TestLogger.info(String.format("Successfully created %s assay '%s' in '%s':\n%s", _providerName,
-            protocol.getName(), containerPath, protocol.toJSONObject().toString(2)));
+        TestLogger.log().debug(() -> String.format("Successfully created %s assay '%s':\n%s", _providerName,
+                protocol.getName(), protocol.toJSONObject().toString(2)));
 
         return protocol;
     }

--- a/src/org/labkey/test/tests/DataClassFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/DataClassFolderExportImportTest.java
@@ -134,7 +134,7 @@ public class DataClassFolderExportImportTest extends BaseWebDriverTest
             ph.addWebPart("Experiment Runs");
         });
 
-        DataRegionTable sourceRunsTable = DataRegionTable.DataRegion(getDriver()).withName("Runs").waitFor();
+        DataRegionTable sourceRunsTable = DataRegionTable.DataRegion(getDriver()).inWebPart("Experiment Runs").waitFor();
         List<String> runNames = sourceRunsTable.getColumnDataAsText("Name");
 
         clickAndWait(Locator.linkWithText(testDataClass));
@@ -158,7 +158,7 @@ public class DataClassFolderExportImportTest extends BaseWebDriverTest
         importFolderFromZip(exportedFolderFile, false, 1);
         goToProjectFolder(IMPORT_PROJECT_NAME, importFolder);
 
-        List<String> importedRunNames = DataRegionTable.DataRegion(getDriver()).withName("Runs").waitFor()
+        List<String> importedRunNames = DataRegionTable.DataRegion(getDriver()).inWebPart("Experiment Runs").waitFor()
                 .getColumnDataAsText("Name");
         for (String sourceRun : runNames)
         {
@@ -172,7 +172,7 @@ public class DataClassFolderExportImportTest extends BaseWebDriverTest
         List<Map<String, String>> destRowData = destTable.getTableData();
 
         // now ensure expected data in the sampleType made it to the destination folder
-        for (Map exportedRow : sourceRowData)
+        for (Map<String, String> exportedRow : sourceRowData)
         {
             // find the map from the exported project with the same name
             Map<String, String> matchingMap = destRowData.stream().filter(a-> a.get("Name").equals(exportedRow.get("Name")))
@@ -289,7 +289,7 @@ public class DataClassFolderExportImportTest extends BaseWebDriverTest
         List<Map<String, String>> destRowData = importTable.getTableData();
 
         // now ensure expected data in the sampleType made it to the destination folder
-        for (Map exportedRow : sourceRowData)
+        for (Map<String, String> exportedRow : sourceRowData)
         {
             // find the map from the exported project with the same name
             Map<String, String> matchingMap = destRowData.stream().filter(a-> a.get("Name").equals(exportedRow.get("Name")))

--- a/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
+++ b/src/org/labkey/test/tests/SampleTypeFolderExportImportTest.java
@@ -17,7 +17,6 @@ package org.labkey.test.tests;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
@@ -60,7 +59,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -141,17 +140,9 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
             return false;
 
         // Order the two lists so compare can be done by index and not by searching the two lists.
-        Collections.sort(list01, (Map<String, String> o1, Map<String, String> o2)->
-                {
-                    return o1.get("Name").compareTo(o2.get("Name"));
-                }
-        );
+        list01.sort(Comparator.comparing((Map<String, String> o) -> o.get("Name")));
 
-        Collections.sort(list02, (Map<String, String> o1, Map<String, String> o2)->
-                {
-                    return o1.get("Name").compareTo(o2.get("Name"));
-                }
-        );
+        list02.sort(Comparator.comparing((Map<String, String> o) -> o.get("Name")));
 
         boolean areEqual = true;
 
@@ -485,11 +476,12 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
                 "ParentAlias", "Parent3, Parent2", "SelfParent", "Child5", "DataClassParent", "data2, data3"));
         testDgen.insertRows();
 
-        PortalHelper portalHelper = new PortalHelper(this);
-        portalHelper.addWebPart("Sample Types");
-        portalHelper.addWebPart("Experiment Runs");
+        new PortalHelper(this).doInAdminMode(portalHelper -> {
+            portalHelper.addWebPart("Sample Types");
+            portalHelper.addWebPart("Experiment Runs");
+        });
 
-        DataRegionTable sourceRunsTable = DataRegionTable.DataRegion(getDriver()).withName("Runs").waitFor();
+        DataRegionTable sourceRunsTable = DataRegionTable.DataRegion(getDriver()).inWebPart("Experiment Runs").waitFor();
         List<String> runNames = sourceRunsTable.getColumnDataAsText("Name");
 
         clickAndWait(Locator.linkWithText(testSamples));
@@ -510,7 +502,7 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         importFolderFromZip(exportedFolderFile, false, 1);
         goToProjectFolder(IMPORT_PROJECT_NAME, importFolder);
 
-        List<String> importedRunNames = DataRegionTable.DataRegion(getDriver()).withName("Runs").waitFor()
+        List<String> importedRunNames = DataRegionTable.DataRegion(getDriver()).inWebPart("Experiment Runs").waitFor()
                 .getColumnDataAsText("Name");
         for (String sourceRun : runNames)
         {
@@ -530,7 +522,7 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
         List<Map<String, String>> destRowData = destSamplesTable.getTableData();
 
         // now ensure expected data in the sampleType made it to the destination folder
-        for (Map exportedRow : sourceRowData)
+        for (Map<String, String> exportedRow : sourceRowData)
         {
             // find the map from the exported project with the same name
             Map<String, String> matchingMap = destRowData.stream().filter(a-> a.get("Name").equals(exportedRow.get("Name")))
@@ -550,11 +542,11 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
             assertThat("expect export and import values to be equivalent",
                     exportedRow.get(decimalColFieldKey), equalTo(matchingMap.get(decimalColFieldKey)));
 
-            List<String> sourceParents = Arrays.asList(exportedRow.get("Inputs/Materials/parentSamples").toString()
+            List<String> sourceParents = Arrays.asList(exportedRow.get("Inputs/Materials/parentSamples")
                     .replace(" ", "").split(","));
             String[] importedParents = matchingMap.get("Inputs/Materials/parentSamples").replace(" ", "").split(",");
             assertThat("expect parent sampleType derivation to round trip with equivalent values", sourceParents, hasItems(importedParents));
-            List<String> sourceDataParents = Arrays.asList(exportedRow.get("Inputs/Data/parentDataClass").toString()
+            List<String> sourceDataParents = Arrays.asList(exportedRow.get("Inputs/Data/parentDataClass")
                     .replace(" ", "").split(","));
             String[] importedDataParents = matchingMap.get("Inputs/Data/parentDataClass").replace(" ", "").split(",");
             assertThat("expect parent dataClass derivation to round trip with equivalent values", sourceDataParents, hasItems(importedDataParents));
@@ -761,7 +753,7 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
             importData.add(importedDataTable.getRowDataAsMap(i));
         }
 
-        for (Map exportedRow : exportData)
+        for (Map<String, String> exportedRow : exportData)
         {
             // find the map from the exported project with the same name
             Map<String, String> matchingMap = importData.stream().filter(a -> a.get("sampleId").equals(exportedRow.get("sampleId")))
@@ -797,14 +789,14 @@ public class SampleTypeFolderExportImportTest extends BaseWebDriverTest
             if (field.isNamePartMatch(namePart))
                 return field;
         }
-        return null;
+        throw new RuntimeException("Field " + namePart + " not found: " + fields.stream().map(FieldDefinition::getName).toList());
     }
 
     private StringBuilder checkDisplayFields(String displayField, List<String> columnLabels)
     {
         StringBuilder tmpString = new StringBuilder();
 
-        if(!columnLabels.contains("Name"))
+        if(!columnLabels.contains(displayField))
         {
             String errorMsg = "Did not find the 'Name' column.";
             log("\n*************** ERROR ***************\n" + errorMsg + "\n*************** ERROR ***************");

--- a/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
+++ b/src/org/labkey/test/tests/SampleTypeLinkToStudyTest.java
@@ -40,11 +40,13 @@ import org.labkey.test.pages.study.ManageVisitPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.DomainUtils;
 import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
 import org.labkey.test.util.StudyHelper;
 import org.labkey.test.util.TestDataGenerator;
+import org.labkey.test.util.data.TestDataUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -82,7 +84,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
         init.doSetup();
     }
 
-    private void doSetup()
+    private void doSetup() throws IOException
     {
         _containerHelper.createProject(getProjectName(), null);
         _containerHelper.createProject(VISIT_BASED_STUDY, "Study");
@@ -112,7 +114,7 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
 
 
 
-    private void createSampleTypes()
+    private void createSampleTypes() throws IOException
     {
         SampleTypeHelper sampleHelper = new SampleTypeHelper(this);
 
@@ -130,11 +132,12 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
                         new FieldDefinition("ParticipantId", FieldDefinition.ColumnType.Subject))), data1);
 
         goToProjectHome(SAMPLE_TYPE_PROJECT);
-        String data2 = "Name\tVisitLabel\tVisitDate\tParticipantId\n" +
-                "First\t" + visitLabel1 + "\t" + now + "\tP1\n" +
-                "Second\t" + visitLabel2 + "\t" + now + "\tP2\n" +
-                "Third\t" + visitLabel1 + "\t" + now + "\tP3\n" +
-                "Fourth\t" + visitLabel2 + "\t" + now + "\tP4\n";
+        File data2 = TestDataUtils.writeRowsToFile("samples.tsv", List.of(
+                List.of("Name", "VisitLabel", "VisitDate", "ParticipantId"),
+                List.of("First", visitLabel1, now, "P1"),
+                List.of("Second", visitLabel2, now, "P2"),
+                List.of("Third", visitLabel1, now, "P3"),
+                List.of("Fourth", visitLabel2, now, "P4")));
 
         sampleHelper.createSampleType(new SampleTypeDefinition(SAMPLE_TYPE2)
                 .setFields(List.of(
@@ -777,14 +780,10 @@ public class SampleTypeLinkToStudyTest extends BaseWebDriverTest
     public void preTest() throws Exception
     {
         //deleting the datasets from study folders.
-        if (TestDataGenerator.doesDomainExists(DATE_BASED_STUDY, "study", "Sample type 1"))
-            TestDataGenerator.deleteDomain(DATE_BASED_STUDY, "study", "Sample type 1");
-        if (TestDataGenerator.doesDomainExists(DATE_BASED_STUDY, "study", "Sample type 2"))
-            TestDataGenerator.deleteDomain(DATE_BASED_STUDY, "study", "Sample type 2");
-        if (TestDataGenerator.doesDomainExists(VISIT_BASED_STUDY, "study", "Sample type 1"))
-            TestDataGenerator.deleteDomain(VISIT_BASED_STUDY, "study", "Sample type 1");
-        if (TestDataGenerator.doesDomainExists(VISIT_BASED_STUDY, "study", "Sample type 2"))
-            TestDataGenerator.deleteDomain(VISIT_BASED_STUDY, "study", "Sample type 2");
+        DomainUtils.ensureDeleted(DATE_BASED_STUDY, "study", "Sample type 1");
+        DomainUtils.ensureDeleted(DATE_BASED_STUDY, "study", "Sample type 2");
+        DomainUtils.ensureDeleted(VISIT_BASED_STUDY, "study", "Sample type 1");
+        DomainUtils.ensureDeleted(VISIT_BASED_STUDY, "study", "Sample type 2");
     }
 
     private void createNewVisits(String label, String startRange, String endRange)

--- a/src/org/labkey/test/util/DataRegionTable.java
+++ b/src/org/labkey/test/util/DataRegionTable.java
@@ -207,6 +207,12 @@ public class DataRegionTable extends DataRegion
             return this;
         }
 
+        public DataRegionFinder inWebPart(String webPartTitle)
+        {
+            _loc = PortalHelper.Locators.webPart(webPartTitle).append(Locators.dataRegion());
+            return this;
+        }
+
         @Override
         protected Locator locator()
         {
@@ -233,15 +239,22 @@ public class DataRegionTable extends DataRegion
         }
     }
 
+    /**
+     * @deprecated Use {@link DataRegionFinder} directly
+     */
     @Deprecated
     public static DataRegionTable findDataRegion(WebDriverWrapper test)
     {
         return DataRegion(test.getDriver()).find();
     }
 
+    /**
+     * @deprecated Use {@link DataRegionFinder#inWebPart(String)}
+     */
+    @Deprecated
     public static DataRegionTable findDataRegionWithinWebpart(WebDriverWrapper test, String webPartTitle)
     {
-        return DataRegion(test.getDriver()).find(new RefindingWebElement(PortalHelper.Locators.webPart(webPartTitle), test.getDriver()));
+        return DataRegion(test.getDriver()).inWebPart(webPartTitle).find();
     }
 
     public int getColumnCount()

--- a/src/org/labkey/test/util/SampleTypeHelper.java
+++ b/src/org/labkey/test/util/SampleTypeHelper.java
@@ -15,8 +15,8 @@
  */
 package org.labkey.test.util;
 
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.query.InsertRowsCommand;
@@ -388,7 +388,6 @@ public class SampleTypeHelper extends WebDriverWrapper
 
         DataRegionTable table =  new DataRegionTable("query", getDriver());
         table.clickHeaderButtonAndWait("Link to Study");
-        assertNoLabKeyErrors();
         return table;
     }
 }

--- a/src/org/labkey/test/util/SampleTypeHelper.java
+++ b/src/org/labkey/test/util/SampleTypeHelper.java
@@ -15,8 +15,8 @@
  */
 package org.labkey.test.util;
 
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.query.InsertRowsCommand;
@@ -388,6 +388,7 @@ public class SampleTypeHelper extends WebDriverWrapper
 
         DataRegionTable table =  new DataRegionTable("query", getDriver());
         table.clickHeaderButtonAndWait("Link to Study");
+        assertNoLabKeyErrors();
         return table;
     }
 }


### PR DESCRIPTION
## Rationale
"Experiment Runs" data region no longer has a predictable name ("Runs"). Tests need to be updated.
```
org.openqa.selenium.NoSuchElementException: Expected condition failed: waiting for css=form[data-region-form="Runs"]
(tried for 30 seconds with 100 milliseconds interval)
  [...] app//org.labkey.test.components.WebDriverComponent$WebDriverComponentFinder.waitFor(WebDriverComponent.java:86)
  at app//org.labkey.test.tests.DataClassFolderExportImportTest.testExportImportSimpleDataClass(DataClassFolderExportImportTest.java:137)
```

Also fixing and cleaning up some nearby test code.

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7846

## Changes
- Update Locator for "Experiment Runs" data region
- Add `DataRegionFinder.inWebPart`
- Fix TSV formatting for `SampleTypeLinkToStudyTest`
- Disable verbose JSON logging for assay creation