### PR TITLE
Fix intermittent SMSampleFinderGridActionsTest.testExport

### DIFF
--- a/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
+++ b/src/org/labkey/test/components/ui/grids/ResponsiveGrid.java
@@ -789,8 +789,9 @@ public class ResponsiveGrid<T extends ResponsiveGrid<?>> extends WebDriverCompon
 
     public List<String> getGridMessages()
     {
-        return getWrapper().getTexts(Locator.tagWithClass("div", "grid-messages")
-                .child(Locator.tagWithClass("div", "grid-message")).findElements(this));
+        return getWrapper().shortWait().ignoring(StaleElementReferenceException.class)
+                .until(d -> getWrapper().getTexts(Locator.tagWithClass("div", "grid-messages")
+                        .child(Locator.tagWithClass("div", "grid-message")).findElements(this)));
     }
 
     public boolean hasGridError()


### PR DESCRIPTION
## Rationale
`getGridMessages()` intermittently threw a `StaleElementReferenceException` when reading the last grid message.

## Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

## Changes
- added retry that ignores `StaleElementReferenceException` when reading grid messages

<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->