### PR TITLE
Status Menu Test Fixes

### DIFF
--- a/src/org/labkey/test/components/ui/navigation/NavBar.java
+++ b/src/org/labkey/test/components/ui/navigation/NavBar.java
@@ -95,7 +95,7 @@ public abstract class NavBar extends WebDriverComponent<NavBar.ElementCache>
      */
     public ServerNotificationMenu getNotificationMenu()
     {
-        return elementCache().notificationsMenu;
+        return elementCache().notificationsMenu();
     }
 
     public ProductMenu getProductMenu()
@@ -130,6 +130,9 @@ public abstract class NavBar extends WebDriverComponent<NavBar.ElementCache>
         public Input searchBox = Input.Input(Locator.tagWithClass("input", "navbar__search-input"), getDriver()).refindWhenNeeded(this);
         public MultiMenu searchMenu = new MultiMenu.MultiMenuFinder(getDriver()).withButtonClass("navbar__find-and-search-button").refindWhenNeeded(this);
         public final ProductMenu productMenu = ProductMenu.finder(getDriver()).timeout(1000).refindWhenNeeded(this);
-        public final ServerNotificationMenu notificationsMenu = ServerNotificationMenu.finder(getDriver()).timeout(1000).refindWhenNeeded(this);
+        public final ServerNotificationMenu notificationsMenu()
+        {
+            return ServerNotificationMenu.finder(getDriver()).timeout(1000).refindWhenNeeded(this);
+        }
     }
 }

--- a/src/org/labkey/test/components/ui/notifications/ServerNotificationMenu.java
+++ b/src/org/labkey/test/components/ui/notifications/ServerNotificationMenu.java
@@ -139,7 +139,7 @@ public class ServerNotificationMenu extends WebDriverComponent<ServerNotificatio
     protected boolean isExpanded()
     {
         boolean ariaExpanded = "true".equals(elementCache().toggle.getAttribute("aria-expanded"));
-        boolean menuContentDisplayed = elementCache().menuContent.isDisplayed();
+        boolean menuContentDisplayed = elementCache().menuContent().isDisplayed();
 
         return ariaExpanded && menuContentDisplayed;
     }
@@ -201,16 +201,14 @@ public class ServerNotificationMenu extends WebDriverComponent<ServerNotificatio
 
         // Wait for the listing container to show up. The listing container is in the open menu, scope the search to that.
         Locator notificationsContainerLocator = Locator.tagWithClass("div", "server-notifications-listing-container");
-        WebDriverWrapper.waitFor(()-> notificationsContainerLocator.refindWhenNeeded(elementCache().menuContent).isDisplayed(),
+        WebDriverWrapper.waitFor(()-> notificationsContainerLocator.areAnyVisible(elementCache().menuContent()),
                 "List container did not render.", 500);
 
         // Find again (lambda requires a final reference to the component).
-        WebElement listContainer = notificationsContainerLocator.refindWhenNeeded(elementCache().menuContent);
+        WebElement listContainer = notificationsContainerLocator.refindWhenNeeded(elementCache().menuContent());
 
         // It may be a moment before any notifications show up.
-        WebDriverWrapper.waitFor(()-> Locator.tagWithClass("ul", "server-notifications-listing")
-                        .refindWhenNeeded(listContainer)
-                        .isDisplayed(),
+        WebDriverWrapper.waitFor(()-> Locator.tagWithClass("ul", "server-notifications-listing").areAnyVisible(listContainer),
                 "There are no notifications in the drop down.", 1_000);
 
         // Just wait for a moment in case the list is slow to update with the most recent notification.
@@ -223,7 +221,7 @@ public class ServerNotificationMenu extends WebDriverComponent<ServerNotificatio
 
         // Find the container again, don't return listContainer WebElement previously found. If the list was slow to
         // update with the most recent notification the old reference will be stale.
-        return notificationsContainerLocator.refindWhenNeeded((elementCache().menuContent));
+        return notificationsContainerLocator.refindWhenNeeded((elementCache().menuContent()));
     }
 
     /**
@@ -282,7 +280,10 @@ public class ServerNotificationMenu extends WebDriverComponent<ServerNotificatio
 
     protected class ElementCache extends Component<?>.ElementCache
     {
-        public final WebElement menuContent = Locator.byClass("navbar-menu__content").refindWhenNeeded(this);
+        public final WebElement menuContent()
+        {
+            return Locator.byClass("navbar-menu__content").refindWhenNeeded(this);
+        }
 
         public final WebElement toggle = Locator.byClass("navbar-menu-button").refindWhenNeeded(this);
 
@@ -293,14 +294,14 @@ public class ServerNotificationMenu extends WebDriverComponent<ServerNotificatio
 
         public final WebElement noNotificationsElement()
         {
-            return Locator.tagWithClass("div", "server-notifications-footer").refindWhenNeeded(elementCache().menuContent);
+            return Locator.tagWithClass("div", "server-notifications-footer").refindWhenNeeded(elementCache().menuContent());
         }
 
         public final WebElement markAll()
         {
             return Locator.tagWithClass("h3", "navbar-menu-header")
                     .child(Locator.byClass("clickable-text"))
-                    .refindWhenNeeded(elementCache().menuContent);
+                    .refindWhenNeeded(elementCache().menuContent());
         }
 
         public final WebElement viewAllLink()


### PR DESCRIPTION
## Rationale
Status menu test fixes.
Using areAnyVisible is the safer choice because:
It does a fresh DOM search every poll, so there's no stale element concern at all
It won't throw if results haven't appeared yet — it just keeps waiting
It naturally handles the case where multiple results are present

## Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2351

## Changes
- Use areAnyVisible when waiting (handles nulls better)
- Find the notification menu every time it is called.