### PR TITLE
Enable CSP enforcement between tests

### DIFF
--- a/src/org/labkey/test/TestScrubber.java
+++ b/src/org/labkey/test/TestScrubber.java
@@ -28,6 +28,7 @@ import org.labkey.test.pages.core.admin.LimitActiveUserPage;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PipelineToolsHelper;
 import org.labkey.test.util.TestLogger;
+import org.labkey.test.util.core.admin.CspConfigHelper;
 import org.labkey.test.util.core.login.DbLoginUtils;
 import org.labkey.test.util.login.AuthenticationAPIUtils;
 import org.openqa.selenium.WebDriverException;
@@ -169,6 +170,15 @@ public class TestScrubber extends ExtraSiteWrapper
         catch (Exception e)
         {
             TestLogger.error("Failed to disable pipeline triggers after test", e);
+        }
+
+        try
+        {
+            new CspConfigHelper(this::createDefaultConnection).setEnforceCsp(true);
+        }
+        catch (NullPointerException e)
+        {
+            TestLogger.error("Failed to enable CSP enforcement after test", e);
         }
 
     }

--- a/src/org/labkey/test/tests/CrawlerTest.java
+++ b/src/org/labkey/test/tests/CrawlerTest.java
@@ -59,6 +59,7 @@ public class CrawlerTest extends BaseWebDriverTest
     {
         super.doCleanup(afterTest);
         _userHelper.deleteUsers(afterTest, USER);
+        _cspConfigHelper.setEnforceCsp(true);
     }
 
     @BeforeClass


### PR DESCRIPTION
## Rationale
Some tests will fail if there is an unexpected warning banner. The `disableEnforceCsp` flag is now deprecated rather than experimental, which displays a banner if left enabled.
<img width="727" height="66" alt="image" src="https://github.com/user-attachments/assets/616beece-5c3e-4091-9092-89b3961a4d8d" />

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7890

## Changes
- Enable CSP enforcement between tests