### PR TITLE
Update selenium test dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,20 +25,18 @@ project.dependencies {
     api("org.seleniumhq.selenium:selenium-api:${seleniumVersion}")
     api("org.assertj:assertj-core:${assertjVersion}")
     implementation("org.awaitility:awaitility:${awaitilityVersion}")
-    implementation("commons-io:commons-io:${commonsIoVersion}")
+    implementation("commons-io:commons-io:${commonsIoVersion}") // Dependency of poi, tika, and commons-compress
     implementation("com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}")
     implementation("org.bouncycastle:bcprov-jdk18on:${bouncycastleVersion}")
     implementation("org.apache.commons:commons-csv:${apacheCommonsCsvVersion}")
 
-    //api "org.seleniumhq.selenium:selenium-server:${seleniumVersion}"
     implementation("org.seleniumhq.selenium:selenium-firefox-driver:${seleniumVersion}")
     api("org.seleniumhq.selenium:selenium-support:${seleniumVersion}")
     implementation("org.seleniumhq.selenium:selenium-remote-driver:${seleniumVersion}")
     implementation("org.seleniumhq.selenium:selenium-chrome-driver:${seleniumVersion}")
     implementation "org.seleniumhq.selenium:selenium-ie-driver:${seleniumVersion}"
-    implementation("org.eclipse.jetty:jetty-util:${jettyVersion}")
 
-    implementation("com.google.guava:guava:${guavaVersion}")
+    implementation("com.google.guava:guava:${guavaVersion}") // Dependency of mockserver
     api("org.apache.httpcomponents.core5:httpcore5:${httpcore5Version}")
     api("org.apache.httpcomponents.client5:httpclient5:${httpclient5Version}")
     api("org.hamcrest:hamcrest:${hamcrestVersion}")
@@ -50,8 +48,8 @@ project.dependencies {
     implementation "org.apache.logging.log4j:log4j-core:${log4j2Version}"
     implementation "org.apache.logging.log4j:log4j-iostreams:${log4j2Version}"
     api "com.github.lookfirst:sardine:${project.lookfirstSardineVersion}"
-    implementation "javax.xml.bind:jaxb-api:${jaxbApiOldVersion}"
-    implementation "org.glassfish.jaxb:jaxb-runtime:${jaxbOldVersion}"
+//    implementation "javax.xml.bind:jaxb-api:${jaxbApiOldVersion}"
+//    implementation "org.glassfish.jaxb:jaxb-runtime:${jaxbOldVersion}"
     implementation "org.glassfish.jersey.media:jersey-media-multipart:${jerseyVersion}"
     api "commons-beanutils:commons-beanutils:${commonsBeanutilsVersion}"
     implementation "org.apache.tika:tika-core:${tikaVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'maven-publish'
 }
 
-import org.labkey.gradle.task.RunTestSuite
+
 import org.labkey.gradle.task.RunUiTest
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
@@ -52,6 +52,7 @@ project.dependencies {
     api "com.github.lookfirst:sardine:${project.lookfirstSardineVersion}"
     implementation "javax.xml.bind:jaxb-api:${jaxbApiOldVersion}"
     implementation "org.glassfish.jaxb:jaxb-runtime:${jaxbOldVersion}"
+    implementation "org.glassfish.jersey.media:jersey-media-multipart:${jerseyVersion}"
     api "commons-beanutils:commons-beanutils:${commonsBeanutilsVersion}"
     implementation "org.apache.tika:tika-core:${tikaVersion}"
     implementation "org.apache.commons:commons-compress:${commonsCompressVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -48,8 +48,6 @@ project.dependencies {
     implementation "org.apache.logging.log4j:log4j-core:${log4j2Version}"
     implementation "org.apache.logging.log4j:log4j-iostreams:${log4j2Version}"
     api "com.github.lookfirst:sardine:${project.lookfirstSardineVersion}"
-//    implementation "javax.xml.bind:jaxb-api:${jaxbApiOldVersion}"
-//    implementation "org.glassfish.jaxb:jaxb-runtime:${jaxbOldVersion}"
     implementation "org.glassfish.jersey.media:jersey-media-multipart:${jerseyVersion}"
     api "commons-beanutils:commons-beanutils:${commonsBeanutilsVersion}"
     implementation "org.apache.tika:tika-core:${tikaVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,8 +10,6 @@ lookfirstSardineVersion=5.13
 
 jerseyVersion=4.0.2
 
-jettyVersion=12.1.12
-
 seleniumVersion=4.46.0
 
 mockserverNettyVersion=7.4.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,10 +8,12 @@ awaitilityVersion=4.3.0
 
 lookfirstSardineVersion=5.13
 
-jettyVersion=12.1.10
+jerseyVersion=4.0.2
 
-seleniumVersion=4.45.0
+jettyVersion=12.1.12
 
-mockserverNettyVersion=5.15.0
+seleniumVersion=4.46.0
+
+mockserverNettyVersion=7.4.0
 
 labkeySchemasTestVersion=26.7-SNAPSHOT

--- a/src/org/labkey/test/util/EscapeUtil.java
+++ b/src/org/labkey/test/util/EscapeUtil.java
@@ -18,7 +18,6 @@ package org.labkey.test.util;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.poi.ss.util.WorkbookUtil;
-import org.eclipse.jetty.util.URIUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.test.params.FieldKey;
@@ -153,14 +152,17 @@ public class EscapeUtil
     }
 
     /**
-     * Encode a string to be used as a URL path
-     * For now, simply designates to URIUtil. Will replace with an impl that doesn't require Jetty utils.
+     * Encode a string to be used as a URL path. Doesn't encode '/' because they are not allowed in any path parts such
+     * as project, folder, or file names.
+     *
      * @param path Path to be encoded
-     * @return encoded value or empty string if provided string was `null`
+     * @return encoded path
      */
     public static String encodeUriPath(String path)
     {
-        return URIUtil.encodePath(path);
+        return URLEncoder.encode(StringUtils.trimToEmpty(path), StandardCharsets.UTF_8)
+                .replace("%2F", "/") // '/' is a separator, shouldn't be encoded
+                .replace("+", "%20"); // labKey doesn't, generally, encode space as '+'
     }
 
     /**
@@ -176,13 +178,15 @@ public class EscapeUtil
 
     /**
      * Decode a string representing a URL path
-     * For now, simply designates to URIUtil. Will replace with an impl that doesn't require Jetty utils.
+     *
      * @param path path to be decoded
-     * @return decoded value or empty string if the provided string was `null`
+     * @return decoded path
      */
     public static String decodeUriPath(String path)
     {
-        return URIUtil.decodePath(path);
+        // Prevent '+' becoming ' '
+        path = StringUtils.trimToEmpty(path).replace("+", "%2B");
+        return URLDecoder.decode(path, StandardCharsets.UTF_8);
     }
 
     public static String fieldKeyEncodePart(String str)

--- a/src/org/labkey/test/util/SimpleHttpRequest.java
+++ b/src/org/labkey/test/util/SimpleHttpRequest.java
@@ -18,13 +18,12 @@ package org.labkey.test.util;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.labkey.remoteapi.Connection;
 import org.labkey.test.TestFileUtils;
 import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebDriver;
 
-import javax.mail.internet.ContentDisposition;
-import javax.mail.internet.ParseException;
 import java.io.File;
 import java.io.IOException;
 import java.net.Authenticator;
@@ -32,6 +31,7 @@ import java.net.HttpURLConnection;
 import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
@@ -184,7 +184,7 @@ public class SimpleHttpRequest
                 {
                     try
                     {
-                        responseFilename = new ContentDisposition(contentDisposition).getParameter("filename");
+                        responseFilename = new ContentDisposition(contentDisposition).getFileName();
                     }
                     catch (ParseException ignore) { }
                 }


### PR DESCRIPTION
## Rationale
Monthly java dependency update.

## Related Pull Requests
- N/A

## Changes
- Update dependencies
- Remove unused jaxb dependencies
- Refactor Content-Disposition header parsing in `SimpleHttpRequest`
  - _used a transitive dependency of `mockserver-netty` that went away with the version update_
- Remove Jetty dependency (flagged for removal in `EscapeUtil`)