### PR TITLE
GitHub Issue #159: Require all assay transform scripts to reside in container's @scripts dir

### DIFF
--- a/src/org/labkey/test/components/ui/files/AttachmentCard.java
+++ b/src/org/labkey/test/components/ui/files/AttachmentCard.java
@@ -109,6 +109,13 @@ public class AttachmentCard extends WebDriverComponent<AttachmentCard.ElementCac
         return elementCache().unavailableWarning.isPresent();
     }
 
+    public void clickMenuOption(String optionText)
+    {
+        if (!elementCache().menu.isPresent())
+            throw new IllegalStateException("Unable to find menu");
+        elementCache().menu.get().clickSubMenu(false, optionText);
+    }
+
     public boolean canRemove()
     {
         return getRemoveOption() != null;

--- a/src/org/labkey/test/components/ui/files/AttachmentCard.java
+++ b/src/org/labkey/test/components/ui/files/AttachmentCard.java
@@ -109,11 +109,9 @@ public class AttachmentCard extends WebDriverComponent<AttachmentCard.ElementCac
         return elementCache().unavailableWarning.isPresent();
     }
 
-    public void clickMenuOption(String optionText)
+    public String getDescription()
     {
-        if (!elementCache().menu.isPresent())
-            throw new IllegalStateException("Unable to find menu");
-        elementCache().menu.get().clickSubMenu(false, optionText);
+        return elementCache().description.getText();
     }
 
     public boolean canRemove()
@@ -153,6 +151,7 @@ public class AttachmentCard extends WebDriverComponent<AttachmentCard.ElementCac
     protected class ElementCache extends Component<?>.ElementCache
     {
         final WebElement fileSize = Locator.byClass("attachment-card__size").findWhenNeeded(this);
+        final WebElement description = Locator.byClass("attachment-card__description").refindWhenNeeded(this);
         final WebElement icon = Locator.byClass("attachment-card__icon_img").findWhenNeeded(this);
         Optional<BootstrapMenu> menu = BootstrapMenu.finder(getDriver())
                 .locatedBy(Locator.tagWithClass("div", "attachment-card__menu"))

--- a/src/org/labkey/test/pages/ReactAssayDesignerPage.java
+++ b/src/org/labkey/test/pages/ReactAssayDesignerPage.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.test.pages;
 
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
@@ -320,7 +319,7 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
      */
     private void removeExistingScriptFile(String fileName)
     {
-        String manageScriptsUrl = StringUtils.stripEnd(elementCache().manageScriptFilesLink.getDomProperty("href"), "/");
+        String manageScriptsUrl = elementCache().manageScriptFilesLink.getDomProperty("href");
         WebDavUploadHelper webDavHelper = new WebDavUploadHelper(WebDavUrlFactory.fromDirectoryUrl(manageScriptsUrl));
         if (webDavHelper.fileExists(fileName))
         {
@@ -339,11 +338,15 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
         return this;
     }
 
-    public String getTransformScriptPath(String fileName) throws Exception
+    /**
+     * The server side path of a transform script configured on this assay design, as shown on the script's card. This
+     * is the same value as the card's "Copy path" menu option, read from the DOM to avoid a clipboard round trip.
+     * @param fileName Name of the transform script file
+     */
+    public String getTransformScriptPath(String fileName)
     {
         AttachmentCard card = new AttachmentCard.FileAttachmentCardFinder(getDriver()).withTitle(fileName).waitFor(this);
-        card.clickMenuOption("Copy path");
-        return getWrapper().getClipboardContent();
+        return card.getDescription();
     }
 
     public enum MetadataInputFormat implements OptionSelect.SelectOption

--- a/src/org/labkey/test/pages/ReactAssayDesignerPage.java
+++ b/src/org/labkey/test/pages/ReactAssayDesignerPage.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.pages;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
@@ -29,6 +30,9 @@ import org.labkey.test.components.html.OptionSelect;
 import org.labkey.test.components.ui.files.AttachmentCard;
 import org.labkey.test.pages.assay.plate.PlateTemplateListPage;
 import org.labkey.test.util.Maps;
+import org.labkey.test.util.TestLogger;
+import org.labkey.test.util.core.webdav.WebDavUploadHelper;
+import org.labkey.test.util.core.webdav.WebDavUrlFactory;
 import org.labkey.test.util.selenium.WebElementUtils;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -256,7 +260,7 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
 
     public ReactAssayDesignerPage addTransformScript(File transformScript)
     {
-        return setTransformScript(transformScript, false, null);
+        return setTransformScript(transformScript, true, null);
     }
 
     public ReactAssayDesignerPage addTransformScript(File transformScript, boolean usingFileUpload)
@@ -278,6 +282,11 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
         String targetPath = transformScript.getAbsolutePath();
         if (usingFileUpload)
         {
+            // GitHub Issue #159: The upload fails if a file of the same name is already in the assay's "@scripts" dir,
+            // so remove any leftover file first.
+            if (expectedError == null)
+                removeExistingScriptFile(transformScript.getName());
+
             getWrapper().setFormElement(Locator.tagWithClass("input", "file-upload__input"), transformScript);
             targetPath = "/@scripts/" + transformScript.getName();
         }
@@ -302,6 +311,22 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
         }
 
         return this;
+    }
+
+    /**
+     * Remove a file from the "@scripts" dir of the container that this assay design lives in, if it is present. Uses
+     * WebDav directly instead of the "Manage script files" UI, which opens in a separate browser tab.
+     * @param fileName Name of the transform script file to remove
+     */
+    private void removeExistingScriptFile(String fileName)
+    {
+        String manageScriptsUrl = StringUtils.stripEnd(elementCache().manageScriptFilesLink.getDomProperty("href"), "/");
+        WebDavUploadHelper webDavHelper = new WebDavUploadHelper(WebDavUrlFactory.fromDirectoryUrl(manageScriptsUrl));
+        if (webDavHelper.fileExists(fileName))
+        {
+            TestLogger.log("Removing existing transform script file: " + fileName);
+            webDavHelper.deleteFile(fileName);
+        }
     }
 
     public ReactAssayDesignerPage removeTransformScript(String fileName)
@@ -388,6 +413,8 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
         final Checkbox qcEnabledCheckbox = Checkbox(Locator.checkboxById("assay-design-qcEnabled")).findWhenNeeded(propertiesPanel);
         final Checkbox plateTemplateCheckbox = Checkbox(Locator.checkboxById("assay-design-plateMetadata")).findWhenNeeded(propertiesPanel);
         final Checkbox activeStatusCheckBox = Checkbox(Locator.checkboxById("assay-design-status")).findWhenNeeded(propertiesPanel);
+        final WebElement manageScriptFilesLink = Locator.tagWithClass("div", "transform-script--manage-link")
+                .child(Locator.linkWithText("Manage script files")).refindWhenNeeded(propertiesPanel);
 
         final WebElement hitSelectionCriteriaBtn = Locator.tagWithClass("div", "filter-criteria-input__button")
                 .child(Locator.button("Edit Criteria")).findWhenNeeded(propertiesPanel);

--- a/src/org/labkey/test/pages/ReactAssayDesignerPage.java
+++ b/src/org/labkey/test/pages/ReactAssayDesignerPage.java
@@ -339,6 +339,13 @@ public class ReactAssayDesignerPage extends DomainDesignerPage
         return this;
     }
 
+    public String getTransformScriptPath(String fileName) throws Exception
+    {
+        AttachmentCard card = new AttachmentCard.FileAttachmentCardFinder(getDriver()).withTitle(fileName).waitFor(this);
+        card.clickMenuOption("Copy path");
+        return getWrapper().getClipboardContent();
+    }
+
     public enum MetadataInputFormat implements OptionSelect.SelectOption
     {
         MANUAL,

--- a/src/org/labkey/test/tests/GpatAssayTest.java
+++ b/src/org/labkey/test/tests/GpatAssayTest.java
@@ -282,6 +282,22 @@ public class GpatAssayTest extends BaseWebDriverTest
         return assayDesignerPage;
     }
 
+    @Test // GitHub Issue #159
+    public void testAssayTransformScriptPathError()
+    {
+        File trialData = TestFileUtils.getSampleData("GPAT/renameAssayTrial.xls");
+        String assayName = TestDataGenerator.randomDomainName();
+        log(String.format("Create an assay named '%s'.", assayName));
+        ReactAssayDesignerPage assayDesignerPage = startCreateGpatAssay(trialData, assayName);
+
+        log("Verify error message when trying to add transform script with path outside of @scripts dir");
+        assayDesignerPage.addTransformScript(RTRANSFORM_SCRIPT_FILE_NOOP, false);
+        List<String> errors = assayDesignerPage.clickSaveExpectingErrors();
+        Assert.assertTrue("Error msg not as expected during assay creation",
+                errors.contains("The transform script must exist within this folder's @scripts directory."));
+        assayDesignerPage.clickCancel();
+    }
+
     @Test
     public void testMultipleFileUploadInAssayRun()
     {

--- a/src/org/labkey/test/tests/assay/AssayTransformMissingParentDirTest.java
+++ b/src/org/labkey/test/tests/assay/AssayTransformMissingParentDirTest.java
@@ -15,9 +15,9 @@
  */
 package org.labkey.test.tests.assay;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.labkey.api.util.FileUtil;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Assays;
@@ -26,11 +26,10 @@ import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.pages.assay.AssayImportPage;
 import org.labkey.test.pages.assay.AssayRunsPage;
+import org.labkey.test.pages.files.WebDavPage;
 import org.labkey.test.params.assay.GeneralAssayDesign;
 
 import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -40,28 +39,38 @@ import java.util.List;
 @Category({Assays.class, Daily.class})
 public class AssayTransformMissingParentDirTest extends AbstractAssayTransformTest
 {
+    private static final File RTRANSFORM_SCRIPT_FILE_NOOP = TestFileUtils.getSampleData("qc/noopTransform.R");
+
     @Test
     public void testMissingParentDirectoryRegression() throws Exception
     {
-        // Create a nested directory and an R transform script within it
+        // create a General assay and add the transform
         String assayName = "missingParentDirAssay";
-        Path parentDir = Files.createTempDirectory("assay-transform-parent-");
-        Path nestedDir = FileUtil.createDirectories(parentDir.resolve("child"), false);
-        String scriptName = "transformMissingParent.R";
-        String transformContent = "library(Rlabkey);";
-        File transformFile = nestedDir.resolve(scriptName).toFile();
-        TestFileUtils.writeFile(transformFile, transformContent);
-
-        // Create a General assay and add the transform by absolute path (not upload)
+        String transformFileName = RTRANSFORM_SCRIPT_FILE_NOOP.getName();
         var protocolResponse = new GeneralAssayDesign(assayName).setBatchFields(List.of(), false).createAssay(getProjectName(), createDefaultConnection());
         var assayDesignerPage = ReactAssayDesignerPage.beginAt(this, getProjectName(), protocolResponse.getProtocolId(),
                 "general", "");
-        // add by path so the absolute path is stored; this allows reproducing the missing parent dir scenario
-        assayDesignerPage.addTransformScript(transformFile);
+        assayDesignerPage.addTransformScript(RTRANSFORM_SCRIPT_FILE_NOOP);
+        String transformScriptPath = assayDesignerPage.getTransformScriptPath(transformFileName);
         assayDesignerPage.clickSave();
 
-        // Now delete the parent dir to ensure we handle it reasonably
-        TestFileUtils.deleteDirWithRetry(parentDir.toFile());
+        // move the script into a nested directory in the @scripts webdav path
+        WebDavPage webDavPage = WebDavPage.beginAt(this, getProjectName() + "/@scripts");
+        webDavPage.getFileBrowserHelper().createFolder("child");
+        File transformFile = new File(transformScriptPath);
+        File destinationFile = new File(transformFile.getParent() + "/child", transformFileName);
+        FileUtils.moveFile(transformFile, destinationFile);
+
+        // update the assay design with the new nested dir file path
+        assayDesignerPage = ReactAssayDesignerPage.beginAt(this, getProjectName(), protocolResponse.getProtocolId(),
+                "general", "");
+        assayDesignerPage.removeTransformScript(transformFileName);
+        assayDesignerPage.addTransformScript(destinationFile, false);
+        assayDesignerPage.clickSave();
+
+        // Now delete the nested dir to ensure we handle it reasonably
+        File destinationDir = new File(transformFile.getParent() + "/child");
+        FileUtils.deleteDirectory(destinationDir);
 
         // Attempt to import data and verify a reasonable error message is shown
         String importData = """
@@ -69,7 +78,8 @@ public class AssayTransformMissingParentDirTest extends AbstractAssayTransformTe
                 1\tP1\timport after parent deleted
                 """;
 
-        new AssayRunsPage(getDriver()).getTable().clickHeaderButtonAndWait("Import Data");
+        AssayRunsPage.beginAt(this, getProjectName(), protocolResponse.getProtocolId())
+            .getTable().clickHeaderButtonAndWait("Import Data");
         var importPage = new AssayImportPage(getDriver());
         importPage.setNamedInputText("Name", "missingParentImport");
         importPage.setNamedTextAreaValue(AssayConstants.TEXT_AREA_DATA_COLLECTOR_TEXT_AREA_NAME, importData);
@@ -77,16 +87,15 @@ public class AssayTransformMissingParentDirTest extends AbstractAssayTransformTe
 
         // Expect an error page/message indicating the transform script path cannot be used
         // Be tolerant to platform-specific phrasing; assert any of these appear
-        String expectedPath = transformFile.getAbsolutePath();
         checker().withScreenshot("missing-parent-error")
                 .verifyTrue("Expect an error message about the transform script path not being found",
-                        isTextPresent("transformMissingParent.R, configured for this assay does not exist."));
+                        isTextPresent(transformFileName + ", configured for this assay does not exist."));
 
         // Fix the assay design by removing the transform script
         goToProjectHome();
         assayDesignerPage = ReactAssayDesignerPage.beginAt(this, getProjectName(), protocolResponse.getProtocolId(),
                 "general", getURL().toString());
-        assayDesignerPage.removeTransformScript(scriptName);
+        assayDesignerPage.removeTransformScript(transformFileName);
         assayDesignerPage.clickSave();
 
         // Retry the import and verify it succeeds without the transform

--- a/src/org/labkey/test/tests/assay/AssayTransformWarningTest.java
+++ b/src/org/labkey/test/tests/assay/AssayTransformWarningTest.java
@@ -310,7 +310,6 @@ public class AssayTransformWarningTest extends BaseWebDriverTest
 
         // verify check for valid script engine defined for the file extension
         assayDesignerPage.addTransformScript(JAVA_INVALID_TRANSFORM_SCRIPT, true, "Script engine for the extension '.java' has not been registered.");
-        assayDesignerPage.addTransformScript(JAVA_INVALID_TRANSFORM_SCRIPT, false, "Script engine for the extension '.java' has not been registered.");
 
         // verify check for duplicate file in @scripts dir
         assayDesignerPage.addTransformScript(R_TRANSFORM_ERROR_SCRIPT, true);

--- a/src/org/labkey/test/util/core/webdav/WebDavUrlFactory.java
+++ b/src/org/labkey/test/util/core/webdav/WebDavUrlFactory.java
@@ -55,5 +55,15 @@ public class WebDavUrlFactory
     {
         return new WebDavUrlFactory(buildBaseWebfilesUrl(containerPath));
     }
+
+    /**
+     * For cases where the WebDav directory URL is already known (e.g. taken from the 'href' of a link rendered by the
+     * server or a React component) and doesn't need to be constructed from a container path.
+     * @param directoryUrl Absolute URL of a WebDav directory
+     */
+    public static WebDavUrlFactory fromDirectoryUrl(String directoryUrl)
+    {
+        return new WebDavUrlFactory(directoryUrl);
+    }
 }
 


### PR DESCRIPTION
## Rationale
https://github.com/LabKey/internal-issues/issues/159

Assay transform scripts configured through the designer must now live in the design's own container `@scripts` directory (writable only by platform developers), enforced by a new validateScriptLocation() in the save path, with a site-wide deprecated feature flag as an escape hatch and a usage metric approximating how many existing designs are non-compliant. The Selenium page object switches the default addTransformScript(File) to file-upload mode, deleting any same-named leftover from `@scripts` first.

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7895
- https://github.com/LabKey/testAutomation/pull/3133
- https://github.com/LabKey/limsModules/pull/2369

## Changes
- Selenium test updates to use file upload for addTransformScript
- addTransformScript to check for and remove file from `@scripts` if it already exists