### PR TITLE
Parse report-to CSP reports

### DIFF
--- a/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
+++ b/src/org/labkey/test/tests/elispotassay/ElispotAssayTest.java
@@ -757,7 +757,7 @@ public class ElispotAssayTest extends AbstractAssayTest
         List<String> expected4FMedians = Arrays.asList("0.0", "0.0", "6666.7", "0.0");
         List<String> expected6FMeans = Arrays.asList("0.0", "0.0", "0.0", "0.0");
         List<String> expected6FMedians = Arrays.asList("0.0", "0.0", "0.0", "0.0");
-        Bag<List<String>> expectedRows = new HashBag<>(DataRegionTable.collateColumnsIntoRows(
+        MultiSet<List<String>> expectedRows = new HashMultiSet<>(DataRegionTable.collateColumnsIntoRows(
                 expectedPtids,
                 expected2FMeans,
                 expected2FMedians,
@@ -766,7 +766,7 @@ public class ElispotAssayTest extends AbstractAssayTest
                 expected6FMeans,
                 expected6FMedians));
 
-        Bag<List<String>> actualRows = new HashBag<>(table.getRows(
+        MultiSet<List<String>> actualRows = new HashMultiSet<>(table.getRows(
                 "ParticipantID",
                 "Atg2FMean",
                 "Atg2FMedian",

--- a/src/org/labkey/test/util/CspLogUtil.java
+++ b/src/org/labkey/test/util/CspLogUtil.java
@@ -123,7 +123,7 @@ public class CspLogUtil
                     throw new RuntimeException("Failed to read recent CSP violations.", e);
                 }
 
-                boolean foundVioloation = false;
+                boolean foundViolation = false;
                 MultiValuedMap<Crawler.ControllerActionId, String> violations = new HashSetValuedHashMap<>();
                 List<CspReport> cspReports = new ArrayList<>();
                 StringBuilder sb = new StringBuilder();
@@ -137,11 +137,11 @@ public class CspLogUtil
                     {
                         cspReports.add(new CspReport(sb.toString()));
                         sb = new StringBuilder();
-                        foundVioloation = true;
+                        foundViolation = true;
                     }
                 }
 
-                if (!foundVioloation)
+                if (!foundViolation)
                 {
                     throw new AssertionError("Detected CSP violations but unable to parse log file: " + recentWarningsFile.getAbsolutePath());
                 }
@@ -225,10 +225,20 @@ class CspReport
 
     CspReport(String reportStr)
     {
-        // Support report-to reports only. GitHub Issue #900
-        JSONObject report = new JSONObject(reportStr).getJSONObject("body");
-        _violatedDirective = report.getString("effectiveDirective");
-        _documentUrl = report.getString("documentURL");
+        // Support report-uri and report-to reports
+        JSONObject json = new JSONObject(reportStr);
+        JSONObject report = json.optJSONObject("body");
+        if (report != null)
+        {
+            _violatedDirective = report.getString("effectiveDirective");
+            _documentUrl = report.getString("documentURL");
+        }
+        else
+        {
+            report = json.getJSONObject("csp-report");
+            _violatedDirective = report.getString("violated-directive");
+            _documentUrl = report.getString("document-uri");
+        }
     }
 
     public String getViolatedDirective()

--- a/src/org/labkey/test/util/CspLogUtil.java
+++ b/src/org/labkey/test/util/CspLogUtil.java
@@ -41,8 +41,8 @@ import java.util.Set;
 public class CspLogUtil
 {
     private static final List<String> ignoredViolations = List.of(
-            "/_rstudio/",
-            "/_rstudioReport/"
+        "/_rstudio/",
+        "/_rstudioReport/"
     );
     private static final Set<String> ignoredDirectives = Collections.emptySet();
 
@@ -124,7 +124,7 @@ public class CspLogUtil
                 }
 
                 boolean foundVioloation = false;
-                MultiValuedMap<Crawler.ControllerActionId, String> violoations = new HashSetValuedHashMap<>();
+                MultiValuedMap<Crawler.ControllerActionId, String> violations = new HashSetValuedHashMap<>();
                 List<CspReport> cspReports = new ArrayList<>();
                 StringBuilder sb = new StringBuilder();
                 for (String line : warningLines)
@@ -148,7 +148,7 @@ public class CspLogUtil
 
                 for (CspReport cspReport : cspReports)
                 {
-                    String url = cspReport.getDocumentUri();
+                    String url = cspReport.getDocumentUrl();
                     String violatedDirective = cspReport.getViolatedDirective();
                     if (ignoredViolations.stream().anyMatch(url::contains) || ignoredDirectives.contains(violatedDirective))
                     {
@@ -157,20 +157,20 @@ public class CspLogUtil
                     else
                     {
                         Crawler.ControllerActionId actionId = new Crawler.ControllerActionId(url);
-                        violoations.put(actionId, cspReport.toString());
+                        violations.put(actionId, cspReport.toString());
                     }
                 }
 
-                if (!violoations.isEmpty())
+                if (!violations.isEmpty())
                 {
                     StringBuilder errorMessage = new StringBuilder()
                             .append("Detected CSP violations on the following actions (See log for more detail: ")
                             .append(recentWarningsFile.getAbsolutePath())
                             .append("):");
-                    for (Crawler.ControllerActionId actionId : violoations.keySet())
+                    for (Crawler.ControllerActionId actionId : violations.keySet())
                     {
                         errorMessage.append("\n\t");
-                        Collection<String> urls = violoations.get(actionId);
+                        Collection<String> urls = violations.get(actionId);
                         errorMessage.append(actionId);
                         if (urls.size() > 1)
                         {
@@ -221,13 +221,14 @@ public class CspLogUtil
 class CspReport
 {
     private final String _violatedDirective;
-    private final String _documentUri;
+    private final String _documentUrl;
 
     CspReport(String reportStr)
     {
-        JSONObject report = new JSONObject(reportStr).getJSONObject("csp-report");
-        _violatedDirective = report.getString("violated-directive");
-        _documentUri = report.getString("document-uri");
+        // Support report-to reports only. GitHub Issue #900
+        JSONObject report = new JSONObject(reportStr).getJSONObject("body");
+        _violatedDirective = report.getString("effectiveDirective");
+        _documentUrl = report.getString("documentURL");
     }
 
     public String getViolatedDirective()
@@ -235,14 +236,14 @@ class CspReport
         return _violatedDirective;
     }
 
-    public String getDocumentUri()
+    public String getDocumentUrl()
     {
-        return _documentUri;
+        return _documentUrl;
     }
 
     @Override
     public String toString()
     {
-        return getViolatedDirective() + ": " + getDocumentUri();
+        return getViolatedDirective() + ": " + getDocumentUrl();
     }
 }


### PR DESCRIPTION
## Rationale
Now that TeamCity is using a Firefox ESR that supports the `report-to` directive, our test framework should be able to parse report-to CSP reports. Once TeamCity supports report-to smoothly, we'll look at pursuing https://github.com/LabKey/internal-issues/issues/900