### PR TITLE
Fix intermittent SAML re-auth test failure

### DIFF
--- a/src/org/labkey/test/pages/test/TestReauthPage.java
+++ b/src/org/labkey/test/pages/test/TestReauthPage.java
@@ -23,6 +23,7 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.pages.LabKeyPage;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.Map;
 import java.util.Optional;
@@ -56,7 +57,16 @@ public class TestReauthPage extends LabKeyPage<TestReauthPage.ElementCache>
 
     public void clickReauth()
     {
-        clickAndWait(elementCache().reauthLink);
+        WebElement link = elementCache().reauthLink;
+
+        shortWait().until(
+                ExpectedConditions.attributeContains(
+                        link,
+                        "href",
+                        "returnUrl"
+                )
+        );
+        clickAndWait(link);
         clearCache();
     }
 

--- a/src/org/labkey/test/tests/AbstractReauthTest.java
+++ b/src/org/labkey/test/tests/AbstractReauthTest.java
@@ -20,6 +20,7 @@ import org.junit.Assume;
 import org.junit.Test;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.pages.test.TestReauthPage;
 
 import java.util.Arrays;
@@ -122,12 +123,17 @@ public abstract class AbstractReauthTest extends BaseWebDriverTest
         signOut();
         clickSignIn();
         authenticate(user.email, user.password);
+        // An IdP's SAML POST-binding page auto-submits to LabKey, so the browser can still be on the IdP
+        // origin here. getCurrentUser() copies only the cookies visible to the current URL, which excludes
+        // LabKey's session cookie, so wait for the browser to land back on LabKey before checking the user.
+        waitFor(() -> getDriver().getCurrentUrl().startsWith(WebTestHelper.getBaseURL()),
+            "Browser didn't return to LabKey after authenticating", WAIT_FOR_PAGE);
         assertSignedInAs(user);
     }
 
     private void assertSignedInAs(User user)
     {
-        if (!waitFor(() -> getCurrentUser().equals(user.email), 1_000))
+        if (!waitFor(() -> getCurrentUser().equals(user.email), WAIT_FOR_PAGE))
             assertEquals("Signed in as", user.email, getCurrentUser());
     }
 


### PR DESCRIPTION
## Rationale
`SAMLReauthTest.testReauthWithBadPassword()` was failing intermittently