### PR TITLE
BaseReactSelect: support for "Add New"

### DIFF
--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -431,8 +431,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
     public boolean isAddNewVisible()
     {
         open();
-        WebElement addNew = Locators.addEntitiesFooter.findElementOrNull(getComponentElement());
-        return addNew != null && addNew.isDisplayed();
+        return Locators.addEntitiesFooter.isDisplayed(this);
     }
 
     /**
@@ -443,15 +442,18 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
     public void clickAddNew()
     {
         open();
-        WebElement addNew = Locators.addEntitiesFooter.waitForElement(getComponentElement(), WAIT_FOR_JAVASCRIPT);
+
         try
         {
-            addNew.click();
+            Locators.addEntitiesFooter.findElement(this).click();
         }
-        catch (WebDriverException wde) // handle the "another element would receive the click" situation
+        catch (WebDriverException e)
         {
-            getWrapper().scrollIntoView(addNew);
-            getWrapper().fireEvent(addNew, WebDriverWrapper.SeleniumEvent.click);
+            // ReactSelect is notoriously bad at positioning the menu so that it does not render off the screen.
+            // That said, it can behave better if you close and reopen the menu.
+            close();
+            open();
+            Locators.addEntitiesFooter.findElement(this).click();
         }
     }
 

--- a/src/org/labkey/test/components/react/BaseReactSelect.java
+++ b/src/org/labkey/test/components/react/BaseReactSelect.java
@@ -422,6 +422,39 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
         return elementCache().input.getAttribute("name");
     }
 
+    /**
+     * Determines whether the "Add New" menu footer is present at the bottom of the select's menu area. This item is
+     * rendered only when the underlying schema/query is registered and configured to support adding new values.
+     *
+     * @return true if the "Add New" menu item is visible, otherwise false
+     */
+    public boolean isAddNewVisible()
+    {
+        open();
+        WebElement addNew = Locators.addEntitiesFooter.findElementOrNull(getComponentElement());
+        return addNew != null && addNew.isDisplayed();
+    }
+
+    /**
+     * Clicks the "Add New" menu item at the bottom of the select's menu area. The menu is opened first if it is not
+     * already expanded. This intentionally returns void: the resulting UI varies by schema/query, so the caller is
+     * responsible for constructing and interacting with whatever the click produces.
+     */
+    public void clickAddNew()
+    {
+        open();
+        WebElement addNew = Locators.addEntitiesFooter.waitForElement(getComponentElement(), WAIT_FOR_JAVASCRIPT);
+        try
+        {
+            addNew.click();
+        }
+        catch (WebDriverException wde) // handle the "another element would receive the click" situation
+        {
+            getWrapper().scrollIntoView(addNew);
+            getWrapper().fireEvent(addNew, WebDriverWrapper.SeleniumEvent.click);
+        }
+    }
+
     protected T scrollIntoView()
     {
         try
@@ -515,6 +548,7 @@ public abstract class BaseReactSelect<T extends BaseReactSelect<T>> extends WebD
         }
 
         public static final Locator.XPathLocator option = Locator.tagWithClass("div", "select-input__option");
+        public static final Locator.XPathLocator addEntitiesFooter = Locator.tagWithClass("div", "add-entities-footer");
         public static final Locator placeholder = Locator.tagWithClass("div", "select-input__placeholder");
         public static final Locator clear = Locator.tagWithClass("div","select-input__clear-indicator");
         public static final Locator arrow = Locator.tagWithClass("div","select-input__dropdown-indicator");

--- a/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
+++ b/src/org/labkey/test/components/ui/entities/EntityBulkUpdateDialog.java
@@ -264,8 +264,7 @@ public class EntityBulkUpdateDialog extends EntityBulkDialog
      */
     private FileAttachmentContainer getFileField(CharSequence fieldIdentifier)
     {
-        FieldKey identifier = FileAttachmentContainer.fileUploadFieldKey(fieldIdentifier);
-        return enableAndWait(identifier, elementCache().fileUploadField(identifier));
+        return enableAndWait(fieldIdentifier, elementCache().fileUploadField(fieldIdentifier));
     }
 
     /**
@@ -307,8 +306,7 @@ public class EntityBulkUpdateDialog extends EntityBulkDialog
 
     public FileUploadField getExistingFileCard(CharSequence fieldIdentifier)
     {
-        FieldKey identifier = FileAttachmentContainer.fileUploadFieldKey(fieldIdentifier);
-        return enableAndWait(identifier, elementCache().fileField(identifier));
+        return enableAndWait(fieldIdentifier, elementCache().fileField(fieldIdentifier));
     }
 
     /**

--- a/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
+++ b/src/org/labkey/test/components/ui/entities/ParentEntityEditPanel.java
@@ -102,7 +102,7 @@ public class ParentEntityEditPanel extends Panel<ParentEntityEditPanel.ElementCa
                                 .find(this);
 
                         // For the first parent the panel is ready if the entity type selector is ready and the options have been populated.
-                        return firstParentSelector.isInteractive() && !firstParentSelector.getOptions().isEmpty();
+                        return firstParentSelector.isInteractive();
 
                     }
                 }

--- a/src/org/labkey/test/components/ui/files/FileAttachmentContainer.java
+++ b/src/org/labkey/test/components/ui/files/FileAttachmentContainer.java
@@ -21,7 +21,6 @@ import org.labkey.test.components.Component;
 import org.labkey.test.components.WebDriverComponent;
 import org.labkey.test.components.html.FileInput;
 import org.labkey.test.components.html.Input;
-import org.labkey.test.params.FieldKey;
 import org.openqa.selenium.ElementNotInteractableException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -209,16 +208,6 @@ public class FileAttachmentContainer extends WebDriverComponent<FileAttachmentCo
                 .findWhenNeeded(this);
         public Locator uploadAlertLoc = Locator.tagWithClass("div", "alert");
         public Locator fileUploadScrollFooterLoc = Locator.tagWithClass("div", "file-upload__scroll-footer");
-    }
-
-    /**
-     * File upload fields append "-fileUpload" to the field's fieldKey
-     * @param fieldIdentifier Identifier for the field; name ({@link String}) or fieldKey ({@link FieldKey})
-     * @return FieldKey with expected suffix
-     */
-    public static FieldKey fileUploadFieldKey(CharSequence fieldIdentifier)
-    {
-        return FieldKey.fromFieldKey(FieldKey.fromName(fieldIdentifier) + "-fileUpload"); // Issue 53394
     }
 
     public static class FileAttachmentContainerFinder extends WebDriverComponentFinder<FileAttachmentContainer, FileAttachmentContainerFinder>

--- a/src/org/labkey/test/util/AuditLogHelper.java
+++ b/src/org/labkey/test/util/AuditLogHelper.java
@@ -349,7 +349,7 @@ public class AuditLogHelper
             {
                 String expectedValue = expectedDetails.get(key).toString();
                 String actualValue = actualDetails.get(key.name()) != null ? actualDetails.get(key.name()).toString() : null;
-                assertTrue("Detail value for key " + key + " not as expected", actualValue != null && actualValue.contains(expectedValue));
+                assertTrue("Detail value for key " + key + " does not contain \"" + expectedValue + "\"", actualValue != null && actualValue.contains(expectedValue));
             }
             else
                 assertEquals("Detail value for key " + key + " not as expected", expectedDetails.get(key), actualDetails.get(key.name()));


### PR DESCRIPTION
## Rationale
Test component updates for supporting "Add New" in `QuerySelect`.

## Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/2039
- https://github.com/LabKey/labkey-ui-premium/pull/997
- https://github.com/LabKey/limsModules/pull/2347
- https://github.com/LabKey/testAutomation/pull/3126

## Changes
- Add `isAddNewVisible()` and `clickAddNew()` to `BaseReactSelect`.