### PR TITLE
Use details view when looking up samples

### DIFF
--- a/src/org/labkey/test/util/exp/SampleTypeAPIHelper.java
+++ b/src/org/labkey/test/util/exp/SampleTypeAPIHelper.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.util.exp;
 
+import org.json.JSONArray;
 import org.junit.Assert;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
@@ -28,14 +29,12 @@ import org.labkey.test.params.FieldInfo;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.util.DomainUtils;
 import org.labkey.test.util.DomainUtils.DomainKind;
-import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.TestDataGenerator;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -150,19 +149,7 @@ public class SampleTypeAPIHelper
     public static Map<String, Integer> getRowIdsForSamples(String containerPath, String sampleTypeName, List<String> sampleNames) throws IOException, CommandException
     {
         // Use json for the value parameter of the filter. This allows for tricky characters like ";" to be passed to the API.
-        StringBuilder json = new StringBuilder("{json:[");
-
-        Iterator<String> iterator = sampleNames.iterator();
-
-        while (iterator.hasNext())
-        {
-            String sampleName = iterator.next();
-            json.append(EscapeUtil.toJSONStr(sampleName));
-            if (iterator.hasNext())
-                json.append(", ");
-            else
-                json.append("]}");
-        }
+        StringBuilder json = new StringBuilder("{json:").append(new JSONArray(sampleNames)).append("}");
 
         // Use the details view to avoid column and filter settings on the default view
         String detailsView = "~~DETAILS~~";

--- a/src/org/labkey/test/util/exp/SampleTypeAPIHelper.java
+++ b/src/org/labkey/test/util/exp/SampleTypeAPIHelper.java
@@ -149,26 +149,28 @@ public class SampleTypeAPIHelper
      */
     public static Map<String, Integer> getRowIdsForSamples(String containerPath, String sampleTypeName, List<String> sampleNames) throws IOException, CommandException
     {
-
         // Use json for the value parameter of the filter. This allows for tricky characters like ";" to be passed to the API.
         StringBuilder json = new StringBuilder("{json:[");
 
         Iterator<String> iterator = sampleNames.iterator();
 
-        while (iterator.hasNext()) {
+        while (iterator.hasNext())
+        {
             String sampleName = iterator.next();
             json.append(EscapeUtil.toJSONStr(sampleName));
-            if (iterator.hasNext()) {
+            if (iterator.hasNext())
                 json.append(", ");
-            } else {
+            else
                 json.append("]}");
-            }
         }
 
+        // Use the details view to avoid column and filter settings on the default view
+        String detailsView = "~~DETAILS~~";
         Connection connection = WebTestHelper.getRemoteApiConnection();
         SelectRowsCommand cmd = new SelectRowsCommand("samples", sampleTypeName);
-        cmd.setColumns(Arrays.asList("RowId", "Name"));
+        cmd.setColumns(List.of("RowId", "Name"));
         cmd.addFilter("Name", json, Filter.Operator.IN);
+        cmd.setViewName(detailsView);
 
         SelectRowsResponse response = cmd.execute(connection, containerPath);
 
@@ -176,10 +178,11 @@ public class SampleTypeAPIHelper
 
         // There have been some TC failures where selectRows is not returning anything when it should. Adding this
         // logging to help get more logging when/if it happens again.
-        if(response.getRowCount().intValue() == 0)
+        if (response.getRowCount().intValue() == 0)
         {
             cmd = new SelectRowsCommand("samples", sampleTypeName);
-            cmd.setColumns(Arrays.asList("Name"));
+            cmd.setColumns(List.of("Name"));
+            cmd.setViewName(detailsView);
 
             SelectRowsResponse responseCount = cmd.execute(connection, containerPath);
 
@@ -187,7 +190,7 @@ public class SampleTypeAPIHelper
                     sampleTypeName, responseCount.getRowCount().intValue());
 
             List<String> names = new ArrayList<>();
-            for(Map<String, Object> row : responseCount.getRows())
+            for (Map<String, Object> row : responseCount.getRows())
             {
                 Object tempName = row.get("Name");
                 names.add(tempName.toString());
@@ -198,7 +201,7 @@ public class SampleTypeAPIHelper
 
         Map<String, Integer> rowIds = new TreeMap<>();
 
-        for(Map<String, Object> row : response.getRows())
+        for (Map<String, Object> row : response.getRows())
         {
             Object name = row.get("Name");
             Object value = row.get("RowId");
@@ -206,8 +209,7 @@ public class SampleTypeAPIHelper
         }
 
         // Check that the names returned from the query match the names sent in.
-        Assert.assertEquals(errorMsg,
-                new HashSet<>(sampleNames), rowIds.keySet());
+        Assert.assertEquals(errorMsg, new HashSet<>(sampleNames), rowIds.keySet());
 
         return rowIds;
     }


### PR DESCRIPTION
## Rationale
Update test utility function to account for modified default view. Used in testing of [#1357](https://github.com/LabKey/internal-issues/issues/1357).

## Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/2041
- https://github.com/LabKey/labkey-ui-premium/pull/999
- https://github.com/LabKey/limsModules/pull/2365
- https://github.com/LabKey/testAutomation/pull/3132

## Changes
- Use `~~DETAILS~~` view when resolving rowIds for samples
- Use `JSONArray` to JSON serialize the filter value