### PR TITLE
GitHub Issue #159: AssayExportImportTest fix to use assay designer UI to add transform script

### DIFF
--- a/src/org/labkey/test/tests/AssayExportImportTest.java
+++ b/src/org/labkey/test/tests/AssayExportImportTest.java
@@ -166,7 +166,6 @@ public class AssayExportImportTest extends BaseWebDriverTest
         Connection cn = createDefaultConnection();
         Protocol protocol = new GetProtocolCommand("General").execute(cn, projectName).getProtocol();
         protocol.setName(assayName);
-        protocol.setProtocolTransformScripts(List.of(new File(SAMPLE_DATA_LOCATION, PERL_SCRIPT).getAbsolutePath()));
         protocol.setSaveScriptFiles(true);
         protocol.setEditableResults(true);
         protocol.setEditableRuns(true);
@@ -199,7 +198,17 @@ public class AssayExportImportTest extends BaseWebDriverTest
             resultsFields.add(new FieldDefinition("resultFileField", ColumnType.File));
         domains.get("Data Fields").setFields(resultsFields);
 
-        return new SaveProtocolCommand(protocol).execute(cn, projectName).getProtocol().getProtocolId();
+        Integer protocolId = new SaveProtocolCommand(protocol).execute(cn, projectName).getProtocol().getProtocolId();
+
+        // GitHub Issue #159: The transform script must live in the assay's "@scripts" directory, so add it through the
+        // designer's file upload rather than setting an absolute path on the protocol via the API.
+        log("Add the transform script '" + PERL_SCRIPT + "' to the assay design using the designer's file upload.");
+        goToProjectHome(projectName);
+        ReactAssayDesignerPage assayDesignerPage = ReactAssayDesignerPage.beginAt(this, projectName, protocolId, "General", getURL().toString());
+        assayDesignerPage.addTransformScript(new File(SAMPLE_DATA_LOCATION, PERL_SCRIPT));
+        assayDesignerPage.clickFinish();
+
+        return protocolId;
     }
 
     public void addNewField(String projectName, String assayName, FieldDefinition newField)


### PR DESCRIPTION
## Rationale
The changes for this issue https://github.com/LabKey/internal-issues/issues/159 require that assay transform scripts live in the LabKey container's `@scripts` directory. This PR fixes the AssayExportImportTest to upload the script to the expected location using the assay designer UI.

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7895

## Changes
- AssayExportImportTest to upload transform script to @script dir using assay designer UI